### PR TITLE
Add ci script to auto-fail PR if changes in runtime version is not met with the defined conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ addons:
       - gcc
       - binutils-dev
       - libiberty-dev
+      - jq
 
 after_script:
   # Check how much free disk space left after the build

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ before_install:
 
 jobs:
   include:
+    - stage: "Check PR runtime changes"
+      script: travis_wait 180 ./ci/check_pr.sh
     - stage: "Test and build"
       name: "Run runtime tests"
       script: TARGET=runtime-test travis_wait 180 ./ci/script.sh
@@ -41,8 +43,6 @@ jobs:
     - stage: "Build and push Docker image"
       if: (NOT type IN (pull_request)) AND (branch = master)
       script: travis_wait 180 ./ci/docker.sh
-    - stage: "Check PR runtime changes"
-      script: travis_wait 180 ./ci/check_pr.sh
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ addons:
       - gcc
       - binutils-dev
       - libiberty-dev
-      - jq
 
 after_script:
   # Check how much free disk space left after the build

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
     - stage: "Build and push Docker image"
       if: (NOT type IN (pull_request)) AND (branch = master)
       script: travis_wait 180 ./ci/docker.sh
+    - stage: "Check PR runtime changes"
+      script: travis_wait 180 ./ci/check_pr.sh
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       if: (NOT type IN (pull_request)) AND (branch = master)
       script: travis_wait 180 ./ci/docker.sh
     - stage: "Check PR runtime changes"
-      script: ./ci/check_pr.sh
+      script: travis_wait 180 ./ci/check_pr.sh
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       if: (NOT type IN (pull_request)) AND (branch = master)
       script: travis_wait 180 ./ci/docker.sh
     - stage: "Check PR runtime changes"
-      script: travis_wait 360 ./ci/check_pr.sh
+      script: ./ci/check_pr.sh
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 jobs:
   include:
     - stage: "Check PR runtime changes"
-      script: travis_wait 180 ./ci/check_pr.sh
+      script: travis_wait 180 ./ci/check_runtime_changes.sh
     - stage: "Test and build"
       name: "Run runtime tests"
       script: TARGET=runtime-test travis_wait 180 ./ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       if: (NOT type IN (pull_request)) AND (branch = master)
       script: travis_wait 180 ./ci/docker.sh
     - stage: "Check PR runtime changes"
-      script: travis_wait 180 ./ci/check_pr.sh
+      script: travis_wait 360 ./ci/check_pr.sh
 
 addons:
   apt:

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -79,8 +79,8 @@ LABEL_MARKER="breakapi"
 LABELED_MARKER_COUNT=$(echo -e "${pr_label}" | grep -w ${LABEL_MARKER} | wc -l)
 
 if [ $RUNTIME_FILE_CHANGED != "0" ]
-	then
-		echo "There are ${RUNTIME_FILE_CHANGED} files changed in runtime "
+then
+	echo "There are ${RUNTIME_FILE_CHANGED} files changed in runtime "
 
 	if [ "${LABELED_MARKER_COUNT}" != "0" ]
 	then
@@ -112,6 +112,9 @@ if [ $RUNTIME_FILE_CHANGED != "0" ]
 			echo "ERROR: impl_version should be changed in ${VERSIONS_FILE}"
 		fi
 	fi
+else
+	echo "OK: No changes in runtime, no need for version change"
+	exit 0
 fi
 
 exit 1

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -4,13 +4,13 @@
 # - if runtime files are changed:
 #	- Check if the spec_version is incremented
 # 	- If spec_version incremented, ensure impl_version is 0 and exit successfully
-# 	- if spec_version is not incremented, check if the impl_version is incremented
+# 	- if spec_version is NOT incremented, check if the impl_version is incremented
 # 		- if impl_version incremented, then exit successfully
-# 		- if not then fail the script
-# - if runtime files are not changed, exit successfully
+# 		- if impl_version is NOT incremented then fail the script
+# - if runtime files are NOT changed, exit successfully
 #
 
-# base the origin/master as the base commit
+# origin/master as the base commit
 BASE_COMMIT="origin/master"
 VERSIONS_FILE="runtime/src/lib.rs"
 
@@ -26,12 +26,13 @@ yellow='\033[01;33m'
 
 OK="${green}${block}OK${nc}"
 ERROR="${red}${block}ERROR${nc}"
+FATAL="${red}${block}FATAL${nc}"
 
 
 # show the diff of origin/master and this PR sha
 CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT}...${PR_COMMIT})
 
-echo "Changed files: ${CHANGED_FILES}"
+#echo "Changed files: ${CHANGED_FILES}"
 
 # count the number of files changed in runtime directory
 RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
@@ -45,17 +46,28 @@ then
 	exit 0
 fi
 
-
+# Extract the spec_version  and impl_version from origin/master and the PR
 BASE_SPEC_VERSION=$(git show ${BASE_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+spec_version: +([0-9]+),$/\1/p")
 BASE_IMPL_VERSION=$(git show ${BASE_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+impl_version: +([0-9]+),$/\1/p")
 
 PR_SPEC_VERSION=$(git show ${PR_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+spec_version: +([0-9]+),$/\1/p")
 PR_IMPL_VERSION=$(git show ${PR_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+impl_version: +([0-9]+),$/\1/p")
 
+# Show the changes in the versions
+echo "|"
 echo "| ${BASE_COMMIT} spec_version: ${BASE_SPEC_VERSION}"
 echo "| ${BASE_COMMIT} impl_version: ${BASE_IMPL_VERSION}"
+echo "| "
 echo "| PR spec_version: ${PR_SPEC_VERSION}"
 echo "| PR impl_version: ${PR_IMPL_VERSION}"
+echo "|"
+
+# spec_version should never decremented, show a fatal alert it that's the case
+if (( $PR_SPEC_VERSION < $BASE_SPEC_VERSION ))
+then
+	echo -e "${FATAL}: ${yellow}spec_version${nc} is decremented"
+	exit 1
+fi
 
 # Check if the PR spec version is incremented
 if (( $PR_SPEC_VERSION > $BASE_SPEC_VERSION ))
@@ -67,8 +79,11 @@ then
 		echo -e "| ${OK}: ${yellow}impl_version${nc} is set to 0"
 		exit 0
 	else
+		# The impl_version is not reset to 0 and should fail
 		echo -e "| ${ERROR}: ${yellow}impl_version${nc} must be reset to 0 when ${yellow}spec_version${nc} is incremented"
+		exit 1
 	fi
+# The spec_version is not changed
 else
 	# if spec_version is not incremented
 	# Check if impl_version is incremented
@@ -78,8 +93,10 @@ else
 		echo -e "| ${OK}: ${yellow}impl_version${nc} is incremented"
 		exit 0
 	else
+		# The impl_version is not incremented, and should fail
 		echo -e "| ${ERROR}: ${yellow}impl_version${nc} is NOT incremented"
-		echo -e "|	Note: either ${yellow}impl_version${nc} or ${yellow}spec_version${nc} should be incremented when there is changed in the runtime"
+		echo -e "|	Note: either ${yellow}impl_version${nc} or ${yellow}spec_version${nc} should be incremented when there is changes in the runtime"
+		exit 1
 	fi
 fi
 

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
-
+#set -x
 # check for any changes in the runtime/ . if
 # there are any changes found, it should mark the PR breaksconsensus and
 # "auto-fail" the PR if there isn't a change in the runtime/src/lib.rs file
@@ -22,7 +22,6 @@ VERSIONS_FILE="runtime/src/lib.rs"
 # show the diff of origin/master and this PR sha
 CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT}...${CI_COMMIT_SHA})
 
-echo "Changed files $CHANGED_FILES"
 
 # count the number of files changed in runtime directory
 RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
@@ -50,9 +49,9 @@ RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
 # returns the PR number where a commit hash belongs to
 github_pr_from_commit () {
 	commit_details=$(curl -s https://api.github.com/search/issues?q=sha:${1})
-	first_result=$(echo ${commit_details} | jq '.items[0]')
-	pr_id=$(echo ${first_result} | jq '.number' )
-	echo ${pr_id}
+	first_result=$(echo "${commit_details}" | jq '.items[0]')
+	pr_id=$(echo "${first_result}" | jq '.number' )
+	echo "${pr_id}"
 }
 
 
@@ -61,18 +60,18 @@ github_pr_from_commit () {
 # Note: the label names is double quoted
 github_label_from_pr () {
 	pr_info=$(curl -s https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/${1})
-	labels=$(echo ${pr_info} | jq '.labels' )
+	labels=$(echo "${pr_info}" | jq '.labels' )
 	if [ "$labels" != "null" ]; then 
-		label_names=$(echo ${labels} | jq '.[] | .name')
-		echo ${label_names}
+		label_names=$(echo "${labels}" | jq '.[] | .name')
+		echo "${label_names}"
 	fi
 }
 
 
-PR_ID=$(github_pr_from_commit ${CI_COMMIT_SHA})
+PR_ID=$(github_pr_from_commit "${CI_COMMIT_SHA}")
 pr_label=$(github_label_from_pr "${PR_ID}")
 
-echo "pr_label:[${pr_label}]"
+echo "PR labels: ${pr_label}"
 
 LABEL_MARKER="breakapi"
 
@@ -80,7 +79,7 @@ LABELED_MARKER_COUNT=$(echo -e "${pr_label}" | grep -w ${LABEL_MARKER} | wc -l)
 
 if [ $RUNTIME_FILE_CHANGED != "0" ]
 then
-	echo "There are ${RUNTIME_FILE_CHANGED} files changed in runtime "
+	echo "There are ${RUNTIME_FILE_CHANGED} file(s) changed in runtime "
 
 	if [ "${LABELED_MARKER_COUNT}" != "0" ]
 	then

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -94,7 +94,7 @@ if [ $RUNTIME_FILE_CHANGED != "0" ]
 			echo "OK: spec_version is changed.. "
 			exit 0
 		else
-			echo "ERROR: Spec version should be changed in ${VERSIONS_FILE}"
+			echo "ERROR: spec_version should be changed in ${VERSIONS_FILE}"
 		fi
 	else
 		echo "Not a breaking change"

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -39,7 +39,7 @@ RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
 echo "There are ${RUNTIME_FILE_CHANGED} file(s) changed in runtime "
 
 # If there are no changes in the runtime file, exit sucessfully
-if (( RUNTIME_FILE_CHANGED == 0 ))
+if (( $RUNTIME_FILE_CHANGED == 0 ))
 then
 	echo -e "| ${OK} Nothing is changed in runtime"
 	exit 0
@@ -52,15 +52,15 @@ BASE_IMPL_VERSION=$(git show ${BASE_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:
 PR_SPEC_VERSION=$(git show ${PR_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+spec_version: +([0-9]+),$/\1/p")
 PR_IMPL_VERSION=$(git show ${PR_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+impl_version: +([0-9]+),$/\1/p")
 
-echo "| ${BASE_COMMIT} -> spec_version: ${BASE_SPEC_VERSION}"
-echo "| ${BASE_COMMIT} -> impl_version: ${BASE_IMPL_VERSION}"
-echo "| PR -> spec_version: ${PR_SPEC_VERSION}"
-echo "| PR -> impl_version: ${PR_IMPL_VERSION}"
+echo "| ${BASE_COMMIT} spec_version: ${BASE_SPEC_VERSION}"
+echo "| ${BASE_COMMIT} impl_version: ${BASE_IMPL_VERSION}"
+echo "| PR spec_version: ${PR_SPEC_VERSION}"
+echo "| PR impl_version: ${PR_IMPL_VERSION}"
 
 # Check if the PR spec version is incremented
 if (( $PR_SPEC_VERSION > $BASE_SPEC_VERSION ))
 then
-	echo -e "${BASE_SPEC_VERSION} -> ${PR_SPEC_VERSION}"
+	echo -e "| spec_version is changed: ${BASE_SPEC_VERSION} -> ${PR_SPEC_VERSION}"
 	# Ensure impl_version in the PR is set to 0 when spec_version is incremented
 	if (( $PR_IMPL_VERSION == 0 ))
 	then
@@ -74,6 +74,7 @@ else
 	# Check if impl_version is incremented
 	if (( $PR_IMPL_VERSION > $BASE_IMPL_VERSION ))
 	then
+		echo -e "| impl_version is changed: ${BASE_IMPL_VERSION} -> ${PR_IMPL_VERSION}"
 		echo -e "| ${OK}: ${yellow}impl_version${nc} is incremented"
 		exit 0
 	else

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -31,6 +31,8 @@ ERROR="${red}${block}ERROR${nc}"
 # show the diff of origin/master and this PR sha
 CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT}...${PR_COMMIT})
 
+echo "Changed files: ${CHANGED_FILES}"
+
 # count the number of files changed in runtime directory
 RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
 

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -8,6 +8,15 @@
 
 # get the commit sha for this PR
 CI_COMMIT_SHA=$(git rev-parse HEAD)
+echo "commit: ${CI_COMMIT_SHA}"
+
+LABEL_BREAKS_API="breaks-api"
+LABEL_CHANGES_RUNTIME="changes-runtime"
+red='\033[0;31m'
+bold='\033[1m'
+nc='\033[0m' # No Color
+green='\033[01;32m'
+yellow='\033[01;33m'
 
 
 boldprint () { printf "|\n| \033[1m${@}\033[0m\n|\n" ; }
@@ -40,7 +49,7 @@ RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
 # The labels is then extracted from the PR info using
 #   jq '.labels' | jq ' .[] | .name '
 #
-# ie: curl -s https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/119 | jq '.labels' | jq '.[] | .name'
+# ie: curl -s https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/119 | jq '.labels' | jq -r '.[] | .name'
 # This will list down the list of labels on that PR
 
 
@@ -62,26 +71,29 @@ github_label_from_pr () {
 	pr_info=$(curl -s https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/${1})
 	labels=$(echo "${pr_info}" | jq '.labels' )
 	if [ "$labels" != "null" ]; then 
-		label_names=$(echo "${labels}" | jq '.[] | .name')
+		label_names=$(echo "${labels}" | jq -r '.[] | .name')
 		echo "${label_names}"
 	fi
 }
 
 
 PR_ID=$(github_pr_from_commit "${CI_COMMIT_SHA}")
-pr_label=$(github_label_from_pr "${PR_ID}")
+PR_LABEL=$(github_label_from_pr "${PR_ID}")
 
-echo "PR labels: ${pr_label}"
 
-LABEL_MARKER="breakapi"
+echo -e ""
+echo -e "| PR labels: ${yellow}${PR_LABEL}${nc}"
 
-LABELED_MARKER_COUNT=$(echo -e "${pr_label}" | grep -w ${LABEL_MARKER} | wc -l)
+
+LABEL_BREAK_API_COUNT=$(echo "${PR_LABEL}" | grep -w ${LABEL_BREAKS_API} | wc -l)
+LABEL_CHANGES_RUNTIME_COUNT=$(echo "${PR_LABEL}" | grep -w ${LABEL_CHANGES_RUNTIME} | wc -l)
+
 
 if [ $RUNTIME_FILE_CHANGED != "0" ]
 then
 	echo "There are ${RUNTIME_FILE_CHANGED} file(s) changed in runtime "
 
-	if [ "${LABELED_MARKER_COUNT}" != "0" ]
+	if [ "${LABEL_BREAK_API_COUNT}" != "0" ]
 	then
 		add_spec_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
 			| sed -n -r "s/^\+[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
@@ -90,26 +102,35 @@ then
 
 		if [ "${add_spec_version}" != "${sub_spec_version}" ]
 		then
-			echo "OK: spec_version is changed.. "
+			echo -e "| ${green}${bold}OK:${nc} PR has label ${yellow}${LABEL_BREAKS_API}${nc} and spec_version is changed.. "
 			exit 0
 		else
-			echo "ERROR: spec_version should be changed in ${VERSIONS_FILE}"
+			echo -e "| ${red}${bold}ERROR:${nc} PR has label ${yellow}${LABEL_BREAKS_API}${nc}, but spec_version remains the same in ${VERSIONS_FILE}"
 		fi
-	else
-		echo "Not a breaking change"
+	elif [ "${LABEL_CHANGES_RUNTIME_COUNT}" != "0" ]
+	then
 
-		add_impl_version="$(git diff tags/release...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+		add_impl_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
 			| sed -n -r 's/^\+[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
-		sub_impl_version="$(git diff tags/release...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+		sub_impl_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
 			| sed -n -r 's/^\-[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
 
 		if [ "${add_impl_version}" != "${sub_impl_version}" ]
 		then
-			echo "OK: impl_version is changed..."
+			echo -e "| ${green}${bold}OK:${nc} PR has label ${yellow}${LABEL_CHANGES_RUNTIME}${nc} and impl_version is changed..."
 			exit 0
 		else
-			echo "ERROR: impl_version should be changed in ${VERSIONS_FILE}"
+			echo -e "| ${red}${bold}ERROR:${nc} PR has label ${yellow}${LABEL_CHANGES_RUNTIME}${nc}, but impl_version remains the same in ${VERSIONS_FILE}"
 		fi
+	else
+		echo -e ""
+		echo -e "| ${red}${bold}ERROR:${nc} There are changes in runtime but PR has no required label"
+		echo -e "|    Required label is one of: ${yellow}${LABEL_BREAKS_API}${nc},${yellow}${LABEL_CHANGES_RUNTIME}${nc}"
+		if [ "${PR_LABEL}" != "" ]
+		then
+			echo -e "| PR has these labels: ${yellow}${PR_LABEL}${nc}"
+		fi
+		echo -e "| "
 	fi
 else
 	echo "OK: No changes in runtime, no need for version change"

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -1,140 +1,83 @@
 #!/bin/bash
+
+# 
+# - if runtime files are changed:
+#	- Check if the spec_version is incremented
+# 	- If spec_version incremented, ensure impl_version is 0 and exit successfully
+# 	- if spec_version is not incremented, check if the impl_version is incremented
+# 		- if impl_version incremented, then exit successfully
+# 		- if not then fail the script
+# - if runtime files are not changed, exit successfully
 #
-#set -x
-# check for any changes in the runtime/ . if
-# there are any changes found, it should mark the PR breaksconsensus and
-# "auto-fail" the PR if there isn't a change in the runtime/src/lib.rs file
-# that alters the version.
 
-# get the commit sha for this PR
-CI_COMMIT_SHA=$(git rev-parse HEAD)
-echo "commit: ${CI_COMMIT_SHA}"
+# base the origin/master as the base commit
+BASE_COMMIT="origin/master"
+VERSIONS_FILE="runtime/src/lib.rs"
 
-LABEL_BREAKS_API="breaks-api"
-LABEL_CHANGES_RUNTIME="changes-runtime"
+PR_COMMIT=$(git rev-parse HEAD)
+echo "commit: ${PR_COMMIT}"
+
+# use color in echo for indicating success or fail
 red='\033[0;31m'
 bold='\033[1m'
 nc='\033[0m' # No Color
 green='\033[01;32m'
 yellow='\033[01;33m'
 
+OK="${green}${block}OK${nc}"
+ERROR="${red}${block}ERROR${nc}"
 
-boldprint () { printf "|\n| \033[1m${@}\033[0m\n|\n" ; }
-
-boldprint "latest 10 commits of ${CI_COMMIT_REF_NAME}"
-git log --graph --oneline --decorate=short -n 10
-
-# base the origin/master as the base commit
-BASE_COMMIT="origin/master"
-VERSIONS_FILE="runtime/src/lib.rs"
 
 # show the diff of origin/master and this PR sha
-CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT}...${CI_COMMIT_SHA})
-
+CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT}...${PR_COMMIT})
 
 # count the number of files changed in runtime directory
 RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
 
+echo "There are ${RUNTIME_FILE_CHANGED} file(s) changed in runtime "
 
-
-
-# Get the PR id from the commit hash using github API:
-# ie: curl -s https://api.github.com/search/issues?q=sha:22681fb3ae899448d73124b047f006ce84164234
-#
-# Use jq to extract the PR number 
-#	jq '.number'
-#   
-# The PR number is used to get the PR information
-# ie: https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/119
-# The labels is then extracted from the PR info using
-#   jq '.labels' | jq ' .[] | .name '
-#
-# ie: curl -s https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/119 | jq '.labels' | jq -r '.[] | .name'
-# This will list down the list of labels on that PR
-
-
-
-
-# returns the PR number where a commit hash belongs to
-github_pr_from_commit () {
-	commit_details=$(curl -s https://api.github.com/search/issues?q=sha:${1})
-	first_result=$(echo "${commit_details}" | jq '.items[0]')
-	pr_id=$(echo "${first_result}" | jq '.number' )
-	echo "${pr_id}"
-}
-
-
-
-# returns the label names separated by a new line
-# Note: the label names is double quoted
-github_label_from_pr () {
-	pr_info=$(curl -s https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/${1})
-	labels=$(echo "${pr_info}" | jq '.labels' )
-	if [ "$labels" != "null" ]; then 
-		label_names=$(echo "${labels}" | jq -r '.[] | .name')
-		echo "${label_names}"
-	fi
-}
-
-
-PR_ID=$(github_pr_from_commit "${CI_COMMIT_SHA}")
-PR_LABEL=$(github_label_from_pr "${PR_ID}")
-
-
-echo -e ""
-echo -e "| PR labels: ${yellow}${PR_LABEL}${nc}"
-
-
-LABEL_BREAK_API_COUNT=$(echo "${PR_LABEL}" | grep -w ${LABEL_BREAKS_API} | wc -l)
-LABEL_CHANGES_RUNTIME_COUNT=$(echo "${PR_LABEL}" | grep -w ${LABEL_CHANGES_RUNTIME} | wc -l)
-
-
-if [ $RUNTIME_FILE_CHANGED != "0" ]
+# If there are no changes in the runtime file, exit sucessfully
+if (( RUNTIME_FILE_CHANGED == 0 ))
 then
-	echo "There are ${RUNTIME_FILE_CHANGED} file(s) changed in runtime "
+	echo -e "| ${OK} Nothing is changed in runtime"
+	exit 0
+fi
 
-	if [ "${LABEL_BREAK_API_COUNT}" != "0" ]
+
+BASE_SPEC_VERSION=$(git show ${BASE_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+spec_version: +([0-9]+),$/\1/p")
+BASE_IMPL_VERSION=$(git show ${BASE_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+impl_version: +([0-9]+),$/\1/p")
+
+PR_SPEC_VERSION=$(git show ${PR_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+spec_version: +([0-9]+),$/\1/p")
+PR_IMPL_VERSION=$(git show ${PR_COMMIT}:${VERSIONS_FILE} | sed -n -r "s/^[[:space:]]+impl_version: +([0-9]+),$/\1/p")
+
+echo "| ${BASE_COMMIT} -> spec_version: ${BASE_SPEC_VERSION}"
+echo "| ${BASE_COMMIT} -> impl_version: ${BASE_IMPL_VERSION}"
+echo "| PR -> spec_version: ${PR_SPEC_VERSION}"
+echo "| PR -> impl_version: ${PR_IMPL_VERSION}"
+
+# Check if the PR spec version is incremented
+if (( $PR_SPEC_VERSION > $BASE_SPEC_VERSION ))
+then
+	echo -e "${BASE_SPEC_VERSION} -> ${PR_SPEC_VERSION}"
+	# Ensure impl_version in the PR is set to 0 when spec_version is incremented
+	if (( $PR_IMPL_VERSION == 0 ))
 	then
-		add_spec_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
-			| sed -n -r "s/^\+[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
-		sub_spec_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
-			| sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
-
-		if [ "${add_spec_version}" != "${sub_spec_version}" ]
-		then
-			echo -e "| ${green}${bold}OK:${nc} PR has label ${yellow}${LABEL_BREAKS_API}${nc} and spec_version is changed.. "
-			exit 0
-		else
-			echo -e "| ${red}${bold}ERROR:${nc} PR has label ${yellow}${LABEL_BREAKS_API}${nc}, but spec_version remains the same in ${VERSIONS_FILE}"
-		fi
-	elif [ "${LABEL_CHANGES_RUNTIME_COUNT}" != "0" ]
-	then
-
-		add_impl_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
-			| sed -n -r 's/^\+[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
-		sub_impl_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
-			| sed -n -r 's/^\-[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
-
-		if [ "${add_impl_version}" != "${sub_impl_version}" ]
-		then
-			echo -e "| ${green}${bold}OK:${nc} PR has label ${yellow}${LABEL_CHANGES_RUNTIME}${nc} and impl_version is changed..."
-			exit 0
-		else
-			echo -e "| ${red}${bold}ERROR:${nc} PR has label ${yellow}${LABEL_CHANGES_RUNTIME}${nc}, but impl_version remains the same in ${VERSIONS_FILE}"
-		fi
+		echo -e "| ${OK}: ${yellow}impl_version${nc} is set to 0"
+		exit 0
 	else
-		echo -e ""
-		echo -e "| ${red}${bold}ERROR:${nc} There are changes in runtime but PR has no required label"
-		echo -e "|    Required label is one of: ${yellow}${LABEL_BREAKS_API}${nc},${yellow}${LABEL_CHANGES_RUNTIME}${nc}"
-		if [ "${PR_LABEL}" != "" ]
-		then
-			echo -e "| PR has these labels: ${yellow}${PR_LABEL}${nc}"
-		fi
-		echo -e "| "
+		echo -e "| ${ERROR}: ${yellow}impl_version${nc} must be reset to 0 when ${yellow}spec_version${nc} is incremented"
 	fi
 else
-	echo "OK: No changes in runtime, no need for version change"
-	exit 0
+	# if spec_version is not incremented
+	# Check if impl_version is incremented
+	if (( $PR_IMPL_VERSION > $BASE_IMPL_VERSION ))
+	then
+		echo -e "| ${OK}: ${yellow}impl_version${nc} is incremented"
+		exit 0
+	else
+		echo -e "| ${ERROR}: ${yellow}impl_version${nc} is NOT incremented"
+		echo -e "|	Note: either ${yellow}impl_version${nc} or ${yellow}spec_version${nc} should be incremented when there is changed in the runtime"
+	fi
 fi
 
 exit 1

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -74,7 +74,7 @@ pr_label=$(github_label_from_pr "${PR_ID}")
 
 echo "pr_label:[${pr_label}]"
 
-LABEL_MARKER="BREAK"
+LABEL_MARKER="breakapi"
 
 LABELED_MARKER_COUNT=$(echo -e "${pr_label}" | grep -w ${LABEL_MARKER} | wc -l)
 

--- a/ci/check_pr.sh
+++ b/ci/check_pr.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+#
+
+# check for any changes in the runtime/ . if
+# there are any changes found, it should mark the PR breaksconsensus and
+# "auto-fail" the PR if there isn't a change in the runtime/src/lib.rs file
+# that alters the version.
+
+# get the commit sha for this PR
+CI_COMMIT_SHA=$(git rev-parse HEAD)
+
+# base the origin/master as the base commit
+BASE_COMMIT="origin/master"
+VERSIONS_FILE="runtime/src/lib.rs"
+
+# show the diff of origin/master and this PR sha
+CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT}...${CI_COMMIT_SHA})
+
+echo "Changed files $CHANGED_FILES"
+
+# count the number of files changed in runtime directory
+RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
+echo "There are ${RUNTIME_FILE_CHANGED} files changed in runtime "
+
+
+
+
+# Get the PR id from the commit hash using github API:
+# ie: curl -s https://api.github.com/search/issues?q=sha:22681fb3ae899448d73124b047f006ce84164234
+#
+# Use jq to extract the PR number 
+#	jq '.number'
+#   
+# The PR number is used to get the PR information
+# ie: https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/119
+# The labels is then extracted from the PR info using
+#   jq '.labels' | jq ' .[] | .name '
+#
+# ie: curl -s https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/119 | jq '.labels' | jq '.[] | .name'
+# This will list down the list of labels on that PR
+
+#CI_COMMIT_SHA=22681fb3ae899448d73124b047f006ce84164234
+
+
+
+# returns the PR number where a commit hash belongs to
+github_pr_from_commit () {
+	commit_details=$(curl -s https://api.github.com/search/issues?q=sha:${1})
+	first_result=$(echo ${commit_details} | jq '.items[0]')
+	pr_id=$(echo ${first_result} | jq '.number' )
+	echo ${pr_id}
+}
+
+
+
+# returns the label names separated by a new line
+# Note: the label names is double quoted
+github_label_from_pr () {
+	pr_info=$(curl -s https://api.github.com/repos/centrifuge/centrifuge-chain/pulls/${1})
+	labels=$(echo ${pr_info} | jq '.labels' )
+	if [ "$labels" != "null" ]; then 
+		label_names=$(echo ${labels} | jq '.[] | .name')
+		echo ${label_names}
+	fi
+}
+
+
+PR_ID=$(github_pr_from_commit ${CI_COMMIT_SHA})
+pr_label=$(github_label_from_pr "${PR_ID}")
+
+echo "pr_label:[${pr_label}]"
+
+LABEL_MARKER="BREAK"
+
+LABELED_WIP=$(echo -e "${pr_label}" | grep -w ${LABEL_MARKER} | wc -l)
+echo "LABELED WIP: $LABELED_WIP"
+
+if [ $RUNTIME_FILE_CHANGED != "0" ]
+	then
+		echo "There are ${RUNTIME_FILE_CHANGED} files changed in runtime "
+
+	if [ "${LABELED_WIP}" != "0" ]
+	then
+		add_spec_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+			| sed -n -r "s/^\+[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
+		sub_spec_version="$(git diff ${BASE_COMMIT}...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+			| sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
+
+		if [ "${add_impl_version}" != "${sub_impl_version}" ]
+		then
+			echo "OK: spec_version is changed.. "
+			exit 0
+		else
+			echo "ERROR: Spec version should be changed"
+		fi
+	else
+		add_impl_version="$(git diff tags/release...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+			| sed -n -r 's/^\+[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
+		sub_impl_version="$(git diff tags/release...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+			| sed -n -r 's/^\-[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
+
+		if [ "${add_impl_version}" != "${sub_impl_version}" ]
+		then
+			echo "OK: impl_version is changed..."
+			exit 0
+		else
+			echo "ERROR: impl_version should be changed"
+		fi
+	fi
+fi
+
+exit 1

--- a/ci/check_runtime_changes.sh
+++ b/ci/check_runtime_changes.sh
@@ -32,8 +32,6 @@ FATAL="${red}${block}FATAL${nc}"
 # show the diff of origin/master and this PR sha
 CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT}...${PR_COMMIT})
 
-#echo "Changed files: ${CHANGED_FILES}"
-
 # count the number of files changed in runtime directory
 RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
 


### PR DESCRIPTION
Closes issue #200 

The ci-script behavior:

Any pull request to the `centrifuge-chain` will **auto-fail** if
- there are changes in the `runtime/` and PR is labeled as `breakapi` and `spec_version` is not changed in `runtime/src/lib.rs`.
- there are changes in the `runtime/` and PR is NOT labeled as `breakapi` and `impl_version` is not changed in `runtime/src/lib.rs`.

The script should ensure that changes in `runtime/` will have a appropriate change in the `version`