### PR TITLE
Extend iohandler with default rpcs 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 
 mod api;
 mod chain_spec;
+mod rpc;
 #[macro_use]
 mod service;
 mod cli;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,0 +1,67 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Centrifuge specific rpc endpoints (common endpoints across all environments)
+
+use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
+use runtime_common::{AccountId, Balance, Index};
+use sc_rpc_api::DenyUnsafe;
+use sc_service::TransactionPool;
+use sp_api::ProvideRuntimeApi;
+use sp_block_builder::BlockBuilder;
+use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use std::sync::Arc;
+use substrate_frame_rpc_system::{FullSystem, SystemApi};
+
+/// A type representing all RPC extensions.
+pub type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
+
+/// Full client dependencies.
+pub struct FullDeps<C, P> {
+	/// The client instance to use.
+	pub client: Arc<C>,
+	/// Transaction pool instance.
+	pub pool: Arc<P>,
+	/// Whether to deny unsafe calls
+	pub deny_unsafe: DenyUnsafe,
+}
+
+/// Instantiate all Full RPC extensions.
+pub fn create_full<C, P, Block>(deps: FullDeps<C, P>) -> RpcExtension
+where
+	Block: sp_api::BlockT,
+	C: ProvideRuntimeApi<Block>,
+	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError>,
+	C: Send + Sync + 'static,
+	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: BlockBuilder<Block>,
+	P: TransactionPool + Sync + Send + 'static,
+{
+	let mut io = jsonrpc_core::IoHandler::default();
+	let FullDeps {
+		client,
+		pool,
+		deny_unsafe,
+	} = deps;
+
+	io.extend_with(SystemApi::to_delegate(FullSystem::new(
+		client.clone(),
+		pool,
+		deny_unsafe,
+	)));
+	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
+		client.clone(),
+	)));
+
+	io
+}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -25,18 +25,12 @@ use substrate_frame_rpc_system::{FullSystem, SystemApi};
 /// A type representing all RPC extensions.
 pub type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
 
-/// Full client dependencies.
-pub struct FullDeps<C, P> {
-	/// The client instance to use.
-	pub client: Arc<C>,
-	/// Transaction pool instance.
-	pub pool: Arc<P>,
-	/// Whether to deny unsafe calls
-	pub deny_unsafe: DenyUnsafe,
-}
-
 /// Instantiate all Full RPC extensions.
-pub fn create_full<C, P, Block>(deps: FullDeps<C, P>) -> RpcExtension
+pub fn create_full<C, P, Block>(
+	client: Arc<C>,
+	pool: Arc<P>,
+	deny_unsafe: DenyUnsafe,
+) -> RpcExtension
 where
 	Block: sp_api::BlockT,
 	C: ProvideRuntimeApi<Block>,
@@ -48,17 +42,13 @@ where
 	P: TransactionPool + Sync + Send + 'static,
 {
 	let mut io = jsonrpc_core::IoHandler::default();
-	let FullDeps {
-		client,
-		pool,
-		deny_unsafe,
-	} = deps;
 
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(
 		client.clone(),
 		pool,
 		deny_unsafe,
 	)));
+
 	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
 		client.clone(),
 	)));

--- a/src/service.rs
+++ b/src/service.rs
@@ -459,11 +459,11 @@ pub async fn start_altair_node(
 		polkadot_config,
 		id,
 		|client, pool, deny_unsafe| {
-			let mut io = crate::rpc::create_full(FullDeps {
+			let mut io = crate::rpc::create_full(
 				client: client.clone(),
 				pool,
 				deny_unsafe,
-			});
+			);
 			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},
@@ -623,11 +623,11 @@ pub async fn start_centrifuge_node(
 		polkadot_config,
 		id,
 		|client, pool, deny_unsafe| {
-			let mut io = crate::rpc::create_full(FullDeps {
+			let mut io = crate::rpc::create_full(
 				client: client.clone(),
 				pool,
 				deny_unsafe,
-			});
+			);
 			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},
@@ -787,11 +787,11 @@ pub async fn start_development_node(
 		polkadot_config,
 		id,
 		|client, pool, deny_unsafe| {
-			let mut io = crate::rpc::create_full(FullDeps {
+			let mut io = crate::rpc::create_full(
 				client: client.clone(),
 				pool,
 				deny_unsafe,
-			});
+			);
 			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},

--- a/src/service.rs
+++ b/src/service.rs
@@ -15,7 +15,6 @@
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::{Anchor, AnchorApi};
-use crate::rpc::FullDeps;
 use cumulus_client_consensus_aura::{
 	build_aura_consensus, BuildAuraConsensusParams, SlotProportion,
 };
@@ -459,11 +458,7 @@ pub async fn start_altair_node(
 		polkadot_config,
 		id,
 		|client, pool, deny_unsafe| {
-			let mut io = crate::rpc::create_full(
-				client: client.clone(),
-				pool,
-				deny_unsafe,
-			);
+			let mut io = crate::rpc::create_full(client.clone(), pool, deny_unsafe);
 			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},
@@ -623,11 +618,7 @@ pub async fn start_centrifuge_node(
 		polkadot_config,
 		id,
 		|client, pool, deny_unsafe| {
-			let mut io = crate::rpc::create_full(
-				client: client.clone(),
-				pool,
-				deny_unsafe,
-			);
+			let mut io = crate::rpc::create_full(client.clone(), pool, deny_unsafe);
 			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},
@@ -787,11 +778,7 @@ pub async fn start_development_node(
 		polkadot_config,
 		id,
 		|client, pool, deny_unsafe| {
-			let mut io = crate::rpc::create_full(
-				client: client.clone(),
-				pool,
-				deny_unsafe,
-			);
+			let mut io = crate::rpc::create_full(client.clone(), pool, deny_unsafe);
 			io.extend_with(AnchorApi::to_delegate(Anchor::new(client)));
 			Ok(io)
 		},


### PR DESCRIPTION
This PR extends all nodes (dev, altair, cfg) with the default rpc methods of `PaymentApi`, `SystemApi`.