### PR TITLE
chore: group optional benchmark dependencies

### DIFF
--- a/pallets/claims/Cargo.toml
+++ b/pallets/claims/Cargo.toml
@@ -16,12 +16,14 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.12" }
 node-primitives = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.12" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+
+# optional dependencies for benchmarking
+frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.12" }
 
 [dev-dependencies]
 node-primitives = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.12" }

--- a/pallets/crowdloan-claim/Cargo.toml
+++ b/pallets/crowdloan-claim/Cargo.toml
@@ -22,13 +22,13 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true , branch = "polkadot-v0.9.12" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 
-# Benchmarking dependencies
+# optional dependencies for benchmarking
+frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.12" }
 schnorrkel = { version = "0.10.2", features = ["u64_backend"], default-features = false, optional = true }
 getrandom = { version = "0.2", default-features = false, optional = true }
 rand_core = { version = "0.6.2", default-features = false, optional = true}

--- a/pallets/fees/Cargo.toml
+++ b/pallets/fees/Cargo.toml
@@ -18,6 +18,8 @@ frame-support = { git = "https://github.com/paritytech/substrate", default-featu
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.12" }
+
+# optional dependencies for benchmarking
 frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.12" }
 
 [dev-dependencies]

--- a/pallets/nft/Cargo.toml
+++ b/pallets/nft/Cargo.toml
@@ -17,11 +17,13 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-support = { git = "https://github.com/paritytech/substrate.git", default-features = false , branch = "polkadot-v0.9.12" }
 frame-system = { git = "https://github.com/paritytech/substrate.git", default-features = false , branch = "polkadot-v0.9.12" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", default-features = false, optional = true , branch = "polkadot-v0.9.12" }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", default-features = false , branch = "polkadot-v0.9.12" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", default-features = false , branch = "polkadot-v0.9.12" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", default-features = false , branch = "polkadot-v0.9.12" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+
+# optional dependencies for benchmarking
+frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.12" }
 
 # Centrifuge Chain dependencies
 chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = false, branch = "polkadot-v0.9.12" }


### PR DESCRIPTION
To follow @vedhavyas's suggestion already applied to the collator-allowlist pallet.