### PR TITLE
Apply cargo clippy fixes

### DIFF
--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -379,7 +379,7 @@ fn altair_genesis(
 				.map(|(acc, aura)| {
 					(
 						acc.clone(),                   // account id
-						acc.clone(),                   // validator id
+						acc,                           // validator id
 						get_altair_session_keys(aura), // session keys
 					)
 				})
@@ -453,7 +453,7 @@ fn development_genesis(
 				.map(|(acc, aura)| {
 					(
 						acc.clone(),                        // account id
-						acc.clone(),                        // validator id
+						acc,                                // validator id
 						get_development_session_keys(aura), // session keys
 					)
 				})

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@
 
 use std::path::PathBuf;
 
-use sc_cli;
+
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,6 @@
 
 use std::path::PathBuf;
 
-
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/command.rs
+++ b/src/command.rs
@@ -174,8 +174,7 @@ impl SubstrateCli for RelayChainCli {
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter())
-			.load_spec(id)
+		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter()).load_spec(id)
 	}
 
 	fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {

--- a/src/command.rs
+++ b/src/command.rs
@@ -174,7 +174,7 @@ impl SubstrateCli for RelayChainCli {
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name().to_string()].iter())
+		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter())
 			.load_spec(id)
 	}
 
@@ -265,7 +265,7 @@ pub fn run() -> Result<()> {
 			runner.sync_run(|config| {
 				let polkadot_cli = RelayChainCli::new(
 					&config,
-					[RelayChainCli::executable_name().to_string()]
+					[RelayChainCli::executable_name()]
 						.iter()
 						.chain(cli.relaychain_args.iter()),
 				);
@@ -355,7 +355,7 @@ pub fn run() -> Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				let polkadot_cli = RelayChainCli::new(
 					&config,
-					[RelayChainCli::executable_name().to_string()]
+					[RelayChainCli::executable_name()]
 						.iter()
 						.chain(cli.relaychain_args.iter()),
 				);

--- a/src/service.rs
+++ b/src/service.rs
@@ -153,7 +153,7 @@ where
 
 	let (client, backend, keystore_container, task_manager) =
 		sc_service::new_full_parts::<Block, RuntimeApi, _>(
-			&config,
+			config,
 			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
 			executor,
 		)?;
@@ -418,7 +418,7 @@ pub fn build_altair_import_queue(
 
 			Ok((time, slot))
 		},
-		registry: config.prometheus_registry().clone(),
+		registry: config.prometheus_registry(),
 		can_author_with: sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone()),
 		spawner: &task_manager.spawn_essential_handle(),
 		telemetry,
@@ -447,7 +447,7 @@ pub async fn start_altair_node(
 		id,
 		|client| {
 			let mut io = jsonrpc_core::IoHandler::default();
-			io.extend_with(AnchorApi::to_delegate(Anchor::new(client.clone())));
+			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},
 		build_altair_import_queue,
@@ -466,7 +466,7 @@ pub async fn start_altair_node(
 				task_manager.spawn_handle(),
 				client.clone(),
 				transaction_pool,
-				prometheus_registry.clone(),
+				prometheus_registry,
 				telemetry.clone(),
 			);
 
@@ -514,7 +514,7 @@ pub async fn start_altair_node(
 				block_import: client.clone(),
 				relay_chain_client: relay_chain_node.client.clone(),
 				relay_chain_backend: relay_chain_node.backend.clone(),
-				para_client: client.clone(),
+				para_client: client,
 				backoff_authoring_blocks: Option::<()>::None,
 				sync_oracle,
 				keystore,
@@ -578,7 +578,7 @@ pub fn build_centrifuge_import_queue(
 
 			Ok((time, slot))
 		},
-		registry: config.prometheus_registry().clone(),
+		registry: config.prometheus_registry(),
 		can_author_with: sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone()),
 		spawner: &task_manager.spawn_essential_handle(),
 		telemetry,
@@ -607,7 +607,7 @@ pub async fn start_centrifuge_node(
 		id,
 		|client| {
 			let mut io = jsonrpc_core::IoHandler::default();
-			io.extend_with(AnchorApi::to_delegate(Anchor::new(client.clone())));
+			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},
 		build_centrifuge_import_queue,
@@ -626,7 +626,7 @@ pub async fn start_centrifuge_node(
 				task_manager.spawn_handle(),
 				client.clone(),
 				transaction_pool,
-				prometheus_registry.clone(),
+				prometheus_registry,
 				telemetry.clone(),
 			);
 
@@ -674,7 +674,7 @@ pub async fn start_centrifuge_node(
 				block_import: client.clone(),
 				relay_chain_client: relay_chain_node.client.clone(),
 				relay_chain_backend: relay_chain_node.backend.clone(),
-				para_client: client.clone(),
+				para_client: client,
 				backoff_authoring_blocks: Option::<()>::None,
 				sync_oracle,
 				keystore,
@@ -738,7 +738,7 @@ pub fn build_development_import_queue(
 
 			Ok((time, slot))
 		},
-		registry: config.prometheus_registry().clone(),
+		registry: config.prometheus_registry(),
 		can_author_with: sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone()),
 		spawner: &task_manager.spawn_essential_handle(),
 		telemetry,
@@ -767,7 +767,7 @@ pub async fn start_development_node(
 		id,
 		|client| {
 			let mut io = jsonrpc_core::IoHandler::default();
-			io.extend_with(AnchorApi::to_delegate(Anchor::new(client.clone())));
+			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},
 		build_development_import_queue,
@@ -786,7 +786,7 @@ pub async fn start_development_node(
 				task_manager.spawn_handle(),
 				client.clone(),
 				transaction_pool,
-				prometheus_registry.clone(),
+				prometheus_registry,
 				telemetry.clone(),
 			);
 
@@ -834,7 +834,7 @@ pub async fn start_development_node(
 				block_import: client.clone(),
 				relay_chain_client: relay_chain_node.client.clone(),
 				relay_chain_backend: relay_chain_node.backend.clone(),
-				para_client: client.clone(),
+				para_client: client,
 				backoff_authoring_blocks: Option::<()>::None,
 				sync_oracle,
 				keystore,


### PR DESCRIPTION
Just run `cargo clippy` and applied most of the suggested fixes, mostly unnecessary `clones()`, references, and conversions.