### PR TITLE
Lower minimum vesting amount to 10 CFG/AIR

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -574,7 +574,7 @@ impl pallet_identity::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MinVestedTransfer: Balance = 1000 * AIR;
+	pub const MinVestedTransfer: Balance = MIN_VESTING * AIR;
 }
 
 impl pallet_vesting::Config for Runtime {

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -577,7 +577,7 @@ impl pallet_identity::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MinVestedTransfer: Balance = 1000 * CFG;
+	pub const MinVestedTransfer: Balance = MIN_VESTING * CFG;
 }
 
 impl pallet_vesting::Config for Runtime {

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -121,6 +121,9 @@ pub mod constants {
 	pub const CENTI_CFG: Balance = 10 * MILLI_CFG; // 10−2 	0.01
 	pub const CFG: Balance = 100 * CENTI_CFG;
 
+	/// Minimum vesting amount, in CFG/AIR
+	pub const MIN_VESTING: Balance = 10;
+
 	/// Additional fee charged when moving native tokens to target chains (in CFGs).
 	pub const NATIVE_TOKEN_TRANSFER_FEE: Balance = 2000 * CFG;
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -547,7 +547,7 @@ impl pallet_identity::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MinVestedTransfer: Balance = 1000 * CFG;
+	pub const MinVestedTransfer: Balance = MIN_VESTING * CFG;
 }
 
 impl pallet_vesting::Config for Runtime {


### PR DESCRIPTION
The previous lower bound of 1000 tokens has caused issues with
crowdloan rewards and other small vesting quantities.