### PR TITLE
Use 27-bit fixed point for tranche interest rates

### DIFF
--- a/pallets/loan/src/mock.rs
+++ b/pallets/loan/src/mock.rs
@@ -141,6 +141,7 @@ impl pallet_tinlake_investor_pool::Config for MockRuntime {
 	type Event = Event;
 	type Balance = Balance;
 	type BalanceRatio = Rate;
+	type InterestRate = Rate;
 	type PoolId = PoolId;
 	type TrancheId = u8;
 	type EpochId = u32;

--- a/pallets/tinlake-investor-pool/src/lib.rs
+++ b/pallets/tinlake-investor-pool/src/lib.rs
@@ -1145,7 +1145,7 @@ pub mod pallet {
 				let mut remaining_amount = amount;
 				for tranche in &mut pool.tranches {
 					Self::update_tranche_debt(tranche).ok_or(Error::<T>::Overflow)?;
-					let tranche_amount = if tranche.interest_per_sec != Zero::zero() {
+					let tranche_amount = if tranche.interest_per_sec != One::one() {
 						tranche.ratio.mul_ceil(amount)
 					} else {
 						remaining_amount
@@ -1187,7 +1187,7 @@ pub mod pallet {
 				let mut remaining_amount = amount;
 				for tranche in &mut pool.tranches {
 					Self::update_tranche_debt(tranche).ok_or(Error::<T>::Overflow)?;
-					let tranche_amount = if tranche.interest_per_sec != Zero::zero() {
+					let tranche_amount = if tranche.interest_per_sec != One::one() {
 						tranche.ratio.mul_ceil(amount)
 					} else {
 						remaining_amount

--- a/pallets/tinlake-investor-pool/src/mock.rs
+++ b/pallets/tinlake-investor-pool/src/mock.rs
@@ -6,12 +6,13 @@ use frame_support::{
 use frame_system as system;
 use orml_traits::parameter_type_with_key;
 use primitives_tokens::CurrencyId;
-use runtime_common::Rate;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 };
+
+pub use runtime_common::Rate;
 
 primitives_tokens::impl_tranche_token!();
 
@@ -142,6 +143,7 @@ impl Config for Test {
 	type Event = Event;
 	type Balance = Balance;
 	type BalanceRatio = Rate;
+	type InterestRate = Rate;
 	type PoolId = u64;
 	type TrancheId = u8;
 	type EpochId = u32;

--- a/pallets/tinlake-investor-pool/src/tests.rs
+++ b/pallets/tinlake-investor-pool/src/tests.rs
@@ -316,7 +316,7 @@ fn epoch() {
 		let pool = TinlakeInvestorPool::pool(0).unwrap();
 		assert_eq!(
 			pool.tranches[0].interest_per_sec,
-			Perquintill::from_parts(000000003170979198)
+			Rate::from_inner(1_000000003170979198376458650)
 		);
 		assert_eq!(pool.tranches[0].debt, 0);
 		assert_eq!(pool.tranches[0].reserve, 500 * CURRENCY);

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -708,6 +708,7 @@ impl pallet_tinlake_investor_pool::Config for Runtime {
 	type Event = Event;
 	type Balance = Balance;
 	type BalanceRatio = Rate;
+	type InterestRate = Rate;
 	type PoolId = PoolId;
 	type TrancheId = u8;
 	type EpochId = u32;


### PR DESCRIPTION
This also stores the interest rate in a different fixed format which
avoids some redudant conversionss for every interest calculation

Fixes #558