### PR TITLE
Runtime 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ branches:
   only:
   - master
 
+git:
+  depth: false
+
 env:
   global:
     - RUST_BACKTRACE=1

--- a/ci/check_runtime_changes.sh
+++ b/ci/check_runtime_changes.sh
@@ -37,6 +37,7 @@ echo "Unshallowing git"
 FETCH_OUTPUT=$(git fetch --unshallow)
 GIT_STATUS=$?
 if (( $GIT_STATUS != 0 ))
+then
 	echo -e "${red}${bold}GIT ERROR${nc}: $FETCH_OUTPUT"
 	exit 1
 fi

--- a/ci/check_runtime_changes.sh
+++ b/ci/check_runtime_changes.sh
@@ -33,13 +33,6 @@ OK="${green}${block}OK${nc}"
 ERROR="${red}${block}ERROR${nc}"
 FATAL="${red}${block}FATAL${nc}"
 
-# Testing - show available branches and removes in log
-echo "GIT BRANCHES:"
-git branch -a
-
-echo "GIT REMOTES:"
-git remote -v
-
 
 # show the diff of origin/master and this PR sha
 CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT} ${PR_COMMIT} 2>&1 )

--- a/ci/check_runtime_changes.sh
+++ b/ci/check_runtime_changes.sh
@@ -33,6 +33,13 @@ OK="${green}${block}OK${nc}"
 ERROR="${red}${block}ERROR${nc}"
 FATAL="${red}${block}FATAL${nc}"
 
+# Testing - show available branches and removes in log
+echo "GIT BRANCHES:"
+git branch -a
+
+echo "GIT REMOTES:"
+git remote -v
+
 
 # show the diff of origin/master and this PR sha
 CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT} ${PR_COMMIT} 2>&1 )

--- a/ci/check_runtime_changes.sh
+++ b/ci/check_runtime_changes.sh
@@ -33,13 +33,20 @@ OK="${green}${block}OK${nc}"
 ERROR="${red}${block}ERROR${nc}"
 FATAL="${red}${block}FATAL${nc}"
 
+echo "Unshallowing git"
+FETCH_OUTPUT=$(git fetch --unshallow)
+GIT_STATUS=$?
+if (( $GIT_STATUS != 0 ))
+	echo -e "${red}${bold}GIT ERROR${nc}: $FETCH_OUTPUT"
+	exit 1
+fi
+
 # Testing - show available branches and removes in log
 echo "GIT BRANCHES:"
 git branch -a
 
 echo "GIT REMOTES:"
 git remote -v
-
 
 # show the diff of origin/master and this PR sha
 CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT} ${PR_COMMIT} 2>&1 )

--- a/ci/check_runtime_changes.sh
+++ b/ci/check_runtime_changes.sh
@@ -37,7 +37,6 @@ echo "Unshallowing git"
 FETCH_OUTPUT=$(git fetch --unshallow)
 GIT_STATUS=$?
 if (( $GIT_STATUS != 0 ))
-then
 	echo -e "${red}${bold}GIT ERROR${nc}: $FETCH_OUTPUT"
 	exit 1
 fi

--- a/ci/check_runtime_changes.sh
+++ b/ci/check_runtime_changes.sh
@@ -33,20 +33,13 @@ OK="${green}${block}OK${nc}"
 ERROR="${red}${block}ERROR${nc}"
 FATAL="${red}${block}FATAL${nc}"
 
-echo "Unshallowing git"
-FETCH_OUTPUT=$(git fetch --unshallow)
-GIT_STATUS=$?
-if (( $GIT_STATUS != 0 ))
-	echo -e "${red}${bold}GIT ERROR${nc}: $FETCH_OUTPUT"
-	exit 1
-fi
-
 # Testing - show available branches and removes in log
 echo "GIT BRANCHES:"
 git branch -a
 
 echo "GIT REMOTES:"
 git remote -v
+
 
 # show the diff of origin/master and this PR sha
 CHANGED_FILES=$(git diff --name-only ${BASE_COMMIT} ${PR_COMMIT} 2>&1 )

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 242,
+    spec_version: 243,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -812,7 +812,7 @@ impl bridge::Trait for Runtime {
 
 parameter_types! {
     pub const ChainId: u8 = 1;
-    pub const ProposalLifetime: u32 = 100;
+    pub const ProposalLifetime: u32 = 1000;
 }
 
 impl chainbridge::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -457,7 +457,7 @@ parameter_types! {
 	pub const BondingDuration: pallet_staking::EraIndex = 7; // 7 days
 	pub const SlashDeferDuration: pallet_staking::EraIndex = 6; // 6 days, less than bonding duration
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
-	pub const MaxNominatorRewardedPerValidator: u32 = 64;
+	pub const MaxNominatorRewardedPerValidator: u32 = 128;
 	pub const ElectionLookahead: BlockNumber = 0;
 	pub const MaxIterations: u32 = 10;
 	// 0.05%. The higher the value, the more strict solution acceptance becomes.


### PR DESCRIPTION
This runtime bump includes two changes:
* An increase to the number of nominators that will be rewarded for a given validator, from 64 to 128
* An increase to the proposal lifetime for chainbridge transactions, from 100 blocks (10 minutes) to 1000 (100 minutes)