### PR TITLE
Crowdloan Claim Pallet V1 

### DIFF
--- a/pallets/crowdloan-claim/src/mock.rs
+++ b/pallets/crowdloan-claim/src/mock.rs
@@ -25,7 +25,7 @@
 
 use crate::{self as pallet_crowdloan_claim, Config};
 
-use frame_support::{dispatch::DispatchResult, parameter_types, traits::Contains, weights::Weight};
+use frame_support::{parameter_types, traits::Contains, weights::Weight};
 
 use frame_system::EnsureSignedBy;
 
@@ -37,7 +37,7 @@ use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
     transaction_validity::TransactionPriority,
-    AccountId32, ModuleId, Perbill,
+    AccountId32, ModuleId,
 };
 
 use crate::traits::WeightInfo;
@@ -184,31 +184,6 @@ impl Config for MockRuntime {
     type RewardMechanism = CrowdloanReward;
 }
 
-pub struct Dummy;
-
-impl pallet_crowdloan_claim_reward::Reward for Dummy {
-    type ParachainAccountId = u64;
-    type ContributionAmount = u64;
-    type BlockNumber = u64;
-    type NativeBalance = Balance;
-
-    fn reward(
-        _who: Self::ParachainAccountId,
-        _contribution: Self::ContributionAmount,
-    ) -> DispatchResult {
-        Ok(())
-    }
-
-    fn initialize(
-        _conversion_rate: Self::NativeBalance,
-        _direct_payout_ratio: Perbill,
-        _vesting_period: Self::BlockNumber,
-        _vesting_start: Self::BlockNumber,
-    ) -> DispatchResult {
-        Ok(())
-    }
-}
-
 impl Contains<u64> for One {
     fn sorted_members() -> Vec<u64> {
         vec![1]
@@ -252,7 +227,7 @@ impl TestExternalitiesBuilder {
                 (12, 10 * self.existential_deposit),
                 (
                     CrowdloanReward::account_id(),
-                    1000 * self.existential_deposit,
+                    10000000000000000000 * self.existential_deposit,
                 ),
             ],
         }
@@ -262,7 +237,6 @@ impl TestExternalitiesBuilder {
         pallet_vesting::GenesisConfig::<MockRuntime> {
             vesting: vec![
                 (1, 0, 10, 5 * self.existential_deposit),
-                (2, 10, 20, 0),
                 (12, 10, 20, 5 * self.existential_deposit),
             ],
         }


### PR DESCRIPTION
The test `test_valid_claim` is not working, as the proofs of contribution do not work. In order to examine the problem. I create this intermediate PR. 

Current state: 
* Proofs are generated from a local setup
* The generated nodes are equally for all three contributors of the local crowdloan (which is weird in my opinion). 
* The prefixed storage key and the keys themself inside this child storage are correct
     -> I can extract the contributions from the storage via these keys. (Allthough, the decoding function of scale, does not decode the stored `memo` correctly (See `test_valid_claim` line 234-241), but when done manually, the hex-string does represent the correct message. NOTE: The hex string here is retrieved from the local-chain-storage via the UI)
* The root hash is found in the provided proofs.
   -> Easiest is to debug through the code and set breakpoints in the `triedb.rs` line 70 (check of root existence) and go through the `triedb/lookup.rs` function `look_up` line 41-ff.


Appreciate any thoughts on this 