### PR TITLE
Fix migration benchmarking

### DIFF
--- a/pallets/migration/src/benchmarking.rs
+++ b/pallets/migration/src/benchmarking.rs
@@ -92,7 +92,7 @@ benchmarks! {
 		for ( id, vesting_info) in data {
 			let storage_vesting_info: VestingInfo<<<T as pallet_vesting::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance,
 			T::BlockNumber> =
-				pallet_vesting::Vesting::<T>::try_get(id).unwrap();
+				pallet_vesting::Vesting::<T>::get(id).unwrap().first().unwrap().clone();
 
 			assert_eq!(vesting_info, storage_vesting_info);
 		}


### PR DESCRIPTION
Currently, building the benchmarks fails to compile with the following error:

``` rust
error[E0308]: mismatched types
  --> pallets/migration/src/benchmarking.rs:95:5
   |
93 |   ...   let storage_vesting_info: VestingInfo<<<T as pallet_vesting::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>...
   |  _________________________________-
94 | | ...   T::BlockNumber> =
   | |_____________________- expected due to this
95 |   ...       pallet_vesting::Vesting::<T>::try_get(id).unwrap();
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `VestingInfo`, found struct `frame_support::BoundedVec`
```

It seems that the Api has changed, which we fix in this PR. Please check carefully whether my _fix_ is fair.