### PR TITLE
Crowdloan Claim Pallet V2 -Alternative to  #385

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "environmental"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6576a1755ddffd988788025e75bce9e74b018f7cc226198fe931d077911c6d7e"
+checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "erased-serde"

--- a/pallets/crowdloan-claim/crowdloan-claim-reward/src/lib.rs
+++ b/pallets/crowdloan-claim/crowdloan-claim-reward/src/lib.rs
@@ -1,14 +1,12 @@
-use frame_support::dispatch::Codec;
+use frame_support::dispatch::{Codec, DispatchResultWithPostInfo};
 use frame_support::Parameter;
 use sp_runtime::traits::{
     AtLeast32BitUnsigned, Bounded, MaybeDisplay, MaybeMallocSizeOf, MaybeSerialize,
     MaybeSerializeDeserialize, Member, Zero,
 };
-use sp_runtime::{DispatchResult, Perbill};
 use sp_std::hash::Hash;
 use std::fmt::Debug;
 use std::str::FromStr;
-
 /// A trait used for loosely coupling the claim pallet with a reward mechanism.
 ///
 /// ## Overview
@@ -59,15 +57,6 @@ pub trait Reward {
         + Member
         + Parameter;
 
-    type NativeBalance: Parameter
-        + Member
-        + AtLeast32BitUnsigned
-        + Codec
-        + Default
-        + Copy
-        + MaybeSerializeDeserialize
-        + Debug;
-
     /// Rewarding function that is invoked from the claim pallet.
     ///
     /// If this function returns successfully, any subsequent claim of the same claimer will be
@@ -75,16 +64,5 @@ pub trait Reward {
     fn reward(
         who: Self::ParachainAccountId,
         contribution: Self::ContributionAmount,
-    ) -> DispatchResult;
-
-    /// Initialize function that will be called during the initialization of the crowdloan claim pallet.
-    ///
-    /// The main purpose of this function is to allow a dynamic configuration of the crowdloan reward
-    /// pallet.
-    fn initialize(
-        conversion_rate: Self::NativeBalance,
-        direct_payout_ratio: Perbill,
-        vesting_period: Self::BlockNumber,
-        vesting_start: Self::BlockNumber,
-    ) -> DispatchResult;
+    ) -> DispatchResultWithPostInfo;
 }

--- a/pallets/crowdloan-claim/src/mock.rs
+++ b/pallets/crowdloan-claim/src/mock.rs
@@ -25,7 +25,7 @@
 
 use crate::{self as pallet_crowdloan_claim, Config};
 
-use frame_support::{dispatch::DispatchResult, parameter_types, traits::Contains, weights::Weight};
+use frame_support::{parameter_types, traits::Contains, weights::Weight};
 
 use frame_system::EnsureSignedBy;
 
@@ -37,7 +37,7 @@ use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
     transaction_validity::TransactionPriority,
-    AccountId32, ModuleId, Perbill,
+    AccountId32, ModuleId,
 };
 
 use crate::traits::WeightInfo;
@@ -184,31 +184,6 @@ impl Config for MockRuntime {
     type RewardMechanism = CrowdloanReward;
 }
 
-pub struct Dummy;
-
-impl pallet_crowdloan_claim_reward::Reward for Dummy {
-    type ParachainAccountId = u64;
-    type ContributionAmount = u64;
-    type BlockNumber = u64;
-    type NativeBalance = Balance;
-
-    fn reward(
-        _who: Self::ParachainAccountId,
-        _contribution: Self::ContributionAmount,
-    ) -> DispatchResult {
-        Ok(())
-    }
-
-    fn initialize(
-        _conversion_rate: Self::NativeBalance,
-        _direct_payout_ratio: Perbill,
-        _vesting_period: Self::BlockNumber,
-        _vesting_start: Self::BlockNumber,
-    ) -> DispatchResult {
-        Ok(())
-    }
-}
-
 impl Contains<u64> for One {
     fn sorted_members() -> Vec<u64> {
         vec![1]
@@ -252,7 +227,7 @@ impl TestExternalitiesBuilder {
                 (12, 10 * self.existential_deposit),
                 (
                     CrowdloanReward::account_id(),
-                    1000 * self.existential_deposit,
+                    10000000000000000000 * self.existential_deposit,
                 ),
             ],
         }
@@ -262,7 +237,6 @@ impl TestExternalitiesBuilder {
         pallet_vesting::GenesisConfig::<MockRuntime> {
             vesting: vec![
                 (1, 0, 10, 5 * self.existential_deposit),
-                (2, 10, 20, 0),
                 (12, 10, 20, 5 * self.existential_deposit),
             ],
         }

--- a/pallets/crowdloan-claim/src/mock.rs
+++ b/pallets/crowdloan-claim/src/mock.rs
@@ -63,6 +63,26 @@ impl WeightInfo for MockWeightInfo {
     fn claim_reward() -> Weight {
         0 as Weight
     }
+
+    fn set_lease_start() -> u64 {
+        0 as Weight
+    }
+
+    fn set_lease_period() -> u64 {
+        0 as Weight
+    }
+
+    fn set_locked_at() -> u64 {
+        0 as Weight
+    }
+
+    fn set_contributions_root() -> u64 {
+        0 as Weight
+    }
+
+    fn set_crowdloan_trie_index() -> u64 {
+        0 as Weight
+    }
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<MockRuntime>;

--- a/pallets/crowdloan-claim/src/weights.rs
+++ b/pallets/crowdloan-claim/src/weights.rs
@@ -31,4 +31,24 @@ impl WeightInfo for () {
     fn claim_reward() -> Weight {
         10_000 as Weight
     }
+
+    fn set_lease_start() -> u64 {
+        10_000 as Weight
+    }
+
+    fn set_lease_period() -> u64 {
+        10_000 as Weight
+    }
+
+    fn set_locked_at() -> u64 {
+        10_000 as Weight
+    }
+
+    fn set_contributions_root() -> u64 {
+        10_000 as Weight
+    }
+
+    fn set_crowdloan_trie_index() -> u64 {
+        10_000 as Weight
+    }
 }


### PR DESCRIPTION
This PR is an alternative to #385. 
The difference here are that the pallets need to be initialized separately. Hence, the `Reward` trait has a smaller interface and only provides a rewarding functionality. 
Furthermore, the claim pallet is changed, in order to provide the possibility to initialize it multiple times.