### PR TITLE
Switch from sub ratio to risk buffer for tranche constraints

### DIFF
--- a/pallets/tinlake-investor-pool/src/tests.rs
+++ b/pallets/tinlake-investor-pool/src/tests.rs
@@ -129,25 +129,25 @@ fn pool_constraints_pool_reserve_above_max_reserve() {
 fn pool_constraints_tranche_violates_sub_ratio() {
 	new_test_ext().execute_with(|| {
 		let tranche_a = Tranche {
-			min_subordination_ratio: Perquintill::from_float(0.4), // Violates constraint here
+			min_risk_buffer: Perquintill::from_float(0.4), // Violates constraint here
 			epoch_supply: 100,
 			epoch_redeem: Zero::zero(),
 			..Default::default()
 		};
 		let tranche_b = Tranche {
-			min_subordination_ratio: Perquintill::from_float(0.5),
+			min_risk_buffer: Perquintill::from_float(0.2),
 			epoch_supply: Zero::zero(),
 			epoch_redeem: 20,
 			..Default::default()
 		};
 		let tranche_c = Tranche {
-			min_subordination_ratio: Perquintill::from_float(0.5),
+			min_risk_buffer: Perquintill::from_float(0.1),
 			epoch_supply: Zero::zero(),
 			epoch_redeem: Zero::zero(),
 			..Default::default()
 		};
 		let tranche_d = Tranche {
-			min_subordination_ratio: Perquintill::zero(),
+			min_risk_buffer: Perquintill::zero(),
 			epoch_supply: Zero::zero(),
 			epoch_redeem: Zero::zero(),
 			..Default::default()
@@ -192,7 +192,7 @@ fn pool_constraints_tranche_violates_sub_ratio() {
 
 		assert_noop!(
 			TinlakeInvestorPool::is_epoch_valid(pool, &epoch, &full_solution),
-			Error::<Test>::SubordinationRatioViolated
+			Error::<Test>::RiskBufferViolated
 		);
 	});
 }
@@ -201,25 +201,25 @@ fn pool_constraints_tranche_violates_sub_ratio() {
 fn pool_constraints_pass() {
 	new_test_ext().execute_with(|| {
 		let tranche_a = Tranche {
-			min_subordination_ratio: Perquintill::from_float(0.2),
+			min_risk_buffer: Perquintill::from_float(0.2),
 			epoch_supply: 100,
 			epoch_redeem: Zero::zero(),
 			..Default::default()
 		};
 		let tranche_b = Tranche {
-			min_subordination_ratio: Perquintill::from_float(0.5),
+			min_risk_buffer: Perquintill::from_float(0.1),
 			epoch_supply: Zero::zero(),
 			epoch_redeem: 30,
 			..Default::default()
 		};
 		let tranche_c = Tranche {
-			min_subordination_ratio: Perquintill::from_float(0.5),
+			min_risk_buffer: Perquintill::from_float(0.05),
 			epoch_supply: Zero::zero(),
 			epoch_redeem: Zero::zero(),
 			..Default::default()
 		};
 		let tranche_d = Tranche {
-			min_subordination_ratio: Perquintill::zero(),
+			min_risk_buffer: Perquintill::zero(),
 			epoch_supply: Zero::zero(),
 			epoch_redeem: Zero::zero(),
 			..Default::default()


### PR DESCRIPTION
Min risk buffer is defined as `<subordinate tranche sum>/<total value>`.

The previous definition was `<subordinate tranche sum>/<tranche value>`.