### PR TITLE
Initial code for pallet_bridge based on chainsafe/chainbridge example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ dependencies = [
 name = "centrifuge-chain-runtime"
 version = "2.0.0"
 dependencies = [
- "chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0)",
+ "chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=60e12d1b8d0f94b0533651c7de3a289f1e803817)",
  "frame-executive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "chainbridge"
 version = "0.0.1"
-source = "git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0#8b4a6c7e3953881e3b863243de2f655b7bd611f0"
+source = "git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=60e12d1b8d0f94b0533651c7de3a289f1e803817#60e12d1b8d0f94b0533651c7de3a289f1e803817"
 dependencies = [
  "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
@@ -6528,7 +6528,7 @@ dependencies = [
 "checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
-"checksum chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0)" = "<none>"
+"checksum chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=60e12d1b8d0f94b0533651c7de3a289f1e803817)" = "<none>"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 "checksum clang-sys 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f92986241798376849e1a007827041fed9bb36195822c2049d18e174420e0534"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
 name = "centrifuge-chain-runtime"
 version = "2.0.0"
 dependencies = [
+ "chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0)",
  "frame-executive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
@@ -549,6 +550,23 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "chainbridge"
+version = "0.0.1"
+source = "git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0#8b4a6c7e3953881e3b863243de2f655b7bd611f0"
+dependencies = [
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "pallet-balances 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "substrate-wasm-builder-runner 1.0.5 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
 ]
 
 [[package]]
@@ -6510,6 +6528,7 @@ dependencies = [
 "checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
+"checksum chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0)" = "<none>"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 "checksum clang-sys 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f92986241798376849e1a007827041fed9bb36195822c2049d18e174420e0534"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -302,6 +302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "centrifuge-chain-runtime"
 version = "2.0.0"
 dependencies = [
+ "chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0)",
  "frame-executive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
@@ -362,6 +363,23 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "chainbridge"
+version = "0.0.1"
+source = "git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0#8b4a6c7e3953881e3b863243de2f655b7bd611f0"
+dependencies = [
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "pallet-balances 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
+ "substrate-wasm-builder-runner 1.0.5 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
 ]
 
 [[package]]
@@ -3876,6 +3894,7 @@ dependencies = [
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
+"checksum chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0)" = "<none>"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum const-random 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -302,7 +302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "centrifuge-chain-runtime"
 version = "2.0.0"
 dependencies = [
- "chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0)",
+ "chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=60e12d1b8d0f94b0533651c7de3a289f1e803817)",
  "frame-executive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "chainbridge"
 version = "0.0.1"
-source = "git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0#8b4a6c7e3953881e3b863243de2f655b7bd611f0"
+source = "git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=60e12d1b8d0f94b0533651c7de3a289f1e803817#60e12d1b8d0f94b0533651c7de3a289f1e803817"
 dependencies = [
  "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
  "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?rev=013c1ee167354a08283fb69915fda56a62fee943)",
@@ -3894,7 +3894,7 @@ dependencies = [
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
-"checksum chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=8b4a6c7e3953881e3b863243de2f655b7bd611f0)" = "<none>"
+"checksum chainbridge 0.0.1 (git+https://github.com/ChainSafe/chainbridge-substrate.git?rev=60e12d1b8d0f94b0533651c7de3a289f1e803817)" = "<none>"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum const-random 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/centrifuge/centrifuge-chain"
 [dependencies]
 # external pallet
 substrate-pallet-multi-account = { version = "2.0.0-alpha.3", git = "https://github.com/centrifuge/substrate-pallet-multi-account", rev = "35fe33019a6cdf72137712d290a0965ac5eb71fb", default-features = false }
+chainbridge = { version = "0.0.1", git = "https://github.com/ChainSafe/chainbridge-substrate.git", rev = "8b4a6c7e3953881e3b863243de2f655b7bd611f0" , default-features = false}
 
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false, features = ["derive"] }
@@ -114,4 +115,5 @@ std = [
 	"pallet-utility/std",
 	"sp-version/std",
 	"pallet-identity/std",
+    "chainbridge/std",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/centrifuge/centrifuge-chain"
 [dependencies]
 # external pallet
 substrate-pallet-multi-account = { version = "2.0.0-alpha.3", git = "https://github.com/centrifuge/substrate-pallet-multi-account", rev = "35fe33019a6cdf72137712d290a0965ac5eb71fb", default-features = false }
-chainbridge = { version = "0.0.1", git = "https://github.com/ChainSafe/chainbridge-substrate.git", rev = "8b4a6c7e3953881e3b863243de2f655b7bd611f0" , default-features = false}
+chainbridge = { version = "0.0.1", git = "https://github.com/ChainSafe/chainbridge-substrate.git", rev = "60e12d1b8d0f94b0533651c7de3a289f1e803817" , default-features = false}
 
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false, features = ["derive"] }

--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -45,7 +45,8 @@ decl_module! {
             T::Currency::transfer(&source, &bridge_id, amount.into(), AllowDeath)?;
 
             let resource_id = T::NativeTokenId::get();
-            <chainbridge::Module<T>>::transfer_fungible(dest_id, resource_id, recipient, amount)
+            <chainbridge::Module<T>>::transfer_fungible(dest_id, resource_id, recipient, amount)?;
+			Ok(())
         }
 
 

--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -67,6 +67,17 @@ decl_module! {
             Ok(())
         }
 
+		pub fn transfer_generic(
+			origin,
+			dest_id: chainbridge::ChainId,
+			resource_id: ResourceId,
+			metadata: Vec<u8>,
+		) -> DispatchResult {
+			T::BridgeOrigin::ensure_origin(origin)?;
+			<chainbridge::Module<T>>::transfer_generic(dest_id, resource_id, metadata)?;
+			Ok(())
+		}
+
     }
 }
 

--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -68,12 +68,11 @@ decl_module! {
         }
 
 		pub fn transfer_generic(
-			origin,
+			_origin,
 			dest_id: chainbridge::ChainId,
 			resource_id: ResourceId,
 			metadata: Vec<u8>,
 		) -> DispatchResult {
-			T::BridgeOrigin::ensure_origin(origin)?;
 			<chainbridge::Module<T>>::transfer_generic(dest_id, resource_id, metadata)?;
 			Ok(())
 		}

--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -1,0 +1,477 @@
+use frame_support::traits::{Currency, ExistenceRequirement::AllowDeath, Get};
+use frame_support::{decl_error, decl_event, decl_module, dispatch::DispatchResult, ensure};
+use frame_system::{self as system, ensure_signed};
+use sp_runtime::traits::EnsureOrigin;
+use sp_std::prelude::*;
+
+type ResourceId = chainbridge::ResourceId;
+
+pub trait Trait: system::Trait + chainbridge::Trait {
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+    /// Specifies the origin check provided by the chainbridge for calls that can only be called by the chainbridge pallet
+    type BridgeOrigin: EnsureOrigin<Self::Origin, Success = Self::AccountId>;
+
+    /// Ids can be defined by the runtime and passed in, perhaps from blake2b_128 hashes.
+    type HashId: Get<ResourceId>;
+    type NativeTokenId: Get<ResourceId>;
+}
+
+decl_event! {
+    pub enum Event<T> where
+        <T as frame_system::Trait>::Hash,
+    {
+        Remark(Hash),
+    }
+}
+
+decl_error! {
+    pub enum Error for Module<T: Trait>{
+        InvalidTransfer,
+    }
+}
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        const HashId: ResourceId = T::HashId::get();
+        const NativeTokenId: ResourceId = T::NativeTokenId::get();
+
+        fn deposit_event() = default;
+
+        //
+        // Initiation calls. These start a chainbridge transfer.
+        //
+
+        /// Transfers an arbitrary hash to a (whitelisted) destination chain.
+        pub fn transfer_hash(origin, hash: T::Hash, dest_id: chainbridge::ChainId) -> DispatchResult {
+            ensure_signed(origin)?;
+
+            let resource_id = T::HashId::get();
+            let metadata: Vec<u8> = hash.as_ref().to_vec();
+            <chainbridge::Module<T>>::transfer_generic(dest_id, resource_id, metadata)
+        }
+
+        /// Transfers some amount of the native token to some recipient on a (whitelisted) destination chain.
+        pub fn transfer_native(origin, amount: u32, recipient: Vec<u8>, dest_id: chainbridge::ChainId) -> DispatchResult {
+            let source = ensure_signed(origin)?;
+            ensure!(<chainbridge::Module<T>>::chain_whitelisted(dest_id), Error::<T>::InvalidTransfer);
+            let bridge_id = <chainbridge::Module<T>>::account_id();
+            T::Currency::transfer(&source, &bridge_id, amount.into(), AllowDeath)?;
+
+            let resource_id = T::NativeTokenId::get();
+            <chainbridge::Module<T>>::transfer_fungible(dest_id, resource_id, recipient, amount)
+        }
+
+
+        //
+        // Executable calls. These can be triggered by a chainbridge transfer initiated on another chain
+        //
+
+        /// Executes a simple currency transfer using the chainbridge account as the source
+        pub fn transfer(origin, to: T::AccountId, amount: u32) -> DispatchResult {
+            let source = T::BridgeOrigin::ensure_origin(origin)?;
+            T::Currency::transfer(&source, &to, amount.into(), AllowDeath)?;
+            Ok(())
+        }
+
+        /// This can be called by the chainbridge to demonstrate an arbitrary call from a proposal.
+        pub fn remark(origin, hash: T::Hash) -> DispatchResult {
+            T::BridgeOrigin::ensure_origin(origin)?;
+            Self::deposit_event(RawEvent::Remark(hash));
+            Ok(())
+        }
+
+    }
+}
+
+#[cfg(test)]
+mod tests{
+	use super::*;
+	use frame_support::dispatch::DispatchError;
+	use frame_support::{assert_noop, assert_ok};
+	use codec::Encode;
+	use sp_core::{blake2_256, H256};
+	use frame_support::{ord_parameter_types, parameter_types, weights::Weight};
+	use frame_system::{self as system};
+	use sp_core::hashing::blake2_128;
+	use sp_runtime::{
+		testing::Header,
+		traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, IdentityLookup},
+		BuildStorage, ModuleId, Perbill,
+	};
+	use crate::bridge as pallet_bridge;
+	use crate::bridge::Module;
+
+	pub use pallet_balances as balances;
+
+	const TEST_THRESHOLD: u32 = 2;
+
+
+
+	parameter_types! {
+		pub const BlockHashCount: u64 = 250;
+		pub const MaximumBlockWeight: Weight = 1024;
+		pub const MaximumBlockLength: u32 = 2 * 1024;
+		pub const AvailableBlockRatio: Perbill = Perbill::one();
+	}
+
+	impl frame_system::Trait for Test {
+		type Origin = Origin;
+		type Call = ();
+		type Index = u64;
+		type BlockNumber = u64;
+		type Hash = H256;
+		type Hashing = BlakeTwo256;
+		type AccountId = u64;
+		type Lookup = IdentityLookup<Self::AccountId>;
+		type Header = Header;
+		type Event = Event;
+		type BlockHashCount = BlockHashCount;
+		type MaximumBlockWeight = MaximumBlockWeight;
+		type MaximumBlockLength = MaximumBlockLength;
+		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
+		type ModuleToIndex = ();
+		type AccountData = balances::AccountData<u64>;
+		type OnNewAccount = ();
+		type OnKilledAccount = ();
+	}
+
+	parameter_types! {
+		pub const ExistentialDeposit: u64 = 1;
+	}
+
+	ord_parameter_types! {
+		pub const One: u64 = 1;
+	}
+
+	impl pallet_balances::Trait for Test {
+		type Balance = u64;
+		type DustRemoval = ();
+		type Event = Event;
+		type ExistentialDeposit = ExistentialDeposit;
+		type AccountStore = System;
+	}
+
+	parameter_types! {
+		pub const TestChainId: u8 = 5;
+	}
+
+	impl chainbridge::Trait for Test {
+		type Event = Event;
+		type Currency = Balances;
+		type Proposal = Call;
+		type ChainId = TestChainId;
+	}
+
+	parameter_types! {
+		pub const HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"hash"));
+		pub const NativeTokenId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"xRAD"));
+	}
+
+	impl Trait for Test {
+		type Event = Event;
+		type BridgeOrigin = chainbridge::EnsureBridge<Test>;
+		type HashId = HashId;
+		type NativeTokenId = NativeTokenId;
+	}
+
+	pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+	pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
+
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic
+		{
+			System: system::{Module, Call, Event<T>},
+			Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
+			ChainBridge: chainbridge::{Module, Call, Storage, Event<T>},
+			PalletBridge: pallet_bridge::{Module, Call, Event<T>}
+		}
+	);
+
+	pub const RELAYER_A: u64 = 0x2;
+	pub const RELAYER_B: u64 = 0x3;
+	pub const RELAYER_C: u64 = 0x4;
+	pub const ENDOWED_BALANCE: u64 = 100_000_000;
+
+	pub fn new_test_ext() -> sp_io::TestExternalities {
+		let bridge_id = ModuleId(*b"cb/bridg").into_account();
+		GenesisConfig {
+			balances: Some(balances::GenesisConfig {
+				balances: vec![(bridge_id, ENDOWED_BALANCE), (RELAYER_A, ENDOWED_BALANCE)],
+			}),
+		}
+		.build_storage()
+		.unwrap()
+		.into()
+	}
+
+	fn last_event() -> Event {
+		system::Module::<Test>::events()
+			.pop()
+			.map(|e| e.event)
+			.expect("Event expected")
+	}
+
+	pub fn expect_event<E: Into<Event>>(e: E) {
+		assert_eq!(last_event(), e.into());
+	}
+
+	// Asserts that the event was emitted at some point.
+	pub fn event_exists<E: Into<Event>>(e: E) {
+		let actual: Vec<Event> = system::Module::<Test>::events()
+			.iter()
+			.map(|e| e.event.clone())
+			.collect();
+		let e: Event = e.into();
+		let mut exists = false;
+		for evt in actual {
+			if evt == e {
+				exists = true;
+				break;
+			}
+		}
+		assert!(exists);
+	}
+
+	// Checks events against the latest. A contiguous set of events must be provided. They must
+	// include the most recent event, but do not have to include every past event.
+	pub fn assert_events(mut expected: Vec<Event>) {
+		let mut actual: Vec<Event> = system::Module::<Test>::events()
+			.iter()
+			.map(|e| e.event.clone())
+			.collect();
+
+		expected.reverse();
+
+		for evt in expected {
+			let next = actual.pop().expect("event expected");
+			assert_eq!(next, evt.into(), "Events don't match");
+		}
+	}
+
+	fn make_remark_proposal(hash: H256) -> Call {
+		Call::PalletBridge(crate::bridge::Call::remark(hash))
+	}
+
+	fn make_transfer_proposal(to: u64, amount: u32) -> Call {
+		Call::PalletBridge(crate::bridge::Call::transfer(to, amount))
+	}
+
+
+	#[test]
+	fn transfer_hash() {
+		new_test_ext().execute_with(|| {
+			let dest_chain = 0;
+			let resource_id = HashId::get();
+			let hash: H256 = "ABC".using_encoded(blake2_256).into();
+
+			assert_ok!(ChainBridge::set_threshold(Origin::ROOT, TEST_THRESHOLD,));
+
+			assert_ok!(ChainBridge::whitelist_chain(Origin::ROOT, dest_chain.clone()));
+			assert_ok!(PalletBridge::transfer_hash(
+				Origin::signed(1),
+				hash.clone(),
+				dest_chain,
+			));
+
+			expect_event(chainbridge::RawEvent::GenericTransfer(
+				dest_chain,
+				1,
+				resource_id,
+				hash.as_ref().to_vec(),
+			));
+		})
+	}
+
+	#[test]
+	fn transfer_native() {
+		new_test_ext().execute_with(|| {
+			let dest_chain = 0;
+			let resource_id = NativeTokenId::get();
+			let amount: u32 = 100;
+			let recipient = vec![99];
+
+			assert_ok!(ChainBridge::whitelist_chain(Origin::ROOT, dest_chain.clone()));
+			assert_ok!(PalletBridge::transfer_native(
+				Origin::signed(RELAYER_A),
+				amount.clone(),
+				recipient.clone(),
+				dest_chain,
+			));
+
+			expect_event(chainbridge::RawEvent::FungibleTransfer(
+				dest_chain,
+				1,
+				resource_id,
+				amount,
+				recipient,
+			));
+		})
+	}
+
+
+	#[test]
+	fn execute_remark() {
+		new_test_ext().execute_with(|| {
+			let hash: H256 = "ABC".using_encoded(blake2_256).into();
+			let proposal = make_remark_proposal(hash.clone());
+			let prop_id = 1;
+			let src_id = 1;
+			let r_id = chainbridge::derive_resource_id(src_id, b"hash");
+			let resource = b"PalletBridge.remark".to_vec();
+
+			assert_ok!(ChainBridge::set_threshold(Origin::ROOT, TEST_THRESHOLD,));
+			assert_ok!(ChainBridge::add_relayer(Origin::ROOT, RELAYER_A));
+			assert_ok!(ChainBridge::add_relayer(Origin::ROOT, RELAYER_B));
+			assert_ok!(ChainBridge::whitelist_chain(Origin::ROOT, src_id));
+			assert_ok!(ChainBridge::set_resource(Origin::ROOT, r_id, resource));
+
+			assert_ok!(ChainBridge::acknowledge_proposal(
+				Origin::signed(RELAYER_A),
+				prop_id,
+				src_id,
+				r_id,
+				Box::new(proposal.clone())
+			));
+			assert_ok!(ChainBridge::acknowledge_proposal(
+				Origin::signed(RELAYER_B),
+				prop_id,
+				src_id,
+				r_id,
+				Box::new(proposal.clone())
+			));
+
+			event_exists(RawEvent::Remark(hash));
+		})
+	}
+
+	#[test]
+	fn execute_remark_bad_origin() {
+		new_test_ext().execute_with(|| {
+			let hash: H256 = "ABC".using_encoded(blake2_256).into();
+
+			assert_ok!(PalletBridge::remark(Origin::signed(ChainBridge::account_id()), hash));
+			// Don't allow any signed origin except from chainbridge addr
+			assert_noop!(
+				PalletBridge::remark(Origin::signed(RELAYER_A), hash),
+				DispatchError::BadOrigin
+			);
+			// Don't allow root calls
+			assert_noop!(
+				PalletBridge::remark(Origin::ROOT, hash),
+				DispatchError::BadOrigin
+			);
+		})
+	}
+
+	#[test]
+	fn transfer() {
+		new_test_ext().execute_with(|| {
+			// Check inital state
+			let bridge_id: u64 = ChainBridge::account_id();
+			assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE);
+			// Transfer and check result
+			assert_ok!(PalletBridge::transfer(
+				Origin::signed(ChainBridge::account_id()),
+				RELAYER_A,
+				10
+			));
+			assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE - 10);
+			assert_eq!(Balances::free_balance(RELAYER_A), ENDOWED_BALANCE + 10);
+
+			assert_events(vec![Event::balances(balances::RawEvent::Transfer(
+				ChainBridge::account_id(),
+				RELAYER_A,
+				10,
+			))]);
+		})
+	}
+
+	#[test]
+	fn create_sucessful_transfer_proposal() {
+		new_test_ext().execute_with(|| {
+			let prop_id = 1;
+			let src_id = 1;
+			let r_id = chainbridge::derive_resource_id(src_id, b"transfer");
+			let resource = b"PalletBridge.transfer".to_vec();
+			let proposal = make_transfer_proposal(RELAYER_A, 10);
+
+			assert_ok!(ChainBridge::set_threshold(Origin::ROOT, TEST_THRESHOLD,));
+			assert_ok!(ChainBridge::add_relayer(Origin::ROOT, RELAYER_A));
+			assert_ok!(ChainBridge::add_relayer(Origin::ROOT, RELAYER_B));
+			assert_ok!(ChainBridge::add_relayer(Origin::ROOT, RELAYER_C));
+			assert_ok!(ChainBridge::whitelist_chain(Origin::ROOT, src_id));
+			assert_ok!(ChainBridge::set_resource(Origin::ROOT, r_id, resource));
+
+			// Create proposal (& vote)
+			assert_ok!(ChainBridge::acknowledge_proposal(
+				Origin::signed(RELAYER_A),
+				prop_id,
+				src_id,
+				r_id,
+				Box::new(proposal.clone())
+			));
+			let prop = ChainBridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+			let expected = chainbridge::ProposalVotes {
+				votes_for: vec![RELAYER_A],
+				votes_against: vec![],
+				status: chainbridge::ProposalStatus::Active,
+			};
+			assert_eq!(prop, expected);
+
+			// Second relayer votes against
+			assert_ok!(ChainBridge::reject(
+				Origin::signed(RELAYER_B),
+				prop_id,
+				src_id,
+				r_id,
+				Box::new(proposal.clone())
+			));
+			let prop = ChainBridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+			let expected = chainbridge::ProposalVotes {
+				votes_for: vec![RELAYER_A],
+				votes_against: vec![RELAYER_B],
+				status: chainbridge::ProposalStatus::Active,
+			};
+			assert_eq!(prop, expected);
+
+			// Third relayer votes in favour
+			assert_ok!(ChainBridge::acknowledge_proposal(
+				Origin::signed(RELAYER_C),
+				prop_id,
+				src_id,
+				r_id,
+				Box::new(proposal.clone())
+			));
+			let prop = ChainBridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+			let expected = chainbridge::ProposalVotes {
+				votes_for: vec![RELAYER_A, RELAYER_C],
+				votes_against: vec![RELAYER_B],
+				status: chainbridge::ProposalStatus::Approved,
+			};
+			assert_eq!(prop, expected);
+
+			assert_eq!(Balances::free_balance(RELAYER_A), ENDOWED_BALANCE + 10);
+			assert_eq!(
+				Balances::free_balance(ChainBridge::account_id()),
+				ENDOWED_BALANCE - 10
+			);
+
+			assert_events(vec![
+				Event::chainbridge(chainbridge::RawEvent::VoteFor(src_id, prop_id, RELAYER_A)),
+				Event::chainbridge(chainbridge::RawEvent::VoteAgainst(src_id, prop_id, RELAYER_B)),
+				Event::chainbridge(chainbridge::RawEvent::VoteFor(src_id, prop_id, RELAYER_C)),
+				Event::chainbridge(chainbridge::RawEvent::ProposalApproved(src_id, prop_id)),
+				Event::balances(balances::RawEvent::Transfer(
+					ChainBridge::account_id(),
+					RELAYER_A,
+					10,
+				)),
+				Event::chainbridge(chainbridge::RawEvent::ProposalSucceeded(src_id, prop_id)),
+			]);
+		})
+	}
+}

--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -37,19 +37,6 @@ decl_module! {
 
         fn deposit_event() = default;
 
-        //
-        // Initiation calls. These start a chainbridge transfer.
-        //
-
-        /// Transfers an arbitrary hash to a (whitelisted) destination chain.
-        pub fn transfer_hash(origin, hash: T::Hash, dest_id: chainbridge::ChainId) -> DispatchResult {
-            ensure_signed(origin)?;
-
-            let resource_id = T::HashId::get();
-            let metadata: Vec<u8> = hash.as_ref().to_vec();
-            <chainbridge::Module<T>>::transfer_generic(dest_id, resource_id, metadata)
-        }
-
         /// Transfers some amount of the native token to some recipient on a (whitelisted) destination chain.
         pub fn transfer_native(origin, amount: u32, recipient: Vec<u8>, dest_id: chainbridge::ChainId) -> DispatchResult {
             let source = ensure_signed(origin)?;

--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -97,7 +97,6 @@ mod tests{
 		BuildStorage, ModuleId, Perbill,
 	};
 	use crate::bridge as pallet_bridge;
-	use crate::bridge::Module;
 
 	pub use pallet_balances as balances;
 

--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -67,16 +67,6 @@ decl_module! {
             Ok(())
         }
 
-		pub fn transfer_generic(
-			_origin,
-			dest_id: chainbridge::ChainId,
-			resource_id: ResourceId,
-			metadata: Vec<u8>,
-		) -> DispatchResult {
-			<chainbridge::Module<T>>::transfer_generic(dest_id, resource_id, metadata)?;
-			Ok(())
-		}
-
     }
 }
 

--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -259,31 +259,6 @@ mod tests{
 
 
 	#[test]
-	fn transfer_hash() {
-		new_test_ext().execute_with(|| {
-			let dest_chain = 0;
-			let resource_id = HashId::get();
-			let hash: H256 = "ABC".using_encoded(blake2_256).into();
-
-			assert_ok!(ChainBridge::set_threshold(Origin::ROOT, TEST_THRESHOLD,));
-
-			assert_ok!(ChainBridge::whitelist_chain(Origin::ROOT, dest_chain.clone()));
-			assert_ok!(PalletBridge::transfer_hash(
-				Origin::signed(1),
-				hash.clone(),
-				dest_chain,
-			));
-
-			expect_event(chainbridge::RawEvent::GenericTransfer(
-				dest_chain,
-				1,
-				resource_id,
-				hash.as_ref().to_vec(),
-			));
-		})
-	}
-
-	#[test]
 	fn transfer_native() {
 		new_test_ext().execute_with(|| {
 			let dest_chain = 0;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -49,6 +49,7 @@ pub use pallet_staking::StakerStatus;
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
 use impls::{CurrencyToVoteHandler, Author, LinearWeightToFee, TargetedFeeAdjustment};
+use bridge as pallet_bridge;
 
 /// Used for anchor module
 pub mod anchor;
@@ -597,7 +598,7 @@ construct_runtime!(
 		Nfts: nfts::{Module, Call, Event<T>},
 		MultiAccount: substrate_pallet_multi_account::{Module, Call, Storage, Event<T>, Config<T>},
 		Identity: pallet_identity::{Module, Call, Storage, Event<T>},
-		PalletBridge: bridge::{Module, Call, Event<T>},
+		PalletBridge: pallet_bridge::{Module, Call, Event<T>},
 		ChainBridge: chainbridge::{Module, Call, Storage, Event<T>},
 	}
 );

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -598,7 +598,7 @@ construct_runtime!(
 		MultiAccount: substrate_pallet_multi_account::{Module, Call, Storage, Event<T>, Config<T>},
 		Identity: pallet_identity::{Module, Call, Storage, Event<T>},
 		PalletBridge: bridge::{Module, Call, Event<T>},
-		ChainBridge: chainbridge::{Module, Call, Event<T>},
+		ChainBridge: chainbridge::{Module, Call, Storage, Event<T>},
 	}
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -87,7 +87,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
     spec_version: 227,
-    impl_version: 0,
+    impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
 };
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,12 +28,14 @@ use sp_version::RuntimeVersion;
 #[cfg(any(feature = "std", test))]
 use sp_version::NativeVersion;
 use sp_core::OpaqueMetadata;
+use sp_io::hashing::blake2_128;
 use pallet_grandpa::AuthorityList as GrandpaAuthorityList;
 use pallet_grandpa::fg_primitives;
 use pallet_im_online::sr25519::{AuthorityId as ImOnlineId};
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 use frame_system::offchain::TransactionSubmitter;
+use frame_system::EnsureSigned;
 use sp_inherents::{InherentData, CheckInherentsResult};
 use crate::anchor::AnchorData;
 use pallet_collective::EnsureProportionMoreThan;
@@ -62,6 +64,9 @@ mod proofs;
 
 /// nft module
 mod nfts;
+
+/// bridge module
+mod bridge;
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -538,6 +543,31 @@ impl pallet_identity::Trait for Runtime {
     type ForceOrigin = EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>;
 }
 
+
+parameter_types! {
+    pub const HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"hash"));
+	pub const NativeTokenId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"xRAD"));
+}
+
+impl bridge::Trait for Runtime {
+	type Event = Event;
+	type BridgeOrigin = EnsureSigned<AccountId>;
+	type HashId = HashId;
+	type NativeTokenId = NativeTokenId;
+}
+
+
+parameter_types! {
+    pub const ChainId: u8 = 0;
+}
+impl chainbridge::Trait for Runtime {
+    type Event = Event;
+    type Currency = Balances;
+    type Proposal = Call;
+    type ChainId = ChainId;
+
+}
+
 construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
@@ -567,6 +597,8 @@ construct_runtime!(
 		Nfts: nfts::{Module, Call, Event<T>},
 		MultiAccount: substrate_pallet_multi_account::{Module, Call, Storage, Event<T>, Config<T>},
 		Identity: pallet_identity::{Module, Call, Storage, Event<T>},
+		PalletBridge: bridge::{Module, Call, Event<T>},
+		ChainBridge: chainbridge::{Module, Call, Event<T>},
 	}
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -545,7 +545,7 @@ impl pallet_identity::Trait for Runtime {
 
 
 parameter_types! {
-    pub const HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"hash"));
+    pub const HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"cent_nft_hash"));
 	pub const NativeTokenId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"xRAD"));
 }
 
@@ -558,7 +558,7 @@ impl bridge::Trait for Runtime {
 
 
 parameter_types! {
-    pub const ChainId: u8 = 0;
+    pub const ChainId: u8 = 1;
 }
 impl chainbridge::Trait for Runtime {
     type Event = Event;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -553,6 +553,7 @@ parameter_types! {
 impl bridge::Trait for Runtime {
 	type Event = Event;
 	type BridgeOrigin = EnsureSigned<AccountId>;
+	type Currency = Balances;
 	type HashId = HashId;
 	type NativeTokenId = NativeTokenId;
 }
@@ -563,7 +564,6 @@ parameter_types! {
 }
 impl chainbridge::Trait for Runtime {
     type Event = Event;
-    type Currency = Balances;
     type Proposal = Call;
     type ChainId = ChainId;
 

--- a/runtime/src/nfts.rs
+++ b/runtime/src/nfts.rs
@@ -149,18 +149,17 @@ mod tests {
 	impl pallet_bridge::Trait for Test {
 		type Event = ();
 		type BridgeOrigin = chainbridge::EnsureBridge<Test>;
+		type Currency = Balances;
 		type HashId = HashId;
 		type NativeTokenId = NativeTokenId;
 	}
 
 	parameter_types! {
 		pub const TestChainId: u8 = 5;
-		pub const TestCurrency: u32 = 0;
 	}
 
 	impl chainbridge::Trait for Test {
 		type Event = ();
-		type Currency = Balances;
 		type Proposal = Call;
 		type ChainId = TestChainId;
 	}

--- a/runtime/src/nfts.rs
+++ b/runtime/src/nfts.rs
@@ -381,7 +381,7 @@ mod tests {
                     deposit_address,
                     vec![pf],
                     static_proofs,
-					1
+					0
                 ),
                 "Invalid proofs"
             );
@@ -391,6 +391,7 @@ mod tests {
     #[test]
     fn valid_proof() {
         new_test_ext().execute_with(|| {
+            let dest_id = 0;
             let deposit_address: [u8; 20] = [0; 20];
             let pre_image = <Test as frame_system::Trait>::Hashing::hash_of(&0);
             let anchor_id = (pre_image).using_encoded(<Test as frame_system::Trait>::Hashing::hash);
@@ -403,13 +404,14 @@ mod tests {
                 common::MS_PER_DAY + 1
             ));
 
+            assert_ok!(ChainBridge::whitelist_chain(Origin::ROOT, dest_id.clone()));
             assert_ok!(Nfts::validate_mint(
                 Origin::signed(1),
                 anchor_id,
                 deposit_address,
                 vec![pf],
                 static_proofs,
-				1
+				0
             ),);
         })
     }

--- a/runtime/src/nfts.rs
+++ b/runtime/src/nfts.rs
@@ -1,6 +1,6 @@
 use crate::{anchor, proofs, proofs::Proof};
 use frame_support::{
-    decl_event, decl_module, dispatch::DispatchResult, ensure, weights::SimpleDispatchInfo,
+    decl_event, decl_module, dispatch::DispatchResult, ensure, weights::SimpleDispatchInfo, traits::Get,
 };
 use frame_system::{self as system, ensure_signed};
 use sp_core::H256;
@@ -40,12 +40,10 @@ decl_module! {
 
             // get the bundled hash
             let bundled_hash = Self::get_bundled_hash(pfs, deposit_address);
-
             Self::deposit_event(RawEvent::DepositAsset(bundled_hash));
 
-            let resource_id = [0;32]; //TODO: where to get this?
-			let metadata = Vec::with_capacity(0); // TODO: what's the content of metadata
-
+			let metadata = bundled_hash.as_ref().to_vec();
+			let resource_id = <T as pallet_bridge::Trait>::HashId::get();
 			<pallet_bridge::Module<T>>::transfer_generic(origin, dest_id, resource_id, metadata)?;
 
             Ok(())

--- a/runtime/src/nfts.rs
+++ b/runtime/src/nfts.rs
@@ -30,7 +30,7 @@ decl_module! {
         /// # </weight>
         #[weight = SimpleDispatchInfo::FixedNormal(1_500_000)]
         fn validate_mint(origin, anchor_id: T::Hash, deposit_address: [u8; 20], pfs: Vec<Proof>, static_proofs: [H256;3], dest_id: chainbridge::ChainId) -> DispatchResult {
-            ensure_signed(origin.clone())?;
+            ensure_signed(origin)?;
 
             // get the anchor data from anchor ID
             let anchor_data = <anchor::Module<T>>::get_anchor_by_id(anchor_id).ok_or("Anchor doesn't exist")?;
@@ -44,8 +44,7 @@ decl_module! {
 
 			let metadata = bundled_hash.as_ref().to_vec();
 			let resource_id = <T as pallet_bridge::Trait>::HashId::get();
-			<pallet_bridge::Module<T>>::transfer_generic(origin, dest_id, resource_id, metadata)?;
-
+			<chainbridge::Module<T>>::transfer_generic(dest_id, resource_id, metadata)?;
             Ok(())
         }
     }


### PR DESCRIPTION
This is based on [ChainSafe/chainbridge](https://github.com/ChainSafe/chainbridge-substrate) example pallet.

## Request for comment on:
- rename `bridge` module as `pallet_bridge` to have a clear distinction from `chainbridge`
 
- needs enhancements on the doc comment on the module functions
    - `transfer_hash`
     - `transfer_native`
     - `transfer` 
     - `remark`

- Erc721 `parameter_types` is not included.
```rust
parameter_types!{
     pub const Erc721Id: bridge::ResourceId = bridge::derive_resource_id(1, &blake2_128(b"NFT"));
}
```
- No `GenesisConfig` defined in `chain_spec`.
     - in the chainsafe example `bridge_pallet` has no defined `decl_storage!`
     - `bridge_pallet` inherits on `chainbridge::Trait` where a `decl_storage` is defined.
         - will this have an entry into the `GenesisConfig` in `chain_spec`?
```rust
pub trait Trait: system::Trait + chainbridge::Trait {
...
}
```

