### PR TITLE
transfer anchor state rent to block author

### DIFF
--- a/runtime/src/anchor/mod.rs
+++ b/runtime/src/anchor/mod.rs
@@ -65,7 +65,11 @@ impl<Hash, BlockNumber> AnchorData<Hash, BlockNumber> {
 
 /// The module's configuration trait.
 pub trait Trait:
-    frame_system::Trait + pallet_timestamp::Trait + fees::Trait + pallet_balances::Trait
+    frame_system::Trait
+    + pallet_timestamp::Trait
+    + fees::Trait
+    + pallet_balances::Trait
+    + pallet_authorship::Trait
 {
 }
 
@@ -192,7 +196,11 @@ decl_module! {
             // we use the fee config setup on genesis for anchoring to calculate the state rent
             let fee = <fees::Module<T>>::price_of(Self::fee_key()).unwrap() *
                 <T as pallet_balances::Trait>::Balance::from(stored_until_date_from_epoch - today_in_days_from_epoch);
-            <fees::Module<T>>::pay_fee_given(who, fee)?;
+            // fetch the author of the current block
+            let author = <pallet_authorship::Module<T>>::author();
+
+            // transfer fees to the block author
+            <fees::Module<T>>::pay_fee_given_to(who, author, fee)?;
 
             let block_num = <frame_system::Module<T>>::block_number();
             let child_storage_key = common::generate_child_storage_key(stored_until_date_from_epoch);

--- a/runtime/src/anchor/mod.rs
+++ b/runtime/src/anchor/mod.rs
@@ -65,11 +65,7 @@ impl<Hash, BlockNumber> AnchorData<Hash, BlockNumber> {
 
 /// The module's configuration trait.
 pub trait Trait:
-    frame_system::Trait
-    + pallet_timestamp::Trait
-    + fees::Trait
-    + pallet_balances::Trait
-    + pallet_authorship::Trait
+    frame_system::Trait + pallet_timestamp::Trait + fees::Trait + pallet_balances::Trait
 {
 }
 
@@ -196,11 +192,9 @@ decl_module! {
             // we use the fee config setup on genesis for anchoring to calculate the state rent
             let fee = <fees::Module<T>>::price_of(Self::fee_key()).unwrap() *
                 <T as pallet_balances::Trait>::Balance::from(stored_until_date_from_epoch - today_in_days_from_epoch);
-            // fetch the author of the current block
-            let author = <pallet_authorship::Module<T>>::author();
 
             // transfer fees to the block author
-            <fees::Module<T>>::pay_fee_given_to(who, author, fee)?;
+            <fees::Module<T>>::pay_fee_to_author(who, fee)?;
 
             let block_num = <frame_system::Module<T>>::block_number();
             let child_storage_key = common::generate_child_storage_key(stored_until_date_from_epoch);

--- a/runtime/src/anchor/mod.rs
+++ b/runtime/src/anchor/mod.rs
@@ -193,7 +193,7 @@ decl_module! {
             let fee = <fees::Module<T>>::price_of(Self::fee_key()).unwrap() *
                 <T as pallet_balances::Trait>::Balance::from(stored_until_date_from_epoch - today_in_days_from_epoch);
 
-            // transfer fees to the block author
+            // pay state rent to block author
             <fees::Module<T>>::pay_fee_to_author(who, fee)?;
 
             let block_num = <frame_system::Module<T>>::block_number();

--- a/runtime/src/anchor/tests.rs
+++ b/runtime/src/anchor/tests.rs
@@ -71,6 +71,13 @@ impl pallet_balances::Trait for Test {
     type AccountStore = System;
 }
 
+impl pallet_authorship::Trait for Test {
+    type FindAuthor = ();
+    type UncleGenerations = ();
+    type FilterUncle = ();
+    type EventHandler = ();
+}
+
 impl Trait for Test {}
 
 impl Test {

--- a/runtime/src/nfts.rs
+++ b/runtime/src/nfts.rs
@@ -132,6 +132,13 @@ mod tests {
         type MinimumPeriod = ();
     }
 
+    impl pallet_authorship::Trait for Test {
+        type FindAuthor = ();
+        type UncleGenerations = ();
+        type FilterUncle = ();
+        type EventHandler = ();
+    }
+
     impl fees::Trait for Test {
         type Event = ();
         type FeeChangeOrigin = frame_system::EnsureRoot<u64>;


### PR DESCRIPTION
closes centrifuge/roadmap#130

This PR ensures the state rent is paid to block author.

`pallet_authorship::author()` returns either the primary or secondary author of the current block this is being included in. 
More on this is found here - https://github.com/paritytech/substrate/blob/master/frame/babe/src/lib.rs#L207

I have updated the `fees` module to take the `to` account to which the fees will be transferred to. Even though we use this for anchor state rent, it would be more reusable to take `from` and `to` rather than `fees` module implementing `pallet_authorship` 