### PR TITLE
Implement benchmarking for `anchors` pallet

### DIFF
--- a/pallets/anchors/Cargo.toml
+++ b/pallets/anchors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-anchors'
-authors = ["Centrifuge <admin@centrifuge.io>"]
+authors = ["Centrifuge Contributors <admin@centrifuge.io>"]
 description = 'Anchors pallet for runtime'
 edition = '2018'
 license = "LGPL-3.0"
@@ -12,22 +12,23 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 serde = { version = "1.0.102" }
-codec = { package = 'parity-scale-codec', version = '2.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '2.0.0', features = ['derive'], default-features = false }
 
-frame-support = { git = "https://github.com/centrifuge/substrate", default-features = false , branch = "master" }
-frame-system = { git = "https://github.com/centrifuge/substrate", default-features = false , branch = "master" }
-sp-runtime = { git = "https://github.com/centrifuge/substrate", default-features = false , branch = "master" }
-sp-std = { git = "https://github.com/centrifuge/substrate",  default-features = false , branch = "master" }
-sp-arithmetic = { git = "https://github.com/centrifuge/substrate",  default-features = false , branch = "master" }
-pallet-timestamp = { git = "https://github.com/centrifuge/substrate",  default-features = false , branch = "master" }
+frame-support = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+frame-system = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+frame-benchmarking = { git = "https://github.com/centrifuge/substrate", default-features = false, optional = true, branch = "master" }
+sp-runtime = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+sp-std = { git = "https://github.com/centrifuge/substrate",  default-features = false, branch = "master" }
+sp-arithmetic = { git = "https://github.com/centrifuge/substrate",  default-features = false, branch = "master" }
+pallet-timestamp = { git = "https://github.com/centrifuge/substrate",  default-features = false, branch = "master" }
 pallet-fees = { path = "../fees", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/centrifuge/substrate", default-features = false , branch = "master" }
-sp-io = { git = "https://github.com/centrifuge/substrate", default-features = false , branch = "master" }
-pallet-randomness-collective-flip = { git = "https://github.com/centrifuge/substrate",  default-features = false , branch = "master" }
-pallet-balances = { git = "https://github.com/centrifuge/substrate",  default-features = false , branch = "master" }
-pallet-authorship = { git = "https://github.com/centrifuge/substrate",  default-features = false , branch = "master" }
+sp-core = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+sp-io = { git = "https://github.com/centrifuge/substrate", default-features = false, branch = "master" }
+pallet-randomness-collective-flip = { git = "https://github.com/centrifuge/substrate",  default-features = false, branch = "master" }
+pallet-balances = { git = "https://github.com/centrifuge/substrate",  default-features = false, branch = "master" }
+pallet-authorship = { git = "https://github.com/centrifuge/substrate",  default-features = false, branch = "master" }
 
 [features]
 default = ['std']
@@ -41,3 +42,5 @@ std = [
     'pallet-timestamp/std',
     'pallet-fees/std',
 ]
+runtime-benchmarks = ["frame-benchmarking"]
+

--- a/pallets/anchors/src/benchmarking.rs
+++ b/pallets/anchors/src/benchmarking.rs
@@ -1,0 +1,87 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! # Anchors pallet benchmarking routines used for calculating extrinsics weights.
+//! 
+//! ##Overview
+//! As stated in Susbstrate documentation on [benchmarking](https://substrate.dev/docs/en/knowledgebase/runtime/benchmarking),
+//! "the time it takes to execute an extrinsic may vary based on the computational complexity, 
+//! storage complexity, hardware used, and many other factors. We use generic measurement called 
+//! weight to represent how many extrinsics can fit into one block".
+//! 
+//! ## References
+//! [Substrate Benchmarking Documentation](https://www.shawntabrizi.com/substrate-graph-benchmarks/docs/#/)
+
+// ----------------------------------------------------------------------------
+// Module imports and re-exports
+// ----------------------------------------------------------------------------
+
+// Import crate components
+use super::*;
+use crate::{self as pallet_bridge, Pallet as Bridge};
+
+// Import basic benchmarking primitives
+use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
+
+// Proofs primitives and processing routines
+use proofs::Proof;
+
+// ----------------------------------------------------------------------------
+// Benchmarks implementation
+// ----------------------------------------------------------------------------
+
+benchmarks! {
+
+    // Benchmark `pre_commit` extrinsic.
+    pre_commit_benchmark {
+
+        // Initialize seminal state
+    } : {
+        // Execute extrinsics
+//       pre_commit();
+    } verify {
+        // Check final state (i.e. verifying that all goes well)
+    }
+
+} // end of 'benchmarks' macro
+
+
+// ----------------------------------------------------------------------------
+// Benchmarking test cases generation
+// ----------------------------------------------------------------------------
+
+// The following macro generates test cases for benchmarking, and could be ru
+// with the following command:
+//   `cargo test -p pallet-anchors --all-features`
+//
+// You will see one line per benchmarking test case, namely:
+//   `test benchmarking::pre_commit_benchmark ... ok`
+//   ... and so on
+//
+// The line generates three steps per benchmark, with repeat=1 and the three steps are
+// [low, mid, high] of the range.
+impl_benchmark_test_suite!(
+	Pallet,
+	crate::mock::TestExternalitiesBuilder::default().build(None),
+	crate::mock::MockRuntime,
+);
+
+// ----------------------------------------------------------------------------
+// Helper functions
+// ----------------------------------------------------------------------------
+
+mod helpers {
+
+    // Implement helper functions here
+
+} // end of 'helpers' module

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -568,7 +568,7 @@ impl pallet_fees::Config for Runtime {
 }
 
 impl pallet_anchors::Config for Runtime {
-	type WeightInfo = ();
+	type WeightInfo = pallet_anchors::weights::SubstrateWeight<Self>;
 }
 
 // Parameterize claims pallet
@@ -861,6 +861,7 @@ impl_runtime_apis! {
 			let params = (&config, &whitelist);
 
 			add_benchmark!(params, batches, pallet_fees, Fees);
+			add_benchmark!(params, batches, pallet_anchors, Anchor);
 			add_benchmark!(params, batches, pallet_migration_manager, Migration);
 			add_benchmark!(params, batches, pallet_crowdloan_claim, CrowdloanClaim);
 			add_benchmark!(params, batches, pallet_crowdloan_reward, CrowdloanReward);


### PR DESCRIPTION
This PR aims at:
- Configure benchmarking support for `anchors` pallet (priority for coming Altair runtime upgrade)
- Implement benchmarks for `anchors` pallets extrinsics
- Remove existing traits and implementation for weights.
- Add benchmarking support for `anchors` pallet in `development` and `altair` runtimes