### PR TITLE
Replace Vesting proxy with NonProxy proxy

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -253,17 +253,7 @@ impl InstanceFilter<Call> for ProxyType {
                 Call::Session(..) |
 				Call::Utility(..)
             ),
-            ProxyType::NonProxy => !matches!(c,
-                Call::Proxy(pallet_proxy::Call::add_proxy(..)) |
-                Call::Proxy(pallet_proxy::Call::remove_proxy(..)) |
-                Call::Proxy(pallet_proxy::Call::remove_proxies(..)) |
-                Call::Proxy(pallet_proxy::Call::anonymous(..)) |
-                Call::Proxy(pallet_proxy::Call::kill_anonymous(..)) |
-                Call::Proxy(pallet_proxy::Call::announce(..)) |
-                Call::Proxy(pallet_proxy::Call::remove_announcement(..)) |
-                Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
-                Call::Proxy(pallet_proxy::Call::proxy_announced(..)) |
-            )
+            ProxyType::NonProxy => matches!(c, Call::Proxy(pallet_proxy::Call::proxy(..))) || !matches!(c, Call::Proxy(..))
         }
     }
     fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 243,
+    spec_version: 244,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -261,6 +261,7 @@ impl InstanceFilter<Call> for ProxyType {
             (x, y) if x == y => true,
             (ProxyType::Any, _) => true,
             (_, ProxyType::Any) => false,
+            (_, ProxyType::NonProxy) => false,
             (ProxyType::NonTransfer, _) => true,
             _ => false,
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -231,7 +231,7 @@ pub enum ProxyType {
     NonTransfer,
     Governance,
     Staking,
-    Vesting,
+    NonProxy,
 }
 impl Default for ProxyType { fn default() -> Self { Self::Any } }
 impl InstanceFilter<Call> for ProxyType {
@@ -253,15 +253,17 @@ impl InstanceFilter<Call> for ProxyType {
                 Call::Session(..) |
 				Call::Utility(..)
             ),
-            ProxyType::Vesting => matches!(c,
-                Call::Staking(..) |
-                Call::Session(..) |
-                Call::Democracy(..) |
-				Call::Council(..) |
-				Call::Elections(..) |
-				Call::Vesting(pallet_vesting::Call::vest(..)) |
-				Call::Vesting(pallet_vesting::Call::vest_other(..))
-            ),
+            ProxyType::NonProxy => !matches!(c,
+                Call::Proxy(pallet_proxy::Call::add_proxy(..)) |
+                Call::Proxy(pallet_proxy::Call::remove_proxy(..)) |
+                Call::Proxy(pallet_proxy::Call::remove_proxies(..)) |
+                Call::Proxy(pallet_proxy::Call::anonymous(..)) |
+                Call::Proxy(pallet_proxy::Call::kill_anonymous(..)) |
+                Call::Proxy(pallet_proxy::Call::announce(..)) |
+                Call::Proxy(pallet_proxy::Call::remove_announcement(..)) |
+                Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
+                Call::Proxy(pallet_proxy::Call::proxy_announced(..)) |
+            )
         }
     }
     fn is_superset(&self, o: &Self) -> bool {


### PR DESCRIPTION
This removes the `Vesting` proxy type, and replaces it with a `NonProxy` proxy type. This new proxy type forbids all proxy operations on the proxied account **except** for calling `proxy::proxy(..)` to invoke an account which is proxied by the proxied account.