### PR TITLE
ci: config dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This will create automatic PRs to keep our actions up to date.

It will only trigger once the PR is merged though, as the file needs to be on the default branch - so we can't really test it.