### PR TITLE
Use `ensure_can_withdraw` in chain bridge transfers

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 243,
+    spec_version: 244,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 244,
+    spec_version: 245,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Previously, the chain bridge transfer checked that the total transfer
amount + fee was greater than the "free" balance in the account. This
does not take into account various types of locks that can be on an
account.

This PR changes to use the `ensure_can_withdraw` function from the
Currency trait. This function checks all locks and fails the
transaction if there is not enough available balance in the account.