### PR TITLE
runtime/Cargo.toml: fix wasm-builder-runner version

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -77,7 +77,7 @@ pallet-vesting = { version = "2.0.0-rc6", git = "https://github.com/centrifuge/s
 frame-benchmarking = { version = "2.0.0-rc6", git = "https://github.com/centrifuge/substrate.git", rev = "e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd", default-features = false, optional = true }
 
 [build-dependencies]
-wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", git = "https://github.com/centrifuge/substrate.git", rev = "e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd" }
+wasm-builder-runner = { version = "1.0.6", package = "substrate-wasm-builder-runner", git = "https://github.com/centrifuge/substrate.git", rev = "e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd" }
 
 [features]
 default = ["std"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
     spec_version: 240,
-    impl_version: 0,
+    impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
 };


### PR DESCRIPTION
The `wasm-builder-package` at the specified commit has version 1.0.6:

https://github.com/centrifuge/substrate/blob/e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd/utils/wasm-builder-runner/Cargo.toml#L3