### PR TITLE
CI: skip building when source hasn't changed

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "gitignore-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1611672876,
-        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1611179033,
@@ -34,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "gitignore-nix": "gitignore-nix",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "gitignore-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1611179033,
@@ -18,6 +34,7 @@
     },
     "root": {
       "inputs": {
+        "gitignore-nix": "gitignore-nix",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,9 @@
       name = "centrifuge-chain";
       version = "2.0.0";
       pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
-      gitignore = (import inputs.gitignore-nix { inherit (inputs.nixpkgs.legacyPackages.x86_64-linux) lib; });
 
       # srcFilter is used to keep out of the build non-source files,
-      # so that we don't trigger a rebuild when not necessary.
+      # so that we only trigger a rebuild when necessary.
       srcFilter = path: type:
         let
           p = baseNameOf path;

--- a/flake.nix
+++ b/flake.nix
@@ -21,11 +21,14 @@
           srcIgnored = gitignore.gitignoreFilter src;
         in
         path: type:
+          let
+            p = baseNameOf path;
+          in
           srcIgnored path type
-          # ignore .github/
-          || !(type == "directory" && baseNameOf path == ".github")
+          # ignore CI directories
+          || !(type == "directory" && p == ".github")
           # ignore flake.(nix|lock)
-          || !(baseNameOf path == "flake.nix" || baseNameOf path == "flake.lock");
+          || !(p == "flake.nix" || p == "flake.lock");
 
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,20 @@
 {
   description = "Nix package for centrifuge-chain";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-20.09;
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-20.09;
+    gitignore-nix = {
+      url = github:hercules-ci/gitignore.nix;
+      flake = false;
+    };
+  };
 
   outputs = inputs:
     let
       name = "centrifuge-chain";
       version = "2.0.0";
       pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
+      gitignore = (import inputs.gitignore-nix { inherit (inputs.nixpkgs.legacyPackages.x86_64-linux) lib; }).gitignoreSource;
     in
     {
       packages.x86_64-linux.centrifuge-chain =
@@ -15,7 +22,7 @@
           pname = name;
           version = version;
 
-          src = inputs.self;
+          src = gitignore ./.;
 
           cargoSha256 = "sha256-52CN7N9FQiJSODloo0VZGPNw4P5XsaWfaQxEf6Nm2gI=";
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,15 @@
           in
           srcIgnored path type
           # ignore CI directories
-          || !(type == "directory" && p == ".github")
+          || !(type == "directory" && (p == ".github" || p == "ci"))
+          # ignore CI files
+          || !(p == ".travis.yml" || p == "cloudbuild.yaml")
           # ignore flake.(nix|lock)
-          || !(p == "flake.nix" || p == "flake.lock");
+          || !(p == "flake.nix" || p == "flake.lock")
+          # ignore docker files
+          || !(p == ".dockerignore" || p == "docker-compose.yml")
+          # ignore misc
+          || !(p == "rustfmt.toml");
 
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -22,13 +22,13 @@
             # ignore CI directories
             (type == "directory" && (p == ".github" || p == "ci")) ||
             # ignore CI files
-            (p == ".travis.yml" || p == "cloudbuild.yaml") ||
+            p == ".travis.yml" || p == "cloudbuild.yaml" ||
             # ignore flake.(nix|lock)
-            (p == "flake.nix" || p == "flake.lock") ||
+            p == "flake.nix" || p == "flake.lock" ||
             # ignore docker files
-            (p == ".dockerignore" || p == "docker-compose.yml") ||
+            p == ".dockerignore" || p == "docker-compose.yml" ||
             # ignore misc
-            (p == "rustfmt.toml")
+            p == "rustfmt.toml"
           );
 
     in

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,8 @@
       pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
       gitignore = (import inputs.gitignore-nix { inherit (inputs.nixpkgs.legacyPackages.x86_64-linux) lib; });
 
+      # srcFilter is used to keep out of the build non-source files,
+      # so that we don't trigger a rebuild when not necessary.
       srcFilter = path: type:
         let
           p = baseNameOf path;


### PR DESCRIPTION
This should ensure we don't trigger nix builds when not necessary, giving us much faster CI feedback.

We achieve this by ignoring the files listed in the `srcFilter` function, meaning that:

- they won't end up in the nix package
- a change to one of these files won't trigger a new nix build
- the respective docker image generation will be much faster

/cc @lucasvo