### PR TITLE
Rename PalletBridge storage

### DIFF
--- a/runtime/src/bridge.rs
+++ b/runtime/src/bridge.rs
@@ -24,7 +24,7 @@ pub trait Trait: system::Trait + chainbridge::Trait {
 }
 
 decl_storage! {
-	trait Store for Module<T: Trait> as Bridge {}
+	trait Store for Module<T: Trait> as PalletBridge {}
 
 	add_extra_genesis {
         config(chains): Vec<u8>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -87,7 +87,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
     spec_version: 228,
-    impl_version: 2,
+    impl_version: 3,
     apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
Fixes conflicting storage names with ChainSafe Bridge storage pallet.