### PR TITLE
Adds the NonProxy Type to Proxies

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -231,7 +231,7 @@ pub enum ProxyType {
     NonTransfer,
     Governance,
     Staking,
-    Vesting,
+    NonProxy,
 }
 impl Default for ProxyType { fn default() -> Self { Self::Any } }
 impl InstanceFilter<Call> for ProxyType {
@@ -253,15 +253,17 @@ impl InstanceFilter<Call> for ProxyType {
                 Call::Session(..) |
 				Call::Utility(..)
             ),
-            ProxyType::Vesting => matches!(c,
-                Call::Staking(..) |
-                Call::Session(..) |
-                Call::Democracy(..) |
-				Call::Council(..) |
-				Call::Elections(..) |
-				Call::Vesting(pallet_vesting::Call::vest(..)) |
-				Call::Vesting(pallet_vesting::Call::vest_other(..))
-            ),
+            ProxyType::NonProxy => !matches!(c,
+                Call::Proxy(pallet_proxy::Call::add_proxy(..)) |
+                Call::Proxy(pallet_proxy::Call::remove_proxy(..)) |
+                Call::Proxy(pallet_proxy::Call::remove_proxies(..)) |
+                Call::Proxy(pallet_proxy::Call::anonymous(..)) |
+                Call::Proxy(pallet_proxy::Call::kill_anonymous(..)) |
+                Call::Proxy(pallet_proxy::Call::announce(..)) |
+                Call::Proxy(pallet_proxy::Call::remove_announcement(..)) |
+                Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
+                Call::Proxy(pallet_proxy::Call::proxy_announced(..)) |
+            )
         }
     }
     fn is_superset(&self, o: &Self) -> bool {


### PR DESCRIPTION
This commit removes the Vesting type in favor of the NonProxy type.
The new proxy type forbids an account of this type to execute
any proxy pallet related operations, besides executing as a different
call as a proxy himself.

## Questions
* [SOLVED] Is it possible to call a forbidden proxy extrinsic as a parameter of the `pallet_proxy::Call::proxy(..)`? 
   UPDATE: [This](https://github.com/paritytech/substrate/blob/e5437efefa82bd8eb567f1245f0a7443ac4e4fe7/frame/proxy/src/lib.rs#L748) should block this.