### PR TITLE
Allow specifying parachain ID for genesis from the CLI

### DIFF
--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -47,7 +47,7 @@ where
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
-pub fn charcoal_local_network() -> ChainSpec {
+pub fn charcoal_local_network(para_id: ParaId) -> ChainSpec {
 	ChainSpec::from_genesis(
 		"Charcoal Local Testnet",
 		"charcoal_local_testnet",
@@ -72,7 +72,7 @@ pub fn charcoal_local_network() -> ChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				10001_u32.into(),
+				para_id,
 			)
 		},
 		vec![],
@@ -83,7 +83,7 @@ pub fn charcoal_local_network() -> ChainSpec {
 	)
 }
 
-pub fn charcoal_rococo_staging_network() -> ChainSpec {
+pub fn charcoal_rococo_staging_network(para_id: ParaId) -> ChainSpec {
 	ChainSpec::from_genesis(
 		"Charcoal Rococo Testnet",
 		"charcoal_rococo_testnet",
@@ -93,7 +93,6 @@ pub fn charcoal_rococo_staging_network() -> ChainSpec {
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
 				vec![
 					get_from_seed::<AuraId>("Alice"),
-					get_from_seed::<AuraId>("Bob"),
 				],
 				vec![
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
@@ -109,7 +108,7 @@ pub fn charcoal_rococo_staging_network() -> ChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				10001_u32.into(),
+				para_id,
 			)
 		},
 		vec![],
@@ -123,7 +122,7 @@ pub fn charcoal_rococo_staging_network() -> ChainSpec {
 	)
 }
 
-pub fn charcoal_chachacha_staging_network() -> ChainSpec {
+pub fn charcoal_chachacha_staging_network(para_id: ParaId) -> ChainSpec {
 	ChainSpec::from_genesis(
 		"Charcoal Chachacha Testnet",
 		"charcoal_chachacha_testnet",
@@ -133,7 +132,6 @@ pub fn charcoal_chachacha_staging_network() -> ChainSpec {
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
 				vec![
 					get_from_seed::<AuraId>("Alice"),
-					get_from_seed::<AuraId>("Bob"),
 				],
 				vec![
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
@@ -149,7 +147,7 @@ pub fn charcoal_chachacha_staging_network() -> ChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				10001_u32.into(),
+				para_id,
 			)
 		},
 		vec![],

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,10 @@ pub struct ExportGenesisStateCommand {
 	#[structopt(short, long)]
 	pub raw: bool,
 
+	/// Id of the parachain this state is for.
+	#[structopt(long)]
+	pub parachain_id: Option<u32>,
+
 	/// The name of the chain for that the genesis state should be exported.
 	#[structopt(long)]
 	pub chain: Option<String>,

--- a/src/command.rs
+++ b/src/command.rs
@@ -39,12 +39,13 @@ use std::{io::Write, net::SocketAddr};
 
 fn load_spec(
 	id: &str,
+	para_id: ParaId,
 ) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	match id {
 		"charcoal-rococo" => Ok(Box::new(chain_spec::charcoal_rococo_config())),
-		"charcoal-rococo-staging" => Ok(Box::new(chain_spec::charcoal_rococo_staging_network())),
-		"charcoal-chachacha-local" => Ok(Box::new(chain_spec::charcoal_local_network())),
-		"charcoal-chachacha-staging" => Ok(Box::new(chain_spec::charcoal_chachacha_staging_network())),
+		"charcoal-rococo-staging" => Ok(Box::new(chain_spec::charcoal_rococo_staging_network(para_id))),
+		"charcoal-chachacha-local" => Ok(Box::new(chain_spec::charcoal_local_network(para_id))),
+		"charcoal-chachacha-staging" => Ok(Box::new(chain_spec::charcoal_chachacha_staging_network(para_id))),
 		"charcoal-chachacha" => Ok(Box::new(chain_spec::charcoal_chachacha_config())),
 		path => Ok(Box::new(chain_spec::ChainSpec::from_json_file(
 			path.into(),
@@ -84,7 +85,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		load_spec(id)
+		load_spec(id, self.run.parachain_id.unwrap_or(10001).into())
 	}
 
 	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
@@ -213,7 +214,8 @@ pub fn run() -> Result<()> {
 			let _ = builder.init();
 
 			let block: Block = generate_genesis_block(&load_spec(
-				&params.chain.clone().unwrap_or_default())?)?;
+				&params.chain.clone().unwrap_or_default(),
+				params.parachain_id.unwrap_or(10001).into())?)?;
 			let raw_header = block.header().encode();
 			let output_buf = if params.raw {
 				raw_header


### PR DESCRIPTION
This is necesary for compatibility with `polkadot-launch`