### PR TITLE
Fix the onboard-chain script param error

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -48,9 +48,9 @@ start-parachain)
 onboard-parachain)
   yarn global add @polkadot/api-cli@0.32.1
   genesis=$(./target/release/centrifuge-chain export-genesis-state --chain="${parachain}" --parachain-id="${para_id}")
-  wasm=$(./target/release/centrifuge-chain export-genesis-wasm --chain="${parachain}")
+  wasm_path="./target/release/wbuild/centrifuge-runtime/centrifuge_runtime.compact.wasm"
   echo "Genesis state:" $genesis
-  echo "WASM:" "./target/release/wbuild/centrifuge-runtime/centrifuge_runtime.compact.wasm"
+  echo "WASM:" $wasm_path
 
   polkadot-js-api \
           --ws ws://0.0.0.0:9944 \
@@ -58,7 +58,7 @@ onboard-parachain)
           --sudo \
           tx.parasSudoWrapper.sudoScheduleParaInitialize \
           2000 \
-          "{ \"genesisHead\":\"${genesis?}\", \"validationCode\": \"${wasm}\", \"parachain\": true }"
+          "{ \"genesisHead\":\"${genesis?}\", \"validationCode\": \"${wasm_path}\", \"parachain\": true }"
   ;;
 
 benchmark)

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -46,7 +46,7 @@ start-parachain)
   ;;
 
 onboard-parachain)
-  yarn global add @polkadot/api-cli@0.32.1
+  yarn global add @polkadot/api-cli@0.48.6
   genesis=$(./target/release/centrifuge-chain export-genesis-state --chain="${parachain}" --parachain-id="${para_id}")
   wasm_path="./target/release/wbuild/centrifuge-runtime/centrifuge_runtime.compact.wasm"
   echo "Genesis state:" $genesis


### PR DESCRIPTION
Currently, running `./scripts/init.sh onboard-parachain` with an error related to the argument list being too long. A quick debugging revealed that the issue laid with passing the `wasm` inline.

Instead, we pass the path to the wasm file as the `validationCode` param. I am not sure yet whether this actually works because my parachain is not producing blocks but I am investigating it. 