### PR TITLE
Dynamic Call-Filter via Migration-Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10775,15 +10775,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-<<<<<<< HEAD
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
-=======
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
->>>>>>> Added finalize extrinsic and call-filter via pallet
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10775,9 +10775,15 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
+<<<<<<< HEAD
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+=======
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+>>>>>>> Added finalize extrinsic and call-filter via pallet
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pallets/migration/src/benchmarking.rs
+++ b/pallets/migration/src/benchmarking.rs
@@ -12,6 +12,12 @@ use sp_runtime::{traits::Zero, AccountId32};
 use sp_std::convert::TryInto;
 
 benchmarks! {
+	finalize{
+		// No setup needed
+	}: finalize(RawOrigin::Root)
+	verify {
+		assert!(<Completed<T>>::get());
+	}
   migrate_system_account{
 		let n in 1 .. <T as Config>::MigrationMaxAccounts::get();
 		inject_total_issuance();

--- a/pallets/migration/src/benchmarking.rs
+++ b/pallets/migration/src/benchmarking.rs
@@ -13,10 +13,13 @@ use sp_std::convert::TryInto;
 
 benchmarks! {
 	finalize{
-		// No setup needed
+		let additional_issuance: <T as pallet_balances::Config>::Balance =
+			codec::Decode::decode(&mut test_data::balances_total_issuance::TOTAL_ISSUANCE.value[..].as_ref()).unwrap();
+
+		Pallet::<T>::migrate_balances_issuance(RawOrigin::Root.into(), additional_issuance).unwrap();
 	}: finalize(RawOrigin::Root)
 	verify {
-		assert!(<Completed<T>>::get());
+		assert!(<Completed<T>>::get() == Status::Complete);
 	}
   migrate_system_account{
 		let n in 1 .. <T as Config>::MigrationMaxAccounts::get();

--- a/pallets/migration/src/lib.rs
+++ b/pallets/migration/src/lib.rs
@@ -389,7 +389,7 @@ pub mod pallet {
 			)
 		}
 
-		/// This extrinsic disables the call-filter. After this has been called the chain will acceppt
+		/// This extrinsic disables the call-filter. After this has been called the chain will accept
 		/// all calls again.
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::finalize())]
 		#[transactional]

--- a/pallets/migration/src/mock.rs
+++ b/pallets/migration/src/mock.rs
@@ -20,9 +20,11 @@ use crate as pallet_migration_manager;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::sp_runtime::traits::ConvertInto;
-use frame_support::traits::Everything;
 use frame_support::{
-	parameter_types, scale_info::TypeInfo, traits::InstanceFilter, weights::Weight,
+	parameter_types,
+	scale_info::TypeInfo,
+	traits::{Contains, InstanceFilter},
+	weights::Weight,
 };
 use sp_core::{RuntimeDebug, H256};
 use sp_runtime::{
@@ -153,7 +155,7 @@ parameter_types! {
 
 // Implement frame system pallet configuration for mock runtime
 impl frame_system::Config for MockRuntime {
-	type BaseCallFilter = Everything;
+	type BaseCallFilter = Migration;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type Origin = Origin;
@@ -195,7 +197,24 @@ impl pallet_migration_manager::Config for MockRuntime {
 	type MigrationMaxProxies = MigrationMaxProxies;
 	type Event = Event;
 	type WeightInfo = ();
-	type Filter = ();
+	type Filter = BaseFilter;
+}
+
+// our base filter
+// allow base system calls needed for block production and runtime upgrade
+// other calls will be disallowed
+pub struct BaseFilter;
+
+impl Contains<Call> for BaseFilter {
+	fn contains(c: &Call) -> bool {
+		matches!(
+			c,
+			// Calls for runtime upgrade
+			|Call::System(frame_system::Call::set_code { .. })| Call::System(
+				frame_system::Call::set_code_without_checks { .. }
+			) // Calls that are present in each block
+		)
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -228,17 +247,15 @@ impl TestExternalitiesBuilder {
 
 	// Build a genesis storage key/value store
 	pub fn build<R>(self, execute: impl FnOnce() -> R) -> sp_io::TestExternalities {
-		let storage = frame_system::GenesisConfig::default()
+		let mut storage = frame_system::GenesisConfig::default()
 			.build_storage::<MockRuntime>()
 			.unwrap();
 
-		/*pallet_balances::GenesisConfig::<MockRuntime> { balances: vec![] }
-			.assimilate_storage(&mut storage)
-			.unwrap();
-
-		pallet_vesting::GenesisConfig::<MockRuntime> { vesting: vec![] }
-			.assimilate_storage(&mut storage)
-			.unwrap();*/
+		pallet_balances::GenesisConfig::<MockRuntime> {
+			balances: vec![(get_account(), 1000)],
+		}
+		.assimilate_storage(&mut storage)
+		.unwrap();
 
 		let mut ext = sp_io::TestExternalities::new(storage);
 		ext.execute_with(|| {
@@ -247,6 +264,15 @@ impl TestExternalitiesBuilder {
 		ext.execute_with(execute);
 		ext
 	}
+}
+
+pub(crate) fn get_account() -> AccountId {
+	let pub_key: [u8; 32] = [
+		89, 211, 18, 12, 18, 109, 171, 175, 21, 236, 203, 33, 33, 168, 153, 55, 198, 227, 184, 139,
+		77, 115, 132, 73, 59, 235, 90, 175, 221, 88, 44, 247,
+	];
+
+	codec::Decode::decode(&mut &pub_key[..]).unwrap()
 }
 
 pub(crate) fn reward_events() -> Vec<pallet_migration_manager::Event<MockRuntime>> {

--- a/pallets/migration/src/mock.rs
+++ b/pallets/migration/src/mock.rs
@@ -20,6 +20,7 @@ use crate as pallet_migration_manager;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::sp_runtime::traits::ConvertInto;
+use frame_support::traits::Everything;
 use frame_support::{
 	parameter_types,
 	scale_info::TypeInfo,
@@ -51,7 +52,7 @@ frame_support::construct_runtime!(
 		Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
 		Vesting: pallet_vesting::{Pallet, Call, Storage, Event<T>},
 		Proxy: pallet_proxy::{Pallet, Call, Storage, Event<T>},
-		Migration: pallet_migration_manager::{Pallet, Call, Config, Storage, Event<T>},
+		Migration: pallet_migration_manager::{Pallet, Call, Storage, Event<T>},
 	}
 );
 
@@ -197,7 +198,9 @@ impl pallet_migration_manager::Config for MockRuntime {
 	type MigrationMaxProxies = MigrationMaxProxies;
 	type Event = Event;
 	type WeightInfo = ();
-	type Filter = BaseFilter;
+	type FinalizedFilter = Everything;
+	type InactiveFilter = BaseFilter;
+	type OngoingFilter = BaseFilter;
 }
 
 // our base filter

--- a/pallets/migration/src/mock.rs
+++ b/pallets/migration/src/mock.rs
@@ -195,6 +195,7 @@ impl pallet_migration_manager::Config for MockRuntime {
 	type MigrationMaxProxies = MigrationMaxProxies;
 	type Event = Event;
 	type WeightInfo = ();
+	type Filter = ();
 }
 
 // ----------------------------------------------------------------------------

--- a/pallets/migration/src/tests.rs
+++ b/pallets/migration/src/tests.rs
@@ -4,6 +4,7 @@ use crate::test_data::balances_total_issuance::TOTAL_ISSUANCE;
 use crate::test_data::proxy_proxies::PROXY_PROXIES;
 use crate::test_data::system_account::*;
 use crate::test_data::vesting_vesting::VESTING_VESTING;
+use frame_support::traits::Contains;
 use frame_support::{assert_noop, BoundedVec};
 use frame_system::AccountInfo;
 use pallet_balances::AccountData;
@@ -18,7 +19,25 @@ fn finalize_works() {
 		.existential_deposit(1)
 		.build(|| {})
 		.execute_with(|| {
+			assert!(
+				!<<MockRuntime as frame_system::Config>::BaseCallFilter as Contains<Call>>::contains(
+					&Call::Balances(pallet_balances::Call::transfer{
+						dest: crate::mock::get_account(),
+						value: 1000
+					})
+				)
+			);
+
 			pallet_migration_manager::Pallet::<MockRuntime>::finalize(Origin::root()).unwrap();
+
+			assert!(
+				<<MockRuntime as frame_system::Config>::BaseCallFilter as Contains<Call>>::contains(
+					&Call::Balances(pallet_balances::Call::transfer {
+						dest: crate::mock::get_account(),
+						value: 1000
+					})
+				)
+			);
 
 			assert_noop!(
 				pallet_migration_manager::Pallet::<MockRuntime>::finalize(Origin::root()),

--- a/pallets/migration/src/tests.rs
+++ b/pallets/migration/src/tests.rs
@@ -19,6 +19,10 @@ fn finalize_works() {
 		.existential_deposit(1)
 		.build(|| {})
 		.execute_with(|| {
+			// Call filter is inactive
+			// We need to actually trigger storage to change status to Status::Ongoing
+			helper_migrate_total_issuance();
+
 			assert!(
 				!<<MockRuntime as frame_system::Config>::BaseCallFilter as Contains<Call>>::contains(
 					&Call::Balances(pallet_balances::Call::transfer{
@@ -41,7 +45,7 @@ fn finalize_works() {
 
 			assert_noop!(
 				pallet_migration_manager::Pallet::<MockRuntime>::finalize(Origin::root()),
-				pallet_migration_manager::Error::<MockRuntime>::MigrationAlreadyCompleted,
+				pallet_migration_manager::Error::<MockRuntime>::OnlyFinalizeOngoing,
 			);
 
 			assert_noop!(

--- a/pallets/migration/src/tests.rs
+++ b/pallets/migration/src/tests.rs
@@ -13,6 +13,53 @@ use rand::Rng;
 use sp_runtime::AccountId32;
 
 #[test]
+fn finalize_works() {
+	TestExternalitiesBuilder::default()
+		.existential_deposit(1)
+		.build(|| {})
+		.execute_with(|| {
+			pallet_migration_manager::Pallet::<MockRuntime>::finalize(Origin::root()).unwrap();
+
+			assert_noop!(
+				pallet_migration_manager::Pallet::<MockRuntime>::finalize(Origin::root()),
+				pallet_migration_manager::Error::<MockRuntime>::MigrationAlreadyCompleted,
+			);
+
+			assert_noop!(
+				pallet_migration_manager::Pallet::<MockRuntime>::migrate_balances_issuance(
+					Origin::root(),
+					0u32.into()
+				),
+				pallet_migration_manager::Error::<MockRuntime>::MigrationAlreadyCompleted,
+			);
+
+			assert_noop!(
+				pallet_migration_manager::Pallet::<MockRuntime>::migrate_system_account(
+					Origin::root(),
+					Vec::new(),
+				),
+				pallet_migration_manager::Error::<MockRuntime>::MigrationAlreadyCompleted,
+			);
+
+			assert_noop!(
+				pallet_migration_manager::Pallet::<MockRuntime>::migrate_proxy_proxies(
+					Origin::root(),
+					Vec::new()
+				),
+				pallet_migration_manager::Error::<MockRuntime>::MigrationAlreadyCompleted,
+			);
+
+			assert_noop!(
+				pallet_migration_manager::Pallet::<MockRuntime>::migrate_vesting_vesting(
+					Origin::root(),
+					Vec::new()
+				),
+				pallet_migration_manager::Error::<MockRuntime>::MigrationAlreadyCompleted,
+			);
+		})
+}
+
+#[test]
 fn migrate_system_account() {
 	TestExternalitiesBuilder::default()
 		.existential_deposit(1)

--- a/pallets/migration/src/weights.rs
+++ b/pallets/migration/src/weights.rs
@@ -33,11 +33,17 @@ pub trait WeightInfo {
 	fn migrate_balances_issuance() -> Weight;
 	fn migrate_vesting_vesting(n: u32) -> Weight;
 	fn migrate_proxy_proxies(n: u32) -> Weight;
+	fn finalize() -> Weight;
 }
 
 /// Weights for pallet_migration_manager using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	fn finalize() -> Weight {
+		(28_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 	fn migrate_system_account(n: u32) -> Weight {
 		(26_566_000 as Weight)
 			// Standard Error: 1_000
@@ -64,6 +70,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
+	fn finalize() -> Weight {
+		(28_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
 	fn migrate_system_account(n: u32) -> Weight {
 		(26_566_000 as Weight)
 			// Standard Error: 1_000

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -146,7 +146,7 @@ impl Contains<Call> for BaseFilter {
 
 // system support impls
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = BaseFilter;
+	type BaseCallFilter = Migration;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	/// The ubiquitous origin type.
@@ -720,6 +720,7 @@ impl pallet_migration_manager::Config for Runtime {
 	type MigrationMaxProxies = MigrationMaxProxies;
 	type Event = Event;
 	type WeightInfo = pallet_migration_manager::SubstrateWeight<Self>;
+	type Filter = BaseFilter;
 }
 
 // Parameterize crowdloan reward pallet configuration

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -50,6 +50,7 @@ pub mod constants;
 /// Constant values used within the runtime.
 use constants::currency::*;
 
+use frame_benchmarking::frame_support::traits::Everything;
 /// common types for the runtime.
 pub use runtime_common::*;
 
@@ -720,7 +721,9 @@ impl pallet_migration_manager::Config for Runtime {
 	type MigrationMaxProxies = MigrationMaxProxies;
 	type Event = Event;
 	type WeightInfo = pallet_migration_manager::SubstrateWeight<Self>;
-	type Filter = BaseFilter;
+	type FinalizedFilter = Everything;
+	type InactiveFilter = BaseFilter;
+	type OngoingFilter = BaseFilter;
 }
 
 // Parameterize crowdloan reward pallet configuration

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -146,7 +146,7 @@ impl Contains<Call> for BaseFilter {
 
 // system support impls
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = Migration;
+	type BaseCallFilter = BaseFilter;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	/// The ubiquitous origin type.
@@ -721,8 +721,8 @@ impl pallet_migration_manager::Config for Runtime {
 	type Event = Event;
 	type WeightInfo = pallet_migration_manager::SubstrateWeight<Self>;
 	type FinalizedFilter = Everything;
-	type InactiveFilter = BaseFilter;
-	type OngoingFilter = BaseFilter;
+	type InactiveFilter = Everything;
+	type OngoingFilter = Everything;
 }
 
 // Parameterize crowdloan reward pallet configuration

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -7,7 +7,7 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Contains, InstanceFilter, LockIdentifier, U128CurrencyToVote},
+	traits::{Contains, Everything, InstanceFilter, LockIdentifier, U128CurrencyToVote},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight},
 		DispatchClass, Weight,
@@ -50,7 +50,6 @@ pub mod constants;
 /// Constant values used within the runtime.
 use constants::currency::*;
 
-use frame_benchmarking::frame_support::traits::Everything;
 /// common types for the runtime.
 pub use runtime_common::*;
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -47,6 +47,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 
+use frame_benchmarking::frame_support::traits::Everything;
 pub use primitives_tokens::CurrencyId;
 
 /// common types for the runtime.
@@ -734,7 +735,9 @@ impl pallet_migration_manager::Config for Runtime {
 	type MigrationMaxProxies = MigrationMaxProxies;
 	type Event = Event;
 	type WeightInfo = pallet_migration_manager::SubstrateWeight<Self>;
-	type Filter = BaseFilter;
+	type FinalizedFilter = Everything;
+	type InactiveFilter = BaseFilter;
+	type OngoingFilter = BaseFilter;
 }
 
 // our base filter

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -748,15 +748,16 @@ impl Contains<Call> for BaseFilter {
 			c,
 			// Calls from Sudo
 			Call::Sudo(..)
-
-				// Calls for runtime upgrade
-				| Call::System(frame_system::Call::set_code(..))
-				| Call::System(frame_system::Call::set_code_without_checks(..))
-
-				// Calls that are present in each block
-				| Call::ParachainSystem(
-					cumulus_pallet_parachain_system::Call::set_validation_data(..)
-				) | Call::Timestamp(pallet_timestamp::Call::set(..))
+			// Calls for runtime upgrade
+			| Call::System(frame_system::Call::set_code{..})
+			| Call::System(frame_system::Call::set_code_without_checks{..})
+			// Calls that are present in each block
+			| Call::ParachainSystem(
+				cumulus_pallet_parachain_system::Call::set_validation_data{..}
+			)
+			| Call::Timestamp(pallet_timestamp::Call::set{..})
+			// Claiming logic is also enabled
+			| Call::CrowdloanClaim(pallet_crowdloan_claim::Call::claim_reward{..})
 		)
 	}
 }

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -736,7 +736,7 @@ impl pallet_migration_manager::Config for Runtime {
 	type Event = Event;
 	type WeightInfo = pallet_migration_manager::SubstrateWeight<Self>;
 	type FinalizedFilter = Everything;
-	type InactiveFilter = BaseFilter;
+	type InactiveFilter = Everything;
 	type OngoingFilter = BaseFilter;
 }
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -7,7 +7,7 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Contains, InstanceFilter, LockIdentifier, U128CurrencyToVote},
+	traits::{Contains, Everything, InstanceFilter, LockIdentifier, U128CurrencyToVote},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight},
 		DispatchClass, Weight,


### PR DESCRIPTION
I think this could be a possible way to remove the call filter based on extriniscs after we migrated the data correctly.

Pallet still needs an extriniscs to actually change the storage with a sudo call.

## Tasks

- [x] ~~Needs bench on cloud machine again before merge~~ -> moved to #582