### PR TITLE
Testbed used to execute Centrifuge Chain behind Parity `substrate-api-sidecar`

### DIFF
--- a/tools/testbed/Makefile
+++ b/tools/testbed/Makefile
@@ -1,0 +1,214 @@
+################################################################################
+# Centrifuge                                                                   #
+# Cash on Steroids                                                             #
+#                                                                              #
+# tools/testbed/Makefile                                                       #
+#                                                                              #
+# Handcrafted since 2020 by Centrifuge Foundation                              #
+# All rights reserved                                                          #
+#                                                                              #
+#                                                                              #
+# Description: Centrifuge chain's testbed infrastructure management script.    #
+################################################################################
+
+
+# ------------------------------------------------------------------------------
+# VARIABLES DEFINITION
+# ------------------------------------------------------------------------------
+
+# Colors definition
+include ../automake/colors.mk
+
+# Project settings (e.g. Rust toolchain version, ...)
+include ./automake/settings.mk
+
+
+# ------------------------------------------------------------------------------
+# FUNCTIONS DEFINITION
+# ------------------------------------------------------------------------------
+
+# Display help/usage message
+define help
+	@echo ""
+	@echo "$(COLOR_WHITE)Centrifuge$(COLOR_RESET)"
+	@echo "$(COLOR_WHITE)Cash on Steroids$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_BLUE)Testbed$(COLOR_RESET)"
+	@echo ""
+	@echo "Handcrafted since 2020 by Centrifuge Foundation"
+	@echo "All rights reserved"
+	@echo ""
+	@echo "$(COLOR_WHITE)Usage:$(COLOR_RESET)"
+	@echo "  make $(COLOR_BLUE)COMMAND$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_WHITE)Commands:$(COLOR_RESET)"
+	@echo "  $(COLOR_BLUE)setup$(COLOR_RESET)        - Setup testbed environment (i.e. build Docker images, ...) - usually executed once only"
+	@echo "  $(COLOR_BLUE)clean$(COLOR_RESET)        - Clean up testbed environment (i.e. remove Docker image and container, ...)"
+	@echo "  $(COLOR_BLUE)start$(COLOR_RESET)        - Start testbed environment (see 'docker-compose-testbed.yml')"
+	@echo "  $(COLOR_BLUE)stop$(COLOR_RESET)         - Stop testbed environment (see 'docker-compose-testbed.yml')"
+	@echo "  $(COLOR_BLUE)status$(COLOR_RESET)       - State of the running testbed environment"
+	@echo "  $(COLOR_BLUE)sandbox$(COLOR_RESET)      - Build a (Rust) sandbox for compiling Centrifuge chain in a containerized environment (optional)"
+	@echo ""
+endef
+
+# Initialize testbed environment
+#
+# This function create a Docker image for a sandbox (i.e. a playground inside which
+# the chain executable is compiled)
+define setup
+	$(call _build_chain_docker_image)
+endef
+
+# Clean up testbed components (i.e. Docker image, containers, ...)
+define clean
+	$(call _stop_sidecar_and_chain_containers)
+	$(call _remove_sandbox_docker_image)
+	$(call _remove_chain_docker_image)
+	$(call _purge_docker_images_and_containers)
+endef
+
+# Start complete testbed environment
+define start
+	$(_start_sidecar_and_chain_containers)
+endef 
+
+# Stop complete testbed environment
+define stop
+	$(_stop_sidecar_and_chain_containers)
+endef 
+
+# Show actual running status of the testbed environment
+define status
+	$(_show_testbed_environment_state)
+endef 
+
+# Build a Docker image for an optional containerized Rust sandbox
+define sandbox
+	$(_build_sandbox_docker_image)
+endef
+
+
+# ------------------------------------------------------------------------------
+# PRIVATE FUNCTIONS
+# ------------------------------------------------------------------------------
+
+# Build compilation sandbox (first stage of the Dockerfile)
+#
+# This is a convenient function if you wanna build the chain manually, inside
+# a Docker container, using the following command:
+#
+# $ docker container run --rm -it --volume `pwd`/..
+define _build_sandbox_docker_image
+	@echo "Build sandbox Docker image $(COLOR_BLUE)$(SANDBOX_DOCKER_IMAGE_NAME):$(SANDBOX_DOCKER_IMAGE_TAG)$(COLOR_RESET)"
+	@docker image build \
+		--build-arg ARG_PROFILE="release" \
+		--build-arg ARG_RUST_TOOLCHAIN=$(RUST_TOOLCHAIN) \
+		--no-cache \
+		--tag=$(SANDBOX_DOCKER_IMAGE_NAME):$(SANDBOX_DOCKER_IMAGE_TAG) \
+		--rm \
+		--file=./docker/Dockerfile \
+		--target=sandbox \
+		.
+endef
+
+# Build the Centrifuge chain Docker image (used in 'docker/docker-compose.yml' file)
+define _build_chain_docker_image
+	@echo "Build Centrifuge chain's Docker image $(COLOR_BLUE)$(CHAIN_DOCKER_IMAGE_NAME):$(CHAIN_DOCKER_IMAGE_TAG)$(COLOR_RESET)"
+	@docker image build \
+		--build-arg ARG_PROFILE="release" \
+		--build-arg ARG_CHAIN_VERSION=$(CHAIN_VERSION) \
+		--build-arg ARG_IMAGE_BUILD_DATE=$(date) \
+		--no-cache \
+		--tag=$(CHAIN_DOCKER_IMAGE_NAME):$(CHAIN_DOCKER_IMAGE_TAG) \
+		--rm \
+		--file=./docker/Dockerfile \
+		--target=service \
+		.
+endef
+
+# Remove compilation sandbox from local Docker repository
+define _remove_sandbox_docker_image
+	@echo "Remove (local) sandbox Docker image $(COLOR_BLUE)$(SANDBOX_DOCKER_IMAGE_NAME):$(SANDBOX_DOCKER_IMAGE_TAG)$(COLOR_RESET)"
+	@docker image rm $(SANDBOX_DOCKER_IMAGE_NAME):$(SANDBOX_DOCKER_IMAGE_TAG) > /dev/null 2>&1 || true
+endef
+
+# Remove chain's Docker image from local Docker repository
+define _remove_chain_docker_image
+	@echo "Remove (local) chain Docker image $(COLOR_BLUE)$(CHAIN_DOCKER_IMAGE_NAME):$(CHAIN_DOCKER_IMAGE_TAG)$(COLOR_RESET)"
+	@docker image rm $(CHAIN_DOCKER_IMAGE_NAME):$(CHAIN_DOCKER_IMAGE_TAG) > /dev/null 2>&1 || true
+endef
+
+# Remove dangling Docker images and stopped containers
+#
+# When building a Docker image, it is frequent that this process
+# crashes, producing intermediate (hence dangling) containers and
+# file system layers. This function helps cleaning up such 'junks'.
+# This function should be called at the end of an image building
+# process.
+define _purge_docker_images_and_containers
+	@docker ps -aq --no-trunc | xargs docker rm
+	@docker images -q --filter dangling=true | xargs docker rmi
+endef
+
+# Start complete testbed components
+define _start_sidecar_and_chain_containers
+	@docker-compose \
+		-f ./docker/docker-compose-networks.yml \
+		-f ./docker/docker-compose-services.yml \
+		up --detach \
+		--force-recreate
+endef
+
+# Stop tesbed environment and remove eventual orphans containers
+define _stop_sidecar_and_chain_containers
+	@docker-compose \
+		-f ./docker/docker-compose-networks.yml \
+		-f ./docker/docker-compose-services.yml \
+		down --remove-orphans
+endef
+
+# Display current running status of the testbed environment
+define _show_testbed_environment_state
+	@docker-compose \
+		-f ./docker/docker-compose-networks.yml \
+		-f ./docker/docker-compose-services.yml \
+		ps
+	@docker network inspect $(DOCKER_NETWORK_NAME)
+endef
+
+
+# ------------------------------------------------------------------------------
+# TARGETS DEFINITION
+# ------------------------------------------------------------------------------
+
+# NOTE:
+# .PHONY directive defines targets that are not associated with files. Generally
+# all targets which do not produce an output file with the same name as the target
+# name should be .PHONY. This typically includes 'all', 'help', 'build', 'clean',
+# and so on.
+
+.PHONY: all help setup clean start stop status sandbox
+
+# Set default target if none is specified
+.DEFAULT_GOAL := help
+
+help:
+	$(call help)
+
+setup:
+	$(call setup)
+
+clean:
+	$(call clean)
+
+start:
+	$(call start)
+
+stop:
+	$(call stop)
+
+status:
+	$(call status)
+
+sandbox:
+	$(call sandbox)

--- a/tools/testbed/README.md
+++ b/tools/testbed/README.md
@@ -1,0 +1,47 @@
+# Centrifuge Chain Testbed
+
+## Introduction
+This testbed environment creates a containerized infrastructure to test the Centrifuge chain, as it is currently used to operate the current [Centrifuge's mainnet](https://portal.chain.centrifuge.io/#/explorer). 
+
+It relies on [Parity Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar) and [`Parity txwrapper-core`](https://github.com/paritytech/txwrapper-core) tools.
+
+## Requisite Tools
+Only the following tools must be installed on your host in order to play with this testbed:
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Make tools](https://www.gnu.org/software/make/)
+## Getting Started
+
+In order to land and work with this testbed environment, please execute the following command in a terminal so that to create the necessary Docker images (be patient folks, it takes time):
+
+```sh
+$ make setup
+```
+This seminal setup command must be run only once, or after you clean up the testbed environment with `make clean`
+command.
+
+You are now ready to launch the testbed infrastructure, that is made up of a container with substrate API sidecar (called `testbed-sidecar`) and another (called `testbed-chain`) with the Centrifuge chain's mainnet. For doing so, enter the following command:
+
+```sh
+$ make start
+```
+
+You are now ready to run transactions (or extrinsics) on the Centrifuge chain using Substrate API service. 
+
+## Tweak Parameters
+
+All parameters are declared in the [`settings.mk`](./automake/settings.mk) file.
+
+See also [`docker-compose-chain.yml`](./docker/docker-compose-chain.yml) and [`docker-compose-sidecar.yml`](./docker/docker-compose-sidecar.yml).
+
+## Testing Scenari
+
+Testing cases can be implemented in Javascript/Typescript, using [`Parity txwrapper-core`](https://github.com/paritytech/txwrapper-core) tools.
+
+Some simple tests will soon be available in the [`tests`](./tests) folder.
+
+## References
+
+[Parity Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar)
+[Parity `txwrapper-core`](https://github.com/paritytech/txwrapper-core)
+[Centrifuge Chain](https://github.com/centrifuge/centrifuge-chain/tree/master)

--- a/tools/testbed/automake/settings.mk
+++ b/tools/testbed/automake/settings.mk
@@ -1,0 +1,44 @@
+###############################################################################
+# Centrifuge Chain                                                            #
+# Cash on Steroids                                                            #
+#                                                                             #
+# tools/testbed/automake/settings.mk                                          #
+#                                                                             #
+# Handcrafted since 2020 by Centrifuge Foundation                             #
+# All rights reserved                                                         #
+#                                                                             #
+#                                                                             #
+# Description: Testbed's configuration, including, for instance, the version  #
+#              of the Rust toolchain, the Docker image name of the developer' #
+#              sandbox, and so on.                                            #
+###############################################################################
+
+# Docker image name for the compilation sandbox
+SANDBOX_DOCKER_IMAGE_NAME=centrifuge/testbed-sandbox
+SANDBOX_DOCKER_IMAGE_TAG=latest
+
+# Docker image name for Centrifuge chain's node
+CHAIN_DOCKER_IMAGE_NAME=centrifuge/testbed-chain
+CHAIN_DOCKER_IMAGE_TAG=$(CHAIN_VERSION)
+
+# Name of Docker network to which the sidecar and the Centrifuge containers
+# are attached (do not forget to modify 'docker/docker-compose-networks.yml'
+# accordingly)
+DOCKER_NETWORK_NAME=testbed-network
+
+# Parameters for the sandbox container
+CONTAINER_MEMORY_SIZE=10GB
+CONTAINER_SWAP_SIZE=2GB
+CONTAINER_CPUS=2
+
+# Name of the Centrifuge chain's executable
+CHAIN_EXECUTABLE=centrifuge-chain
+
+# Centrifuge chain version
+CHAIN_VERSION=v2.0.0-rc6-243
+
+# Parity Substrate API sidecar
+SUBSTRATE_API_SIDECAR_VERSION=8.0.3
+
+# Rust toolchain version
+RUST_TOOLCHAIN=nightly-2020-08-16

--- a/tools/testbed/docker/Dockerfile
+++ b/tools/testbed/docker/Dockerfile
@@ -1,0 +1,119 @@
+
+###############################################################################
+# Centrifuge Chain                                                            #
+# Cash on Steroids                                                            #
+#                                                                             #
+# tools/docker/Dockerfile                                                     #
+#                                                                             #
+# Handcrafted since 2020 by Centrifuge Foundation                             #
+# All rights reserved                                                         #
+#                                                                             #
+#                                                                             #
+# Description: Centrifuge chain's Docker image definition.                    #
+###############################################################################
+
+
+# -----------------------------------------------------------------------------
+# Sandbox (or compilation playground) stage
+# -----------------------------------------------------------------------------
+
+FROM rustlang/rust:nightly AS sandbox
+
+ARG ARG_RUST_TOOLCHAIN="nightly-2020-08-16"
+
+RUN set -eux; \
+    apt-get -y update; \
+    \
+    # Install additional packages (i.e. clan, ssl, ...)
+    apt-get install -y --no-install-recommends \
+		libssl-dev \
+        clang \
+        lld \
+        libclang-dev \
+        make \
+        cmake \
+		git \
+        pkg-config \
+        curl \
+        wget \
+        ca-certificates \
+        ; \
+    # Set a link to Clang
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
+    # Install Rust toolchain and WASM target
+    rustup update $ARG_RUST_TOOLCHAIN; \
+    rustup toolchain install $ARG_RUST_TOOLCHAIN; \
+    rustup default $ARG_RUST_TOOLCHAIN; \
+    rustup component add rustfmt; \
+    rustup target add wasm32-unknown-unknown --toolchain $ARG_RUST_TOOLCHAIN; \
+    # Create workspace directory (in which Centrifuge chain's code is copied for compilation)
+    mkdir /workspace
+
+# Default working directory
+WORKDIR /workspace
+
+
+
+# -----------------------------------------------------------------------------
+# Build Centrifuge chain executable stage
+# -----------------------------------------------------------------------------
+
+FROM sandbox AS builder
+
+ARG ARG_PROFILE="release"
+ARG ARG_CHAIN_VERSION="v2.0.0-rc6-241-1"
+
+# Download Centrifuge chain's code base (in /workspace directory, the default working directory)
+RUN wget -O centrifuge-chain.tar.gz https://github.com/centrifuge/centrifuge-chain/archive/refs/tags/${ARG_CHAIN_VERSION}.tar.gz; \
+    tar xvzf centrifuge-chain.tar.gz --strip 1; \
+    # Build Centrifuge chain's executable, for the given profile (be patient folks)
+    cargo build --$ARG_PROFILE
+
+
+# -----------------------------------------------------------------------------
+# Build Centrifuge chain service stage
+# -----------------------------------------------------------------------------
+
+FROM debian:bullseye-slim AS service
+
+ARG ARG_CHAIN_VERSION="v2.0.0-rc6-241-1"
+ARG ARG_IMAGE_BUILD_DATE="unset"
+ARG ARG_PROFILE="release"
+
+LABEL io.centrifuge.chain.node.maintainer="tribe@centrifuge.io" \
+      io.centrifuge.chain.node.image.version="$ARG_CHAIN_VERSION" \
+      io.centrifuge.chain.node.image.description="Centrifuge Chain" \
+      io.centrifuge.chain.node.image.vendorName="Centrifuge Foundation" \
+      io.centrifuge.chain.node.image.buildDate="$ARG_IMAGE_BUILD_DATE" 
+
+# Install extra runtime dependencies
+#RUN apt-get -y update; \
+#    apt-get install -y --no-install-recommends \
+#      add_package_1 \
+#      add_package_2 \
+#      ; \
+#    apt-get clean; \
+#    rm -rf /var/lib/apt/lists/*; \
+
+# Install Centrifuge chain's executable
+COPY --from=builder /workspace/target/$ARG_PROFILE/centrifuge-chain /usr/local/bin
+
+# Shrink final image size
+RUN rm -rf /usr/lib/python* ; \
+	rm -rf /usr/share/man
+
+# Expose various Substrate ports
+EXPOSE 30333 9933 9944
+
+CMD ["/usr/local/bin/centrifuge-chain"]
+
+
+# -----------------------------------------------------------------------------
+# Default stage (build Centrifuge chain Docker image)
+# -----------------------------------------------------------------------------
+
+FROM service
+
+ARG ARG_CHAIN_VERSION="v2.0.0-rc6-241-1"
+ARG ARG_IMAGE_BUILD_DATE="unset"
+ARG ARG_PROFILE="release"

--- a/tools/testbed/docker/docker-compose-networks.yml
+++ b/tools/testbed/docker/docker-compose-networks.yml
@@ -1,0 +1,5 @@
+version: '3'
+networks:
+  testbed-network:
+    name: testbed-network
+    driver: bridge

--- a/tools/testbed/docker/docker-compose-services.yml
+++ b/tools/testbed/docker/docker-compose-services.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  # Parity Substrate API sidecar service
+  sidecar:
+      container_name: testbed-sidecar
+      image: "parity/substrate-api-sidecar:v8.0.3"
+      ports:
+        - 8080:8080
+      environment: 
+        SAS_SUBSTRATE_WS_URL: "ws://chain:9944"
+      networks:
+        - testbed-network
+      links:
+        - chain
+      depends_on:
+        - chain
+
+  # Centrifuge chain service
+  chain:
+    container_name: testbed-chain
+    image: "centrifuge/testbed-chain:v2.0.0-rc6-241-1"
+    ports:
+      - "30333:30333"
+      - "9933:9933"
+      - "9944:9944"
+    networks:
+      - testbed-network
+    command: >
+      centrifuge-chain --dev --ws-external --rpc-external


### PR DESCRIPTION
This PR implements the following features:
- A Docker-based testbed infrastructure for the Centrifuge Chain (built from source).
- Expose the Centrifuge Chain features behind the Parity Substrate API Sidecar.
- Provide Docker Compose file and Makefile to ease the bootstrap of the testbed infrastructure.