### PR TITLE
Allow arguments to be passed to Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BUILD_TIMESTAMP: $(date -u +%Y%m%d%H%M%S)
     steps:
       - uses: actions/checkout@v2
         with:
@@ -33,13 +35,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Tag docker image
-        run: docker tag centrifugeio/centrifuge-chain:latest "centrifugeio/centrifuge-chain:$(date -u +%Y%m%d)-$(git rev-parse --short HEAD)"
+        run: docker tag centrifugeio/centrifuge-chain:latest "centrifugeio/centrifuge-chain:${BUILD_TIMESTAMP}-$(git rev-parse --short HEAD)"
       - name: List images
         run: docker images
       - name: Push latest to Docker Hub
         run: docker push centrifugeio/centrifuge-chain:latest
         if: steps.extract_branch.outputs.branch == 'master'
       - name: Push rev to Docker Hub
-        run: docker push "centrifugeio/centrifuge-chain:$(date -u +%Y%m%d)-$(git rev-parse --short HEAD)"
+        run: docker push "centrifugeio/centrifuge-chain:${BUILD_TIMESTAMP}-$(git rev-parse --short HEAD)"
         if: steps.extract_branch.outputs.branch == 'master'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
         with:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
-      - uses: docker/setup-buildx-action@v1
       - uses: cachix/install-nix-action@v12
         with:
           install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
@@ -29,6 +28,7 @@ jobs:
     env:
       BUILD_TIMESTAMP: $(date -u +%Y%m%d%H%M%S)
     steps:
+      - uses: docker/setup-buildx-action@v1
       - run: nix build -L .#dockerContainer
       - run: docker load -i result
       - name: Extract branch name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      BUILD_TIMESTAMP: $(date -u +%Y%m%d%H%M%S)
     steps:
       - uses: actions/checkout@v2
         with:
@@ -23,6 +21,14 @@ jobs:
           name: centrifuge-chain
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build -L
+
+  docker:
+    if: ${{ github.event.pull_request.head.repo.full_name == 'centrifuge/centrifuge-chain' }}
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      BUILD_TIMESTAMP: $(date -u +%Y%m%d%H%M%S)
+    steps:
       - run: nix build -L .#dockerContainer
       - run: docker load -i result
       - name: Extract branch name
@@ -44,4 +50,3 @@ jobs:
       - name: Push rev to Docker Hub
         run: docker push "centrifugeio/centrifuge-chain:${BUILD_TIMESTAMP}-$(git rev-parse --short HEAD)"
         if: steps.extract_branch.outputs.branch == 'master'
-

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 **/*.rs.bk
 
 .idea
+
+# nix-related symlink
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "gitignore-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1611672876,
-        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1611179033,
@@ -34,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "gitignore-nix": "gitignore-nix",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "gitignore-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1611179033,
@@ -18,6 +34,7 @@
     },
     "root": {
       "inputs": {
+        "gitignore-nix": "gitignore-nix",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,24 +1,13 @@
 {
   description = "Nix package for centrifuge-chain";
 
-  inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-20.09;
-    gitignore-nix = {
-      url = github:hercules-ci/gitignore.nix;
-      flake = false;
-    };
-  };
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-20.09;
 
   outputs = inputs:
     let
       name = "centrifuge-chain";
       version = "2.0.0";
       pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
-      gitignore = (
-        import inputs.gitignore-nix {
-          inherit (inputs.nixpkgs.legacyPackages.x86_64-linux) lib;
-        }
-      ).gitignoreSource;
     in
     {
       packages.x86_64-linux.centrifuge-chain =
@@ -26,7 +15,7 @@
           pname = name;
           version = version;
 
-          src = gitignore ./.;
+          src = inputs.self;
 
           cargoSha256 = "sha256-52CN7N9FQiJSODloo0VZGPNw4P5XsaWfaQxEf6Nm2gI=";
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
             Volumes = {
               "/data" = { };
             };
-            Entrypoint = [ "/bin/centrifuge-chain" ];
+            Entrypoint = [ "centrifuge-chain" ];
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
 
           config = {
             Env = [
-              "PATH=/bin/centrifuge-chain"
+              "PATH=/bin:$PATH"
             ];
             ExposedPorts = {
               "30333/tcp" = { };

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
           name = "centrifugeio/${name}";
           tag = "latest";
 
+          contents = self.defaultPackage.x86_64-linux;
+
           config = {
             ExposedPorts = {
               "30333/tcp" = {};
@@ -45,7 +47,7 @@
             Volumes = {
                 "/data" = {};
             };
-            Entrypoint = [ "${self.defaultPackage.x86_64-linux}/bin/centrifuge-chain" ];
+            Entrypoint = [ "/bin/centrifuge-chain" ];
           };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,18 @@
 {
   description = "Nix package for centrifuge-chain";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-20.09;
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-20.09;
+    gitignore-nix = {
+      url = github:hercules-ci/gitignore.nix;
+      flake = false;
+    };
+  };
 
-  outputs = { self, nixpkgs, ... }: let
+  outputs = { self, nixpkgs, ... }@inputs: let
     name = "centrifuge-chain";
     version = "2.0.0";
+    gitignore = (import inputs.gitignore-nix { inherit (nixpkgs.legacyPackages.x86_64-linux) lib; }).gitignoreSource;
   in
     {
       defaultPackage.x86_64-linux =
@@ -15,7 +22,7 @@
           pname = name;
           version = version;
 
-          src = self;
+          src = gitignore ./.;
 
           cargoSha256 = "sha256-52CN7N9FQiJSODloo0VZGPNw4P5XsaWfaQxEf6Nm2gI=";
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,11 +9,12 @@
     };
   };
 
-  outputs = { self, nixpkgs, ... }@inputs: let
-    name = "centrifuge-chain";
-    version = "2.0.0";
-    gitignore = (import inputs.gitignore-nix { inherit (nixpkgs.legacyPackages.x86_64-linux) lib; }).gitignoreSource;
-  in
+  outputs = { self, nixpkgs, ... }@inputs:
+    let
+      name = "centrifuge-chain";
+      version = "2.0.0";
+      gitignore = (import inputs.gitignore-nix { inherit (nixpkgs.legacyPackages.x86_64-linux) lib; }).gitignoreSource;
+    in
     {
       defaultPackage.x86_64-linux =
         with import nixpkgs { system = "x86_64-linux"; };
@@ -36,9 +37,10 @@
           doCheck = false;
         };
 
-      packages.x86_64-linux.dockerContainer = let
-        pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      in
+      packages.x86_64-linux.dockerContainer =
+        let
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
+        in
         pkgs.dockerTools.buildImage {
           name = "centrifugeio/${name}";
           tag = "latest";
@@ -50,16 +52,16 @@
               "PATH=/bin/centrifuge-chain"
             ];
             ExposedPorts = {
-              "30333/tcp" = {};
-              "9933/tcp" = {};
-              "9944/tcp" = {};
+              "30333/tcp" = { };
+              "9933/tcp" = { };
+              "9944/tcp" = { };
             };
             Volumes = {
-                "/data" = {};
+              "/data" = { };
             };
             Entrypoint = [ "/bin/centrifuge-chain" ];
           };
-      };
+        };
 
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,9 @@
           contents = self.defaultPackage.x86_64-linux;
 
           config = {
+            Env = [
+              "PATH=/bin/centrifuge-chain"
+            ];
             ExposedPorts = {
               "30333/tcp" = {};
               "9933/tcp" = {};

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       ).gitignoreSource;
     in
     {
-      defaultPackage.x86_64-linux =
+      packages.x86_64-linux.centrifuge-chain =
         pkgs.rustPlatform.buildRustPackage {
           pname = name;
           version = version;
@@ -39,6 +39,8 @@
 
           doCheck = false;
         };
+
+      defaultPackage.x86_64-linux = inputs.self.packages.x86_64-linux.centrifuge-chain;
 
       packages.x86_64-linux.dockerContainer =
         pkgs.dockerTools.buildImage {

--- a/flake.nix
+++ b/flake.nix
@@ -9,15 +9,15 @@
     };
   };
 
-  outputs = { self, nixpkgs, ... }@inputs:
+  outputs = inputs:
     let
       name = "centrifuge-chain";
       version = "2.0.0";
-      gitignore = (import inputs.gitignore-nix { inherit (nixpkgs.legacyPackages.x86_64-linux) lib; }).gitignoreSource;
+      gitignore = (import inputs.gitignore-nix { inherit (inputs.nixpkgs.legacyPackages.x86_64-linux) lib; }).gitignoreSource;
     in
     {
       defaultPackage.x86_64-linux =
-        with import nixpkgs { system = "x86_64-linux"; };
+        with import inputs.nixpkgs { system = "x86_64-linux"; };
 
         rustPlatform.buildRustPackage {
           pname = name;
@@ -39,13 +39,13 @@
 
       packages.x86_64-linux.dockerContainer =
         let
-          pkgs = nixpkgs.legacyPackages.x86_64-linux;
+          pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
         in
         pkgs.dockerTools.buildImage {
           name = "centrifugeio/${name}";
           tag = "latest";
 
-          contents = self.defaultPackage.x86_64-linux;
+          contents = inputs.self.defaultPackage.x86_64-linux;
 
           config = {
             Env = [

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
         };
 
       packages.x86_64-linux.dockerContainer = let
-        pkgs = import nixpkgs { system = "x86_64-linux"; };
+        pkgs = nixpkgs.legacyPackages.x86_64-linux;
       in
         pkgs.dockerTools.buildImage {
           name = "centrifugeio/${name}";

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
             Volumes = {
                 "/data" = {};
             };
-            Cmd = [ "${self.defaultPackage.x86_64-linux}/bin/centrifuge-chain" ];
+            Entrypoint = [ "${self.defaultPackage.x86_64-linux}/bin/centrifuge-chain" ];
           };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,13 +13,16 @@
     let
       name = "centrifuge-chain";
       version = "2.0.0";
-      gitignore = (import inputs.gitignore-nix { inherit (inputs.nixpkgs.legacyPackages.x86_64-linux) lib; }).gitignoreSource;
+      pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
+      gitignore = (
+        import inputs.gitignore-nix {
+          inherit (inputs.nixpkgs.legacyPackages.x86_64-linux) lib;
+        }
+      ).gitignoreSource;
     in
     {
       defaultPackage.x86_64-linux =
-        with import inputs.nixpkgs { system = "x86_64-linux"; };
-
-        rustPlatform.buildRustPackage {
+        pkgs.rustPlatform.buildRustPackage {
           pname = name;
           version = version;
 
@@ -27,20 +30,17 @@
 
           cargoSha256 = "sha256-52CN7N9FQiJSODloo0VZGPNw4P5XsaWfaQxEf6Nm2gI=";
 
-          nativeBuildInputs = [ clang pkg-config ];
-          buildInputs = [ openssl ];
+          nativeBuildInputs = with pkgs; [ clang pkg-config ];
+          buildInputs = with pkgs; [ openssl ];
 
-          LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
-          PROTOC = "${protobuf}/bin/protoc";
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
+          PROTOC = "${pkgs.protobuf}/bin/protoc";
           BUILD_DUMMY_WASM_BINARY = 1;
 
           doCheck = false;
         };
 
       packages.x86_64-linux.dockerContainer =
-        let
-          pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
-        in
         pkgs.dockerTools.buildImage {
           name = "centrifugeio/${name}";
           tag = "latest";


### PR DESCRIPTION
This uses `ENTRYPOINT` instead of `CMD`, which is the correct way to set the
image's "base" command, since it doesn't get overwritten by arguments passed to
`docker run`. 
See [here](https://aws.amazon.com/blogs/opensource/demystifying-entrypoint-cmd-docker/) for an explanation.

Additionally, this PR:

- moves the Docker-related parts of the workflow file behind a check, ensuring they only run on the upstream repo and not on forks
- fixes the Docker tag, adding hours, minutes and seconds to the timestamp
- prepends `/bin` to the `PATH`, so that Kubernetes `Deployement`s don't have to be updated.