### PR TITLE
reformat code using cargo fmt

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use vergen::{ConstantsFlags, generate_cargo_keys};
+use vergen::{generate_cargo_keys, ConstantsFlags};
 
 const ERROR_MSG: &str = "Failed to generate metadata files";
 

--- a/runtime/src/anchor/mod.rs
+++ b/runtime/src/anchor/mod.rs
@@ -7,11 +7,11 @@
 use crate::{common, fees};
 use codec::{Decode, Encode};
 use frame_support::{
-    decl_module, decl_storage,
-    dispatch::{DispatchError, DispatchResult},
-    ensure,
-    storage::child::{self, ChildInfo},
-    weights::SimpleDispatchInfo,
+	decl_module, decl_storage,
+	dispatch::{DispatchError, DispatchResult},
+	ensure,
+	storage::child::{self, ChildInfo},
+	weights::SimpleDispatchInfo,
 };
 use frame_system::ensure_signed;
 use sp_runtime::traits::Hash;
@@ -43,372 +43,372 @@ const CHILD_INFO: ChildInfo<'static> = ChildInfo::new_default(b"anchor");
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct PreCommitData<Hash, AccountId, BlockNumber> {
-    signing_root: Hash,
-    identity: AccountId,
-    expiration_block: BlockNumber,
+	signing_root: Hash,
+	identity: AccountId,
+	expiration_block: BlockNumber,
 }
 
 /// The data structure for storing committed anchors.
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 pub struct AnchorData<Hash, BlockNumber> {
-    id: Hash,
-    pub doc_root: Hash,
-    anchored_block: BlockNumber,
+	id: Hash,
+	pub doc_root: Hash,
+	anchored_block: BlockNumber,
 }
 
 /// The module's configuration trait.
 pub trait Trait:
-    frame_system::Trait + pallet_timestamp::Trait + fees::Trait + pallet_balances::Trait
+	frame_system::Trait + pallet_timestamp::Trait + fees::Trait + pallet_balances::Trait
 {
 }
 
 decl_storage! {
-    trait Store for Module<T: Trait> as Anchor {
+	trait Store for Module<T: Trait> as Anchor {
 
-        /// PreCommits store the map of anchor Id to the pre-commit, which is a lock on an anchor id to be committed
-        /// later
-        PreCommits get(get_pre_commit): map hasher(blake2_256) T::Hash => PreCommitData<T::Hash, T::AccountId, T::BlockNumber>;
+		/// PreCommits store the map of anchor Id to the pre-commit, which is a lock on an anchor id to be committed
+		/// later
+		PreCommits get(get_pre_commit): map hasher(blake2_256) T::Hash => PreCommitData<T::Hash, T::AccountId, T::BlockNumber>;
 
-        /// Pre-commit eviction buckets keep track of which pre-commit can be evicted at which point
-        PreCommitEvictionBuckets get(get_pre_commit_in_evict_bucket_by_index): map hasher(blake2_256) (T::BlockNumber, u64) => T::Hash;
-        PreCommitEvictionBucketIndex get(get_pre_commits_count_in_evict_bucket): map hasher(blake2_256) T::BlockNumber => u64;
+		/// Pre-commit eviction buckets keep track of which pre-commit can be evicted at which point
+		PreCommitEvictionBuckets get(get_pre_commit_in_evict_bucket_by_index): map hasher(blake2_256) (T::BlockNumber, u64) => T::Hash;
+		PreCommitEvictionBucketIndex get(get_pre_commits_count_in_evict_bucket): map hasher(blake2_256) T::BlockNumber => u64;
 
-        /// Index to find the eviction date given an anchor id
-        AnchorEvictDates get(get_anchor_evict_date): map hasher(blake2_256) T::Hash => u32;
+		/// Index to find the eviction date given an anchor id
+		AnchorEvictDates get(get_anchor_evict_date): map hasher(blake2_256) T::Hash => u32;
 
-        /// Incrementing index for anchors for iteration purposes
-        AnchorIndexes get(get_anchor_id_by_index): map hasher(blake2_256) u64 => T::Hash;
+		/// Incrementing index for anchors for iteration purposes
+		AnchorIndexes get(get_anchor_id_by_index): map hasher(blake2_256) u64 => T::Hash;
 
-        /// Latest anchored index
-        LatestAnchorIndex get(get_latest_anchor_index): u64;
+		/// Latest anchored index
+		LatestAnchorIndex get(get_latest_anchor_index): u64;
 
-        /// Latest evicted anchor index. This would keep track of the latest evicted anchor index so
-        /// that we can start the removal of AnchorEvictDates index from that index onwards. Going
-        /// from AnchorIndexes => AnchorEvictDates
-        LatestEvictedAnchorIndex get(get_latest_evicted_anchor_index): u64;
+		/// Latest evicted anchor index. This would keep track of the latest evicted anchor index so
+		/// that we can start the removal of AnchorEvictDates index from that index onwards. Going
+		/// from AnchorIndexes => AnchorEvictDates
+		LatestEvictedAnchorIndex get(get_latest_evicted_anchor_index): u64;
 
-        /// This is to keep track of the date when a child trie of anchors was evicted last. It is
-        /// to evict historic anchor data child tries if they weren't evicted in a timely manner.
-        LatestEvictedDate get(get_latest_evicted_date): u32;
+		/// This is to keep track of the date when a child trie of anchors was evicted last. It is
+		/// to evict historic anchor data child tries if they weren't evicted in a timely manner.
+		LatestEvictedDate get(get_latest_evicted_date): u32;
 
-        /// Storage for evicted anchor child trie roots. Anchors with a given expiry/eviction date
-        /// are stored on-chain in a single child trie. This child trie is removed after the expiry
-        /// date has passed while its root is stored permanently for proving an existence of an
-        /// evicted anchor.
-        EvictedAnchorRoots get(get_evicted_anchor_root_by_day): map hasher(blake2_256) u32 => Vec<u8>;
+		/// Storage for evicted anchor child trie roots. Anchors with a given expiry/eviction date
+		/// are stored on-chain in a single child trie. This child trie is removed after the expiry
+		/// date has passed while its root is stored permanently for proving an existence of an
+		/// evicted anchor.
+		EvictedAnchorRoots get(get_evicted_anchor_root_by_day): map hasher(blake2_256) u32 => Vec<u8>;
 
-        Version: u64;
-    }
+		Version: u64;
+	}
 }
 
 decl_module! {
-    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 
-        /// Obtains an exclusive lock to make the next update to a certain document version
-        /// identified by `anchor_id` on Centrifuge p2p network for a number of blocks given
-        /// by `pre_commit_expiration_duration_blocks` function. `signing_root` is a child node of
-        /// the off-chain merkle tree of that document. In Centrifuge protocol, A document is
-        /// committed only after reaching consensus with the other collaborators on the document.
-        /// Consensus is reached by getting a cryptographic signature from other parties by
-        /// sending them the `signing_root`. To deny the counter-party the free option of publishing
-        /// its own state commitment upon receiving a request for signature, the node can first
-        /// publish a pre-commit. Only the pre-committer account in the Centrifuge chain is
-        /// allowed to `commit` a corresponding anchor before the pre-commit has expired.
-        /// For a more detailed explanation refer section 3.4 of
-        /// [Centrifuge Protocol Paper](https://staticw.centrifuge.io/assets/centrifuge_os_protocol_paper.pdf)
-        ///
-        /// # <weight>
-        /// minimal logic, also needs to be consume less block capacity + cheaper to make the pre-commits viable.
-        /// # </weight>
-        #[weight = SimpleDispatchInfo::FixedNormal(500_000)]
-        pub fn pre_commit(origin, anchor_id: T::Hash, signing_root: T::Hash) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            ensure!(Self::get_anchor_by_id(anchor_id).is_none(), "Anchor already exists");
-            ensure!(!Self::has_valid_pre_commit(anchor_id), "A valid pre-commit already exists");
+		/// Obtains an exclusive lock to make the next update to a certain document version
+		/// identified by `anchor_id` on Centrifuge p2p network for a number of blocks given
+		/// by `pre_commit_expiration_duration_blocks` function. `signing_root` is a child node of
+		/// the off-chain merkle tree of that document. In Centrifuge protocol, A document is
+		/// committed only after reaching consensus with the other collaborators on the document.
+		/// Consensus is reached by getting a cryptographic signature from other parties by
+		/// sending them the `signing_root`. To deny the counter-party the free option of publishing
+		/// its own state commitment upon receiving a request for signature, the node can first
+		/// publish a pre-commit. Only the pre-committer account in the Centrifuge chain is
+		/// allowed to `commit` a corresponding anchor before the pre-commit has expired.
+		/// For a more detailed explanation refer section 3.4 of
+		/// [Centrifuge Protocol Paper](https://staticw.centrifuge.io/assets/centrifuge_os_protocol_paper.pdf)
+		///
+		/// # <weight>
+		/// minimal logic, also needs to be consume less block capacity + cheaper to make the pre-commits viable.
+		/// # </weight>
+		#[weight = SimpleDispatchInfo::FixedNormal(500_000)]
+		pub fn pre_commit(origin, anchor_id: T::Hash, signing_root: T::Hash) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			ensure!(Self::get_anchor_by_id(anchor_id).is_none(), "Anchor already exists");
+			ensure!(!Self::has_valid_pre_commit(anchor_id), "A valid pre-commit already exists");
 
-            let expiration_block = <frame_system::Module<T>>::block_number()  +
-                T::BlockNumber::from(Self::pre_commit_expiration_duration_blocks() as u32);
-            <PreCommits<T>>::insert(anchor_id, PreCommitData {
-                signing_root: signing_root,
-                identity: who.clone(),
-                expiration_block: expiration_block,
-            });
+			let expiration_block = <frame_system::Module<T>>::block_number()  +
+				T::BlockNumber::from(Self::pre_commit_expiration_duration_blocks() as u32);
+			<PreCommits<T>>::insert(anchor_id, PreCommitData {
+				signing_root: signing_root,
+				identity: who.clone(),
+				expiration_block: expiration_block,
+			});
 
-            Self::put_pre_commit_into_eviction_bucket(anchor_id, expiration_block)?;
+			Self::put_pre_commit_into_eviction_bucket(anchor_id, expiration_block)?;
 
-            Ok(())
-        }
+			Ok(())
+		}
 
-        /// Commits a `document_root` of a merklized off chain document in Centrifuge p2p network as
-        /// the latest version id(`anchor_id`) obtained by hashing `anchor_id_preimage`. If a
-        /// pre-commit exists for the obtained `anchor_id`, hash of pre-committed
-        /// `signing_root + proof` must match the given `doc_root`. To avoid state bloat on chain,
-        /// the committed anchor would be evicted after the given `stored_until_date`. The calling
-        /// account would be charged accordingly for the storage period.
-        /// For a more detailed explanation refer section 3.4 of
-        /// [Centrifuge Protocol Paper](https://staticw.centrifuge.io/assets/centrifuge_os_protocol_paper.pdf)
-        ///
-        /// # <weight>
-        /// State rent takes into account the storage cost depending on `stored_until_date`.
-        /// Otherwise independant of the inputs. The weight cost is important as it helps avoid DOS
-        /// using smaller `stored_until_date`s. Computation cost involves timestamp calculations
-        /// and state rent calculations, which we take here to be equivalent to a transfer transaction.
-        /// # </weight>
-        #[weight = SimpleDispatchInfo::FixedNormal(1_000_000)]
-        pub fn commit(origin, anchor_id_preimage: T::Hash, doc_root: T::Hash, proof: T::Hash, stored_until_date: T::Moment) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            ensure!(<pallet_timestamp::Module<T>>::get() + T::Moment::from(common::MS_PER_DAY.try_into().unwrap()) < stored_until_date,
-                "Stored until date must be at least a day later than the current date");
+		/// Commits a `document_root` of a merklized off chain document in Centrifuge p2p network as
+		/// the latest version id(`anchor_id`) obtained by hashing `anchor_id_preimage`. If a
+		/// pre-commit exists for the obtained `anchor_id`, hash of pre-committed
+		/// `signing_root + proof` must match the given `doc_root`. To avoid state bloat on chain,
+		/// the committed anchor would be evicted after the given `stored_until_date`. The calling
+		/// account would be charged accordingly for the storage period.
+		/// For a more detailed explanation refer section 3.4 of
+		/// [Centrifuge Protocol Paper](https://staticw.centrifuge.io/assets/centrifuge_os_protocol_paper.pdf)
+		///
+		/// # <weight>
+		/// State rent takes into account the storage cost depending on `stored_until_date`.
+		/// Otherwise independant of the inputs. The weight cost is important as it helps avoid DOS
+		/// using smaller `stored_until_date`s. Computation cost involves timestamp calculations
+		/// and state rent calculations, which we take here to be equivalent to a transfer transaction.
+		/// # </weight>
+		#[weight = SimpleDispatchInfo::FixedNormal(1_000_000)]
+		pub fn commit(origin, anchor_id_preimage: T::Hash, doc_root: T::Hash, proof: T::Hash, stored_until_date: T::Moment) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			ensure!(<pallet_timestamp::Module<T>>::get() + T::Moment::from(common::MS_PER_DAY.try_into().unwrap()) < stored_until_date,
+				"Stored until date must be at least a day later than the current date");
 
-            // validate the eviction date
-            let eviction_date_u64 = TryInto::<u64>::try_into(stored_until_date)
-                .map_err(|_e| "Can not convert eviction date to u64")
-                .unwrap();
-            let stored_until_date_from_epoch = common::get_days_since_epoch(eviction_date_u64);
-            ensure!(Self::anchor_storage_max_days_from_now() >= stored_until_date_from_epoch, "The provided stored until date is more than the maximum allowed from now");
+			// validate the eviction date
+			let eviction_date_u64 = TryInto::<u64>::try_into(stored_until_date)
+				.map_err(|_e| "Can not convert eviction date to u64")
+				.unwrap();
+			let stored_until_date_from_epoch = common::get_days_since_epoch(eviction_date_u64);
+			ensure!(Self::anchor_storage_max_days_from_now() >= stored_until_date_from_epoch, "The provided stored until date is more than the maximum allowed from now");
 
-            let anchor_id = (anchor_id_preimage)
-                .using_encoded(<T as frame_system::Trait>::Hashing::hash);
-            ensure!(Self::get_anchor_by_id(anchor_id).is_none(), "Anchor already exists");
+			let anchor_id = (anchor_id_preimage)
+				.using_encoded(<T as frame_system::Trait>::Hashing::hash);
+			ensure!(Self::get_anchor_by_id(anchor_id).is_none(), "Anchor already exists");
 
-            if Self::has_valid_pre_commit(anchor_id) {
-                ensure!(<PreCommits<T>>::get(anchor_id).identity == who, "Pre-commit owned by someone else");
-                ensure!(Self::has_valid_pre_commit_proof(anchor_id, doc_root, proof), "Pre-commit proof not valid");
-            }
+			if Self::has_valid_pre_commit(anchor_id) {
+				ensure!(<PreCommits<T>>::get(anchor_id).identity == who, "Pre-commit owned by someone else");
+				ensure!(Self::has_valid_pre_commit_proof(anchor_id, doc_root, proof), "Pre-commit proof not valid");
+			}
 
-             // pay the state rent
-            let today_in_days_from_epoch = TryInto::<u64>::try_into(<pallet_timestamp::Module<T>>::get())
-                .map(common::get_days_since_epoch)
-                .map_err(|_e| "Can not convert timestamp to u64")
-                .unwrap();
+			 // pay the state rent
+			let today_in_days_from_epoch = TryInto::<u64>::try_into(<pallet_timestamp::Module<T>>::get())
+				.map(common::get_days_since_epoch)
+				.map_err(|_e| "Can not convert timestamp to u64")
+				.unwrap();
 
-            // we use the fee config setup on genesis for anchoring to calculate the state rent
-            let fee = <fees::Module<T>>::price_of(Self::fee_key()).unwrap() *
-                <T as pallet_balances::Trait>::Balance::from(stored_until_date_from_epoch - today_in_days_from_epoch);
+			// we use the fee config setup on genesis for anchoring to calculate the state rent
+			let fee = <fees::Module<T>>::price_of(Self::fee_key()).unwrap() *
+				<T as pallet_balances::Trait>::Balance::from(stored_until_date_from_epoch - today_in_days_from_epoch);
 
-            // pay state rent to block author
-            <fees::Module<T>>::pay_fee_to_author(who, fee)?;
+			// pay state rent to block author
+			<fees::Module<T>>::pay_fee_to_author(who, fee)?;
 
-            let block_num = <frame_system::Module<T>>::block_number();
-            let child_storage_key = common::generate_child_storage_key(stored_until_date_from_epoch);
-            let anchor_data = AnchorData {
-                id: anchor_id,
-                doc_root: doc_root,
-                anchored_block: block_num
-            };
+			let block_num = <frame_system::Module<T>>::block_number();
+			let child_storage_key = common::generate_child_storage_key(stored_until_date_from_epoch);
+			let anchor_data = AnchorData {
+				id: anchor_id,
+				doc_root: doc_root,
+				anchored_block: block_num
+			};
 
-            let anchor_data_encoded = anchor_data.encode();
-            child::put_raw(&child_storage_key, CHILD_INFO, anchor_id.as_ref(), &anchor_data_encoded);
+			let anchor_data_encoded = anchor_data.encode();
+			child::put_raw(&child_storage_key, CHILD_INFO, anchor_id.as_ref(), &anchor_data_encoded);
 
-            // update indexes
-            <AnchorEvictDates<T>>::insert(&anchor_id, &stored_until_date_from_epoch);
-            let idx = LatestAnchorIndex::get() + 1;
-            <AnchorIndexes<T>>::insert(idx, &anchor_id);
-            LatestAnchorIndex::put(idx);
-            Ok(())
-        }
+			// update indexes
+			<AnchorEvictDates<T>>::insert(&anchor_id, &stored_until_date_from_epoch);
+			let idx = LatestAnchorIndex::get() + 1;
+			<AnchorIndexes<T>>::insert(idx, &anchor_id);
+			LatestAnchorIndex::put(idx);
+			Ok(())
+		}
 
-        /// Initiates eviction of pre-commits that has expired given that the current block number
-        /// has progressed past the block number provided in `evict_bucket`. `evict_bucket` is also
-        /// the index to find the pre-commits stored in storage to be evicted when the
-        /// `evict_bucket` number of blocks has expired.
-        ///
-        /// # <weight>
-        /// - discourage DoS
-        /// # </weight>
-        #[weight = SimpleDispatchInfo::FixedOperational(1_000_000)]
-        pub fn evict_pre_commits(origin, evict_bucket: T::BlockNumber) -> DispatchResult {
-            ensure_signed(origin)?;
-            ensure!(<frame_system::Module<T>>::block_number() >= evict_bucket,
-                "eviction only possible for bucket expiring < current block height");
+		/// Initiates eviction of pre-commits that has expired given that the current block number
+		/// has progressed past the block number provided in `evict_bucket`. `evict_bucket` is also
+		/// the index to find the pre-commits stored in storage to be evicted when the
+		/// `evict_bucket` number of blocks has expired.
+		///
+		/// # <weight>
+		/// - discourage DoS
+		/// # </weight>
+		#[weight = SimpleDispatchInfo::FixedOperational(1_000_000)]
+		pub fn evict_pre_commits(origin, evict_bucket: T::BlockNumber) -> DispatchResult {
+			ensure_signed(origin)?;
+			ensure!(<frame_system::Module<T>>::block_number() >= evict_bucket,
+				"eviction only possible for bucket expiring < current block height");
 
-            let pre_commits_count = Self::get_pre_commits_count_in_evict_bucket(evict_bucket);
-            for idx in (0..pre_commits_count).rev() {
-                if pre_commits_count - idx > MAX_LOOP_IN_TX {
-                    break;
-                }
+			let pre_commits_count = Self::get_pre_commits_count_in_evict_bucket(evict_bucket);
+			for idx in (0..pre_commits_count).rev() {
+				if pre_commits_count - idx > MAX_LOOP_IN_TX {
+					break;
+				}
 
-                let pre_commit_id =
-                    Self::get_pre_commit_in_evict_bucket_by_index((evict_bucket, idx));
-                <PreCommits<T>>::remove(pre_commit_id);
+				let pre_commit_id =
+					Self::get_pre_commit_in_evict_bucket_by_index((evict_bucket, idx));
+				<PreCommits<T>>::remove(pre_commit_id);
 
-                <PreCommitEvictionBuckets<T>>::remove((evict_bucket, idx));
+				<PreCommitEvictionBuckets<T>>::remove((evict_bucket, idx));
 
-                // decreases the evict bucket item count or remove index completely if empty
-                if idx == 0 {
-                    <PreCommitEvictionBucketIndex<T>>::remove(evict_bucket);
-                } else {
-                    <PreCommitEvictionBucketIndex<T>>::insert(evict_bucket, idx);
-                }
-            }
-            Ok(())
-        }
+				// decreases the evict bucket item count or remove index completely if empty
+				if idx == 0 {
+					<PreCommitEvictionBucketIndex<T>>::remove(evict_bucket);
+				} else {
+					<PreCommitEvictionBucketIndex<T>>::insert(evict_bucket, idx);
+				}
+			}
+			Ok(())
+		}
 
-        /// Initiates eviction of expired anchors. Since anchors are stored on a child trie indexed by
-        /// their eviction date, what this function does is to remove those child tries which has
-        /// date_represented_by_root < current_date. Additionally it needs to take care of indexes
-        /// created for accessing anchors, eg: to find an anchor given an id.
-        ///
-        /// # <weight>
-        /// - discourage DoS
-        /// # </weight>
-        #[weight = SimpleDispatchInfo::FixedOperational(1_000_000)]
-        pub fn evict_anchors(origin) -> DispatchResult {
-            ensure_signed(origin)?;
-            let current_timestamp = <pallet_timestamp::Module<T>>::get();
+		/// Initiates eviction of expired anchors. Since anchors are stored on a child trie indexed by
+		/// their eviction date, what this function does is to remove those child tries which has
+		/// date_represented_by_root < current_date. Additionally it needs to take care of indexes
+		/// created for accessing anchors, eg: to find an anchor given an id.
+		///
+		/// # <weight>
+		/// - discourage DoS
+		/// # </weight>
+		#[weight = SimpleDispatchInfo::FixedOperational(1_000_000)]
+		pub fn evict_anchors(origin) -> DispatchResult {
+			ensure_signed(origin)?;
+			let current_timestamp = <pallet_timestamp::Module<T>>::get();
 
-            // get the today counting epoch, so that we can remove the corresponding child trie
-            let today_in_days_from_epoch = TryInto::<u64>::try_into(current_timestamp)
-                .map(common::get_days_since_epoch)
-                .map_err(|_e| "Can not convert timestamp to u64")
-                .unwrap();
-            let evict_date = LatestEvictedDate::get();
+			// get the today counting epoch, so that we can remove the corresponding child trie
+			let today_in_days_from_epoch = TryInto::<u64>::try_into(current_timestamp)
+				.map(common::get_days_since_epoch)
+				.map_err(|_e| "Can not convert timestamp to u64")
+				.unwrap();
+			let evict_date = LatestEvictedDate::get();
 
-            // remove child tries starting from day next to last evicted day
-            let _evicted_trie_count = Self::evict_anchor_child_tries(evict_date + 1, today_in_days_from_epoch);
+			// remove child tries starting from day next to last evicted day
+			let _evicted_trie_count = Self::evict_anchor_child_tries(evict_date + 1, today_in_days_from_epoch);
 
-            // store yesterday as the last day of eviction
-            let yesterday = today_in_days_from_epoch - 1;
-            LatestEvictedDate::put(yesterday);
-            let _evicted_anchor_indexes_count = Self::remove_anchor_indexes(yesterday);
+			// store yesterday as the last day of eviction
+			let yesterday = today_in_days_from_epoch - 1;
+			LatestEvictedDate::put(yesterday);
+			let _evicted_anchor_indexes_count = Self::remove_anchor_indexes(yesterday);
 
-            Ok(())
-        }
-    }
+			Ok(())
+		}
+	}
 }
 
 impl<T: Trait> Module<T> {
-    /// Checks if the given `anchor_id` has a valid pre-commit, i.e it has a pre-commit with
-    /// `expiration_block` < `current_block_number`.
-    fn has_valid_pre_commit(anchor_id: T::Hash) -> bool {
-        if !<PreCommits<T>>::contains_key(&anchor_id) {
-            return false;
-        }
+	/// Checks if the given `anchor_id` has a valid pre-commit, i.e it has a pre-commit with
+	/// `expiration_block` < `current_block_number`.
+	fn has_valid_pre_commit(anchor_id: T::Hash) -> bool {
+		if !<PreCommits<T>>::contains_key(&anchor_id) {
+			return false;
+		}
 
-        <PreCommits<T>>::get(anchor_id).expiration_block > <frame_system::Module<T>>::block_number()
-    }
+		<PreCommits<T>>::get(anchor_id).expiration_block > <frame_system::Module<T>>::block_number()
+	}
 
-    /// Checks if `hash(signing_root, proof) == doc_root` for the given `anchor_id`. Concatenation
-    /// of `signing_root` and `proof` is done in a fixed order (signing_root + proof).
-    fn has_valid_pre_commit_proof(anchor_id: T::Hash, doc_root: T::Hash, proof: T::Hash) -> bool {
-        let signing_root = <PreCommits<T>>::get(anchor_id).signing_root;
-        let mut concatenated_bytes = signing_root.as_ref().to_vec();
-        let proof_bytes = proof.as_ref().to_vec();
+	/// Checks if `hash(signing_root, proof) == doc_root` for the given `anchor_id`. Concatenation
+	/// of `signing_root` and `proof` is done in a fixed order (signing_root + proof).
+	fn has_valid_pre_commit_proof(anchor_id: T::Hash, doc_root: T::Hash, proof: T::Hash) -> bool {
+		let signing_root = <PreCommits<T>>::get(anchor_id).signing_root;
+		let mut concatenated_bytes = signing_root.as_ref().to_vec();
+		let proof_bytes = proof.as_ref().to_vec();
 
-        // concat hashes
-        concatenated_bytes.extend(proof_bytes);
-        let calculated_root = <T as frame_system::Trait>::Hashing::hash(&concatenated_bytes);
-        return doc_root == calculated_root;
-    }
+		// concat hashes
+		concatenated_bytes.extend(proof_bytes);
+		let calculated_root = <T as frame_system::Trait>::Hashing::hash(&concatenated_bytes);
+		return doc_root == calculated_root;
+	}
 
-    /// How long before we expire a pre-commit
-    fn pre_commit_expiration_duration_blocks() -> u64 {
-        PRE_COMMIT_EXPIRATION_DURATION_BLOCKS
-    }
+	/// How long before we expire a pre-commit
+	fn pre_commit_expiration_duration_blocks() -> u64 {
+		PRE_COMMIT_EXPIRATION_DURATION_BLOCKS
+	}
 
-    /// Get the maximum days allowed for an anchor to be stored on chain from unix epoch onwards.
-    fn anchor_storage_max_days_from_now() -> u32 {
-        STORAGE_MAX_DAYS
-    }
+	/// Get the maximum days allowed for an anchor to be stored on chain from unix epoch onwards.
+	fn anchor_storage_max_days_from_now() -> u32 {
+		STORAGE_MAX_DAYS
+	}
 
-    /// Puts the pre-commit (based on anchor_id) into the correct eviction bucket
-    fn put_pre_commit_into_eviction_bucket(
-        anchor_id: T::Hash,
-        expiration_block: T::BlockNumber,
-    ) -> DispatchResult {
-        // determine which eviction bucket to put into
-        let evict_after_block = Self::determine_pre_commit_eviction_bucket(expiration_block)?;
+	/// Puts the pre-commit (based on anchor_id) into the correct eviction bucket
+	fn put_pre_commit_into_eviction_bucket(
+		anchor_id: T::Hash,
+		expiration_block: T::BlockNumber,
+	) -> DispatchResult {
+		// determine which eviction bucket to put into
+		let evict_after_block = Self::determine_pre_commit_eviction_bucket(expiration_block)?;
 
-        // get current index in eviction bucket and increment
-        let mut eviction_bucket_size =
-            Self::get_pre_commits_count_in_evict_bucket(evict_after_block);
+		// get current index in eviction bucket and increment
+		let mut eviction_bucket_size =
+			Self::get_pre_commits_count_in_evict_bucket(evict_after_block);
 
-        // add to eviction bucket and update bucket counter
-        <PreCommitEvictionBuckets<T>>::insert(
-            (evict_after_block.clone(), eviction_bucket_size.clone()),
-            anchor_id,
-        );
-        eviction_bucket_size += 1;
-        <PreCommitEvictionBucketIndex<T>>::insert(evict_after_block, eviction_bucket_size);
-        Ok(())
-    }
+		// add to eviction bucket and update bucket counter
+		<PreCommitEvictionBuckets<T>>::insert(
+			(evict_after_block.clone(), eviction_bucket_size.clone()),
+			anchor_id,
+		);
+		eviction_bucket_size += 1;
+		<PreCommitEvictionBucketIndex<T>>::insert(evict_after_block, eviction_bucket_size);
+		Ok(())
+	}
 
-    /// Determines the next eviction bucket number based on the given BlockNumber
-    /// This can be used to determine which eviction bucket a pre-commit
-    /// should be put into for later eviction.
-    fn determine_pre_commit_eviction_bucket(
-        pre_commit_expiration_block: T::BlockNumber,
-    ) -> Result<T::BlockNumber, DispatchError> {
-        let result = TryInto::<u32>::try_into(pre_commit_expiration_block);
-        match result {
-            Ok(u32_expiration_block) => {
-                let expiration_horizon = Self::pre_commit_expiration_duration_blocks() as u32
-                    * PRE_COMMIT_EVICTION_BUCKET_MULTIPLIER as u32;
-                let put_into_bucket = u32_expiration_block
-                    - (u32_expiration_block % expiration_horizon)
-                    + expiration_horizon;
+	/// Determines the next eviction bucket number based on the given BlockNumber
+	/// This can be used to determine which eviction bucket a pre-commit
+	/// should be put into for later eviction.
+	fn determine_pre_commit_eviction_bucket(
+		pre_commit_expiration_block: T::BlockNumber,
+	) -> Result<T::BlockNumber, DispatchError> {
+		let result = TryInto::<u32>::try_into(pre_commit_expiration_block);
+		match result {
+			Ok(u32_expiration_block) => {
+				let expiration_horizon = Self::pre_commit_expiration_duration_blocks() as u32
+					* PRE_COMMIT_EVICTION_BUCKET_MULTIPLIER as u32;
+				let put_into_bucket = u32_expiration_block
+					- (u32_expiration_block % expiration_horizon)
+					+ expiration_horizon;
 
-                Ok(T::BlockNumber::from(put_into_bucket))
-            }
-            Err(_e) => Err(DispatchError::Other("pre commit expiration block too big")),
-        }
-    }
+				Ok(T::BlockNumber::from(put_into_bucket))
+			}
+			Err(_e) => Err(DispatchError::Other("pre commit expiration block too big")),
+		}
+	}
 
-    /// Remove child tries starting with `from` day to `until` day returning the
-    /// count of tries removed.
-    fn evict_anchor_child_tries(from: u32, until: u32) -> usize {
-        (from..until)
-            .map(|day| (day, common::generate_child_storage_key(day)))
-            // store the root of child trie for the day on chain before eviction. Checks if it
-            // exists before hand to ensure that it doesn't overwrite a root.
-            .map(|(day, key)| {
-                if !EvictedAnchorRoots::contains_key(day) {
-                    EvictedAnchorRoots::insert(day, child::child_root(&key));
-                }
-                key
-            })
-            .map(|key| child::kill_storage(&key, CHILD_INFO))
-            .count()
-    }
+	/// Remove child tries starting with `from` day to `until` day returning the
+	/// count of tries removed.
+	fn evict_anchor_child_tries(from: u32, until: u32) -> usize {
+		(from..until)
+			.map(|day| (day, common::generate_child_storage_key(day)))
+			// store the root of child trie for the day on chain before eviction. Checks if it
+			// exists before hand to ensure that it doesn't overwrite a root.
+			.map(|(day, key)| {
+				if !EvictedAnchorRoots::contains_key(day) {
+					EvictedAnchorRoots::insert(day, child::child_root(&key));
+				}
+				key
+			})
+			.map(|key| child::kill_storage(&key, CHILD_INFO))
+			.count()
+	}
 
-    /// Iterate from the last evicted anchor to latest anchor, while removing indexes that
-    /// are no longer valid because they belong to an expired/evicted anchor. The loop is
-    /// only allowed to run MAX_LOOP_IN_TX at a time.
-    fn remove_anchor_indexes(yesterday: u32) -> usize {
-        (LatestEvictedAnchorIndex::get() + 1..LatestAnchorIndex::get() + 1)
-            // limit to only MAX_LOOP_IN_TX number of anchor indexes to remove
-            .take(MAX_LOOP_IN_TX as usize)
-            // get eviction date of the anchor given by index
-            .map(|idx| {
-                (
-                    idx,
-                    <AnchorEvictDates<T>>::get(<AnchorIndexes<T>>::get(idx)),
-                )
-            })
-            // filter out evictable anchors, anchor_evict_date can be 0 when evicting before any anchors are created
-            .filter(|(_, anchor_evict_date)| anchor_evict_date <= &yesterday)
-            // remove indexes
-            .map(|(idx, _)| {
-                <AnchorEvictDates<T>>::remove(<AnchorIndexes<T>>::get(idx));
-                <AnchorIndexes<T>>::remove(idx);
-                LatestEvictedAnchorIndex::put(idx);
-            })
-            .count()
-    }
+	/// Iterate from the last evicted anchor to latest anchor, while removing indexes that
+	/// are no longer valid because they belong to an expired/evicted anchor. The loop is
+	/// only allowed to run MAX_LOOP_IN_TX at a time.
+	fn remove_anchor_indexes(yesterday: u32) -> usize {
+		(LatestEvictedAnchorIndex::get() + 1..LatestAnchorIndex::get() + 1)
+			// limit to only MAX_LOOP_IN_TX number of anchor indexes to remove
+			.take(MAX_LOOP_IN_TX as usize)
+			// get eviction date of the anchor given by index
+			.map(|idx| {
+				(
+					idx,
+					<AnchorEvictDates<T>>::get(<AnchorIndexes<T>>::get(idx)),
+				)
+			})
+			// filter out evictable anchors, anchor_evict_date can be 0 when evicting before any anchors are created
+			.filter(|(_, anchor_evict_date)| anchor_evict_date <= &yesterday)
+			// remove indexes
+			.map(|(idx, _)| {
+				<AnchorEvictDates<T>>::remove(<AnchorIndexes<T>>::get(idx));
+				<AnchorIndexes<T>>::remove(idx);
+				LatestEvictedAnchorIndex::put(idx);
+			})
+			.count()
+	}
 
-    /// Get an anchor by its id in the child storage
-    pub fn get_anchor_by_id(anchor_id: T::Hash) -> Option<AnchorData<T::Hash, T::BlockNumber>> {
-        let anchor_evict_date = <AnchorEvictDates<T>>::get(anchor_id);
-        let storage_key = common::generate_child_storage_key(anchor_evict_date);
+	/// Get an anchor by its id in the child storage
+	pub fn get_anchor_by_id(anchor_id: T::Hash) -> Option<AnchorData<T::Hash, T::BlockNumber>> {
+		let anchor_evict_date = <AnchorEvictDates<T>>::get(anchor_id);
+		let storage_key = common::generate_child_storage_key(anchor_evict_date);
 
-        child::get_raw(&storage_key, CHILD_INFO, anchor_id.as_ref())
-            .map(|data| AnchorData::decode(&mut &*data).ok().unwrap())
-    }
+		child::get_raw(&storage_key, CHILD_INFO, anchor_id.as_ref())
+			.map(|data| AnchorData::decode(&mut &*data).ok().unwrap())
+	}
 
-    fn fee_key() -> <T as frame_system::Trait>::Hash {
-        <T as frame_system::Trait>::Hashing::hash_of(&0)
-    }
+	fn fee_key() -> <T as frame_system::Trait>::Hash {
+		<T as frame_system::Trait>::Hashing::hash_of(&0)
+	}
 }
 
 /// tests for anchor module

--- a/runtime/src/anchor/tests.rs
+++ b/runtime/src/anchor/tests.rs
@@ -1,19 +1,19 @@
 use super::*;
 
 use frame_support::{
-    assert_err, assert_ok, impl_outer_origin, parameter_types, traits::Randomness, weights::Weight,
+	assert_err, assert_ok, impl_outer_origin, parameter_types, traits::Randomness, weights::Weight,
 };
 use frame_system::{self as system};
 use sp_core::H256;
 use sp_runtime::{
-    testing::Header,
-    traits::{BadOrigin, BlakeTwo256, IdentityLookup},
-    Perbill,
+	testing::Header,
+	traits::{BadOrigin, BlakeTwo256, IdentityLookup},
+	Perbill,
 };
 use std::time::Instant;
 
 impl_outer_origin! {
-    pub enum Origin for Test {}
+	pub enum Origin for Test {}
 }
 
 // For testing the module, we construct most of a mock runtime. This means
@@ -22,92 +22,92 @@ impl_outer_origin! {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {
-    pub const BlockHashCount: u64 = 250;
-    pub const MaximumBlockWeight: Weight = 1024;
-    pub const MaximumBlockLength: u32 = 2 * 1024;
-    pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 }
 impl frame_system::Trait for Test {
-    type AccountId = u64;
-    type Call = ();
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Index = u64;
-    type BlockNumber = u64;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type Header = Header;
-    type Event = ();
-    type Origin = Origin;
-    type BlockHashCount = BlockHashCount;
-    type MaximumBlockWeight = MaximumBlockWeight;
-    type MaximumBlockLength = MaximumBlockLength;
-    type AvailableBlockRatio = AvailableBlockRatio;
-    type Version = ();
-    type ModuleToIndex = ();
-    type AccountData = pallet_balances::AccountData<u64>;
-    type OnNewAccount = ();
-    type OnKilledAccount = pallet_balances::Module<Test>;
+	type AccountId = u64;
+	type Call = ();
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type Header = Header;
+	type Event = ();
+	type Origin = Origin;
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
+	type ModuleToIndex = ();
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = pallet_balances::Module<Test>;
 }
 
 impl pallet_timestamp::Trait for Test {
-    type Moment = u64;
-    type OnTimestampSet = ();
-    type MinimumPeriod = ();
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = ();
 }
 
 impl fees::Trait for Test {
-    type Event = ();
-    type FeeChangeOrigin = frame_system::EnsureRoot<u64>;
+	type Event = ();
+	type FeeChangeOrigin = frame_system::EnsureRoot<u64>;
 }
 
 parameter_types! {
-    pub const ExistentialDeposit: u64 = 1;
+	pub const ExistentialDeposit: u64 = 1;
 }
 impl pallet_balances::Trait for Test {
-    type Balance = u64;
-    type DustRemoval = ();
-    type Event = ();
-    type ExistentialDeposit = ExistentialDeposit;
-    type AccountStore = System;
+	type Balance = u64;
+	type DustRemoval = ();
+	type Event = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
 }
 
 impl pallet_authorship::Trait for Test {
-    type FindAuthor = ();
-    type UncleGenerations = ();
-    type FilterUncle = ();
-    type EventHandler = ();
+	type FindAuthor = ();
+	type UncleGenerations = ();
+	type FilterUncle = ();
+	type EventHandler = ();
 }
 
 impl Trait for Test {}
 
 impl Test {
-    fn test_document_hashes() -> (
-        <Test as frame_system::Trait>::Hash,
-        <Test as frame_system::Trait>::Hash,
-        <Test as frame_system::Trait>::Hash,
-    ) {
-        // first is the hash of concatenated last two in sorted order
-        (
-            // doc_root
-            [
-                238, 250, 118, 84, 35, 55, 212, 193, 69, 104, 25, 244, 240, 31, 54, 36, 85, 171,
-                12, 71, 247, 81, 74, 10, 127, 127, 185, 158, 253, 100, 206, 130,
-            ]
-            .into(),
-            // signing root
-            [
-                63, 39, 76, 249, 122, 12, 22, 110, 110, 63, 161, 193, 10, 51, 83, 226, 96, 179,
-                203, 22, 42, 255, 135, 63, 160, 26, 73, 222, 175, 198, 94, 200,
-            ]
-            .into(),
-            // proof hash
-            [
-                192, 195, 141, 209, 99, 91, 39, 154, 243, 6, 188, 4, 144, 5, 89, 252, 52, 105, 112,
-                173, 143, 101, 65, 6, 191, 206, 210, 2, 176, 103, 161, 14,
-            ]
-            .into(),
-        )
-    }
+	fn test_document_hashes() -> (
+		<Test as frame_system::Trait>::Hash,
+		<Test as frame_system::Trait>::Hash,
+		<Test as frame_system::Trait>::Hash,
+	) {
+		// first is the hash of concatenated last two in sorted order
+		(
+			// doc_root
+			[
+				238, 250, 118, 84, 35, 55, 212, 193, 69, 104, 25, 244, 240, 31, 54, 36, 85, 171,
+				12, 71, 247, 81, 74, 10, 127, 127, 185, 158, 253, 100, 206, 130,
+			]
+			.into(),
+			// signing root
+			[
+				63, 39, 76, 249, 122, 12, 22, 110, 110, 63, 161, 193, 10, 51, 83, 226, 96, 179,
+				203, 22, 42, 255, 135, 63, 160, 26, 73, 222, 175, 198, 94, 200,
+			]
+			.into(),
+			// proof hash
+			[
+				192, 195, 141, 209, 99, 91, 39, 154, 243, 6, 188, 4, 144, 5, 89, 252, 52, 105, 112,
+				173, 143, 101, 65, 6, 191, 206, 210, 2, 176, 103, 161, 14,
+			]
+			.into(),
+		)
+	}
 }
 
 type Anchor = Module<Test>;
@@ -116,1009 +116,1008 @@ type System = frame_system::Module<Test>;
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 fn new_test_ext() -> sp_io::TestExternalities {
-    let mut t = frame_system::GenesisConfig::default()
-        .build_storage::<Test>()
-        .unwrap();
-    fees::GenesisConfig::<Test> {
-        initial_fees: vec![(
-            // anchoring state rent fee per day
-            H256::from(&[
-                17, 218, 109, 31, 118, 29, 223, 155, 219, 76, 157, 110, 83, 3, 235, 212, 31, 97,
-                133, 141, 10, 86, 71, 161, 167, 191, 224, 137, 191, 146, 27, 233,
-            ]),
-            // state rent 0 for tests
-            0,
-        )],
-    }
-    .assimilate_storage(&mut t)
-    .unwrap();
-    t.into()
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap();
+	fees::GenesisConfig::<Test> {
+		initial_fees: vec![(
+			// anchoring state rent fee per day
+			H256::from(&[
+				17, 218, 109, 31, 118, 29, 223, 155, 219, 76, 157, 110, 83, 3, 235, 212, 31, 97,
+				133, 141, 10, 86, 71, 161, 167, 191, 224, 137, 191, 146, 27, 233,
+			]),
+			// state rent 0 for tests
+			0,
+		)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+	t.into()
 }
 
 #[test]
 fn basic_pre_commit() {
-    new_test_ext().execute_with(|| {
-        let anchor_id = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+	new_test_ext().execute_with(|| {
+		let anchor_id = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
 
-        // reject unsigned
-        assert_err!(
-            Anchor::pre_commit(Origin::NONE, anchor_id, signing_root),
-            BadOrigin
-        );
+		// reject unsigned
+		assert_err!(
+			Anchor::pre_commit(Origin::NONE, anchor_id, signing_root),
+			BadOrigin
+		);
 
-        // happy
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id,
-            signing_root
-        ));
-        // asserting that the stored pre-commit has the intended values set
-        let a = Anchor::get_pre_commit(anchor_id);
-        assert_eq!(a.identity, 1);
-        assert_eq!(a.signing_root, signing_root);
-        assert_eq!(
-            a.expiration_block,
-            Anchor::pre_commit_expiration_duration_blocks() + 1
-        );
-    });
+		// happy
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id,
+			signing_root
+		));
+		// asserting that the stored pre-commit has the intended values set
+		let a = Anchor::get_pre_commit(anchor_id);
+		assert_eq!(a.identity, 1);
+		assert_eq!(a.signing_root, signing_root);
+		assert_eq!(
+			a.expiration_block,
+			Anchor::pre_commit_expiration_duration_blocks() + 1
+		);
+	});
 }
 
 #[test]
 fn pre_commit_fail_anchor_exists() {
-    new_test_ext().execute_with(|| {
-        let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        // anchor
-        assert_ok!(Anchor::commit(
-            Origin::signed(1),
-            pre_image,
-            <Test as frame_system::Trait>::Hashing::hash_of(&0),
-            <Test as frame_system::Trait>::Hashing::hash_of(&0),
-            common::MS_PER_DAY + 1
-        ));
+	new_test_ext().execute_with(|| {
+		let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		// anchor
+		assert_ok!(Anchor::commit(
+			Origin::signed(1),
+			pre_image,
+			<Test as frame_system::Trait>::Hashing::hash_of(&0),
+			<Test as frame_system::Trait>::Hashing::hash_of(&0),
+			common::MS_PER_DAY + 1
+		));
 
-        // fails because of existing anchor
-        assert_err!(
-            Anchor::pre_commit(Origin::signed(1), anchor_id, signing_root),
-            "Anchor already exists"
-        );
-    });
+		// fails because of existing anchor
+		assert_err!(
+			Anchor::pre_commit(Origin::signed(1), anchor_id, signing_root),
+			"Anchor already exists"
+		);
+	});
 }
 
 #[test]
 fn pre_commit_fail_anchor_exists_different_acc() {
-    new_test_ext().execute_with(|| {
-        let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        // anchor
-        assert_ok!(Anchor::commit(
-            Origin::signed(2),
-            pre_image,
-            <Test as frame_system::Trait>::Hashing::hash_of(&0),
-            <Test as frame_system::Trait>::Hashing::hash_of(&0),
-            common::MS_PER_DAY + 1
-        ));
+	new_test_ext().execute_with(|| {
+		let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		// anchor
+		assert_ok!(Anchor::commit(
+			Origin::signed(2),
+			pre_image,
+			<Test as frame_system::Trait>::Hashing::hash_of(&0),
+			<Test as frame_system::Trait>::Hashing::hash_of(&0),
+			common::MS_PER_DAY + 1
+		));
 
-        // fails because of existing anchor
-        assert_err!(
-            Anchor::pre_commit(Origin::signed(1), anchor_id, signing_root),
-            "Anchor already exists"
-        );
-    });
+		// fails because of existing anchor
+		assert_err!(
+			Anchor::pre_commit(Origin::signed(1), anchor_id, signing_root),
+			"Anchor already exists"
+		);
+	});
 }
 
 #[test]
 fn pre_commit_fail_pre_commit_exists() {
-    new_test_ext().execute_with(|| {
-        let anchor_id = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+	new_test_ext().execute_with(|| {
+		let anchor_id = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
 
-        // first pre-commit
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id,
-            signing_root
-        ));
-        let a = Anchor::get_pre_commit(anchor_id);
-        assert_eq!(a.identity, 1);
-        assert_eq!(a.signing_root, signing_root);
-        assert_eq!(
-            a.expiration_block,
-            Anchor::pre_commit_expiration_duration_blocks() + 1
-        );
+		// first pre-commit
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id,
+			signing_root
+		));
+		let a = Anchor::get_pre_commit(anchor_id);
+		assert_eq!(a.identity, 1);
+		assert_eq!(a.signing_root, signing_root);
+		assert_eq!(
+			a.expiration_block,
+			Anchor::pre_commit_expiration_duration_blocks() + 1
+		);
 
-        // fail, pre-commit exists
-        assert_err!(
-            Anchor::pre_commit(Origin::signed(1), anchor_id, signing_root),
-            "A valid pre-commit already exists"
-        );
+		// fail, pre-commit exists
+		assert_err!(
+			Anchor::pre_commit(Origin::signed(1), anchor_id, signing_root),
+			"A valid pre-commit already exists"
+		);
 
-        // expire the pre-commit
-        System::set_block_number(Anchor::pre_commit_expiration_duration_blocks() + 2);
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id,
-            signing_root
-        ));
-    });
+		// expire the pre-commit
+		System::set_block_number(Anchor::pre_commit_expiration_duration_blocks() + 2);
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id,
+			signing_root
+		));
+	});
 }
 
 #[test]
 fn pre_commit_fail_pre_commit_exists_different_acc() {
-    new_test_ext().execute_with(|| {
-        let anchor_id = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+	new_test_ext().execute_with(|| {
+		let anchor_id = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
 
-        // first pre-commit
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id,
-            signing_root
-        ));
-        let a = Anchor::get_pre_commit(anchor_id);
-        assert_eq!(a.identity, 1);
-        assert_eq!(a.signing_root, signing_root);
-        assert_eq!(
-            a.expiration_block,
-            Anchor::pre_commit_expiration_duration_blocks() + 1
-        );
+		// first pre-commit
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id,
+			signing_root
+		));
+		let a = Anchor::get_pre_commit(anchor_id);
+		assert_eq!(a.identity, 1);
+		assert_eq!(a.signing_root, signing_root);
+		assert_eq!(
+			a.expiration_block,
+			Anchor::pre_commit_expiration_duration_blocks() + 1
+		);
 
-        // fail, pre-commit exists
-        assert_err!(
-            Anchor::pre_commit(Origin::signed(2), anchor_id, signing_root),
-            "A valid pre-commit already exists"
-        );
+		// fail, pre-commit exists
+		assert_err!(
+			Anchor::pre_commit(Origin::signed(2), anchor_id, signing_root),
+			"A valid pre-commit already exists"
+		);
 
-        // expire the pre-commit
-        System::set_block_number(Anchor::pre_commit_expiration_duration_blocks() + 2);
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(2),
-            anchor_id,
-            signing_root
-        ));
-    });
+		// expire the pre-commit
+		System::set_block_number(Anchor::pre_commit_expiration_duration_blocks() + 2);
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(2),
+			anchor_id,
+			signing_root
+		));
+	});
 }
 
 #[test]
 fn basic_commit() {
-    new_test_ext().execute_with(|| {
-        let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let pre_image2 = <Test as frame_system::Trait>::Hashing::hash_of(&1);
-        let anchor_id2 = (pre_image2).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let doc_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        // reject unsigned
-        assert_err!(
-            Anchor::commit(
-                Origin::NONE,
-                pre_image,
-                doc_root,
-                <Test as frame_system::Trait>::Hashing::hash_of(&0),
-                1
-            ),
-            BadOrigin
-        );
+	new_test_ext().execute_with(|| {
+		let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let pre_image2 = <Test as frame_system::Trait>::Hashing::hash_of(&1);
+		let anchor_id2 = (pre_image2).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let doc_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		// reject unsigned
+		assert_err!(
+			Anchor::commit(
+				Origin::NONE,
+				pre_image,
+				doc_root,
+				<Test as frame_system::Trait>::Hashing::hash_of(&0),
+				1
+			),
+			BadOrigin
+		);
 
-        // happy
-        assert_ok!(Anchor::commit(
-            Origin::signed(1),
-            pre_image,
-            doc_root,
-            <Test as frame_system::Trait>::Hashing::hash_of(&0),
-            1567589834087
-        ));
-        // asserting that the stored anchor id is what we sent the pre-image for
-        let mut a = Anchor::get_anchor_by_id(anchor_id).unwrap();
-        assert_eq!(a.id, anchor_id);
-        assert_eq!(a.doc_root, doc_root);
-        assert_eq!(Anchor::get_anchor_evict_date(anchor_id), 18144);
-        assert_eq!(
-            Anchor::get_anchor_id_by_index(Anchor::get_latest_anchor_index()),
-            anchor_id
-        );
-        assert_eq!(Anchor::get_anchor_id_by_index(1), anchor_id);
+		// happy
+		assert_ok!(Anchor::commit(
+			Origin::signed(1),
+			pre_image,
+			doc_root,
+			<Test as frame_system::Trait>::Hashing::hash_of(&0),
+			1567589834087
+		));
+		// asserting that the stored anchor id is what we sent the pre-image for
+		let mut a = Anchor::get_anchor_by_id(anchor_id).unwrap();
+		assert_eq!(a.id, anchor_id);
+		assert_eq!(a.doc_root, doc_root);
+		assert_eq!(Anchor::get_anchor_evict_date(anchor_id), 18144);
+		assert_eq!(
+			Anchor::get_anchor_id_by_index(Anchor::get_latest_anchor_index()),
+			anchor_id
+		);
+		assert_eq!(Anchor::get_anchor_id_by_index(1), anchor_id);
 
-        // commit second anchor to test index updates
-        assert_ok!(Anchor::commit(
-            Origin::signed(1),
-            pre_image2,
-            doc_root,
-            <Test as frame_system::Trait>::Hashing::hash_of(&0),
-            1567589844087
-        ));
-        a = Anchor::get_anchor_by_id(anchor_id2).unwrap();
-        assert_eq!(a.id, anchor_id2);
-        assert_eq!(a.doc_root, doc_root);
-        assert_eq!(Anchor::get_anchor_evict_date(anchor_id2), 18144);
-        assert_eq!(Anchor::get_anchor_id_by_index(2), anchor_id2);
-        assert_eq!(
-            Anchor::get_anchor_id_by_index(Anchor::get_latest_anchor_index()),
-            anchor_id2
-        );
+		// commit second anchor to test index updates
+		assert_ok!(Anchor::commit(
+			Origin::signed(1),
+			pre_image2,
+			doc_root,
+			<Test as frame_system::Trait>::Hashing::hash_of(&0),
+			1567589844087
+		));
+		a = Anchor::get_anchor_by_id(anchor_id2).unwrap();
+		assert_eq!(a.id, anchor_id2);
+		assert_eq!(a.doc_root, doc_root);
+		assert_eq!(Anchor::get_anchor_evict_date(anchor_id2), 18144);
+		assert_eq!(Anchor::get_anchor_id_by_index(2), anchor_id2);
+		assert_eq!(
+			Anchor::get_anchor_id_by_index(Anchor::get_latest_anchor_index()),
+			anchor_id2
+		);
 
-        // commit anchor with a less than required number of minimum storage days
-        assert_err!(
-            Anchor::commit(
-                Origin::signed(1),
-                pre_image2,
-                doc_root,
-                <Test as frame_system::Trait>::Hashing::hash_of(&0),
-                2 // some arbitrary store until date that is less than the required minimum
-            ),
-            "Stored until date must be at least a day later than the current date"
-        );
-    });
+		// commit anchor with a less than required number of minimum storage days
+		assert_err!(
+			Anchor::commit(
+				Origin::signed(1),
+				pre_image2,
+				doc_root,
+				<Test as frame_system::Trait>::Hashing::hash_of(&0),
+				2 // some arbitrary store until date that is less than the required minimum
+			),
+			"Stored until date must be at least a day later than the current date"
+		);
+	});
 }
 
 #[test]
 fn commit_fail_anchor_exists() {
-    new_test_ext().execute_with(|| {
-        let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let doc_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+	new_test_ext().execute_with(|| {
+		let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let doc_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
 
-        // happy
-        assert_ok!(Anchor::commit(
-            Origin::signed(1),
-            pre_image,
-            doc_root,
-            <Test as frame_system::Trait>::Hashing::hash_of(&0),
-            common::MS_PER_DAY + 1
-        ));
-        // asserting that the stored anchor id is what we sent the pre-image for
-        let a = Anchor::get_anchor_by_id(anchor_id).unwrap();
-        assert_eq!(a.id, anchor_id);
-        assert_eq!(a.doc_root, doc_root);
+		// happy
+		assert_ok!(Anchor::commit(
+			Origin::signed(1),
+			pre_image,
+			doc_root,
+			<Test as frame_system::Trait>::Hashing::hash_of(&0),
+			common::MS_PER_DAY + 1
+		));
+		// asserting that the stored anchor id is what we sent the pre-image for
+		let a = Anchor::get_anchor_by_id(anchor_id).unwrap();
+		assert_eq!(a.id, anchor_id);
+		assert_eq!(a.doc_root, doc_root);
 
-        assert_err!(
-            Anchor::commit(
-                Origin::signed(1),
-                pre_image,
-                doc_root,
-                <Test as frame_system::Trait>::Hashing::hash_of(&0),
-                common::MS_PER_DAY + 1
-            ),
-            "Anchor already exists"
-        );
+		assert_err!(
+			Anchor::commit(
+				Origin::signed(1),
+				pre_image,
+				doc_root,
+				<Test as frame_system::Trait>::Hashing::hash_of(&0),
+				common::MS_PER_DAY + 1
+			),
+			"Anchor already exists"
+		);
 
-        // different acc
-        assert_err!(
-            Anchor::commit(
-                Origin::signed(2),
-                pre_image,
-                doc_root,
-                <Test as frame_system::Trait>::Hashing::hash_of(&0),
-                common::MS_PER_DAY + 1
-            ),
-            "Anchor already exists"
-        );
-    });
+		// different acc
+		assert_err!(
+			Anchor::commit(
+				Origin::signed(2),
+				pre_image,
+				doc_root,
+				<Test as frame_system::Trait>::Hashing::hash_of(&0),
+				common::MS_PER_DAY + 1
+			),
+			"Anchor already exists"
+		);
+	});
 }
 
 #[test]
 fn basic_pre_commit_commit() {
-    new_test_ext().execute_with(|| {
-        let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let random_doc_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let (doc_root, signing_root, proof) = Test::test_document_hashes();
+	new_test_ext().execute_with(|| {
+		let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let random_doc_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let (doc_root, signing_root, proof) = Test::test_document_hashes();
 
-        // happy
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id,
-            signing_root
-        ));
+		// happy
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id,
+			signing_root
+		));
 
-        // wrong doc root
-        assert_err!(
-            Anchor::commit(
-                Origin::signed(1),
-                pre_image,
-                random_doc_root,
-                proof,
-                common::MS_PER_DAY + 1
-            ),
-            "Pre-commit proof not valid"
-        );
+		// wrong doc root
+		assert_err!(
+			Anchor::commit(
+				Origin::signed(1),
+				pre_image,
+				random_doc_root,
+				proof,
+				common::MS_PER_DAY + 1
+			),
+			"Pre-commit proof not valid"
+		);
 
-        // happy
-        assert_ok!(Anchor::commit(
-            Origin::signed(1),
-            pre_image,
-            doc_root,
-            proof,
-            common::MS_PER_DAY + 1
-        ));
-        // asserting that the stored anchor id is what we sent the pre-image for
-        let a = Anchor::get_anchor_by_id(anchor_id).unwrap();
-        assert_eq!(a.id, anchor_id);
-        assert_eq!(a.doc_root, doc_root);
-    });
+		// happy
+		assert_ok!(Anchor::commit(
+			Origin::signed(1),
+			pre_image,
+			doc_root,
+			proof,
+			common::MS_PER_DAY + 1
+		));
+		// asserting that the stored anchor id is what we sent the pre-image for
+		let a = Anchor::get_anchor_by_id(anchor_id).unwrap();
+		assert_eq!(a.id, anchor_id);
+		assert_eq!(a.doc_root, doc_root);
+	});
 }
 
 #[test]
 fn pre_commit_expired_when_anchoring() {
-    new_test_ext().execute_with(|| {
-        let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let (doc_root, signing_root, proof) = Test::test_document_hashes();
+	new_test_ext().execute_with(|| {
+		let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let (doc_root, signing_root, proof) = Test::test_document_hashes();
 
-        // happy
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id,
-            signing_root
-        ));
-        // expire the pre-commit
-        System::set_block_number(Anchor::pre_commit_expiration_duration_blocks() + 2);
+		// happy
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id,
+			signing_root
+		));
+		// expire the pre-commit
+		System::set_block_number(Anchor::pre_commit_expiration_duration_blocks() + 2);
 
-        // happy from a different account
-        assert_ok!(Anchor::commit(
-            Origin::signed(2),
-            pre_image,
-            doc_root,
-            proof,
-            common::MS_PER_DAY + 1
-        ));
-        // asserting that the stored anchor id is what we sent the pre-image for
-        let a = Anchor::get_anchor_by_id(anchor_id).unwrap();
-        assert_eq!(a.id, anchor_id);
-        assert_eq!(a.doc_root, doc_root);
-    });
+		// happy from a different account
+		assert_ok!(Anchor::commit(
+			Origin::signed(2),
+			pre_image,
+			doc_root,
+			proof,
+			common::MS_PER_DAY + 1
+		));
+		// asserting that the stored anchor id is what we sent the pre-image for
+		let a = Anchor::get_anchor_by_id(anchor_id).unwrap();
+		assert_eq!(a.id, anchor_id);
+		assert_eq!(a.doc_root, doc_root);
+	});
 }
 
 #[test]
 fn pre_commit_commit_fail_from_another_acc() {
-    new_test_ext().execute_with(|| {
-        let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let (doc_root, signing_root, proof) = Test::test_document_hashes();
+	new_test_ext().execute_with(|| {
+		let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let (doc_root, signing_root, proof) = Test::test_document_hashes();
 
-        // happy
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id,
-            signing_root
-        ));
+		// happy
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id,
+			signing_root
+		));
 
-        // fail from a different account
-        assert_err!(
-            Anchor::commit(
-                Origin::signed(2),
-                pre_image,
-                doc_root,
-                proof,
-                common::MS_PER_DAY + 1
-            ),
-            "Pre-commit owned by someone else"
-        );
-    });
+		// fail from a different account
+		assert_err!(
+			Anchor::commit(
+				Origin::signed(2),
+				pre_image,
+				doc_root,
+				proof,
+				common::MS_PER_DAY + 1
+			),
+			"Pre-commit owned by someone else"
+		);
+	});
 }
 
 // #### Pre Commit Eviction Tests
 #[test]
 fn pre_commit_commit_bucket_gets_determined_correctly() {
-    new_test_ext().execute_with(|| {
-        let current_block: <Test as frame_system::Trait>::BlockNumber = 1;
-        let expected_evict_bucket: <Test as frame_system::Trait>::BlockNumber =
-            PRE_COMMIT_EXPIRATION_DURATION_BLOCKS * PRE_COMMIT_EVICTION_BUCKET_MULTIPLIER;
-        assert_eq!(
-            Ok(expected_evict_bucket),
-            Anchor::determine_pre_commit_eviction_bucket(current_block)
-        );
+	new_test_ext().execute_with(|| {
+		let current_block: <Test as frame_system::Trait>::BlockNumber = 1;
+		let expected_evict_bucket: <Test as frame_system::Trait>::BlockNumber =
+			PRE_COMMIT_EXPIRATION_DURATION_BLOCKS * PRE_COMMIT_EVICTION_BUCKET_MULTIPLIER;
+		assert_eq!(
+			Ok(expected_evict_bucket),
+			Anchor::determine_pre_commit_eviction_bucket(current_block)
+		);
 
-        let current_block2: <Test as frame_system::Trait>::BlockNumber = expected_evict_bucket + 1;
-        let expected_evict_bucket2: <Test as frame_system::Trait>::BlockNumber =
-            expected_evict_bucket * 2;
-        assert_eq!(
-            Ok(expected_evict_bucket2),
-            Anchor::determine_pre_commit_eviction_bucket(current_block2)
-        );
+		let current_block2: <Test as frame_system::Trait>::BlockNumber = expected_evict_bucket + 1;
+		let expected_evict_bucket2: <Test as frame_system::Trait>::BlockNumber =
+			expected_evict_bucket * 2;
+		assert_eq!(
+			Ok(expected_evict_bucket2),
+			Anchor::determine_pre_commit_eviction_bucket(current_block2)
+		);
 
-        //testing with current bucket being even multiplier of EXPIRATION_DURATION_BLOCKS
-        let current_block3: <Test as frame_system::Trait>::BlockNumber = expected_evict_bucket2;
-        let expected_evict_bucket3: <Test as frame_system::Trait>::BlockNumber =
-            expected_evict_bucket * 3;
-        assert_eq!(
-            Ok(expected_evict_bucket3),
-            Anchor::determine_pre_commit_eviction_bucket(current_block3)
-        );
-    });
+		//testing with current bucket being even multiplier of EXPIRATION_DURATION_BLOCKS
+		let current_block3: <Test as frame_system::Trait>::BlockNumber = expected_evict_bucket2;
+		let expected_evict_bucket3: <Test as frame_system::Trait>::BlockNumber =
+			expected_evict_bucket * 3;
+		assert_eq!(
+			Ok(expected_evict_bucket3),
+			Anchor::determine_pre_commit_eviction_bucket(current_block3)
+		);
+	});
 }
 
 #[test]
 fn put_pre_commit_into_eviction_bucket_basic_pre_commit_eviction_bucket_registration() {
-    new_test_ext().execute_with(|| {
-        let anchor_id_0 = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id_1 = <Test as frame_system::Trait>::Hashing::hash_of(&1);
-        let anchor_id_2 = <Test as frame_system::Trait>::Hashing::hash_of(&2);
-        let anchor_id_3 = <Test as frame_system::Trait>::Hashing::hash_of(&3);
+	new_test_ext().execute_with(|| {
+		let anchor_id_0 = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id_1 = <Test as frame_system::Trait>::Hashing::hash_of(&1);
+		let anchor_id_2 = <Test as frame_system::Trait>::Hashing::hash_of(&2);
+		let anchor_id_3 = <Test as frame_system::Trait>::Hashing::hash_of(&3);
 
-        // three different block heights that will put anchors into different eviction buckets
-        let block_height_0 = 1;
-        let block_height_1 =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() + block_height_0;
-        let block_height_2 =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap() + block_height_0;
+		// three different block heights that will put anchors into different eviction buckets
+		let block_height_0 = 1;
+		let block_height_1 =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() + block_height_0;
+		let block_height_2 =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap() + block_height_0;
 
-        // ------ First run ------
-        // register anchor_id_0 into block_height_0
-        System::set_block_number(block_height_0);
-        assert_ok!(Anchor::put_pre_commit_into_eviction_bucket(
-            anchor_id_0,
-            block_height_0
-        ));
+		// ------ First run ------
+		// register anchor_id_0 into block_height_0
+		System::set_block_number(block_height_0);
+		assert_ok!(Anchor::put_pre_commit_into_eviction_bucket(
+			anchor_id_0,
+			block_height_0
+		));
 
-        let mut current_pre_commit_evict_bucket =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
+		let mut current_pre_commit_evict_bucket =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
 
-        // asserting that the right bucket was used to store
-        let mut pre_commits_count =
-            Anchor::get_pre_commits_count_in_evict_bucket(current_pre_commit_evict_bucket);
-        assert_eq!(pre_commits_count, 1);
-        let mut stored_pre_commit_id =
-            Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 0));
-        assert_eq!(stored_pre_commit_id, anchor_id_0);
+		// asserting that the right bucket was used to store
+		let mut pre_commits_count =
+			Anchor::get_pre_commits_count_in_evict_bucket(current_pre_commit_evict_bucket);
+		assert_eq!(pre_commits_count, 1);
+		let mut stored_pre_commit_id =
+			Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 0));
+		assert_eq!(stored_pre_commit_id, anchor_id_0);
 
-        // ------ Second run ------
-        // register anchor_id_1 and anchor_id_2 into block_height_1
-        System::set_block_number(block_height_1);
-        assert_ok!(Anchor::put_pre_commit_into_eviction_bucket(
-            anchor_id_1,
-            block_height_1
-        ));
-        assert_ok!(Anchor::put_pre_commit_into_eviction_bucket(
-            anchor_id_2,
-            block_height_1
-        ));
+		// ------ Second run ------
+		// register anchor_id_1 and anchor_id_2 into block_height_1
+		System::set_block_number(block_height_1);
+		assert_ok!(Anchor::put_pre_commit_into_eviction_bucket(
+			anchor_id_1,
+			block_height_1
+		));
+		assert_ok!(Anchor::put_pre_commit_into_eviction_bucket(
+			anchor_id_2,
+			block_height_1
+		));
 
-        current_pre_commit_evict_bucket =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap();
+		current_pre_commit_evict_bucket =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap();
 
-        // asserting that the right bucket was used to store
-        pre_commits_count =
-            Anchor::get_pre_commits_count_in_evict_bucket(current_pre_commit_evict_bucket);
-        assert_eq!(pre_commits_count, 2);
-        // first pre-commit
-        stored_pre_commit_id =
-            Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 0));
-        assert_eq!(stored_pre_commit_id, anchor_id_1);
-        // second pre-commit
-        stored_pre_commit_id =
-            Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 1));
-        assert_eq!(stored_pre_commit_id, anchor_id_2);
+		// asserting that the right bucket was used to store
+		pre_commits_count =
+			Anchor::get_pre_commits_count_in_evict_bucket(current_pre_commit_evict_bucket);
+		assert_eq!(pre_commits_count, 2);
+		// first pre-commit
+		stored_pre_commit_id =
+			Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 0));
+		assert_eq!(stored_pre_commit_id, anchor_id_1);
+		// second pre-commit
+		stored_pre_commit_id =
+			Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 1));
+		assert_eq!(stored_pre_commit_id, anchor_id_2);
 
-        // ------ Third run ------
-        // register anchor_id_3 into block_height_2
-        System::set_block_number(block_height_2);
-        assert_ok!(Anchor::put_pre_commit_into_eviction_bucket(
-            anchor_id_3,
-            block_height_2
-        ));
-        current_pre_commit_evict_bucket =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_2).unwrap();
+		// ------ Third run ------
+		// register anchor_id_3 into block_height_2
+		System::set_block_number(block_height_2);
+		assert_ok!(Anchor::put_pre_commit_into_eviction_bucket(
+			anchor_id_3,
+			block_height_2
+		));
+		current_pre_commit_evict_bucket =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_2).unwrap();
 
-        // asserting that the right bucket was used to store
-        pre_commits_count =
-            Anchor::get_pre_commits_count_in_evict_bucket(current_pre_commit_evict_bucket);
-        assert_eq!(pre_commits_count, 1);
-        stored_pre_commit_id =
-            Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 0));
-        assert_eq!(stored_pre_commit_id, anchor_id_3);
+		// asserting that the right bucket was used to store
+		pre_commits_count =
+			Anchor::get_pre_commits_count_in_evict_bucket(current_pre_commit_evict_bucket);
+		assert_eq!(pre_commits_count, 1);
+		stored_pre_commit_id =
+			Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 0));
+		assert_eq!(stored_pre_commit_id, anchor_id_3);
 
-        // finally a sanity check that the previous bucketed items are untouched by the subsequent runs
-        // checking run #1 again
-        current_pre_commit_evict_bucket =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
-        pre_commits_count =
-            Anchor::get_pre_commits_count_in_evict_bucket(current_pre_commit_evict_bucket);
-        assert_eq!(pre_commits_count, 1);
-        stored_pre_commit_id =
-            Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 0));
-        assert_eq!(stored_pre_commit_id, anchor_id_0);
-    });
+		// finally a sanity check that the previous bucketed items are untouched by the subsequent runs
+		// checking run #1 again
+		current_pre_commit_evict_bucket =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
+		pre_commits_count =
+			Anchor::get_pre_commits_count_in_evict_bucket(current_pre_commit_evict_bucket);
+		assert_eq!(pre_commits_count, 1);
+		stored_pre_commit_id =
+			Anchor::get_pre_commit_in_evict_bucket_by_index((current_pre_commit_evict_bucket, 0));
+		assert_eq!(stored_pre_commit_id, anchor_id_0);
+	});
 }
 
 #[test]
 fn pre_commit_with_pre_commit_eviction_bucket_registration() {
-    new_test_ext().execute_with(|| {
-        let anchor_id_0 = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id_1 = <Test as frame_system::Trait>::Hashing::hash_of(&1);
-        let anchor_id_2 = <Test as frame_system::Trait>::Hashing::hash_of(&2);
+	new_test_ext().execute_with(|| {
+		let anchor_id_0 = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id_1 = <Test as frame_system::Trait>::Hashing::hash_of(&1);
+		let anchor_id_2 = <Test as frame_system::Trait>::Hashing::hash_of(&2);
 
-        let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
 
-        // three different block heights that will put anchors into different eviction buckets
-        let block_height_0 = 1;
-        let block_height_1 =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() + block_height_0;
+		// three different block heights that will put anchors into different eviction buckets
+		let block_height_0 = 1;
+		let block_height_1 =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() + block_height_0;
 
-        // ------ Register the pre-commits ------
-        // register anchor_id_0 into block_height_0
-        System::set_block_number(block_height_0);
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id_0,
-            signing_root
-        ));
+		// ------ Register the pre-commits ------
+		// register anchor_id_0 into block_height_0
+		System::set_block_number(block_height_0);
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id_0,
+			signing_root
+		));
 
-        System::set_block_number(block_height_1);
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id_1,
-            signing_root
-        ));
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id_2,
-            signing_root
-        ));
+		System::set_block_number(block_height_1);
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id_1,
+			signing_root
+		));
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id_2,
+			signing_root
+		));
 
-        // verify the pre-commits were registered
-        // asserting that the stored pre-commit has the intended values set
-        let pre_commit_0 = Anchor::get_pre_commit(anchor_id_0);
-        assert_eq!(pre_commit_0.identity, 1);
-        assert_eq!(
-            pre_commit_0.expiration_block,
-            block_height_0 + Anchor::pre_commit_expiration_duration_blocks()
-        );
+		// verify the pre-commits were registered
+		// asserting that the stored pre-commit has the intended values set
+		let pre_commit_0 = Anchor::get_pre_commit(anchor_id_0);
+		assert_eq!(pre_commit_0.identity, 1);
+		assert_eq!(
+			pre_commit_0.expiration_block,
+			block_height_0 + Anchor::pre_commit_expiration_duration_blocks()
+		);
 
-        // verify the registration in evict bucket of anchor 0
-        let mut pre_commit_evict_bucket =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
-        let pre_commits_count =
-            Anchor::get_pre_commits_count_in_evict_bucket(pre_commit_evict_bucket);
-        assert_eq!(pre_commits_count, 1);
-        let stored_pre_commit_id =
-            Anchor::get_pre_commit_in_evict_bucket_by_index((pre_commit_evict_bucket, 0));
-        assert_eq!(stored_pre_commit_id, anchor_id_0);
+		// verify the registration in evict bucket of anchor 0
+		let mut pre_commit_evict_bucket =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
+		let pre_commits_count =
+			Anchor::get_pre_commits_count_in_evict_bucket(pre_commit_evict_bucket);
+		assert_eq!(pre_commits_count, 1);
+		let stored_pre_commit_id =
+			Anchor::get_pre_commit_in_evict_bucket_by_index((pre_commit_evict_bucket, 0));
+		assert_eq!(stored_pre_commit_id, anchor_id_0);
 
-        // verify the expected numbers on the evict bucket IDx
-        pre_commit_evict_bucket =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap();
-        assert_eq!(
-            Anchor::get_pre_commits_count_in_evict_bucket(pre_commit_evict_bucket),
-            2
-        );
-    });
+		// verify the expected numbers on the evict bucket IDx
+		pre_commit_evict_bucket =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap();
+		assert_eq!(
+			Anchor::get_pre_commits_count_in_evict_bucket(pre_commit_evict_bucket),
+			2
+		);
+	});
 }
 
 #[test]
 fn pre_commit_and_then_evict() {
-    new_test_ext().execute_with(|| {
-        let anchor_id_0 = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id_1 = <Test as frame_system::Trait>::Hashing::hash_of(&1);
-        let anchor_id_2 = <Test as frame_system::Trait>::Hashing::hash_of(&2);
+	new_test_ext().execute_with(|| {
+		let anchor_id_0 = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id_1 = <Test as frame_system::Trait>::Hashing::hash_of(&1);
+		let anchor_id_2 = <Test as frame_system::Trait>::Hashing::hash_of(&2);
 
-        let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
 
-        // three different block heights that will put anchors into different eviction buckets
-        let block_height_0 = 1;
-        let block_height_1 =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() + block_height_0;
-        let block_height_2 =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap() + block_height_0;
+		// three different block heights that will put anchors into different eviction buckets
+		let block_height_0 = 1;
+		let block_height_1 =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() + block_height_0;
+		let block_height_2 =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap() + block_height_0;
 
-        // ------ Register the pre-commits ------
-        // register anchor_id_0 into block_height_0
-        System::set_block_number(block_height_0);
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id_0,
-            signing_root
-        ));
+		// ------ Register the pre-commits ------
+		// register anchor_id_0 into block_height_0
+		System::set_block_number(block_height_0);
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id_0,
+			signing_root
+		));
 
-        System::set_block_number(block_height_1);
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id_1,
-            signing_root
-        ));
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id_2,
-            signing_root
-        ));
+		System::set_block_number(block_height_1);
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id_1,
+			signing_root
+		));
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id_2,
+			signing_root
+		));
 
-        // eviction fails within the "non evict time"
-        System::set_block_number(
-            Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() - 1,
-        );
-        assert_err!(
-            Anchor::evict_pre_commits(
-                Origin::signed(1),
-                Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap()
-            ),
-            "eviction only possible for bucket expiring < current block height"
-        );
+		// eviction fails within the "non evict time"
+		System::set_block_number(
+			Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() - 1,
+		);
+		assert_err!(
+			Anchor::evict_pre_commits(
+				Origin::signed(1),
+				Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap()
+			),
+			"eviction only possible for bucket expiring < current block height"
+		);
 
-        // test that eviction works after expiration time
-        System::set_block_number(block_height_2);
-        let bucket_1 = Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
+		// test that eviction works after expiration time
+		System::set_block_number(block_height_2);
+		let bucket_1 = Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
 
-        // before eviction, the pre-commit data findable
-        let a = Anchor::get_pre_commit(anchor_id_0);
-        assert_eq!(a.identity, 1);
-        assert_eq!(a.signing_root, signing_root);
+		// before eviction, the pre-commit data findable
+		let a = Anchor::get_pre_commit(anchor_id_0);
+		assert_eq!(a.identity, 1);
+		assert_eq!(a.signing_root, signing_root);
 
-        //do check counts, evict, check counts again
-        assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 1);
-        assert_ok!(Anchor::evict_pre_commits(Origin::signed(1), bucket_1));
-        assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 0);
+		//do check counts, evict, check counts again
+		assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 1);
+		assert_ok!(Anchor::evict_pre_commits(Origin::signed(1), bucket_1));
+		assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 0);
 
-        // after eviction, the pre-commit data not findable
-        let a_evicted = Anchor::get_pre_commit(anchor_id_0);
-        assert_eq!(a_evicted.identity, 0);
-        assert_eq!(a_evicted.expiration_block, 0);
+		// after eviction, the pre-commit data not findable
+		let a_evicted = Anchor::get_pre_commit(anchor_id_0);
+		assert_eq!(a_evicted.identity, 0);
+		assert_eq!(a_evicted.expiration_block, 0);
 
-        let bucket_2 = Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap();
-        assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_2), 2);
-        assert_ok!(Anchor::evict_pre_commits(Origin::signed(1), bucket_2));
-        assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_2), 0);
-    });
+		let bucket_2 = Anchor::determine_pre_commit_eviction_bucket(block_height_1).unwrap();
+		assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_2), 2);
+		assert_ok!(Anchor::evict_pre_commits(Origin::signed(1), bucket_2));
+		assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_2), 0);
+	});
 }
 
 #[test]
 fn pre_commit_at_7999_and_then_evict_before_expire_and_collaborator_succeed_commit() {
-    new_test_ext().execute_with(|| {
-        let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-        let (doc_root, signing_root, proof) = Test::test_document_hashes();
-        // use as a start block a block that is before an eviction bucket boundary
-        let start_block = Anchor::pre_commit_expiration_duration_blocks()
-            * PRE_COMMIT_EVICTION_BUCKET_MULTIPLIER
-            * 2
-            - 1;
-        // expected expiry block of pre-commit
-        let expiration_block = start_block + Anchor::pre_commit_expiration_duration_blocks(); // i.e 4799 + 800
+	new_test_ext().execute_with(|| {
+		let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		let (doc_root, signing_root, proof) = Test::test_document_hashes();
+		// use as a start block a block that is before an eviction bucket boundary
+		let start_block = Anchor::pre_commit_expiration_duration_blocks()
+			* PRE_COMMIT_EVICTION_BUCKET_MULTIPLIER
+			* 2 - 1;
+		// expected expiry block of pre-commit
+		let expiration_block = start_block + Anchor::pre_commit_expiration_duration_blocks(); // i.e 4799 + 800
 
-        System::set_block_number(start_block);
-        // happy
-        assert_ok!(Anchor::pre_commit(
-            Origin::signed(1),
-            anchor_id,
-            signing_root
-        ));
+		System::set_block_number(start_block);
+		// happy
+		assert_ok!(Anchor::pre_commit(
+			Origin::signed(1),
+			anchor_id,
+			signing_root
+		));
 
-        let a = Anchor::get_pre_commit(anchor_id);
-        assert_eq!(a.expiration_block, expiration_block);
+		let a = Anchor::get_pre_commit(anchor_id);
+		assert_eq!(a.expiration_block, expiration_block);
 
-        // the edge case bug we had - pre-commit eviction time is less than its expiry time
-        assert_eq!(
-            Anchor::determine_pre_commit_eviction_bucket(expiration_block).unwrap()
-                > a.expiration_block,
-            true
-        );
+		// the edge case bug we had - pre-commit eviction time is less than its expiry time
+		assert_eq!(
+			Anchor::determine_pre_commit_eviction_bucket(expiration_block).unwrap()
+				> a.expiration_block,
+			true
+		);
 
-        // this should not evict the pre-commit before its expired
-        System::set_block_number(
-            Anchor::determine_pre_commit_eviction_bucket(start_block).unwrap() + 1,
-        );
-        assert_ok!(Anchor::evict_pre_commits(
-            Origin::signed(1),
-            Anchor::determine_pre_commit_eviction_bucket(start_block).unwrap()
-        ));
+		// this should not evict the pre-commit before its expired
+		System::set_block_number(
+			Anchor::determine_pre_commit_eviction_bucket(start_block).unwrap() + 1,
+		);
+		assert_ok!(Anchor::evict_pre_commits(
+			Origin::signed(1),
+			Anchor::determine_pre_commit_eviction_bucket(start_block).unwrap()
+		));
 
-        // fails
-        assert_err!(
-            Anchor::commit(
-                Origin::signed(2),
-                pre_image,
-                doc_root,
-                proof,
-                common::MS_PER_DAY + 1
-            ),
-            "Pre-commit owned by someone else"
-        );
-    });
+		// fails
+		assert_err!(
+			Anchor::commit(
+				Origin::signed(2),
+				pre_image,
+				doc_root,
+				proof,
+				common::MS_PER_DAY + 1
+			),
+			"Pre-commit owned by someone else"
+		);
+	});
 }
 
 #[test]
 fn pre_commit_and_then_evict_larger_than_max_evict() {
-    new_test_ext().execute_with(|| {
-        let block_height_0 = 1;
-        let block_height_1 =
-            Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() + block_height_0;
-        let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+	new_test_ext().execute_with(|| {
+		let block_height_0 = 1;
+		let block_height_1 =
+			Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap() + block_height_0;
+		let signing_root = <Test as frame_system::Trait>::Hashing::hash_of(&0);
 
-        System::set_block_number(block_height_0);
-        for idx in 0..MAX_LOOP_IN_TX + 6 {
-            assert_ok!(Anchor::pre_commit(
-                Origin::signed(1),
-                <Test as frame_system::Trait>::Hashing::hash_of(&idx),
-                signing_root
-            ));
-        }
+		System::set_block_number(block_height_0);
+		for idx in 0..MAX_LOOP_IN_TX + 6 {
+			assert_ok!(Anchor::pre_commit(
+				Origin::signed(1),
+				<Test as frame_system::Trait>::Hashing::hash_of(&idx),
+				signing_root
+			));
+		}
 
-        System::set_block_number(block_height_1);
-        let bucket_1 = Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
+		System::set_block_number(block_height_1);
+		let bucket_1 = Anchor::determine_pre_commit_eviction_bucket(block_height_0).unwrap();
 
-        //do check counts, evict, check counts again
-        assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 506);
-        assert_ok!(Anchor::evict_pre_commits(Origin::signed(1), bucket_1));
-        assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 6);
+		//do check counts, evict, check counts again
+		assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 506);
+		assert_ok!(Anchor::evict_pre_commits(Origin::signed(1), bucket_1));
+		assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 6);
 
-        // evict again, now should be empty
-        System::set_block_number(block_height_1 + 1);
-        assert_ok!(Anchor::evict_pre_commits(Origin::signed(1), bucket_1));
-        assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 0);
-    });
+		// evict again, now should be empty
+		System::set_block_number(block_height_1 + 1);
+		assert_ok!(Anchor::evict_pre_commits(Origin::signed(1), bucket_1));
+		assert_eq!(Anchor::get_pre_commits_count_in_evict_bucket(bucket_1), 0);
+	});
 }
 // #### End Pre Commit Eviction Tests
 
 #[test]
 fn anchor_evict_single_anchor_per_day_1000_days() {
-    new_test_ext().execute_with(|| {
-        let day = |n| common::MS_PER_DAY * n + 1;
-        let (doc_root, _signing_root, proof) = Test::test_document_hashes();
-        let mut anchors = vec![];
-        let verify_anchor_eviction = |day: usize, anchors: &Vec<H256>| {
-            assert!(Anchor::get_anchor_by_id(anchors[day - 2]).is_none());
-            assert_eq!(Anchor::get_latest_evicted_anchor_index(), (day - 1) as u64);
-            assert_eq!(
-                Anchor::get_anchor_id_by_index((day - 1) as u64),
-                H256([0; 32])
-            );
-            assert!(Anchor::get_evicted_anchor_root_by_day((day - 1) as u32) != [0; 32]);
-            assert_eq!(Anchor::get_anchor_evict_date(anchors[day - 2]), 0);
-        };
-        let verify_next_anchor_after_eviction = |day: usize, anchors: &Vec<H256>| {
-            assert!(Anchor::get_anchor_by_id(anchors[day - 1]).is_some());
-            assert_eq!(Anchor::get_anchor_id_by_index(day as u64), anchors[day - 1]);
-            assert_eq!(
-                Anchor::get_anchor_evict_date(anchors[day - 1]),
-                (day + 1) as u32
-            );
-        };
+	new_test_ext().execute_with(|| {
+		let day = |n| common::MS_PER_DAY * n + 1;
+		let (doc_root, _signing_root, proof) = Test::test_document_hashes();
+		let mut anchors = vec![];
+		let verify_anchor_eviction = |day: usize, anchors: &Vec<H256>| {
+			assert!(Anchor::get_anchor_by_id(anchors[day - 2]).is_none());
+			assert_eq!(Anchor::get_latest_evicted_anchor_index(), (day - 1) as u64);
+			assert_eq!(
+				Anchor::get_anchor_id_by_index((day - 1) as u64),
+				H256([0; 32])
+			);
+			assert!(Anchor::get_evicted_anchor_root_by_day((day - 1) as u32) != [0; 32]);
+			assert_eq!(Anchor::get_anchor_evict_date(anchors[day - 2]), 0);
+		};
+		let verify_next_anchor_after_eviction = |day: usize, anchors: &Vec<H256>| {
+			assert!(Anchor::get_anchor_by_id(anchors[day - 1]).is_some());
+			assert_eq!(Anchor::get_anchor_id_by_index(day as u64), anchors[day - 1]);
+			assert_eq!(
+				Anchor::get_anchor_evict_date(anchors[day - 1]),
+				(day + 1) as u32
+			);
+		};
 
-        // create 1000 anchors one per day
-        for i in 0..1000 {
-            let random_seed = <pallet_randomness_collective_flip::Module<Test>>::random_seed();
-            let pre_image =
-                (random_seed, i).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+		// create 1000 anchors one per day
+		for i in 0..1000 {
+			let random_seed = <pallet_randomness_collective_flip::Module<Test>>::random_seed();
+			let pre_image =
+				(random_seed, i).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 
-            assert_ok!(Anchor::commit(
-                Origin::signed(1),
-                pre_image,
-                doc_root,
-                proof,
-                day(i + 1)
-            ));
+			assert_ok!(Anchor::commit(
+				Origin::signed(1),
+				pre_image,
+				doc_root,
+				proof,
+				day(i + 1)
+			));
 
-            assert!(Anchor::get_anchor_by_id(anchor_id).is_some());
-            assert_eq!(Anchor::get_latest_anchor_index(), i + 1);
-            assert_eq!(Anchor::get_anchor_id_by_index(i + 1), anchor_id);
-            assert_eq!(Anchor::get_latest_evicted_anchor_index(), 0);
-            assert_eq!(Anchor::get_anchor_evict_date(anchor_id), (i + 2) as u32);
+			assert!(Anchor::get_anchor_by_id(anchor_id).is_some());
+			assert_eq!(Anchor::get_latest_anchor_index(), i + 1);
+			assert_eq!(Anchor::get_anchor_id_by_index(i + 1), anchor_id);
+			assert_eq!(Anchor::get_latest_evicted_anchor_index(), 0);
+			assert_eq!(Anchor::get_anchor_evict_date(anchor_id), (i + 2) as u32);
 
-            anchors.push(anchor_id);
-        }
+			anchors.push(anchor_id);
+		}
 
-        // eviction on day 3
-        <pallet_timestamp::Module<Test>>::set_timestamp(day(2));
-        assert!(Anchor::get_anchor_by_id(anchors[0]).is_some());
-        assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-        verify_anchor_eviction(2, &anchors);
-        assert_eq!(
-            Anchor::get_evicted_anchor_root_by_day(2),
-            [
-                55, 192, 161, 216, 22, 212, 57, 53, 159, 127, 131, 202, 44, 242, 140, 108, 238,
-                137, 142, 111, 93, 164, 89, 178, 224, 245, 1, 223, 32, 136, 50, 53
-            ]
-        );
+		// eviction on day 3
+		<pallet_timestamp::Module<Test>>::set_timestamp(day(2));
+		assert!(Anchor::get_anchor_by_id(anchors[0]).is_some());
+		assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+		verify_anchor_eviction(2, &anchors);
+		assert_eq!(
+			Anchor::get_evicted_anchor_root_by_day(2),
+			[
+				55, 192, 161, 216, 22, 212, 57, 53, 159, 127, 131, 202, 44, 242, 140, 108, 238,
+				137, 142, 111, 93, 164, 89, 178, 224, 245, 1, 223, 32, 136, 50, 53
+			]
+		);
 
-        verify_next_anchor_after_eviction(2, &anchors);
+		verify_next_anchor_after_eviction(2, &anchors);
 
-        // do the same as above for next 99 days without child trie root verification
-        for i in 3..102 {
-            <pallet_timestamp::Module<Test>>::set_timestamp(day(i as u64));
-            assert!(Anchor::get_anchor_by_id(anchors[i - 2]).is_some());
+		// do the same as above for next 99 days without child trie root verification
+		for i in 3..102 {
+			<pallet_timestamp::Module<Test>>::set_timestamp(day(i as u64));
+			assert!(Anchor::get_anchor_by_id(anchors[i - 2]).is_some());
 
-            // evict
-            assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-            verify_anchor_eviction(i, &anchors);
-            verify_next_anchor_after_eviction(i, &anchors);
-        }
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 100);
+			// evict
+			assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+			verify_anchor_eviction(i, &anchors);
+			verify_next_anchor_after_eviction(i, &anchors);
+		}
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 100);
 
-        // test out limit on the number of anchors removed at a time
-        // eviction on day 602, i.e 501 anchors to be removed one anchor
-        // per day from the last eviction on day 102
-        <pallet_timestamp::Module<Test>>::set_timestamp(day(602));
-        assert!(Anchor::get_anchor_by_id(anchors[600]).is_some());
-        // evict
-        assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-        // verify anchor data has been removed until 520th anchor
-        for i in 102..602 {
-            assert!(Anchor::get_anchor_by_id(anchors[i - 2]).is_none());
-            assert!(Anchor::get_evicted_anchor_root_by_day(i as u32) != [0; 32]);
-        }
+		// test out limit on the number of anchors removed at a time
+		// eviction on day 602, i.e 501 anchors to be removed one anchor
+		// per day from the last eviction on day 102
+		<pallet_timestamp::Module<Test>>::set_timestamp(day(602));
+		assert!(Anchor::get_anchor_by_id(anchors[600]).is_some());
+		// evict
+		assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+		// verify anchor data has been removed until 520th anchor
+		for i in 102..602 {
+			assert!(Anchor::get_anchor_by_id(anchors[i - 2]).is_none());
+			assert!(Anchor::get_evicted_anchor_root_by_day(i as u32) != [0; 32]);
+		}
 
-        assert!(Anchor::get_anchor_by_id(anchors[600]).is_none());
-        assert!(Anchor::get_anchor_by_id(anchors[601]).is_some());
+		assert!(Anchor::get_anchor_by_id(anchors[600]).is_none());
+		assert!(Anchor::get_anchor_by_id(anchors[601]).is_some());
 
-        // verify that 601st anchors` indexes are left still because of 500 limit while
-        // 600th anchors` indexes have been removed
-        // 600th anchor
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 600);
-        assert_eq!(Anchor::get_anchor_id_by_index(600), H256([0; 32]));
-        assert_eq!(Anchor::get_anchor_evict_date(anchors[599]), 0);
-        // 601st anchor indexes are left
-        assert!(Anchor::get_anchor_id_by_index(601) != H256([0; 32]));
-        assert_eq!(Anchor::get_anchor_evict_date(anchors[600]), 602);
+		// verify that 601st anchors` indexes are left still because of 500 limit while
+		// 600th anchors` indexes have been removed
+		// 600th anchor
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 600);
+		assert_eq!(Anchor::get_anchor_id_by_index(600), H256([0; 32]));
+		assert_eq!(Anchor::get_anchor_evict_date(anchors[599]), 0);
+		// 601st anchor indexes are left
+		assert!(Anchor::get_anchor_id_by_index(601) != H256([0; 32]));
+		assert_eq!(Anchor::get_anchor_evict_date(anchors[600]), 602);
 
-        // call evict on same day to remove the remaining indexes
-        assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-        // verify that 521st anchors indexes are removed since we called a second time
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 601);
-        assert_eq!(Anchor::get_anchor_id_by_index(601), H256([0; 32]));
-        assert_eq!(Anchor::get_anchor_evict_date(anchors[600]), 0);
+		// call evict on same day to remove the remaining indexes
+		assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+		// verify that 521st anchors indexes are removed since we called a second time
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 601);
+		assert_eq!(Anchor::get_anchor_id_by_index(601), H256([0; 32]));
+		assert_eq!(Anchor::get_anchor_evict_date(anchors[600]), 0);
 
-        // remove remaining anchors
-        <pallet_timestamp::Module<Test>>::set_timestamp(day(1001));
-        assert!(Anchor::get_anchor_by_id(anchors[999]).is_some());
-        assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-        assert!(Anchor::get_anchor_by_id(anchors[999]).is_none());
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1000);
-        assert_eq!(Anchor::get_anchor_id_by_index(1000), H256([0; 32]));
-        assert_eq!(Anchor::get_anchor_evict_date(anchors[999]), 0);
-    });
+		// remove remaining anchors
+		<pallet_timestamp::Module<Test>>::set_timestamp(day(1001));
+		assert!(Anchor::get_anchor_by_id(anchors[999]).is_some());
+		assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+		assert!(Anchor::get_anchor_by_id(anchors[999]).is_none());
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1000);
+		assert_eq!(Anchor::get_anchor_id_by_index(1000), H256([0; 32]));
+		assert_eq!(Anchor::get_anchor_evict_date(anchors[999]), 0);
+	});
 }
 
 #[test]
 fn test_remove_anchor_indexes() {
-    new_test_ext().execute_with(|| {
-        let day = |n| common::MS_PER_DAY * n + 1;
-        let (doc_root, _signing_root, proof) = Test::test_document_hashes();
+	new_test_ext().execute_with(|| {
+		let day = |n| common::MS_PER_DAY * n + 1;
+		let (doc_root, _signing_root, proof) = Test::test_document_hashes();
 
-        // create 2000 anchors that expire on same day
-        for i in 0..2000 {
-            let random_seed = <pallet_randomness_collective_flip::Module<Test>>::random_seed();
-            let pre_image =
-                (random_seed, i).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            let _anchor_id =
-                (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            assert_ok!(Anchor::commit(
-                Origin::signed(1),
-                pre_image,
-                doc_root,
-                proof,
-                // all anchors expire on same day
-                day(1)
-            ));
-        }
-        assert_eq!(Anchor::get_latest_anchor_index(), 2000);
+		// create 2000 anchors that expire on same day
+		for i in 0..2000 {
+			let random_seed = <pallet_randomness_collective_flip::Module<Test>>::random_seed();
+			let pre_image =
+				(random_seed, i).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			let _anchor_id =
+				(pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			assert_ok!(Anchor::commit(
+				Origin::signed(1),
+				pre_image,
+				doc_root,
+				proof,
+				// all anchors expire on same day
+				day(1)
+			));
+		}
+		assert_eq!(Anchor::get_latest_anchor_index(), 2000);
 
-        // first MAX_LOOP_IN_TX items
-        let removed = Anchor::remove_anchor_indexes(2);
-        assert_eq!(removed as u64, MAX_LOOP_IN_TX);
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 500);
+		// first MAX_LOOP_IN_TX items
+		let removed = Anchor::remove_anchor_indexes(2);
+		assert_eq!(removed as u64, MAX_LOOP_IN_TX);
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 500);
 
-        // second MAX_LOOP_IN_TX items
-        let removed = Anchor::remove_anchor_indexes(2);
-        assert_eq!(removed as u64, MAX_LOOP_IN_TX);
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1000);
+		// second MAX_LOOP_IN_TX items
+		let removed = Anchor::remove_anchor_indexes(2);
+		assert_eq!(removed as u64, MAX_LOOP_IN_TX);
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1000);
 
-        // third MAX_LOOP_IN_TX items
-        let removed = Anchor::remove_anchor_indexes(2);
-        assert_eq!(removed as u64, MAX_LOOP_IN_TX);
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1500);
+		// third MAX_LOOP_IN_TX items
+		let removed = Anchor::remove_anchor_indexes(2);
+		assert_eq!(removed as u64, MAX_LOOP_IN_TX);
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1500);
 
-        // fourth MAX_LOOP_IN_TX items
-        let removed = Anchor::remove_anchor_indexes(2);
-        assert_eq!(removed as u64, MAX_LOOP_IN_TX);
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 2000);
+		// fourth MAX_LOOP_IN_TX items
+		let removed = Anchor::remove_anchor_indexes(2);
+		assert_eq!(removed as u64, MAX_LOOP_IN_TX);
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 2000);
 
-        // all done
-        let removed = Anchor::remove_anchor_indexes(2);
-        assert_eq!(removed, 0);
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 2000);
-    });
+		// all done
+		let removed = Anchor::remove_anchor_indexes(2);
+		assert_eq!(removed, 0);
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 2000);
+	});
 }
 
 #[test]
 fn test_same_day_1001_anchors() {
-    new_test_ext().execute_with(|| {
-        let day = |n| common::MS_PER_DAY * n + 1;
-        let (doc_root, _signing_root, proof) = Test::test_document_hashes();
-        let mut anchors = vec![];
+	new_test_ext().execute_with(|| {
+		let day = |n| common::MS_PER_DAY * n + 1;
+		let (doc_root, _signing_root, proof) = Test::test_document_hashes();
+		let mut anchors = vec![];
 
-        // create 1001 anchors that expire on same day
-        for i in 0..1001 {
-            let random_seed = <pallet_randomness_collective_flip::Module<Test>>::random_seed();
-            let pre_image =
-                (random_seed, i).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            assert_ok!(Anchor::commit(
-                Origin::signed(1),
-                pre_image,
-                doc_root,
-                proof,
-                // all anchors expire on same day
-                day(1)
-            ));
-            anchors.push(anchor_id);
-        }
-        assert_eq!(Anchor::get_latest_anchor_index(), 1001);
+		// create 1001 anchors that expire on same day
+		for i in 0..1001 {
+			let random_seed = <pallet_randomness_collective_flip::Module<Test>>::random_seed();
+			let pre_image =
+				(random_seed, i).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			assert_ok!(Anchor::commit(
+				Origin::signed(1),
+				pre_image,
+				doc_root,
+				proof,
+				// all anchors expire on same day
+				day(1)
+			));
+			anchors.push(anchor_id);
+		}
+		assert_eq!(Anchor::get_latest_anchor_index(), 1001);
 
-        // first 500
-        <pallet_timestamp::Module<Test>>::set_timestamp(day(2));
-        assert!(Anchor::get_anchor_by_id(anchors[999]).is_some());
-        assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-        assert!(Anchor::get_anchor_by_id(anchors[999]).is_none());
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 500);
-        assert_eq!(Anchor::get_anchor_id_by_index(500), H256([0; 32]));
-        assert_eq!(Anchor::get_anchor_evict_date(anchors[499]), 0);
-        assert_eq!(
-            Anchor::get_evicted_anchor_root_by_day(2),
-            [
-                70, 65, 237, 119, 141, 61, 66, 133, 45, 52, 60, 161, 160, 85, 153, 85, 205, 71,
-                131, 154, 33, 124, 237, 9, 21, 135, 243, 108, 42, 230, 159, 153
-            ]
-        );
+		// first 500
+		<pallet_timestamp::Module<Test>>::set_timestamp(day(2));
+		assert!(Anchor::get_anchor_by_id(anchors[999]).is_some());
+		assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+		assert!(Anchor::get_anchor_by_id(anchors[999]).is_none());
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 500);
+		assert_eq!(Anchor::get_anchor_id_by_index(500), H256([0; 32]));
+		assert_eq!(Anchor::get_anchor_evict_date(anchors[499]), 0);
+		assert_eq!(
+			Anchor::get_evicted_anchor_root_by_day(2),
+			[
+				70, 65, 237, 119, 141, 61, 66, 133, 45, 52, 60, 161, 160, 85, 153, 85, 205, 71,
+				131, 154, 33, 124, 237, 9, 21, 135, 243, 108, 42, 230, 159, 153
+			]
+		);
 
-        // second 500
-        assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1000);
-        assert_eq!(Anchor::get_anchor_id_by_index(1000), H256([0; 32]));
-        assert_eq!(Anchor::get_anchor_evict_date(anchors[999]), 0);
+		// second 500
+		assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1000);
+		assert_eq!(Anchor::get_anchor_id_by_index(1000), H256([0; 32]));
+		assert_eq!(Anchor::get_anchor_evict_date(anchors[999]), 0);
 
-        // remaining
-        assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1001);
-        assert_eq!(Anchor::get_anchor_id_by_index(1001), H256([0; 32]));
-        assert_eq!(Anchor::get_anchor_evict_date(anchors[1000]), 0);
+		// remaining
+		assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1001);
+		assert_eq!(Anchor::get_anchor_id_by_index(1001), H256([0; 32]));
+		assert_eq!(Anchor::get_anchor_evict_date(anchors[1000]), 0);
 
-        // all done
-        assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
-        assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1001);
-    });
+		// all done
+		assert_ok!(Anchor::evict_anchors(Origin::signed(1)));
+		assert_eq!(Anchor::get_latest_evicted_anchor_index(), 1001);
+	});
 }
 
 #[test]
 #[ignore]
 fn basic_commit_perf() {
-    use std::time::{SystemTime, UNIX_EPOCH};
+	use std::time::{SystemTime, UNIX_EPOCH};
 
-    new_test_ext().execute_with(|| {
-        let mut elapsed: u128 = 0;
-        let today_in_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_millis() as u64;
+	new_test_ext().execute_with(|| {
+		let mut elapsed: u128 = 0;
+		let today_in_ms = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.expect("Time went backwards")
+			.as_millis() as u64;
 
-        for i in 0..100000 {
-            let random_seed = <pallet_randomness_collective_flip::Module<Test>>::random_seed();
-            let pre_image =
-                (random_seed, i).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            let (doc_root, signing_root, proof) = Test::test_document_hashes();
+		for i in 0..100000 {
+			let random_seed = <pallet_randomness_collective_flip::Module<Test>>::random_seed();
+			let pre_image =
+				(random_seed, i).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			let (doc_root, signing_root, proof) = Test::test_document_hashes();
 
-            // happy
-            assert_ok!(Anchor::pre_commit(
-                Origin::signed(1),
-                anchor_id,
-                signing_root
-            ));
+			// happy
+			assert_ok!(Anchor::pre_commit(
+				Origin::signed(1),
+				anchor_id,
+				signing_root
+			));
 
-            let now = Instant::now();
+			let now = Instant::now();
 
-            assert_ok!(Anchor::commit(
-                Origin::signed(1),
-                pre_image,
-                doc_root,
-                proof,
-                today_in_ms + common::MS_PER_DAY * 2,
-            ));
+			assert_ok!(Anchor::commit(
+				Origin::signed(1),
+				pre_image,
+				doc_root,
+				proof,
+				today_in_ms + common::MS_PER_DAY * 2,
+			));
 
-            elapsed = elapsed + now.elapsed().as_micros();
-        }
+			elapsed = elapsed + now.elapsed().as_micros();
+		}
 
-        println!("time {}", elapsed);
-    });
+		println!("time {}", elapsed);
+	});
 }

--- a/runtime/src/common.rs
+++ b/runtime/src/common.rs
@@ -8,47 +8,47 @@ pub const MS_PER_DAY: u64 = 86400000;
 
 /// Get days(round up) since epoch given the timestamp in ms
 pub fn get_days_since_epoch(ts: u64) -> u32 {
-    let remainder = ts % MS_PER_DAY;
-    let days = (ts / MS_PER_DAY) as u32;
-    if remainder == 0 {
-        days
-    } else {
-        days + 1
-    }
+	let remainder = ts % MS_PER_DAY;
+	let days = (ts / MS_PER_DAY) as u32;
+	if remainder == 0 {
+		days
+	} else {
+		days + 1
+	}
 }
 
 /// Create a child storage key from the given specific key
 pub fn generate_child_storage_key(specific_key: u32) -> Vec<u8> {
-    let mut child_storage_key = CHILD_STORAGE_DEFAULT_PREFIX.to_vec();
-    child_storage_key.extend_from_slice(&specific_key.encode());
-    child_storage_key
+	let mut child_storage_key = CHILD_STORAGE_DEFAULT_PREFIX.to_vec();
+	child_storage_key.extend_from_slice(&specific_key.encode());
+	child_storage_key
 }
 
 #[cfg(test)]
 mod tests {
 
-    use crate::common::{generate_child_storage_key, get_days_since_epoch};
+	use crate::common::{generate_child_storage_key, get_days_since_epoch};
 
-    #[test]
-    fn test_get_days_since_epoch() {
-        // 1971-01-01  00:00:00
-        assert_eq!(get_days_since_epoch(31536000000), 365);
+	#[test]
+	fn test_get_days_since_epoch() {
+		// 1971-01-01  00:00:00
+		assert_eq!(get_days_since_epoch(31536000000), 365);
 
-        // 1971-01-01  00:00:01
-        assert_eq!(get_days_since_epoch(31536001000), 366);
+		// 1971-01-01  00:00:01
+		assert_eq!(get_days_since_epoch(31536001000), 366);
 
-        // 1970-12-31  11:59:59
-        assert_eq!(get_days_since_epoch(31449600000), 364);
-    }
+		// 1970-12-31  11:59:59
+		assert_eq!(get_days_since_epoch(31449600000), 364);
+	}
 
-    #[test]
-    fn test_child_storage_key() {
-        assert_eq!(
-            generate_child_storage_key(1),
-            vec![
-                58, 99, 104, 105, 108, 100, 95, 115, 116, 111, 114, 97, 103, 101, 58, 100, 101,
-                102, 97, 117, 108, 116, 58, 1, 0, 0, 0
-            ]
-        );
-    }
+	#[test]
+	fn test_child_storage_key() {
+		assert_eq!(
+			generate_child_storage_key(1),
+			vec![
+				58, 99, 104, 105, 108, 100, 95, 115, 116, 111, 114, 97, 103, 101, 58, 100, 101,
+				102, 97, 117, 108, 116, 58, 1, 0, 0, 0
+			]
+		);
+	}
 }

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -2,52 +2,52 @@
 
 /// Money matters.
 pub mod currency {
-    use node_primitives::Balance;
+	use node_primitives::Balance;
 
-    pub const MICRO_RAD: Balance = 1_000_000_000_000; // 10−6 	0.000001
-    pub const MILLI_RAD: Balance = 1_000 * MICRO_RAD; // 10−3 	0.001
-    pub const CENTI_RAD: Balance = 10 * MILLI_RAD; // 10−2 	0.01
-    pub const RAD: Balance = 100 * CENTI_RAD;
+	pub const MICRO_RAD: Balance = 1_000_000_000_000; // 10−6 	0.000001
+	pub const MILLI_RAD: Balance = 1_000 * MICRO_RAD; // 10−3 	0.001
+	pub const CENTI_RAD: Balance = 10 * MILLI_RAD; // 10−2 	0.01
+	pub const RAD: Balance = 100 * CENTI_RAD;
 }
 
 /// Time.
 pub mod time {
-    use node_primitives::{Moment, BlockNumber};
+	use node_primitives::{BlockNumber, Moment};
 
-    /// Since BABE is probabilistic this is the average expected block time that
-    /// we are targetting. Blocks will be produced at a minimum duration defined
-    /// by `SLOT_DURATION`, but some slots will not be allocated to any
-    /// authority and hence no block will be produced. We expect to have this
-    /// block time on average following the defined slot duration and the value
-    /// of `c` configured for BABE (where `1 - c` represents the probability of
-    /// a slot being empty).
-    /// This value is only used indirectly to define the unit constants below
-    /// that are expressed in blocks. The rest of the code should use
+	/// Since BABE is probabilistic this is the average expected block time that
+	/// we are targetting. Blocks will be produced at a minimum duration defined
+	/// by `SLOT_DURATION`, but some slots will not be allocated to any
+	/// authority and hence no block will be produced. We expect to have this
+	/// block time on average following the defined slot duration and the value
+	/// of `c` configured for BABE (where `1 - c` represents the probability of
+	/// a slot being empty).
+	/// This value is only used indirectly to define the unit constants below
+	/// that are expressed in blocks. The rest of the code should use
 	/// `SLOT_DURATION` instead (like the Timestamp pallet for calculating the
-    /// minimum period).
-    ///
-    /// If using BABE with secondary slots (default) then all of the slots will
-    /// always be assigned, in which case `MILLISECS_PER_BLOCK` and
-    /// `SLOT_DURATION` should have the same value.
-    ///
-    /// <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
-    pub const MILLISECS_PER_BLOCK: Moment = 6000;
-    pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
+	/// minimum period).
+	///
+	/// If using BABE with secondary slots (default) then all of the slots will
+	/// always be assigned, in which case `MILLISECS_PER_BLOCK` and
+	/// `SLOT_DURATION` should have the same value.
+	///
+	/// <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
+	pub const MILLISECS_PER_BLOCK: Moment = 6000;
+	pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
 
-    pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
+	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
 
-    // 1 in 4 blocks (on average, not counting collisions) will be primary BABE blocks.
-    pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
+	// 1 in 4 blocks (on average, not counting collisions) will be primary BABE blocks.
+	pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
 
-    pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 6 * HOURS;
-    pub const EPOCH_DURATION_IN_SLOTS: u64 = {
-        const SLOT_FILL_RATE: f64 = MILLISECS_PER_BLOCK as f64 / SLOT_DURATION as f64;
+	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 6 * HOURS;
+	pub const EPOCH_DURATION_IN_SLOTS: u64 = {
+		const SLOT_FILL_RATE: f64 = MILLISECS_PER_BLOCK as f64 / SLOT_DURATION as f64;
 
-        (EPOCH_DURATION_IN_BLOCKS as f64 * SLOT_FILL_RATE) as u64
-    };
+		(EPOCH_DURATION_IN_BLOCKS as f64 * SLOT_FILL_RATE) as u64
+	};
 
-    // These time units are defined in number of blocks.
-    pub const MINUTES: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
-    pub const HOURS: BlockNumber = MINUTES * 60;
-    pub const DAYS: BlockNumber = HOURS * 24;
+	// These time units are defined in number of blocks.
+	pub const MINUTES: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
+	pub const HOURS: BlockNumber = MINUTES * 60;
+	pub const DAYS: BlockNumber = HOURS * 24;
 }

--- a/runtime/src/fees.rs
+++ b/runtime/src/fees.rs
@@ -1,41 +1,41 @@
 /// Handling state rent fee payments for specific transactions
 use codec::{Decode, Encode};
 use frame_support::{
-    decl_event, decl_module, decl_storage,
-    dispatch::DispatchResult,
-    ensure,
-    traits::{Currency, ExistenceRequirement, WithdrawReason},
-    weights::SimpleDispatchInfo,
+	decl_event, decl_module, decl_storage,
+	dispatch::DispatchResult,
+	ensure,
+	traits::{Currency, ExistenceRequirement, WithdrawReason},
+	weights::SimpleDispatchInfo,
 };
 use frame_system::{self as system, ensure_root};
 use sp_runtime::traits::EnsureOrigin;
 
 /// The module's configuration trait.
 pub trait Trait: frame_system::Trait + pallet_balances::Trait + pallet_authorship::Trait {
-    /// The overarching event type.
-    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
-    /// Required origin for changing fees
-    type FeeChangeOrigin: EnsureOrigin<Self::Origin>;
+	/// The overarching event type.
+	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+	/// Required origin for changing fees
+	type FeeChangeOrigin: EnsureOrigin<Self::Origin>;
 }
 
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Fee<Hash, Balance> {
-    key: Hash,
-    price: Balance,
+	key: Hash,
+	price: Balance,
 }
 
 decl_storage! {
-    trait Store for Module<T: Trait> as Fees {
-        Fees get(fee) : map hasher(blake2_256) T::Hash => Fee<T::Hash, T::Balance>;
+	trait Store for Module<T: Trait> as Fees {
+		Fees get(fee) : map hasher(blake2_256) T::Hash => Fee<T::Hash, T::Balance>;
 
-        Version: u64;
-    }
-    add_extra_genesis {
-        // Anchoring state rent fee per day
-        config(initial_fees): Vec<(T::Hash, T::Balance)>;
-        build(|config| Module::<T>::initialize_fees(&config.initial_fees))
-    }
+		Version: u64;
+	}
+	add_extra_genesis {
+		// Anchoring state rent fee per day
+		config(initial_fees): Vec<(T::Hash, T::Balance)>;
+		build(|config| Module::<T>::initialize_fees(&config.initial_fees))
+	}
 }
 
 decl_event!(
@@ -45,347 +45,347 @@ decl_event!(
 );
 
 decl_module! {
-    /// The module declaration.
-    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-        // Initializing events
-        // this is needed only if you are using events in your module
-        fn deposit_event() = default;
+	/// The module declaration.
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		// Initializing events
+		// this is needed only if you are using events in your module
+		fn deposit_event() = default;
 
-        /// Set the given fee for the key
-        ///
-        /// # <weight>
-        /// - Independent of the arguments.
-        /// - Contains a limited number of reads and writes.
-        /// # </weight>
-        #[weight = SimpleDispatchInfo::FixedOperational(1_000_000)]
-        pub fn set_fee(origin, key: T::Hash, new_price: T::Balance) -> DispatchResult {
-            Self::can_change_fee(origin)?;
-            Self::change_fee(key, new_price);
+		/// Set the given fee for the key
+		///
+		/// # <weight>
+		/// - Independent of the arguments.
+		/// - Contains a limited number of reads and writes.
+		/// # </weight>
+		#[weight = SimpleDispatchInfo::FixedOperational(1_000_000)]
+		pub fn set_fee(origin, key: T::Hash, new_price: T::Balance) -> DispatchResult {
+			Self::can_change_fee(origin)?;
+			Self::change_fee(key, new_price);
 
-            Self::deposit_event(RawEvent::FeeChanged(key, new_price));
-            Ok(())
-        }
-    }
+			Self::deposit_event(RawEvent::FeeChanged(key, new_price));
+			Ok(())
+		}
+	}
 }
 
 impl<T: Trait> Module<T> {
-    /// Called by any other module who wants to trigger a fee payment for a given account.
-    /// The current fee price can be retrieved via Fees::price_of()
-    pub fn pay_fee(from: T::AccountId, key: T::Hash) -> DispatchResult {
-        ensure!(<Fees<T>>::contains_key(key), "fee not found for key");
+	/// Called by any other module who wants to trigger a fee payment for a given account.
+	/// The current fee price can be retrieved via Fees::price_of()
+	pub fn pay_fee(from: T::AccountId, key: T::Hash) -> DispatchResult {
+		ensure!(<Fees<T>>::contains_key(key), "fee not found for key");
 
-        let single_fee = <Fees<T>>::get(key);
-        Self::pay_fee_to_author(from, single_fee.price)?;
+		let single_fee = <Fees<T>>::get(key);
+		Self::pay_fee_to_author(from, single_fee.price)?;
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    /// Pay the given fee
-    pub fn pay_fee_to_author(from: T::AccountId, fee: T::Balance) -> DispatchResult {
-        let value = <pallet_balances::Module<T> as Currency<_>>::withdraw(
-            &from,
-            fee,
-            WithdrawReason::Fee.into(),
-            ExistenceRequirement::KeepAlive,
-        )?;
+	/// Pay the given fee
+	pub fn pay_fee_to_author(from: T::AccountId, fee: T::Balance) -> DispatchResult {
+		let value = <pallet_balances::Module<T> as Currency<_>>::withdraw(
+			&from,
+			fee,
+			WithdrawReason::Fee.into(),
+			ExistenceRequirement::KeepAlive,
+		)?;
 
-        let author = <pallet_authorship::Module<T>>::author();
-        <pallet_balances::Module<T> as Currency<_>>::resolve_creating(&author, value);
-        Ok(())
-    }
+		let author = <pallet_authorship::Module<T>>::author();
+		<pallet_balances::Module<T> as Currency<_>>::resolve_creating(&author, value);
+		Ok(())
+	}
 
-    /// Returns the current fee for the key
-    pub fn price_of(key: T::Hash) -> Option<T::Balance> {
-        //why this has been hashed again after passing to the function? sp_io::print(key.as_ref());
-        if <Fees<T>>::contains_key(&key) {
-            let single_fee = <Fees<T>>::get(&key);
-            Some(single_fee.price)
-        } else {
-            None
-        }
-    }
+	/// Returns the current fee for the key
+	pub fn price_of(key: T::Hash) -> Option<T::Balance> {
+		//why this has been hashed again after passing to the function? sp_io::print(key.as_ref());
+		if <Fees<T>>::contains_key(&key) {
+			let single_fee = <Fees<T>>::get(&key);
+			Some(single_fee.price)
+		} else {
+			None
+		}
+	}
 
-    /// Returns true if the given origin can change the fee
-    fn can_change_fee(origin: T::Origin) -> DispatchResult {
-        T::FeeChangeOrigin::try_origin(origin)
-            .map(|_| ())
-            .or_else(ensure_root)?;
+	/// Returns true if the given origin can change the fee
+	fn can_change_fee(origin: T::Origin) -> DispatchResult {
+		T::FeeChangeOrigin::try_origin(origin)
+			.map(|_| ())
+			.or_else(ensure_root)?;
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    /// Initialise fees for a fixed set of keys. i.e. For use in genesis
-    fn initialize_fees(fees: &[(T::Hash, T::Balance)]) {
-        fees.iter()
-            .map(|(ref key, ref fee)| Self::change_fee(*key, *fee))
-            .count();
-    }
+	/// Initialise fees for a fixed set of keys. i.e. For use in genesis
+	fn initialize_fees(fees: &[(T::Hash, T::Balance)]) {
+		fees.iter()
+			.map(|(ref key, ref fee)| Self::change_fee(*key, *fee))
+			.count();
+	}
 
-    /// Change the fee for the given key
-    fn change_fee(key: T::Hash, fee: T::Balance) {
-        let new_fee = Fee {
-            key: key.clone(),
-            price: fee,
-        };
-        <Fees<T>>::insert(key, new_fee);
-    }
+	/// Change the fee for the given key
+	fn change_fee(key: T::Hash, fee: T::Balance) {
+		let new_fee = Fee {
+			key: key.clone(),
+			price: fee,
+		};
+		<Fees<T>>::insert(key, new_fee);
+	}
 }
 
 /// tests for fees module
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    use frame_support::{
-        assert_err, assert_noop, assert_ok, dispatch::DispatchError, impl_outer_origin,
-        ord_parameter_types, parameter_types, traits::FindAuthor, weights::Weight,
-        ConsensusEngineId,
-    };
-    use frame_system::EnsureSignedBy;
-    use sp_core::H256;
-    use sp_runtime::Perbill;
-    use sp_runtime::{
-        testing::Header,
-        traits::{BadOrigin, BlakeTwo256, Hash, IdentityLookup},
-    };
+	use frame_support::{
+		assert_err, assert_noop, assert_ok, dispatch::DispatchError, impl_outer_origin,
+		ord_parameter_types, parameter_types, traits::FindAuthor, weights::Weight,
+		ConsensusEngineId,
+	};
+	use frame_system::EnsureSignedBy;
+	use sp_core::H256;
+	use sp_runtime::Perbill;
+	use sp_runtime::{
+		testing::Header,
+		traits::{BadOrigin, BlakeTwo256, Hash, IdentityLookup},
+	};
 
-    impl_outer_origin! {
-        pub enum Origin for Test  where system = frame_system {}
-    }
+	impl_outer_origin! {
+		pub enum Origin for Test  where system = frame_system {}
+	}
 
-    // For testing the module, we construct most of a mock runtime. This means
-    // first constructing a configuration type (`Test`) which `impl`s each of the
-    // configuration traits of modules we want to use.
-    #[derive(Clone, Eq, PartialEq)]
-    pub struct Test;
-    parameter_types! {
-        pub const BlockHashCount: u64 = 250;
-        pub const MaximumBlockWeight: Weight = 1024;
-        pub const MaximumBlockLength: u32 = 2 * 1024;
-        pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
-    }
-    impl frame_system::Trait for Test {
-        type AccountId = u64;
-        type Call = ();
-        type Lookup = IdentityLookup<Self::AccountId>;
-        type Index = u64;
-        type BlockNumber = u64;
-        type Hash = H256;
-        type Hashing = BlakeTwo256;
-        type Header = Header;
-        type Event = ();
-        type Origin = Origin;
-        type BlockHashCount = BlockHashCount;
-        type MaximumBlockWeight = MaximumBlockWeight;
-        type MaximumBlockLength = MaximumBlockLength;
-        type AvailableBlockRatio = AvailableBlockRatio;
-        type Version = ();
-        type ModuleToIndex = ();
-        type AccountData = pallet_balances::AccountData<u64>;
-        type OnNewAccount = ();
-        type OnKilledAccount = pallet_balances::Module<Test>;
-    }
-    ord_parameter_types! {
-        pub const One: u64 = 1;
-    }
-    impl Trait for Test {
-        type Event = ();
-        type FeeChangeOrigin = EnsureSignedBy<One, u64>;
-    }
-    parameter_types! {
-        pub const ExistentialDeposit: u64 = 1;
-    }
-    impl pallet_balances::Trait for Test {
-        type Balance = u64;
-        type DustRemoval = ();
-        type Event = ();
-        type ExistentialDeposit = ExistentialDeposit;
-        type AccountStore = System;
-    }
+	// For testing the module, we construct most of a mock runtime. This means
+	// first constructing a configuration type (`Test`) which `impl`s each of the
+	// configuration traits of modules we want to use.
+	#[derive(Clone, Eq, PartialEq)]
+	pub struct Test;
+	parameter_types! {
+		pub const BlockHashCount: u64 = 250;
+		pub const MaximumBlockWeight: Weight = 1024;
+		pub const MaximumBlockLength: u32 = 2 * 1024;
+		pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	}
+	impl frame_system::Trait for Test {
+		type AccountId = u64;
+		type Call = ();
+		type Lookup = IdentityLookup<Self::AccountId>;
+		type Index = u64;
+		type BlockNumber = u64;
+		type Hash = H256;
+		type Hashing = BlakeTwo256;
+		type Header = Header;
+		type Event = ();
+		type Origin = Origin;
+		type BlockHashCount = BlockHashCount;
+		type MaximumBlockWeight = MaximumBlockWeight;
+		type MaximumBlockLength = MaximumBlockLength;
+		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
+		type ModuleToIndex = ();
+		type AccountData = pallet_balances::AccountData<u64>;
+		type OnNewAccount = ();
+		type OnKilledAccount = pallet_balances::Module<Test>;
+	}
+	ord_parameter_types! {
+		pub const One: u64 = 1;
+	}
+	impl Trait for Test {
+		type Event = ();
+		type FeeChangeOrigin = EnsureSignedBy<One, u64>;
+	}
+	parameter_types! {
+		pub const ExistentialDeposit: u64 = 1;
+	}
+	impl pallet_balances::Trait for Test {
+		type Balance = u64;
+		type DustRemoval = ();
+		type Event = ();
+		type ExistentialDeposit = ExistentialDeposit;
+		type AccountStore = System;
+	}
 
-    impl pallet_authorship::Trait for Test {
-        type FindAuthor = AuthorGiven;
-        type UncleGenerations = ();
-        type FilterUncle = ();
-        type EventHandler = ();
-    }
+	impl pallet_authorship::Trait for Test {
+		type FindAuthor = AuthorGiven;
+		type UncleGenerations = ();
+		type FilterUncle = ();
+		type EventHandler = ();
+	}
 
-    pub struct AuthorGiven;
+	pub struct AuthorGiven;
 
-    impl FindAuthor<u64> for AuthorGiven {
-        fn find_author<'a, I>(_digests: I) -> Option<u64>
-        where
-            I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
-        {
-            Some(100)
-        }
-    }
+	impl FindAuthor<u64> for AuthorGiven {
+		fn find_author<'a, I>(_digests: I) -> Option<u64>
+		where
+			I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+		{
+			Some(100)
+		}
+	}
 
-    type Fees = Module<Test>;
-    type System = frame_system::Module<Test>;
+	type Fees = Module<Test>;
+	type System = frame_system::Module<Test>;
 
-    // This function basically just builds a genesis storage key/value store according to
-    // our desired mockup.
-    fn new_test_ext() -> sp_io::TestExternalities {
-        let mut t = frame_system::GenesisConfig::default()
-            .build_storage::<Test>()
-            .unwrap();
+	// This function basically just builds a genesis storage key/value store according to
+	// our desired mockup.
+	fn new_test_ext() -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Test>()
+			.unwrap();
 
-        // pre-fill balances
-        // 100 is the block author
-        pallet_balances::GenesisConfig::<Test> {
-            balances: vec![(1, 100000), (2, 100000), (100, 100)],
-        }
-        .assimilate_storage(&mut t)
-        .unwrap();
-        t.into()
-    }
+		// pre-fill balances
+		// 100 is the block author
+		pallet_balances::GenesisConfig::<Test> {
+			balances: vec![(1, 100000), (2, 100000), (100, 100)],
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+		t.into()
+	}
 
-    #[test]
-    fn can_change_fee() {
-        new_test_ext().execute_with(|| {
-            assert_noop!(Fees::can_change_fee(Origin::signed(2)), BadOrigin);
-            assert_ok!(Fees::can_change_fee(Origin::signed(1)));
-        });
-    }
+	#[test]
+	fn can_change_fee() {
+		new_test_ext().execute_with(|| {
+			assert_noop!(Fees::can_change_fee(Origin::signed(2)), BadOrigin);
+			assert_ok!(Fees::can_change_fee(Origin::signed(1)));
+		});
+	}
 
-    #[test]
-    fn multiple_new_fees_are_setable() {
-        new_test_ext().execute_with(|| {
-            let fee_key1 = <Test as frame_system::Trait>::Hashing::hash_of(&11111);
-            let fee_key2 = <Test as frame_system::Trait>::Hashing::hash_of(&22222);
+	#[test]
+	fn multiple_new_fees_are_setable() {
+		new_test_ext().execute_with(|| {
+			let fee_key1 = <Test as frame_system::Trait>::Hashing::hash_of(&11111);
+			let fee_key2 = <Test as frame_system::Trait>::Hashing::hash_of(&22222);
 
-            let price1: <Test as pallet_balances::Trait>::Balance = 666;
-            let price2: <Test as pallet_balances::Trait>::Balance = 777;
+			let price1: <Test as pallet_balances::Trait>::Balance = 666;
+			let price2: <Test as pallet_balances::Trait>::Balance = 777;
 
-            assert_noop!(
-                Fees::set_fee(Origin::signed(2), fee_key1, price1),
-                BadOrigin
-            );
-            assert_ok!(Fees::set_fee(Origin::signed(1), fee_key1, price1));
-            assert_ok!(Fees::set_fee(Origin::signed(1), fee_key2, price2));
+			assert_noop!(
+				Fees::set_fee(Origin::signed(2), fee_key1, price1),
+				BadOrigin
+			);
+			assert_ok!(Fees::set_fee(Origin::signed(1), fee_key1, price1));
+			assert_ok!(Fees::set_fee(Origin::signed(1), fee_key2, price2));
 
-            let loaded_fee1 = Fees::fee(fee_key1);
-            assert_eq!(loaded_fee1.price, price1);
+			let loaded_fee1 = Fees::fee(fee_key1);
+			assert_eq!(loaded_fee1.price, price1);
 
-            let loaded_fee2 = Fees::fee(fee_key2);
-            assert_eq!(loaded_fee2.price, price2);
-        });
-    }
+			let loaded_fee2 = Fees::fee(fee_key2);
+			assert_eq!(loaded_fee2.price, price2);
+		});
+	}
 
-    #[test]
-    fn fee_is_re_setable() {
-        new_test_ext().execute_with(|| {
-            let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&11111);
+	#[test]
+	fn fee_is_re_setable() {
+		new_test_ext().execute_with(|| {
+			let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&11111);
 
-            let initial_price: <Test as pallet_balances::Trait>::Balance = 666;
-            assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, initial_price));
+			let initial_price: <Test as pallet_balances::Trait>::Balance = 666;
+			assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, initial_price));
 
-            let loaded_fee = Fees::fee(fee_key);
-            assert_eq!(loaded_fee.price, initial_price);
+			let loaded_fee = Fees::fee(fee_key);
+			assert_eq!(loaded_fee.price, initial_price);
 
-            let new_price: <Test as pallet_balances::Trait>::Balance = 777;
-            assert_noop!(
-                Fees::set_fee(Origin::signed(2), fee_key, new_price),
-                BadOrigin
-            );
-            assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, new_price));
-            let again_loaded_fee = Fees::fee(fee_key);
-            assert_eq!(again_loaded_fee.price, new_price);
-        });
-    }
+			let new_price: <Test as pallet_balances::Trait>::Balance = 777;
+			assert_noop!(
+				Fees::set_fee(Origin::signed(2), fee_key, new_price),
+				BadOrigin
+			);
+			assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, new_price));
+			let again_loaded_fee = Fees::fee(fee_key);
+			assert_eq!(again_loaded_fee.price, new_price);
+		});
+	}
 
-    #[test]
-    fn fee_payment_errors_if_not_set() {
-        new_test_ext().execute_with(|| {
-            let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&111111);
-            let fee_price: <Test as pallet_balances::Trait>::Balance = 90000;
-            let author_old_balance = <pallet_balances::Module<Test>>::total_balance(&100);
+	#[test]
+	fn fee_payment_errors_if_not_set() {
+		new_test_ext().execute_with(|| {
+			let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&111111);
+			let fee_price: <Test as pallet_balances::Trait>::Balance = 90000;
+			let author_old_balance = <pallet_balances::Module<Test>>::total_balance(&100);
 
-            assert_err!(Fees::pay_fee(1, fee_key), "fee not found for key");
+			assert_err!(Fees::pay_fee(1, fee_key), "fee not found for key");
 
-            assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, fee_price));
+			assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, fee_price));
 
-            // initial time paying will succeed as sufficient balance + fee is set
-            assert_ok!(Fees::pay_fee(1, fee_key));
+			// initial time paying will succeed as sufficient balance + fee is set
+			assert_ok!(Fees::pay_fee(1, fee_key));
 
-            let author_new_balance = <pallet_balances::Module<Test>>::total_balance(&100);
-            assert_eq!(author_new_balance - author_old_balance, fee_price);
+			let author_new_balance = <pallet_balances::Module<Test>>::total_balance(&100);
+			assert_eq!(author_new_balance - author_old_balance, fee_price);
 
-            // second time paying will lead to account having insufficient balance
-            assert_err!(
-                Fees::pay_fee(1, fee_key),
-                DispatchError::Module {
-                    index: 0,
-                    error: 3,
-                    message: Some("InsufficientBalance"),
-                }
-            );
-        });
-    }
+			// second time paying will lead to account having insufficient balance
+			assert_err!(
+				Fees::pay_fee(1, fee_key),
+				DispatchError::Module {
+					index: 0,
+					error: 3,
+					message: Some("InsufficientBalance"),
+				}
+			);
+		});
+	}
 
-    #[test]
-    fn fee_payment_errors_if_insufficient_balance() {
-        new_test_ext().execute_with(|| {
-            let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&111111);
-            let fee_price: <Test as pallet_balances::Trait>::Balance = 90000;
+	#[test]
+	fn fee_payment_errors_if_insufficient_balance() {
+		new_test_ext().execute_with(|| {
+			let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&111111);
+			let fee_price: <Test as pallet_balances::Trait>::Balance = 90000;
 
-            assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, fee_price));
+			assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, fee_price));
 
-            // account 3 is not endowed in the test setup
-            assert_err!(
-                Fees::pay_fee(3, fee_key),
-                DispatchError::Module {
-                    index: 0,
-                    error: 3,
-                    message: Some("InsufficientBalance"),
-                }
-            );
-        });
-    }
+			// account 3 is not endowed in the test setup
+			assert_err!(
+				Fees::pay_fee(3, fee_key),
+				DispatchError::Module {
+					index: 0,
+					error: 3,
+					message: Some("InsufficientBalance"),
+				}
+			);
+		});
+	}
 
-    #[test]
-    fn fee_payment_subtracts_fees_from_account() {
-        new_test_ext().execute_with(|| {
-            let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&111111);
-            let fee_price: <Test as pallet_balances::Trait>::Balance = 90000;
-            assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, fee_price));
+	#[test]
+	fn fee_payment_subtracts_fees_from_account() {
+		new_test_ext().execute_with(|| {
+			let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&111111);
+			let fee_price: <Test as pallet_balances::Trait>::Balance = 90000;
+			assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, fee_price));
 
-            // account 1 is endowed in test setup
-            // initial time paying will succeed as sufficient balance + fee is set
-            assert_ok!(Fees::pay_fee(1, fee_key));
+			// account 1 is endowed in test setup
+			// initial time paying will succeed as sufficient balance + fee is set
+			assert_ok!(Fees::pay_fee(1, fee_key));
 
-            //second time paying will lead to account having insufficient balance
-            assert_err!(
-                Fees::pay_fee(1, fee_key),
-                DispatchError::Module {
-                    index: 0,
-                    error: 3,
-                    message: Some("InsufficientBalance"),
-                }
-            );
-        });
-    }
+			//second time paying will lead to account having insufficient balance
+			assert_err!(
+				Fees::pay_fee(1, fee_key),
+				DispatchError::Module {
+					index: 0,
+					error: 3,
+					message: Some("InsufficientBalance"),
+				}
+			);
+		});
+	}
 
-    #[test]
-    fn fee_is_gettable() {
-        new_test_ext().execute_with(|| {
-            let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&111111);
-            let fee_price: <Test as pallet_balances::Trait>::Balance = 90000;
+	#[test]
+	fn fee_is_gettable() {
+		new_test_ext().execute_with(|| {
+			let fee_key = <Test as frame_system::Trait>::Hashing::hash_of(&111111);
+			let fee_price: <Test as pallet_balances::Trait>::Balance = 90000;
 
-            //First run, the fee is not set yet and should return None
-            match Fees::price_of(fee_key) {
-                Some(_x) => assert!(false, "Should not have a fee set yet"),
-                None => assert!(true),
-            }
+			//First run, the fee is not set yet and should return None
+			match Fees::price_of(fee_key) {
+				Some(_x) => assert!(false, "Should not have a fee set yet"),
+				None => assert!(true),
+			}
 
-            //After setting the fee, the correct fee should be returned
-            assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, fee_price));
-            //First run, the fee is not set yet and should return None
-            match Fees::price_of(fee_key) {
-                Some(x) => assert_eq!(fee_price, x),
-                None => assert!(false, "Fee should have been set"),
-            }
-        });
-    }
+			//After setting the fee, the correct fee should be returned
+			assert_ok!(Fees::set_fee(Origin::signed(1), fee_key, fee_price));
+			//First run, the fee is not set yet and should return None
+			match Fees::price_of(fee_key) {
+				Some(x) => assert_eq!(fee_price, x),
+				None => assert!(false, "Fee should have been set"),
+			}
+		});
+	}
 }

--- a/runtime/src/fees.rs
+++ b/runtime/src/fees.rs
@@ -39,9 +39,9 @@ decl_storage! {
 }
 
 decl_event!(
-    pub enum Event<T> where <T as frame_system::Trait>::Hash, <T as pallet_balances::Trait>::Balance {
-        FeeChanged(Hash, Balance),
-    }
+	pub enum Event<T> where <T as frame_system::Trait>::Hash, <T as pallet_balances::Trait>::Balance {
+		FeeChanged(Hash, Balance),
+	}
 );
 
 decl_module! {

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -1,10 +1,13 @@
 //! Some configurable implementations as associated type for the substrate runtime.
 
+use crate::{Authorship, Balances, MaximumBlockWeight, NegativeImbalance, System};
+use frame_support::{
+	traits::{Currency, Get, OnUnbalanced},
+	weights::Weight,
+};
 use node_primitives::Balance;
 use sp_runtime::traits::{Convert, Saturating};
 use sp_runtime::{Fixed64, Perbill};
-use frame_support::{traits::{OnUnbalanced, Currency, Get}, weights::Weight};
-use crate::{Balances, System, Authorship, MaximumBlockWeight, NegativeImbalance};
 
 pub struct Author;
 impl OnUnbalanced<NegativeImbalance> for Author {
@@ -18,15 +21,21 @@ impl OnUnbalanced<NegativeImbalance> for Author {
 pub struct CurrencyToVoteHandler;
 
 impl CurrencyToVoteHandler {
-	fn factor() -> Balance { (Balances::total_issuance() / u64::max_value() as Balance).max(1) }
+	fn factor() -> Balance {
+		(Balances::total_issuance() / u64::max_value() as Balance).max(1)
+	}
 }
 
 impl Convert<Balance, u64> for CurrencyToVoteHandler {
-	fn convert(x: Balance) -> u64 { (x / Self::factor()) as u64 }
+	fn convert(x: Balance) -> u64 {
+		(x / Self::factor()) as u64
+	}
 }
 
 impl Convert<u128, Balance> for CurrencyToVoteHandler {
-	fn convert(x: u128) -> Balance { x * Self::factor() }
+	fn convert(x: u128) -> Balance {
+		x * Self::factor()
+	}
 }
 
 /// Convert from weight to balance via a simple coefficient multiplication
@@ -85,7 +94,8 @@ impl<T: Get<Perbill>> Convert<Fixed64, Fixed64> for TargetedFeeAdjustment<T> {
 		} else {
 			// Proof: first_term > second_term. Safe subtraction.
 			let negative = first_term - second_term;
-			multiplier.saturating_sub(negative)
+			multiplier
+				.saturating_sub(negative)
 				// despite the fact that apply_to saturates weight (final fee cannot go below 0)
 				// it is crucially important to stop here and don't further reduce the weight fee
 				// multiplier. While at -1, it means that the network is so un-congested that all
@@ -99,10 +109,10 @@ impl<T: Get<Perbill>> Convert<Fixed64, Fixed64> for TargetedFeeAdjustment<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use sp_runtime::assert_eq_error_rate;
-	use crate::{MaximumBlockWeight, AvailableBlockRatio, Runtime};
-	use crate::{constants::currency::*, TransactionPayment, TargetBlockFullness};
+	use crate::{constants::currency::*, TargetBlockFullness, TransactionPayment};
+	use crate::{AvailableBlockRatio, MaximumBlockWeight, Runtime};
 	use frame_support::weights::Weight;
+	use sp_runtime::assert_eq_error_rate;
 
 	fn max() -> Weight {
 		MaximumBlockWeight::get()
@@ -113,7 +123,7 @@ mod tests {
 	}
 
 	// poc reference implementation.
-	fn fee_multiplier_update(block_weight: Weight, previous: Fixed64) -> Fixed64  {
+	fn fee_multiplier_update(block_weight: Weight, previous: Fixed64) -> Fixed64 {
 		let block_weight = block_weight as f32;
 		let v: f32 = 0.00004;
 
@@ -124,7 +134,7 @@ mod tests {
 		// Current saturation in terms of weight
 		let s = block_weight;
 
-		let fm = v * (s/m - ss/m) + v.powi(2) * (s/m - ss/m).powi(2) / 2.0;
+		let fm = v * (s / m - ss / m) + v.powi(2) * (s / m - ss / m).powi(2) / 2.0;
 		let addition_fm = Fixed64::from_parts((fm * 1_000_000_000_f32).round() as i64);
 		previous.saturating_add(addition_fm)
 	}
@@ -133,9 +143,14 @@ mod tests {
 		Fixed64::from_parts(parts)
 	}
 
-	fn run_with_system_weight<F>(w: Weight, assertions: F) where F: Fn() -> () {
-		let mut t: sp_io::TestExternalities =
-			frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap().into();
+	fn run_with_system_weight<F>(w: Weight, assertions: F)
+	where
+		F: Fn() -> (),
+	{
+		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap()
+			.into();
 		t.execute_with(|| {
 			System::set_block_limits(w, 0);
 			assertions()
@@ -173,11 +188,18 @@ mod tests {
 			loop {
 				let next = TargetedFeeAdjustment::<TargetBlockFullness>::convert(fm);
 				fm = next;
-				if fm == Fixed64::from_rational(-1, 1) { break; }
+				if fm == Fixed64::from_rational(-1, 1) {
+					break;
+				}
 				iterations += 1;
 			}
-			println!("iteration {}, new fm = {:?}. Weight fee is now zero", iterations, fm);
-			assert!(iterations > 50_000, "This assertion is just a warning; Don't panic. \
+			println!(
+				"iteration {}, new fm = {:?}. Weight fee is now zero",
+				iterations, fm
+			);
+			assert!(
+				iterations > 50_000,
+				"This assertion is just a warning; Don't panic. \
 				Current substrate/polkadot node are configured with a _slow adjusting fee_ \
 				mechanism. Hence, it is really unlikely that fees collapse to zero even on an \
 				empty chain in less than at least of couple of thousands of empty blocks. But this \
@@ -208,10 +230,13 @@ mod tests {
 			loop {
 				let next = TargetedFeeAdjustment::<TargetBlockFullness>::convert(fm);
 				// if no change, panic. This should never happen in this case.
-				if fm == next { panic!("The fee should ever increase"); }
+				if fm == next {
+					panic!("The fee should ever increase");
+				}
 				fm = next;
 				iterations += 1;
-				let fee = <Runtime as pallet_transaction_payment::Trait>::WeightToFee::convert(tx_weight);
+				let fee =
+					<Runtime as pallet_transaction_payment::Trait>::WeightToFee::convert(tx_weight);
 				let adjusted_fee = fm.saturated_multiply_accumulate(fee);
 				println!(
 					"iteration {}, new fm = {:?}. Fee at this point is: {} units / {} milli RAD, \
@@ -242,7 +267,6 @@ mod tests {
 				TargetedFeeAdjustment::<TargetBlockFullness>::convert(Fixed64::default()),
 				feemul(-5000),
 			);
-
 		});
 		run_with_system_weight(target(), || {
 			// ideal. Original fee. No changes.
@@ -325,9 +349,12 @@ mod tests {
 			10 * mb,
 			Weight::max_value() / 2,
 			Weight::max_value(),
-		].into_iter().for_each(|i| {
+		]
+		.into_iter()
+		.for_each(|i| {
 			run_with_system_weight(i, || {
-				let next = TargetedFeeAdjustment::<TargetBlockFullness>::convert(Fixed64::default());
+				let next =
+					TargetedFeeAdjustment::<TargetBlockFullness>::convert(Fixed64::default());
 				let truth = fee_multiplier_update(i, Fixed64::default());
 				assert_eq_error_rate!(truth.into_inner(), next.into_inner(), 5);
 			});
@@ -335,14 +362,12 @@ mod tests {
 
 		// Some values that are all above the target and will cause an increase.
 		let t = target();
-		vec![t + 100, t * 2, t * 4]
-			.into_iter()
-			.for_each(|i| {
-				run_with_system_weight(i, || {
-					let fm = TargetedFeeAdjustment::<TargetBlockFullness>::convert(max_fm);
-					// won't grow. The convert saturates everything.
-					assert_eq!(fm, max_fm);
-				})
-			});
+		vec![t + 100, t * 2, t * 4].into_iter().for_each(|i| {
+			run_with_system_weight(i, || {
+				let fm = TargetedFeeAdjustment::<TargetBlockFullness>::convert(max_fm);
+				// won't grow. The convert saturates everything.
+				assert_eq!(fm, max_fm);
+			})
+		});
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -548,7 +548,7 @@ construct_runtime!(
 		ImOnline: pallet_im_online::{Module, Call, Storage, Event<T>, ValidateUnsigned, Config<T>},
 		AuthorityDiscovery: pallet_authority_discovery::{Module, Call, Config},
 		Offences: pallet_offences::{Module, Call, Storage, Event},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
+		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
 		Anchor: anchor::{Module, Call, Storage},
 		Fees: fees::{Module, Call, Storage, Event<T>, Config<T>},
 		Nfts: nfts::{Module, Call, Event<T>},

--- a/runtime/src/nfts.rs
+++ b/runtime/src/nfts.rs
@@ -1,13 +1,13 @@
 use crate::{anchor, proofs, proofs::Proof};
 use frame_support::{
-    decl_event, decl_module, dispatch::DispatchResult, ensure, weights::SimpleDispatchInfo,
+	decl_event, decl_module, dispatch::DispatchResult, ensure, weights::SimpleDispatchInfo,
 };
 use frame_system::{self as system, ensure_signed};
 use sp_core::H256;
 use sp_std::vec::Vec;
 
 pub trait Trait: anchor::Trait {
-    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 }
 
 decl_event!(
@@ -17,358 +17,358 @@ decl_event!(
 );
 
 decl_module! {
-    pub struct Module<T: Trait> for enum Call where origin: T::Origin  {
-        fn deposit_event() = default;
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin  {
+		fn deposit_event() = default;
 
-        /// Validates the proofs provided against the document root associated with the anchor_id.
-        /// Once the proofs are verified, we create a bundled hash (deposit_address + [proof[i].hash])
-        /// Bundled Hash is deposited to an DepositAsset event for bridging purposes.
-        ///
-        /// # <weight>
-        /// - depends on the arguments
-        /// # </weight>
-        #[weight = SimpleDispatchInfo::FixedNormal(1_500_000)]
-        fn validate_mint(origin, anchor_id: T::Hash, deposit_address: [u8; 20], pfs: Vec<Proof>, static_proofs: [H256;3]) -> DispatchResult {
-            ensure_signed(origin)?;
+		/// Validates the proofs provided against the document root associated with the anchor_id.
+		/// Once the proofs are verified, we create a bundled hash (deposit_address + [proof[i].hash])
+		/// Bundled Hash is deposited to an DepositAsset event for bridging purposes.
+		///
+		/// # <weight>
+		/// - depends on the arguments
+		/// # </weight>
+		#[weight = SimpleDispatchInfo::FixedNormal(1_500_000)]
+		fn validate_mint(origin, anchor_id: T::Hash, deposit_address: [u8; 20], pfs: Vec<Proof>, static_proofs: [H256;3]) -> DispatchResult {
+			ensure_signed(origin)?;
 
-            // get the anchor data from anchor ID
-            let anchor_data = <anchor::Module<T>>::get_anchor_by_id(anchor_id).ok_or("Anchor doesn't exist")?;
+			// get the anchor data from anchor ID
+			let anchor_data = <anchor::Module<T>>::get_anchor_by_id(anchor_id).ok_or("Anchor doesn't exist")?;
 
-            // validate proofs
-            ensure!(Self::validate_proofs(anchor_data.doc_root, &pfs, static_proofs), "Invalid proofs");
+			// validate proofs
+			ensure!(Self::validate_proofs(anchor_data.doc_root, &pfs, static_proofs), "Invalid proofs");
 
-            // get the bundled hash
-            let bundled_hash = Self::get_bundled_hash(pfs, deposit_address);
+			// get the bundled hash
+			let bundled_hash = Self::get_bundled_hash(pfs, deposit_address);
 
-            Self::deposit_event(RawEvent::DepositAsset(bundled_hash));
+			Self::deposit_event(RawEvent::DepositAsset(bundled_hash));
 
-            Ok(())
-        }
-    }
+			Ok(())
+		}
+	}
 }
 
 impl<T: Trait> Module<T> {
-    /// Validates the proofs again the provided doc_root.
-    /// returns false if any proofs are invalid.
-    fn validate_proofs(doc_root: T::Hash, pfs: &Vec<Proof>, static_proofs: [H256; 3]) -> bool {
-        proofs::validate_proofs(H256::from_slice(doc_root.as_ref()), pfs, static_proofs)
-    }
+	/// Validates the proofs again the provided doc_root.
+	/// returns false if any proofs are invalid.
+	fn validate_proofs(doc_root: T::Hash, pfs: &Vec<Proof>, static_proofs: [H256; 3]) -> bool {
+		proofs::validate_proofs(H256::from_slice(doc_root.as_ref()), pfs, static_proofs)
+	}
 
-    /// Returns a Keccak hash of deposit_address + hash(keccak(name+value+salt)) of each proof provided.
-    fn get_bundled_hash(pfs: Vec<Proof>, deposit_address: [u8; 20]) -> T::Hash {
-        let bh = proofs::bundled_hash(pfs, deposit_address);
-        let mut res: T::Hash = Default::default();
-        res.as_mut().copy_from_slice(&bh[..]);
-        res
-    }
+	/// Returns a Keccak hash of deposit_address + hash(keccak(name+value+salt)) of each proof provided.
+	fn get_bundled_hash(pfs: Vec<Proof>, deposit_address: [u8; 20]) -> T::Hash {
+		let bh = proofs::bundled_hash(pfs, deposit_address);
+		let mut res: T::Hash = Default::default();
+		res.as_mut().copy_from_slice(&bh[..]);
+		res
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    use crate::common;
-    use crate::fees;
-    use crate::proofs::Proof;
-    use codec::Encode;
-    use frame_support::{
-        assert_err, assert_ok, impl_outer_origin, parameter_types, weights::Weight,
-    };
-    use sp_core::H256;
-    use sp_runtime::{
-        testing::Header,
-        traits::{BadOrigin, BlakeTwo256, Hash, IdentityLookup},
-        Perbill,
-    };
+	use crate::common;
+	use crate::fees;
+	use crate::proofs::Proof;
+	use codec::Encode;
+	use frame_support::{
+		assert_err, assert_ok, impl_outer_origin, parameter_types, weights::Weight,
+	};
+	use sp_core::H256;
+	use sp_runtime::{
+		testing::Header,
+		traits::{BadOrigin, BlakeTwo256, Hash, IdentityLookup},
+		Perbill,
+	};
 
-    impl_outer_origin! {
-        pub enum Origin for Test {}
-    }
+	impl_outer_origin! {
+		pub enum Origin for Test {}
+	}
 
-    #[derive(Clone, Eq, PartialEq)]
-    pub struct Test;
+	#[derive(Clone, Eq, PartialEq)]
+	pub struct Test;
 
-    type Nfts = super::Module<Test>;
-    type Anchor = anchor::Module<Test>;
+	type Nfts = super::Module<Test>;
+	type Anchor = anchor::Module<Test>;
 
-    parameter_types! {
-        pub const BlockHashCount: u64 = 250;
-        pub const MaximumBlockWeight: Weight = 1024;
-        pub const MaximumBlockLength: u32 = 2 * 1024;
-        pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
-    }
+	parameter_types! {
+		pub const BlockHashCount: u64 = 250;
+		pub const MaximumBlockWeight: Weight = 1024;
+		pub const MaximumBlockLength: u32 = 2 * 1024;
+		pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	}
 
-    impl frame_system::Trait for Test {
-        type AccountId = u64;
-        type Call = ();
-        type Lookup = IdentityLookup<Self::AccountId>;
-        type Index = u64;
-        type BlockNumber = u64;
-        type Hash = H256;
-        type Hashing = BlakeTwo256;
-        type Header = Header;
-        type Event = ();
-        type Origin = Origin;
-        type BlockHashCount = BlockHashCount;
-        type MaximumBlockWeight = MaximumBlockWeight;
-        type MaximumBlockLength = MaximumBlockLength;
-        type AvailableBlockRatio = AvailableBlockRatio;
-        type Version = ();
-        type ModuleToIndex = ();
-        type AccountData = pallet_balances::AccountData<u64>;
-        type OnNewAccount = ();
-        type OnKilledAccount = pallet_balances::Module<Test>;
-    }
+	impl frame_system::Trait for Test {
+		type AccountId = u64;
+		type Call = ();
+		type Lookup = IdentityLookup<Self::AccountId>;
+		type Index = u64;
+		type BlockNumber = u64;
+		type Hash = H256;
+		type Hashing = BlakeTwo256;
+		type Header = Header;
+		type Event = ();
+		type Origin = Origin;
+		type BlockHashCount = BlockHashCount;
+		type MaximumBlockWeight = MaximumBlockWeight;
+		type MaximumBlockLength = MaximumBlockLength;
+		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
+		type ModuleToIndex = ();
+		type AccountData = pallet_balances::AccountData<u64>;
+		type OnNewAccount = ();
+		type OnKilledAccount = pallet_balances::Module<Test>;
+	}
 
-    impl anchor::Trait for Test {}
+	impl anchor::Trait for Test {}
 
-    impl Trait for Test {
-        type Event = ();
-    }
+	impl Trait for Test {
+		type Event = ();
+	}
 
-    impl pallet_timestamp::Trait for Test {
-        type Moment = u64;
-        type OnTimestampSet = ();
-        type MinimumPeriod = ();
-    }
+	impl pallet_timestamp::Trait for Test {
+		type Moment = u64;
+		type OnTimestampSet = ();
+		type MinimumPeriod = ();
+	}
 
-    impl pallet_authorship::Trait for Test {
-        type FindAuthor = ();
-        type UncleGenerations = ();
-        type FilterUncle = ();
-        type EventHandler = ();
-    }
+	impl pallet_authorship::Trait for Test {
+		type FindAuthor = ();
+		type UncleGenerations = ();
+		type FilterUncle = ();
+		type EventHandler = ();
+	}
 
-    impl fees::Trait for Test {
-        type Event = ();
-        type FeeChangeOrigin = frame_system::EnsureRoot<u64>;
-    }
+	impl fees::Trait for Test {
+		type Event = ();
+		type FeeChangeOrigin = frame_system::EnsureRoot<u64>;
+	}
 
-    parameter_types! {
-        pub const ExistentialDeposit: u64 = 1;
-    }
-    impl pallet_balances::Trait for Test {
-        type Balance = u64;
-        type DustRemoval = ();
-        type Event = ();
-        type ExistentialDeposit = ExistentialDeposit;
-        type AccountStore = System;
-    }
+	parameter_types! {
+		pub const ExistentialDeposit: u64 = 1;
+	}
+	impl pallet_balances::Trait for Test {
+		type Balance = u64;
+		type DustRemoval = ();
+		type Event = ();
+		type ExistentialDeposit = ExistentialDeposit;
+		type AccountStore = System;
+	}
 
-    type System = frame_system::Module<Test>;
+	type System = frame_system::Module<Test>;
 
-    fn new_test_ext() -> sp_io::TestExternalities {
-        let mut t = frame_system::GenesisConfig::default()
-            .build_storage::<Test>()
-            .unwrap();
-        fees::GenesisConfig::<Test> {
-            initial_fees: vec![(
-                // anchoring state rent fee per day
-                H256::from(&[
-                    17, 218, 109, 31, 118, 29, 223, 155, 219, 76, 157, 110, 83, 3, 235, 212, 31,
-                    97, 133, 141, 10, 86, 71, 161, 167, 191, 224, 137, 191, 146, 27, 233,
-                ]),
-                // state rent 0 for tests
-                0,
-            )],
-        }
-        .assimilate_storage(&mut t)
-        .unwrap();
-        t.into()
-    }
+	fn new_test_ext() -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Test>()
+			.unwrap();
+		fees::GenesisConfig::<Test> {
+			initial_fees: vec![(
+				// anchoring state rent fee per day
+				H256::from(&[
+					17, 218, 109, 31, 118, 29, 223, 155, 219, 76, 157, 110, 83, 3, 235, 212, 31,
+					97, 133, 141, 10, 86, 71, 161, 167, 191, 224, 137, 191, 146, 27, 233,
+				]),
+				// state rent 0 for tests
+				0,
+			)],
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+		t.into()
+	}
 
-    fn get_invalid_proof() -> (Proof, H256, [H256; 3]) {
-        let proof = Proof::new(
-            [
-                1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
-                37, 85, 23, 189, 20, 48, 97, 34, 3, 169, 157, 88, 159,
-            ]
-            .into(),
-            vec![
-                [
-                    113, 229, 58, 22, 178, 220, 200, 69, 191, 246, 171, 254, 8, 183, 211, 75, 54,
-                    22, 224, 197, 170, 112, 248, 56, 10, 176, 17, 205, 86, 130, 233, 16,
-                ]
-                .into(),
-                [
-                    133, 11, 212, 75, 212, 65, 247, 178, 200, 157, 5, 39, 57, 135, 63, 126, 166,
-                    92, 23, 170, 4, 155, 223, 237, 50, 237, 43, 101, 180, 104, 126, 84,
-                ]
-                .into(),
-            ],
-        );
+	fn get_invalid_proof() -> (Proof, H256, [H256; 3]) {
+		let proof = Proof::new(
+			[
+				1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
+				37, 85, 23, 189, 20, 48, 97, 34, 3, 169, 157, 88, 159,
+			]
+			.into(),
+			vec![
+				[
+					113, 229, 58, 22, 178, 220, 200, 69, 191, 246, 171, 254, 8, 183, 211, 75, 54,
+					22, 224, 197, 170, 112, 248, 56, 10, 176, 17, 205, 86, 130, 233, 16,
+				]
+				.into(),
+				[
+					133, 11, 212, 75, 212, 65, 247, 178, 200, 157, 5, 39, 57, 135, 63, 126, 166,
+					92, 23, 170, 4, 155, 223, 237, 50, 237, 43, 101, 180, 104, 126, 84,
+				]
+				.into(),
+			],
+		);
 
-        let doc_root: H256 = [
-            48, 123, 58, 192, 8, 62, 20, 55, 99, 52, 37, 73, 174, 123, 214, 104, 37, 41, 189, 170,
-            205, 80, 158, 136, 224, 128, 128, 89, 55, 240, 32, 234,
-        ]
-        .into();
+		let doc_root: H256 = [
+			48, 123, 58, 192, 8, 62, 20, 55, 99, 52, 37, 73, 174, 123, 214, 104, 37, 41, 189, 170,
+			205, 80, 158, 136, 224, 128, 128, 89, 55, 240, 32, 234,
+		]
+		.into();
 
-        let static_proofs: [H256; 3] = [
-            [
-                25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175,
-                70, 161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
-            ]
-            .into(),
-            [
-                61, 164, 199, 22, 164, 251, 58, 14, 67, 56, 242, 60, 86, 203, 128, 203, 138, 129,
-                237, 7, 29, 7, 39, 58, 250, 42, 14, 53, 241, 108, 187, 74,
-            ]
-            .into(),
-            [
-                70, 124, 133, 120, 103, 45, 94, 174, 176, 18, 151, 243, 104, 120, 12, 54, 217, 189,
-                59, 222, 109, 64, 136, 203, 56, 136, 159, 115, 96, 101, 2, 185,
-            ]
-            .into(),
-        ];
+		let static_proofs: [H256; 3] = [
+			[
+				25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175,
+				70, 161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
+			]
+			.into(),
+			[
+				61, 164, 199, 22, 164, 251, 58, 14, 67, 56, 242, 60, 86, 203, 128, 203, 138, 129,
+				237, 7, 29, 7, 39, 58, 250, 42, 14, 53, 241, 108, 187, 74,
+			]
+			.into(),
+			[
+				70, 124, 133, 120, 103, 45, 94, 174, 176, 18, 151, 243, 104, 120, 12, 54, 217, 189,
+				59, 222, 109, 64, 136, 203, 56, 136, 159, 115, 96, 101, 2, 185,
+			]
+			.into(),
+		];
 
-        (proof, doc_root, static_proofs)
-    }
+		(proof, doc_root, static_proofs)
+	}
 
-    fn get_valid_proof() -> (Proof, sp_core::H256, [H256; 3]) {
-        let proof = Proof::new(
-            [
-                1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
-                37, 85, 23, 189, 209, 48, 97, 34, 3, 169, 157, 88, 159,
-            ]
-            .into(),
-            vec![
-                [
-                    113, 229, 58, 223, 178, 220, 200, 69, 191, 246, 171, 254, 8, 183, 211, 75, 54,
-                    223, 224, 197, 170, 112, 248, 56, 10, 176, 17, 205, 86, 130, 233, 16,
-                ]
-                .into(),
-                [
-                    133, 11, 212, 75, 212, 65, 247, 178, 200, 157, 5, 39, 57, 135, 63, 126, 166,
-                    92, 232, 170, 46, 155, 223, 237, 50, 237, 43, 101, 180, 104, 126, 84,
-                ]
-                .into(),
-                [
-                    197, 248, 165, 165, 247, 119, 114, 231, 95, 114, 94, 16, 66, 142, 230, 184, 78,
-                    203, 73, 104, 24, 82, 134, 154, 180, 129, 71, 223, 72, 31, 230, 15,
-                ]
-                .into(),
-                [
-                    50, 5, 28, 219, 118, 141, 222, 221, 133, 174, 178, 212, 71, 94, 64, 44, 80,
-                    218, 29, 92, 77, 40, 241, 16, 126, 48, 119, 31, 6, 147, 224, 5,
-                ]
-                .into(),
-            ],
-        );
+	fn get_valid_proof() -> (Proof, sp_core::H256, [H256; 3]) {
+		let proof = Proof::new(
+			[
+				1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
+				37, 85, 23, 189, 209, 48, 97, 34, 3, 169, 157, 88, 159,
+			]
+			.into(),
+			vec![
+				[
+					113, 229, 58, 223, 178, 220, 200, 69, 191, 246, 171, 254, 8, 183, 211, 75, 54,
+					223, 224, 197, 170, 112, 248, 56, 10, 176, 17, 205, 86, 130, 233, 16,
+				]
+				.into(),
+				[
+					133, 11, 212, 75, 212, 65, 247, 178, 200, 157, 5, 39, 57, 135, 63, 126, 166,
+					92, 232, 170, 46, 155, 223, 237, 50, 237, 43, 101, 180, 104, 126, 84,
+				]
+				.into(),
+				[
+					197, 248, 165, 165, 247, 119, 114, 231, 95, 114, 94, 16, 66, 142, 230, 184, 78,
+					203, 73, 104, 24, 82, 134, 154, 180, 129, 71, 223, 72, 31, 230, 15,
+				]
+				.into(),
+				[
+					50, 5, 28, 219, 118, 141, 222, 221, 133, 174, 178, 212, 71, 94, 64, 44, 80,
+					218, 29, 92, 77, 40, 241, 16, 126, 48, 119, 31, 6, 147, 224, 5,
+				]
+				.into(),
+			],
+		);
 
-        let doc_root: H256 = [
-            48, 123, 58, 192, 8, 62, 20, 55, 99, 52, 37, 73, 174, 123, 214, 104, 37, 41, 189, 170,
-            205, 80, 158, 136, 224, 128, 128, 89, 55, 240, 32, 234,
-        ]
-        .into();
+		let doc_root: H256 = [
+			48, 123, 58, 192, 8, 62, 20, 55, 99, 52, 37, 73, 174, 123, 214, 104, 37, 41, 189, 170,
+			205, 80, 158, 136, 224, 128, 128, 89, 55, 240, 32, 234,
+		]
+		.into();
 
-        let static_proofs: [H256; 3] = [
-            [
-                25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175,
-                70, 161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
-            ]
-            .into(),
-            [
-                61, 164, 199, 22, 164, 251, 58, 14, 67, 56, 242, 60, 86, 203, 128, 203, 138, 129,
-                237, 7, 29, 7, 39, 58, 250, 42, 14, 53, 241, 108, 187, 74,
-            ]
-            .into(),
-            [
-                70, 124, 133, 120, 103, 45, 94, 174, 176, 18, 151, 243, 104, 120, 12, 54, 217, 189,
-                59, 222, 109, 64, 136, 203, 56, 136, 159, 115, 96, 101, 2, 185,
-            ]
-            .into(),
-        ];
+		let static_proofs: [H256; 3] = [
+			[
+				25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175,
+				70, 161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
+			]
+			.into(),
+			[
+				61, 164, 199, 22, 164, 251, 58, 14, 67, 56, 242, 60, 86, 203, 128, 203, 138, 129,
+				237, 7, 29, 7, 39, 58, 250, 42, 14, 53, 241, 108, 187, 74,
+			]
+			.into(),
+			[
+				70, 124, 133, 120, 103, 45, 94, 174, 176, 18, 151, 243, 104, 120, 12, 54, 217, 189,
+				59, 222, 109, 64, 136, 203, 56, 136, 159, 115, 96, 101, 2, 185,
+			]
+			.into(),
+		];
 
-        (proof, doc_root, static_proofs)
-    }
+		(proof, doc_root, static_proofs)
+	}
 
-    fn get_params() -> (sp_core::H256, [u8; 20], Vec<Proof>, [H256; 3]) {
-        let anchor_id = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-        let deposit_address: [u8; 20] = [0; 20];
-        let pfs: Vec<Proof> = vec![];
-        let static_proofs: [H256; 3] = [[0; 32].into(), [0; 32].into(), [0; 32].into()];
-        (anchor_id, deposit_address, pfs, static_proofs)
-    }
+	fn get_params() -> (sp_core::H256, [u8; 20], Vec<Proof>, [H256; 3]) {
+		let anchor_id = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+		let deposit_address: [u8; 20] = [0; 20];
+		let pfs: Vec<Proof> = vec![];
+		let static_proofs: [H256; 3] = [[0; 32].into(), [0; 32].into(), [0; 32].into()];
+		(anchor_id, deposit_address, pfs, static_proofs)
+	}
 
-    #[test]
-    fn bad_origin() {
-        new_test_ext().execute_with(|| {
-            let (anchor_id, deposit_address, pfs, static_proofs) = get_params();
-            assert_err!(
-                Nfts::validate_mint(Origin::NONE, anchor_id, deposit_address, pfs, static_proofs),
-                BadOrigin
-            );
-        })
-    }
+	#[test]
+	fn bad_origin() {
+		new_test_ext().execute_with(|| {
+			let (anchor_id, deposit_address, pfs, static_proofs) = get_params();
+			assert_err!(
+				Nfts::validate_mint(Origin::NONE, anchor_id, deposit_address, pfs, static_proofs),
+				BadOrigin
+			);
+		})
+	}
 
-    #[test]
-    fn missing_anchor() {
-        new_test_ext().execute_with(|| {
-            let (anchor_id, deposit_address, pfs, static_proofs) = get_params();
-            assert_err!(
-                Nfts::validate_mint(
-                    Origin::signed(1),
-                    anchor_id,
-                    deposit_address,
-                    pfs,
-                    static_proofs
-                ),
-                "Anchor doesn't exist"
-            );
-        })
-    }
+	#[test]
+	fn missing_anchor() {
+		new_test_ext().execute_with(|| {
+			let (anchor_id, deposit_address, pfs, static_proofs) = get_params();
+			assert_err!(
+				Nfts::validate_mint(
+					Origin::signed(1),
+					anchor_id,
+					deposit_address,
+					pfs,
+					static_proofs
+				),
+				"Anchor doesn't exist"
+			);
+		})
+	}
 
-    #[test]
-    fn invalid_proof() {
-        new_test_ext().execute_with(|| {
-            let deposit_address: [u8; 20] = [0; 20];
-            let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-            let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            let (pf, doc_root, static_proofs) = get_invalid_proof();
-            assert_ok!(Anchor::commit(
-                Origin::signed(2),
-                pre_image,
-                doc_root,
-                <Test as frame_system::Trait>::Hashing::hash_of(&0),
-                common::MS_PER_DAY + 1
-            ));
+	#[test]
+	fn invalid_proof() {
+		new_test_ext().execute_with(|| {
+			let deposit_address: [u8; 20] = [0; 20];
+			let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+			let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			let (pf, doc_root, static_proofs) = get_invalid_proof();
+			assert_ok!(Anchor::commit(
+				Origin::signed(2),
+				pre_image,
+				doc_root,
+				<Test as frame_system::Trait>::Hashing::hash_of(&0),
+				common::MS_PER_DAY + 1
+			));
 
-            assert_err!(
-                Nfts::validate_mint(
-                    Origin::signed(1),
-                    anchor_id,
-                    deposit_address,
-                    vec![pf],
-                    static_proofs
-                ),
-                "Invalid proofs"
-            );
-        })
-    }
+			assert_err!(
+				Nfts::validate_mint(
+					Origin::signed(1),
+					anchor_id,
+					deposit_address,
+					vec![pf],
+					static_proofs
+				),
+				"Invalid proofs"
+			);
+		})
+	}
 
-    #[test]
-    fn valid_proof() {
-        new_test_ext().execute_with(|| {
-            let deposit_address: [u8; 20] = [0; 20];
-            let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
-            let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
-            let (pf, doc_root, static_proofs) = get_valid_proof();
-            assert_ok!(Anchor::commit(
-                Origin::signed(2),
-                pre_image,
-                doc_root,
-                <Test as frame_system::Trait>::Hashing::hash_of(&0),
-                common::MS_PER_DAY + 1
-            ));
+	#[test]
+	fn valid_proof() {
+		new_test_ext().execute_with(|| {
+			let deposit_address: [u8; 20] = [0; 20];
+			let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
+			let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
+			let (pf, doc_root, static_proofs) = get_valid_proof();
+			assert_ok!(Anchor::commit(
+				Origin::signed(2),
+				pre_image,
+				doc_root,
+				<Test as frame_system::Trait>::Hashing::hash_of(&0),
+				common::MS_PER_DAY + 1
+			));
 
-            assert_ok!(Nfts::validate_mint(
-                Origin::signed(1),
-                anchor_id,
-                deposit_address,
-                vec![pf],
-                static_proofs
-            ),);
-        })
-    }
+			assert_ok!(Nfts::validate_mint(
+				Origin::signed(1),
+				anchor_id,
+				deposit_address,
+				vec![pf],
+				static_proofs
+			),);
+		})
+	}
 }

--- a/runtime/src/nfts.rs
+++ b/runtime/src/nfts.rs
@@ -11,9 +11,9 @@ pub trait Trait: anchor::Trait {
 }
 
 decl_event!(
-    pub enum Event<T> where <T as frame_system::Trait>::Hash {
-        DepositAsset(Hash),
-    }
+	pub enum Event<T> where <T as frame_system::Trait>::Hash {
+		DepositAsset(Hash),
+	}
 );
 
 decl_module! {

--- a/runtime/src/proofs.rs
+++ b/runtime/src/proofs.rs
@@ -6,17 +6,17 @@ use sp_std::vec::Vec;
 #[cfg_attr(not(feature = "std"), derive(sp_runtime::RuntimeDebug))]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Proof {
-    pub leaf_hash: H256,
-    sorted_hashes: Vec<H256>,
+	pub leaf_hash: H256,
+	sorted_hashes: Vec<H256>,
 }
 
 impl Proof {
-    pub fn new(hash: H256, sorted_hashes: Vec<H256>) -> Self {
-        Self {
-            leaf_hash: hash,
-            sorted_hashes,
-        }
-    }
+	pub fn new(hash: H256, sorted_hashes: Vec<H256>) -> Self {
+		Self {
+			leaf_hash: hash,
+			sorted_hashes,
+		}
+	}
 }
 
 /// Validates each proof and return true if all the proofs are valid else returns false
@@ -33,43 +33,43 @@ impl Proof {
 /// reference anchor. static proofs are used to computed the pre computed hashes and the result is
 /// checked against document root provided.
 pub fn validate_proofs(doc_root: H256, proofs: &Vec<Proof>, static_proofs: [H256; 3]) -> bool {
-    if proofs.len() < 1 {
-        return false;
-    }
+	if proofs.len() < 1 {
+		return false;
+	}
 
-    let (valid, mut matches) = pre_matches(static_proofs, doc_root);
-    if !valid {
-        return false;
-    }
+	let (valid, mut matches) = pre_matches(static_proofs, doc_root);
+	if !valid {
+		return false;
+	}
 
-    return proofs
-        .iter()
-        .map(|proof| validate_proof(&mut matches, proof.leaf_hash, proof.sorted_hashes.clone()))
-        .fold(true, |acc, b| acc && b);
+	return proofs
+		.iter()
+		.map(|proof| validate_proof(&mut matches, proof.leaf_hash, proof.sorted_hashes.clone()))
+		.fold(true, |acc, b| acc && b);
 }
 
 // computes blake2 256 sorted hash of the a and b
 // if a < b: blake256(a+b)
 // else: blake256(b+a)
 fn sort_hash_of(a: H256, b: H256) -> H256 {
-    let mut h: Vec<u8> = Vec::with_capacity(64);
-    if a < b {
-        h.extend_from_slice(&a[..]);
-        h.extend_from_slice(&b[..]);
-    } else {
-        h.extend_from_slice(&b[..]);
-        h.extend_from_slice(&a[..]);
-    }
+	let mut h: Vec<u8> = Vec::with_capacity(64);
+	if a < b {
+		h.extend_from_slice(&a[..]);
+		h.extend_from_slice(&b[..]);
+	} else {
+		h.extend_from_slice(&b[..]);
+		h.extend_from_slice(&a[..]);
+	}
 
-    sp_io::hashing::blake2_256(&h).into()
+	sp_io::hashing::blake2_256(&h).into()
 }
 
 // computes blake2 256 hash of the a + b
 fn hash_of(a: H256, b: H256) -> H256 {
-    let mut h: Vec<u8> = Vec::with_capacity(64);
-    h.extend_from_slice(&a[..]);
-    h.extend_from_slice(&b[..]);
-    sp_io::hashing::blake2_256(&h).into()
+	let mut h: Vec<u8> = Vec::with_capacity(64);
+	h.extend_from_slice(&a[..]);
+	h.extend_from_slice(&b[..]);
+	sp_io::hashing::blake2_256(&h).into()
 }
 
 // validates the proof by computing a sorted hash of the provided proofs with hash as initial value.
@@ -77,22 +77,22 @@ fn hash_of(a: H256, b: H256) -> H256 {
 // Validation stops as soon as the any computed hash is found in the matches.
 // if no computed hash is found in the matches, validation fails.
 fn validate_proof(matches: &mut Vec<H256>, hash: H256, proofs: Vec<H256>) -> bool {
-    // if hash is already cached earlier
-    if matches.contains(&hash) {
-        return true;
-    }
+	// if hash is already cached earlier
+	if matches.contains(&hash) {
+		return true;
+	}
 
-    let mut hash = hash;
-    for proof in proofs.into_iter() {
-        matches.push(proof);
-        hash = sort_hash_of(hash, proof);
-        if matches.contains(&hash) {
-            return true;
-        }
-        matches.push(hash)
-    }
+	let mut hash = hash;
+	for proof in proofs.into_iter() {
+		matches.push(proof);
+		hash = sort_hash_of(hash, proof);
+		if matches.contains(&hash) {
+			return true;
+		}
+		matches.push(hash)
+	}
 
-    false
+	false
 }
 
 // pre_matches takes 3 static proofs and calculate document root.
@@ -108,289 +108,289 @@ fn validate_proof(matches: &mut Vec<H256>, hash: H256, proofs: Vec<H256>) -> boo
 //          /          \
 //   data root 1     data root 2
 fn pre_matches(static_proofs: [H256; 3], doc_root: H256) -> (bool, Vec<H256>) {
-    let mut matches = Vec::new();
-    let basic_data_root = static_proofs[0];
-    let zk_data_root = static_proofs[1];
-    let signature_root = static_proofs[2];
-    matches.push(basic_data_root);
-    matches.push(zk_data_root);
-    let signing_root = hash_of(basic_data_root, zk_data_root);
-    matches.push(signing_root);
-    matches.push(signature_root);
-    let calc_doc_root = hash_of(signing_root, signature_root);
-    matches.push(calc_doc_root);
-    (calc_doc_root == doc_root, matches)
+	let mut matches = Vec::new();
+	let basic_data_root = static_proofs[0];
+	let zk_data_root = static_proofs[1];
+	let signature_root = static_proofs[2];
+	matches.push(basic_data_root);
+	matches.push(zk_data_root);
+	let signing_root = hash_of(basic_data_root, zk_data_root);
+	matches.push(signing_root);
+	matches.push(signature_root);
+	let calc_doc_root = hash_of(signing_root, signature_root);
+	matches.push(calc_doc_root);
+	(calc_doc_root == doc_root, matches)
 }
 
 // appends deposit_address and all the hashes from the proofs and returns keccak hash of the result.
 pub fn bundled_hash(proofs: Vec<Proof>, deposit_address: [u8; 20]) -> H256 {
-    let hash = proofs
-        .into_iter()
-        .fold(deposit_address.to_vec(), |mut acc, proof: Proof| {
-            acc.extend_from_slice(&proof.leaf_hash[..]);
-            acc
-        });
+	let hash = proofs
+		.into_iter()
+		.fold(deposit_address.to_vec(), |mut acc, proof: Proof| {
+			acc.extend_from_slice(&proof.leaf_hash[..]);
+			acc
+		});
 
-    sp_io::hashing::keccak_256(hash.as_slice()).into()
+	sp_io::hashing::keccak_256(hash.as_slice()).into()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::proofs::{
-        bundled_hash, pre_matches, sort_hash_of, validate_proof, validate_proofs, Proof,
-    };
-    use sp_core::H256;
+	use crate::proofs::{
+		bundled_hash, pre_matches, sort_hash_of, validate_proof, validate_proofs, Proof,
+	};
+	use sp_core::H256;
 
-    fn proof_from_hash(a: H256) -> Proof {
-        Proof {
-            leaf_hash: a,
-            sorted_hashes: Vec::new(),
-        }
-    }
+	fn proof_from_hash(a: H256) -> Proof {
+		Proof {
+			leaf_hash: a,
+			sorted_hashes: Vec::new(),
+		}
+	}
 
-    #[test]
-    fn hash_of_a_lt_b() {
-        let a: H256 = [
-            85, 191, 116, 245, 55, 139, 29, 147, 139, 183, 161, 63, 60, 101, 130, 105, 30, 215,
-            162, 223, 133, 233, 58, 181, 111, 161, 24, 186, 201, 162, 18, 68,
-        ]
-        .into();
-        let b: H256 = [
-            126, 71, 93, 133, 114, 129, 33, 224, 177, 195, 218, 219, 37, 144, 248, 166, 154, 234,
-            111, 197, 57, 209, 116, 232, 90, 189, 173, 122, 131, 190, 143, 142,
-        ]
-        .into();
-        let res: H256 = [
-            29, 106, 103, 53, 85, 94, 151, 152, 97, 33, 199, 77, 199, 229, 218, 111, 251, 9, 138,
-            235, 120, 71, 98, 105, 91, 212, 180, 209, 164, 91, 87, 156,
-        ]
-        .into();
-        let got = sort_hash_of(a, b);
-        assert!(res == got, "{:?} {:?}", res, got)
-    }
+	#[test]
+	fn hash_of_a_lt_b() {
+		let a: H256 = [
+			85, 191, 116, 245, 55, 139, 29, 147, 139, 183, 161, 63, 60, 101, 130, 105, 30, 215,
+			162, 223, 133, 233, 58, 181, 111, 161, 24, 186, 201, 162, 18, 68,
+		]
+		.into();
+		let b: H256 = [
+			126, 71, 93, 133, 114, 129, 33, 224, 177, 195, 218, 219, 37, 144, 248, 166, 154, 234,
+			111, 197, 57, 209, 116, 232, 90, 189, 173, 122, 131, 190, 143, 142,
+		]
+		.into();
+		let res: H256 = [
+			29, 106, 103, 53, 85, 94, 151, 152, 97, 33, 199, 77, 199, 229, 218, 111, 251, 9, 138,
+			235, 120, 71, 98, 105, 91, 212, 180, 209, 164, 91, 87, 156,
+		]
+		.into();
+		let got = sort_hash_of(a, b);
+		assert!(res == got, "{:?} {:?}", res, got)
+	}
 
-    #[test]
-    fn hash_of_a_ge_b() {
-        let a: H256 = [
-            195, 54, 245, 186, 28, 27, 161, 155, 121, 162, 87, 70, 124, 245, 203, 204, 222, 221,
-            76, 181, 36, 224, 146, 47, 121, 48, 61, 76, 41, 196, 214, 202,
-        ]
-        .into();
-        let b: H256 = [
-            28, 155, 171, 103, 166, 215, 230, 103, 16, 241, 86, 246, 149, 196, 131, 65, 159, 211,
-            236, 57, 178, 89, 170, 125, 116, 181, 197, 170, 8, 84, 41, 159,
-        ]
-        .into();
-        let res: H256 = [
-            237, 165, 215, 95, 110, 141, 136, 232, 17, 105, 160, 71, 23, 210, 172, 113, 170, 84,
-            158, 210, 122, 74, 55, 7, 101, 217, 146, 206, 194, 114, 79, 169,
-        ]
-        .into();
-        let got = sort_hash_of(a, b);
-        assert!(res == got, "{:?} {:?}", res, got)
-    }
+	#[test]
+	fn hash_of_a_ge_b() {
+		let a: H256 = [
+			195, 54, 245, 186, 28, 27, 161, 155, 121, 162, 87, 70, 124, 245, 203, 204, 222, 221,
+			76, 181, 36, 224, 146, 47, 121, 48, 61, 76, 41, 196, 214, 202,
+		]
+		.into();
+		let b: H256 = [
+			28, 155, 171, 103, 166, 215, 230, 103, 16, 241, 86, 246, 149, 196, 131, 65, 159, 211,
+			236, 57, 178, 89, 170, 125, 116, 181, 197, 170, 8, 84, 41, 159,
+		]
+		.into();
+		let res: H256 = [
+			237, 165, 215, 95, 110, 141, 136, 232, 17, 105, 160, 71, 23, 210, 172, 113, 170, 84,
+			158, 210, 122, 74, 55, 7, 101, 217, 146, 206, 194, 114, 79, 169,
+		]
+		.into();
+		let got = sort_hash_of(a, b);
+		assert!(res == got, "{:?} {:?}", res, got)
+	}
 
-    #[test]
-    fn bundled_hash_with_leaves() {
-        let proofs: Vec<Proof> = vec![
-            proof_from_hash(
-                [
-                    103, 46, 60, 60, 148, 2, 8, 108, 29, 15, 111, 98, 88, 90, 56, 3, 57, 124, 5,
-                    25, 100, 82, 231, 99, 186, 115, 165, 102, 22, 245, 83, 147,
-                ]
-                .into(),
-            ),
-            proof_from_hash(
-                [
-                    112, 102, 224, 155, 227, 136, 160, 106, 127, 252, 25, 95, 234, 206, 155, 3,
-                    237, 180, 242, 172, 240, 225, 85, 46, 125, 73, 42, 225, 214, 242, 239, 184,
-                ]
-                .into(),
-            ),
-            proof_from_hash(
-                [
-                    131, 137, 170, 250, 176, 243, 90, 79, 242, 135, 64, 183, 249, 106, 200, 177,
-                    96, 105, 70, 38, 50, 221, 139, 175, 247, 161, 201, 31, 71, 169, 101, 114,
-                ]
-                .into(),
-            ),
-            proof_from_hash(
-                [
-                    181, 110, 49, 204, 113, 201, 241, 253, 213, 177, 124, 217, 157, 68, 43, 8, 157,
-                    127, 218, 194, 90, 40, 153, 33, 125, 155, 10, 73, 20, 173, 89, 193,
-                ]
-                .into(),
-            ),
-        ];
+	#[test]
+	fn bundled_hash_with_leaves() {
+		let proofs: Vec<Proof> = vec![
+			proof_from_hash(
+				[
+					103, 46, 60, 60, 148, 2, 8, 108, 29, 15, 111, 98, 88, 90, 56, 3, 57, 124, 5,
+					25, 100, 82, 231, 99, 186, 115, 165, 102, 22, 245, 83, 147,
+				]
+				.into(),
+			),
+			proof_from_hash(
+				[
+					112, 102, 224, 155, 227, 136, 160, 106, 127, 252, 25, 95, 234, 206, 155, 3,
+					237, 180, 242, 172, 240, 225, 85, 46, 125, 73, 42, 225, 214, 242, 239, 184,
+				]
+				.into(),
+			),
+			proof_from_hash(
+				[
+					131, 137, 170, 250, 176, 243, 90, 79, 242, 135, 64, 183, 249, 106, 200, 177,
+					96, 105, 70, 38, 50, 221, 139, 175, 247, 161, 201, 31, 71, 169, 101, 114,
+				]
+				.into(),
+			),
+			proof_from_hash(
+				[
+					181, 110, 49, 204, 113, 201, 241, 253, 213, 177, 124, 217, 157, 68, 43, 8, 157,
+					127, 218, 194, 90, 40, 153, 33, 125, 155, 10, 73, 20, 173, 89, 193,
+				]
+				.into(),
+			),
+		];
 
-        let deposit_address = [
-            75, 151, 92, 119, 170, 193, 75, 255, 44, 88, 202, 225, 39, 220, 51, 9, 230, 2, 121, 129,
-        ];
+		let deposit_address = [
+			75, 151, 92, 119, 170, 193, 75, 255, 44, 88, 202, 225, 39, 220, 51, 9, 230, 2, 121, 129,
+		];
 
-        let res: H256 = [
-            92, 231, 93, 51, 106, 224, 159, 91, 206, 250, 124, 26, 16, 236, 141, 56, 42, 126, 225,
-            64, 28, 191, 37, 51, 131, 63, 224, 233, 24, 207, 211, 182,
-        ]
-        .into();
-        let got = bundled_hash(proofs, deposit_address);
-        assert!(res == got, "{:?} {:?}", res, got)
-    }
+		let res: H256 = [
+			92, 231, 93, 51, 106, 224, 159, 91, 206, 250, 124, 26, 16, 236, 141, 56, 42, 126, 225,
+			64, 28, 191, 37, 51, 131, 63, 224, 233, 24, 207, 211, 182,
+		]
+		.into();
+		let got = bundled_hash(proofs, deposit_address);
+		assert!(res == got, "{:?} {:?}", res, got)
+	}
 
-    fn get_valid_proof() -> (Proof, H256, [H256; 3]) {
-        let proof = Proof {
-            leaf_hash: [
-                1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
-                37, 85, 23, 189, 209, 48, 97, 34, 3, 169, 157, 88, 159,
-            ]
-            .into(),
-            sorted_hashes: vec![
-                [
-                    113, 229, 58, 223, 178, 220, 200, 69, 191, 246, 171, 254, 8, 183, 211, 75, 54,
-                    223, 224, 197, 170, 112, 248, 56, 10, 176, 17, 205, 86, 130, 233, 16,
-                ]
-                .into(),
-                [
-                    133, 11, 212, 75, 212, 65, 247, 178, 200, 157, 5, 39, 57, 135, 63, 126, 166,
-                    92, 232, 170, 46, 155, 223, 237, 50, 237, 43, 101, 180, 104, 126, 84,
-                ]
-                .into(),
-                [
-                    197, 248, 165, 165, 247, 119, 114, 231, 95, 114, 94, 16, 66, 142, 230, 184, 78,
-                    203, 73, 104, 24, 82, 134, 154, 180, 129, 71, 223, 72, 31, 230, 15,
-                ]
-                .into(),
-                [
-                    50, 5, 28, 219, 118, 141, 222, 221, 133, 174, 178, 212, 71, 94, 64, 44, 80,
-                    218, 29, 92, 77, 40, 241, 16, 126, 48, 119, 31, 6, 147, 224, 5,
-                ]
-                .into(),
-            ],
-        };
+	fn get_valid_proof() -> (Proof, H256, [H256; 3]) {
+		let proof = Proof {
+			leaf_hash: [
+				1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
+				37, 85, 23, 189, 209, 48, 97, 34, 3, 169, 157, 88, 159,
+			]
+			.into(),
+			sorted_hashes: vec![
+				[
+					113, 229, 58, 223, 178, 220, 200, 69, 191, 246, 171, 254, 8, 183, 211, 75, 54,
+					223, 224, 197, 170, 112, 248, 56, 10, 176, 17, 205, 86, 130, 233, 16,
+				]
+				.into(),
+				[
+					133, 11, 212, 75, 212, 65, 247, 178, 200, 157, 5, 39, 57, 135, 63, 126, 166,
+					92, 232, 170, 46, 155, 223, 237, 50, 237, 43, 101, 180, 104, 126, 84,
+				]
+				.into(),
+				[
+					197, 248, 165, 165, 247, 119, 114, 231, 95, 114, 94, 16, 66, 142, 230, 184, 78,
+					203, 73, 104, 24, 82, 134, 154, 180, 129, 71, 223, 72, 31, 230, 15,
+				]
+				.into(),
+				[
+					50, 5, 28, 219, 118, 141, 222, 221, 133, 174, 178, 212, 71, 94, 64, 44, 80,
+					218, 29, 92, 77, 40, 241, 16, 126, 48, 119, 31, 6, 147, 224, 5,
+				]
+				.into(),
+			],
+		};
 
-        let doc_root: H256 = [
-            48, 123, 58, 192, 8, 62, 20, 55, 99, 52, 37, 73, 174, 123, 214, 104, 37, 41, 189, 170,
-            205, 80, 158, 136, 224, 128, 128, 89, 55, 240, 32, 234,
-        ]
-        .into();
+		let doc_root: H256 = [
+			48, 123, 58, 192, 8, 62, 20, 55, 99, 52, 37, 73, 174, 123, 214, 104, 37, 41, 189, 170,
+			205, 80, 158, 136, 224, 128, 128, 89, 55, 240, 32, 234,
+		]
+		.into();
 
-        let static_proofs: [H256; 3] = [
-            [
-                25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175,
-                70, 161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
-            ]
-            .into(),
-            [
-                61, 164, 199, 22, 164, 251, 58, 14, 67, 56, 242, 60, 86, 203, 128, 203, 138, 129,
-                237, 7, 29, 7, 39, 58, 250, 42, 14, 53, 241, 108, 187, 74,
-            ]
-            .into(),
-            [
-                70, 124, 133, 120, 103, 45, 94, 174, 176, 18, 151, 243, 104, 120, 12, 54, 217, 189,
-                59, 222, 109, 64, 136, 203, 56, 136, 159, 115, 96, 101, 2, 185,
-            ]
-            .into(),
-        ];
+		let static_proofs: [H256; 3] = [
+			[
+				25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175,
+				70, 161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
+			]
+			.into(),
+			[
+				61, 164, 199, 22, 164, 251, 58, 14, 67, 56, 242, 60, 86, 203, 128, 203, 138, 129,
+				237, 7, 29, 7, 39, 58, 250, 42, 14, 53, 241, 108, 187, 74,
+			]
+			.into(),
+			[
+				70, 124, 133, 120, 103, 45, 94, 174, 176, 18, 151, 243, 104, 120, 12, 54, 217, 189,
+				59, 222, 109, 64, 136, 203, 56, 136, 159, 115, 96, 101, 2, 185,
+			]
+			.into(),
+		];
 
-        (proof, doc_root, static_proofs)
-    }
+		(proof, doc_root, static_proofs)
+	}
 
-    fn get_invalid_proof() -> (Proof, H256) {
-        let proof = Proof {
-            leaf_hash: [
-                1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
-                37, 85, 23, 189, 20, 48, 97, 34, 3, 169, 157, 88, 159,
-            ]
-            .into(),
-            sorted_hashes: vec![
-                [
-                    113, 229, 58, 22, 178, 220, 200, 69, 191, 246, 171, 254, 8, 183, 211, 75, 54,
-                    223, 224, 197, 170, 112, 248, 56, 10, 176, 17, 205, 86, 130, 233, 16,
-                ]
-                .into(),
-                [
-                    133, 11, 212, 75, 212, 65, 247, 178, 200, 157, 5, 39, 57, 135, 63, 126, 166,
-                    92, 23, 170, 4, 155, 223, 237, 50, 237, 43, 101, 180, 104, 126, 84,
-                ]
-                .into(),
-            ],
-        };
+	fn get_invalid_proof() -> (Proof, H256) {
+		let proof = Proof {
+			leaf_hash: [
+				1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
+				37, 85, 23, 189, 20, 48, 97, 34, 3, 169, 157, 88, 159,
+			]
+			.into(),
+			sorted_hashes: vec![
+				[
+					113, 229, 58, 22, 178, 220, 200, 69, 191, 246, 171, 254, 8, 183, 211, 75, 54,
+					223, 224, 197, 170, 112, 248, 56, 10, 176, 17, 205, 86, 130, 233, 16,
+				]
+				.into(),
+				[
+					133, 11, 212, 75, 212, 65, 247, 178, 200, 157, 5, 39, 57, 135, 63, 126, 166,
+					92, 23, 170, 4, 155, 223, 237, 50, 237, 43, 101, 180, 104, 126, 84,
+				]
+				.into(),
+			],
+		};
 
-        let doc_root: H256 = [
-            25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175, 70,
-            161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
-        ]
-        .into();
+		let doc_root: H256 = [
+			25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175, 70,
+			161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
+		]
+		.into();
 
-        (proof, doc_root)
-    }
+		(proof, doc_root)
+	}
 
-    #[test]
-    fn validate_proof_success() {
-        let (proof, root, static_proofs) = get_valid_proof();
-        let (_, mut matches) = pre_matches(static_proofs, root);
-        assert!(validate_proof(
-            &mut matches,
-            proof.leaf_hash,
-            proof.sorted_hashes
-        ))
-    }
+	#[test]
+	fn validate_proof_success() {
+		let (proof, root, static_proofs) = get_valid_proof();
+		let (_, mut matches) = pre_matches(static_proofs, root);
+		assert!(validate_proof(
+			&mut matches,
+			proof.leaf_hash,
+			proof.sorted_hashes
+		))
+	}
 
-    #[test]
-    fn validate_proof_failed() {
-        let (proof, doc_root) = get_invalid_proof();
-        let mut matches = vec![doc_root];
+	#[test]
+	fn validate_proof_failed() {
+		let (proof, doc_root) = get_invalid_proof();
+		let mut matches = vec![doc_root];
 
-        assert!(!validate_proof(
-            &mut matches,
-            proof.leaf_hash,
-            proof.sorted_hashes
-        ))
-    }
+		assert!(!validate_proof(
+			&mut matches,
+			proof.leaf_hash,
+			proof.sorted_hashes
+		))
+	}
 
-    #[test]
-    fn validate_proof_no_proofs() {
-        let proof = Proof {
-            leaf_hash: [
-                1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
-                37, 85, 23, 189, 209, 48, 97, 34, 3, 169, 157, 88, 159,
-            ]
-            .into(),
-            sorted_hashes: vec![],
-        };
+	#[test]
+	fn validate_proof_no_proofs() {
+		let proof = Proof {
+			leaf_hash: [
+				1, 93, 41, 93, 124, 185, 25, 20, 141, 93, 101, 68, 16, 11, 142, 219, 3, 124, 155,
+				37, 85, 23, 189, 209, 48, 97, 34, 3, 169, 157, 88, 159,
+			]
+			.into(),
+			sorted_hashes: vec![],
+		};
 
-        let mut matches: Vec<H256> = vec![[
-            25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175, 70,
-            161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
-        ]
-        .into()];
+		let mut matches: Vec<H256> = vec![[
+			25, 102, 189, 46, 86, 242, 48, 217, 254, 16, 20, 211, 98, 206, 125, 92, 167, 175, 70,
+			161, 35, 135, 33, 80, 225, 247, 4, 240, 138, 86, 167, 142,
+		]
+		.into()];
 
-        assert!(!validate_proof(
-            &mut matches,
-            proof.leaf_hash,
-            proof.sorted_hashes
-        ))
-    }
+		assert!(!validate_proof(
+			&mut matches,
+			proof.leaf_hash,
+			proof.sorted_hashes
+		))
+	}
 
-    #[test]
-    fn validate_proofs_success() {
-        let (vp1, doc_root, static_proofs) = get_valid_proof();
-        let (vp2, _, _) = get_valid_proof();
-        let proofs = vec![vp1, vp2];
-        assert!(validate_proofs(doc_root, &proofs, static_proofs))
-    }
+	#[test]
+	fn validate_proofs_success() {
+		let (vp1, doc_root, static_proofs) = get_valid_proof();
+		let (vp2, _, _) = get_valid_proof();
+		let proofs = vec![vp1, vp2];
+		assert!(validate_proofs(doc_root, &proofs, static_proofs))
+	}
 
-    #[test]
-    fn validate_proofs_failed() {
-        let (vp, doc_root, static_proofs) = get_valid_proof();
-        let (ivp, _) = get_invalid_proof();
-        let proofs = vec![vp, ivp];
-        assert!(!validate_proofs(doc_root, &proofs, static_proofs))
-    }
+	#[test]
+	fn validate_proofs_failed() {
+		let (vp, doc_root, static_proofs) = get_valid_proof();
+		let (ivp, _) = get_invalid_proof();
+		let proofs = vec![vp, ivp];
+		assert!(!validate_proofs(doc_root, &proofs, static_proofs))
+	}
 
-    #[test]
-    fn validate_proofs_no_proofs() {
-        let (_, doc_root, static_proofs) = get_valid_proof();
-        let proofs = vec![];
-        assert!(!validate_proofs(doc_root, &proofs, static_proofs))
-    }
+	#[test]
+	fn validate_proofs_no_proofs() {
+		let (_, doc_root, static_proofs) = get_valid_proof();
+		let proofs = vec![];
+		assert!(!validate_proofs(doc_root, &proofs, static_proofs))
+	}
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,10 +1,3 @@
-ignore = [
-    "build.rs",
-    "runtime/build.rs",
-    "runtime/src/impls.rs",
-    "runtime/src/lib.rs",
-    "src/chain_spec.rs",
-    "src/cli.rs",
-    "src/main.rs",
-    "src/service.rs",
-]
+max_width = 100
+# substrate devs uses hardtabs as convention
+hard_tabs = true

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,44 +10,44 @@ use std::sync::Arc;
 
 #[rpc]
 pub trait AnchorApi {
-    /// Returns an anchor given an anchor id from the runtime storage
-    #[rpc(name = "anchor_getAnchorById")]
-    fn get_anchor_by_id(&self, id: Hash) -> Result<AnchorData<Hash, BlockNumber>>;
+	/// Returns an anchor given an anchor id from the runtime storage
+	#[rpc(name = "anchor_getAnchorById")]
+	fn get_anchor_by_id(&self, id: Hash) -> Result<AnchorData<Hash, BlockNumber>>;
 }
 
 /// A struct that implements the [`AnchorApi`].
 pub struct Anchor<C, P> {
-    client: Arc<C>,
-    _marker: std::marker::PhantomData<P>,
+	client: Arc<C>,
+	_marker: std::marker::PhantomData<P>,
 }
 
 impl<C, P> Anchor<C, P> {
-    /// Create new `Anchor` with the given reference to the client.
-    pub fn new(client: Arc<C>) -> Self {
-        Anchor {
-            client,
-            _marker: Default::default(),
-        }
-    }
+	/// Create new `Anchor` with the given reference to the client.
+	pub fn new(client: Arc<C>) -> Self {
+		Anchor {
+			client,
+			_marker: Default::default(),
+		}
+	}
 }
 
 impl<C, Block> AnchorApi for Anchor<C, Block>
 where
-    Block: BlockT,
-    C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
-    C::Api: AnchorRuntimeApi<Block>,
+	Block: BlockT,
+	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+	C::Api: AnchorRuntimeApi<Block>,
 {
-    fn get_anchor_by_id(&self, id: Hash) -> Result<AnchorData<Hash, BlockNumber>> {
-        let api = self.client.runtime_api();
-        let best = self.client.info().best_hash;
-        let at = BlockId::hash(best);
-        api.get_anchor_by_id(&at, id)
-            .ok()
-            .unwrap()
-            .ok_or(jsonrpc_core::Error {
-                code: jsonrpc_core::ErrorCode::InternalError,
-                message: "Unable to find anchor".into(),
-                data: Some(format!("{:?}", id).into()),
-            })
-    }
+	fn get_anchor_by_id(&self, id: Hash) -> Result<AnchorData<Hash, BlockNumber>> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+		api.get_anchor_by_id(&at, id)
+			.ok()
+			.unwrap()
+			.ok_or(jsonrpc_core::Error {
+				code: jsonrpc_core::ErrorCode::InternalError,
+				message: "Unable to find anchor".into(),
+				data: Some(format!("{:?}", id).into()),
+			})
+	}
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -14,35 +14,29 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use sc_cli::VersionInfo;
-use crate::service;
 use crate::chain_spec;
 use crate::cli::Cli;
+use crate::service;
+use sc_cli::VersionInfo;
 
 /// Parse and run command line arguments
 pub fn run(version: VersionInfo) -> sc_cli::Result<()> {
-    let opt = sc_cli::from_args::<Cli>(&version);
+	let opt = sc_cli::from_args::<Cli>(&version);
 
-    let mut config = sc_service::Configuration::from_version(&version);
+	let mut config = sc_service::Configuration::from_version(&version);
 
-    match opt.subcommand {
-        Some(subcommand) => {
+	match opt.subcommand {
+		Some(subcommand) => {
 			subcommand.init(&version)?;
 			subcommand.update_config(&mut config, chain_spec::load_spec, &version)?;
-			subcommand.run(
-				config,
-				|config: _| Ok(new_full_start!(config).0),
-			)
-		},
+			subcommand.run(config, |config: _| Ok(new_full_start!(config).0))
+		}
 		None => {
 			opt.run.init(&version)?;
-			opt.run.update_config(&mut config, chain_spec::load_spec, &version)?;
-			opt.run.run(
-				config,
-				service::new_light,
-				service::new_full,
-				&version,
-			)
-		},
-    }
+			opt.run
+				.update_config(&mut config, chain_spec::load_spec, &version)?;
+			opt.run
+				.run(config, service::new_light, service::new_full, &version)
+		}
+	}
 }


### PR DESCRIPTION
The configurations used in in `rustfmt.toml` file, all source files are reformatted to use tabs instead of mix of spaces and tabs
The max_width of a line is set to 100