### PR TITLE
fix: Rename centrifuge-chain-runtime to centrifuge-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Summary:
   Rustc      : rustc 1.43.0-nightly (5e7af4669 2020-02-16)
   Size       : 928 KB (950464 bytes)
   Content    : 0x0061736d0100000001c2022f60037f7f...3436363920323032302d30322d313629
-  Package    : centrifuge-chain-runtime
+  Package    : centrifuge-runtime
   Proposal   : 0x5c3d2cd41d70c514566c9b512743ad229fa96518061fe21c8178ba43cfcf16dc
   SHA256     : 3f0d2e98e2351144027826f26277bda90e5fabc13f0945fc8fec13d116602e2a
-  Wasm       : ./target/srtool/release/wbuild/centrifuge-chain-runtime/centrifuge_chain_runtime.compact.wasm
+  Wasm       : ./target/srtool/release/wbuild/centrifuge-runtime/centrifuge_runtime.compact.wasm
 ```
 4. `Proposal` hash should match the runtime upgrade proposal
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cargo build --release
 ### Tests
 
 ```bash
-cargo test -p centrifuge-chain-runtime --release
+cargo test -p centrifuge-runtime --release
 ```
 
 ### Start local Relay chain(alice and bob) and Parachain(alice)  

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -50,7 +50,7 @@ onboard-parachain)
   genesis=$(./target/release/centrifuge-chain export-genesis-state --chain="${parachain}" --parachain-id="${para_id}")
   wasm=$(./target/release/centrifuge-chain export-genesis-wasm --chain="${parachain}")
   echo "Genesis state:" $genesis
-  echo "WASM:" "./target/release/wbuild/centrifuge-chain-runtime/centrifuge_chain_runtime.compact.wasm"
+  echo "WASM:" "./target/release/wbuild/centrifuge-runtime/centrifuge_runtime.compact.wasm"
 
   polkadot-js-api \
           --ws ws://0.0.0.0:9944 \


### PR DESCRIPTION
We seem to have forgotten to update some references