### PR TITLE
Use ENTRYPOINT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,4 @@ COPY res /resources/
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
 
-CMD ["/usr/local/bin/centrifuge-chain"]
+ENTRYPOINT ["/usr/local/bin/centrifuge-chain"]


### PR DESCRIPTION
As we currently do not have the need to overwrite the default command and this will make our docker images more compatible with the parachain-launch script from web3-foundation, this changes the  `CMD` to `ENTRYPOINT` in the dockerfile.