### PR TITLE
benchmark: fix output dir in run_benchmark

### DIFF
--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -3,11 +3,13 @@
 set -eux
 
 chain=$1
+# The pallet name is expected to be the `name` set in the
+# respective Cargo.toml, e.g. 'pallet-crowdloan-claim'.
 pallet=$2
 output=$3
+
 if [  -z "${output}" ]; then
-    output=$(echo "./${pallet}/src/weights.rs" | sed 's/_/\//')
-    output=$(echo "${output}" | sed 's/pallet\//pallets\//')
+    output=$(echo "./${pallet}/src/weights.rs" | sed 's/pallet-/\pallets\//')
 fi
 
 echo "Benchmark: ${pallet}"


### PR DESCRIPTION
Right now, the `run_benchmark.sh` script sort of expects the `pallet` param to be formatted following the snake_case style, which does not match with the name convention for the our pallets, which causes the `output` weights file to be set to a destination that doesn't exist.

``` bash
$ ./scripts/init.sh benchmark pallet_collator_allowlist
(..)
Running `target/release/centrifuge-chain benchmark --chain=altair-dev --steps=50 --repeat=100 --pallet=pallet_collator_allowlist '--extrinsic=*' --execution=wasm --wasm-execution=compiled --heap-pages=4096 --output=./pallets/collator_allowlist/src/weights.rs --template=./scripts/frame-weight-template.hbs`
2021-12-06 14:41:45 assembling new collators for new session 0 at #0
2021-12-06 14:41:45 assembling new collators for new session 1 at #0
Error: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```


### Proposed solution

Since the pallets are named following a hyphen separator, e.g, `pallet-collator-allowlist`, and that is also used for other commands (e.g. `cargo test -p pallet-collator-allowlist`), we adopt that convention as well in this script.

By doing so, we can now set the correct `output` and have the script running successfully without the need to neither pass a specific `output` param neither to create a tmp directory.
