### PR TITLE
Quick broom 🧹 

### DIFF
--- a/pallets/crowdloan-claim/src/benchmarking.rs
+++ b/pallets/crowdloan-claim/src/benchmarking.rs
@@ -1,14 +1,9 @@
 #![cfg(feature = "runtime-benchmarks")]
 use super::*;
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
-use frame_support::Blake2_128Concat;
 use frame_support::StorageHasher;
 use frame_support::Twox128;
-use frame_system::Account;
-use frame_system::AccountInfo;
 use frame_system::RawOrigin;
-use pallet_balances::AccountData;
-use sp_runtime::traits::AccountIdConversion;
 use sp_runtime::Perbill;
 
 const CONTRIBUTION: u128 = 40000000000000000000;
@@ -135,13 +130,6 @@ impl_benchmark_test_suite!(
 // Helper functions from here on
 //
 fn get_contribution<T: Config>(amount: u128) -> T::Balance {
-	match amount.try_into() {
-		Ok(contribution) => contribution,
-		Err(_) => panic!(),
-	}
-}
-
-fn get_balance<T: Config>(amount: u128) -> T::Balance {
 	match amount.try_into() {
 		Ok(contribution) => contribution,
 		Err(_) => panic!(),

--- a/pallets/migration/src/benchmarking.rs
+++ b/pallets/migration/src/benchmarking.rs
@@ -92,7 +92,7 @@ benchmarks! {
 		for ( id, vesting_info) in data {
 			let storage_vesting_info: VestingInfo<<<T as pallet_vesting::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance,
 			T::BlockNumber> =
-				pallet_vesting::Vesting::<T>::try_get(id).unwrap();
+				pallet_vesting::Vesting::<T>::get(id).unwrap().first().unwrap().clone();
 
 			assert_eq!(vesting_info, storage_vesting_info);
 		}


### PR DESCRIPTION
Back-porting the migration/benchmarking compilation error fix (https://github.com/centrifuge/centrifuge-chain/pull/540) and cleaning unused imports and unused code from `crowdloan-claim/src/benchmarking.rs`.