### PR TITLE
Adds type to ensure root is admin

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -547,27 +547,27 @@ impl pallet_democracy::Config for Runtime {
 	type MinimumDeposit = MinimumDeposit;
 
 	/// A straight majority of the council can decide what their next motion is.
-	type ExternalOrigin = RootOr<HalfOfCouncil>;
+	type ExternalOrigin = HalfOfCouncil;
 
 	/// A super-majority can have the next scheduled referendum be a straight majority-carries vote.
-	type ExternalMajorityOrigin = RootOr<HalfOfCouncil>;
+	type ExternalMajorityOrigin = HalfOfCouncil;
 
 	/// A unanimous council can have the next scheduled referendum be a straight default-carries
 	/// (NTB) vote.
-	type ExternalDefaultOrigin = RootOr<AllOfCouncil>;
+	type ExternalDefaultOrigin = AllOfCouncil;
 
 	/// Half of the council can have an ExternalMajority/ExternalDefault vote
 	/// be tabled immediately and with a shorter voting/enactment period.
-	type FastTrackOrigin = RootOr<HalfOfCouncil>;
+	type FastTrackOrigin = EnsureRootOr<HalfOfCouncil>;
 
-	type InstantOrigin = RootOr<AllOfCouncil>;
+	type InstantOrigin = EnsureRootOr<AllOfCouncil>;
 
 	type InstantAllowed = InstantAllowed;
 
 	type FastTrackVotingPeriod = FastTrackVotingPeriod;
 
 	// To cancel a proposal which has been passed, 2/3 of the council must agree to it.
-	type CancellationOrigin = RootOr<TwoThirdOfCouncil>;
+	type CancellationOrigin = EnsureRootOr<TwoThirdOfCouncil>;
 
 	type BlacklistOrigin = EnsureRoot<AccountId>;
 
@@ -609,8 +609,9 @@ impl pallet_identity::Config for Runtime {
 	type MaxAdditionalFields = MaxAdditionalFields;
 	type MaxRegistrars = MaxRegistrars;
 	type Slashed = Treasury;
-	type ForceOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
-	type RegistrarOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
+	type ForceOrigin = EnsureRootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
+	type RegistrarOrigin =
+		EnsureRootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
 	type WeightInfo = pallet_identity::weights::SubstrateWeight<Self>;
 }
 
@@ -654,9 +655,10 @@ parameter_types! {
 impl pallet_treasury::Config for Runtime {
 	type Currency = Balances;
 	// either democracy or 66% of council votes
-	type ApproveOrigin = RootOr<TwoThirdOfCouncil>;
+	type ApproveOrigin = EnsureRootOr<TwoThirdOfCouncil>;
 	// either democracy or more than 50% council votes
-	type RejectOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
+	type RejectOrigin =
+		EnsureRootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
 	type Event = Event;
 	// slashed amount goes to treasury account
 	type OnSlash = Treasury;
@@ -677,7 +679,7 @@ impl pallet_fees::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	/// A straight majority of the council can change the fees.
-	type FeeChangeOrigin = RootOr<HalfOfCouncil>;
+	type FeeChangeOrigin = EnsureRootOr<HalfOfCouncil>;
 	type WeightInfo = pallet_fees::weights::SubstrateWeight<Self>;
 }
 
@@ -695,7 +697,7 @@ parameter_types! {
 
 // Implement claims pallet configuration trait for the mock runtime
 impl pallet_claims::Config for Runtime {
-	type AdminOrigin = RootOr<HalfOfCouncil>;
+	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type Currency = Balances;
 	type Event = Event;
 	type Longevity = Longevity;
@@ -730,7 +732,7 @@ parameter_types! {
 impl pallet_crowdloan_reward::Config for Runtime {
 	type Event = Event;
 	type PalletId = CrowdloanRewardPalletId;
-	type AdminOrigin = RootOr<HalfOfCouncil>;
+	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type WeightInfo = pallet_crowdloan_reward::weights::SubstrateWeight<Self>;
 }
 
@@ -747,7 +749,7 @@ impl pallet_crowdloan_claim::Config for Runtime {
 	type Event = Event;
 	type PalletId = CrowdloanClaimPalletId;
 	type WeightInfo = pallet_crowdloan_claim::weights::SubstrateWeight<Self>;
-	type AdminOrigin = RootOr<HalfOfCouncil>;
+	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type RelayChainAccountId = AccountId;
 	type MaxProofLength = MaxProofLength;
 	type ClaimTransactionPriority = ClaimTransactionPriority;

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -16,7 +16,7 @@ use frame_support::{
 };
 use frame_system::{
 	limits::{BlockLength, BlockWeights},
-	EnsureOneOf, EnsureRoot,
+	EnsureRoot,
 };
 use pallet_anchors::AnchorData;
 pub use pallet_balances::Call as BalancesCall;
@@ -27,7 +27,7 @@ use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo
 use polkadot_runtime_common::{BlockHashCount, RocksDbWeight, SlowAdjustingFeeUpdate};
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
-use sp_core::u32_trait::{_1, _2, _3, _5};
+use sp_core::u32_trait::{_1, _2, _3};
 use sp_core::OpaqueMetadata;
 use sp_inherents::{CheckInherentsResult, InherentData};
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, ConvertInto};

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -444,17 +444,17 @@ parameter_types! {
 	pub const CouncilMaxMembers: u32 = 100;
 }
 
-/// The council origin
-type CouncilCollectiveOrigin = pallet_collective::Instance1;
+/// The council
+type CouncilCollective = pallet_collective::Instance1;
 
 /// All council members must vote yes to create this origin.
-type AllOfCouncil = EnsureProportionAtLeast<_1, _1, AccountId, CouncilCollectiveOrigin>;
+type AllOfCouncil = EnsureProportionAtLeast<_1, _1, AccountId, CouncilCollective>;
 
 /// 1/2 of all council members must vote yes to create this origin.
-type HalfOfCouncil = EnsureProportionAtLeast<_1, _2, AccountId, CouncilCollectiveOrigin>;
+type HalfOfCouncil = EnsureProportionAtLeast<_1, _2, AccountId, CouncilCollective>;
 
 /// 2/3 of all council members must vote yes to create this origin.
-type TwoThirdOfCouncil = EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollectiveOrigin>;
+type TwoThirdOfCouncil = EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
 
 impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type Origin = Origin;
@@ -609,9 +609,8 @@ impl pallet_identity::Config for Runtime {
 	type MaxAdditionalFields = MaxAdditionalFields;
 	type MaxRegistrars = MaxRegistrars;
 	type Slashed = Treasury;
-	type ForceOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollectiveOrigin>>;
-	type RegistrarOrigin =
-		RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollectiveOrigin>>;
+	type ForceOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
+	type RegistrarOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
 	type WeightInfo = pallet_identity::weights::SubstrateWeight<Self>;
 }
 
@@ -657,8 +656,7 @@ impl pallet_treasury::Config for Runtime {
 	// either democracy or 66% of council votes
 	type ApproveOrigin = RootOr<TwoThirdOfCouncil>;
 	// either democracy or more than 50% council votes
-	type RejectOrigin =
-		RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollectiveOrigin>>;
+	type RejectOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
 	type Event = Event;
 	// slashed amount goes to treasury account
 	type OnSlash = Treasury;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -532,28 +532,27 @@ impl pallet_democracy::Config for Runtime {
 	type MinimumDeposit = MinimumDeposit;
 
 	/// A straight majority of the council can decide what their next motion is.
-	type ExternalOrigin = RootOr<HalfOfCouncil>;
+	type ExternalOrigin = HalfOfCouncil;
 
 	/// A super-majority can have the next scheduled referendum be a straight majority-carries vote.
-	type ExternalMajorityOrigin =
-		RootOr<EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollective>>;
+	type ExternalMajorityOrigin = EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollective>;
 
 	/// A unanimous council can have the next scheduled referendum be a straight default-carries
 	/// (NTB) vote.
-	type ExternalDefaultOrigin = RootOr<AllOfCouncil>;
+	type ExternalDefaultOrigin = AllOfCouncil;
 
 	/// Two thirds of the council can have an ExternalMajority/ExternalDefault vote
 	/// be tabled immediately and with a shorter voting/enactment period.
-	type FastTrackOrigin = RootOr<TwoThirdOfCouncil>;
+	type FastTrackOrigin = EnsureRootOr<TwoThirdOfCouncil>;
 
-	type InstantOrigin = RootOr<AllOfCouncil>;
+	type InstantOrigin = EnsureRootOr<AllOfCouncil>;
 
 	type InstantAllowed = InstantAllowed;
 
 	type FastTrackVotingPeriod = FastTrackVotingPeriod;
 
 	// To cancel a proposal which has been passed, 2/3 of the council must agree to it.
-	type CancellationOrigin = RootOr<TwoThirdOfCouncil>;
+	type CancellationOrigin = EnsureRootOr<TwoThirdOfCouncil>;
 
 	type BlacklistOrigin = EnsureRoot<AccountId>;
 
@@ -595,8 +594,9 @@ impl pallet_identity::Config for Runtime {
 	type MaxAdditionalFields = MaxAdditionalFields;
 	type MaxRegistrars = MaxRegistrars;
 	type Slashed = ();
-	type ForceOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
-	type RegistrarOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
+	type ForceOrigin = EnsureRootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
+	type RegistrarOrigin =
+		EnsureRootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
 	type WeightInfo = pallet_identity::weights::SubstrateWeight<Self>;
 }
 
@@ -618,7 +618,7 @@ impl pallet_fees::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	/// A straight majority of the council can change the fees.
-	type FeeChangeOrigin = RootOr<HalfOfCouncil>;
+	type FeeChangeOrigin = EnsureRootOr<HalfOfCouncil>;
 	type WeightInfo = pallet_fees::weights::SubstrateWeight<Self>;
 }
 
@@ -636,7 +636,7 @@ parameter_types! {
 
 // Implement claims pallet configuration trait for the mock runtime
 impl pallet_claims::Config for Runtime {
-	type AdminOrigin = RootOr<HalfOfCouncil>;
+	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type Currency = Balances;
 	type Event = Event;
 	type Longevity = Longevity;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -429,17 +429,17 @@ parameter_types! {
 	pub const CouncilMaxMembers: u32 = 100;
 }
 
-/// The council origin
-type CouncilCollectiveOrigin = pallet_collective::Instance1;
+/// The council
+type CouncilCollective = pallet_collective::Instance1;
 
 /// All council members must vote yes to create this origin.
-type AllOfCouncil = EnsureProportionAtLeast<_1, _1, AccountId, CouncilCollectiveOrigin>;
+type AllOfCouncil = EnsureProportionAtLeast<_1, _1, AccountId, CouncilCollective>;
 
 /// 1/2 of all council members must vote yes to create this origin.
-type HalfOfCouncil = EnsureProportionAtLeast<_1, _2, AccountId, CouncilCollectiveOrigin>;
+type HalfOfCouncil = EnsureProportionAtLeast<_1, _2, AccountId, CouncilCollective>;
 
 /// 2/3 of all council members must vote yes to create this origin.
-type TwoThirdOfCouncil = EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollectiveOrigin>;
+type TwoThirdOfCouncil = EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
 
 impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type Origin = Origin;
@@ -536,7 +536,7 @@ impl pallet_democracy::Config for Runtime {
 
 	/// A super-majority can have the next scheduled referendum be a straight majority-carries vote.
 	type ExternalMajorityOrigin =
-		RootOr<EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollectiveOrigin>>;
+		RootOr<EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollective>>;
 
 	/// A unanimous council can have the next scheduled referendum be a straight default-carries
 	/// (NTB) vote.
@@ -595,9 +595,8 @@ impl pallet_identity::Config for Runtime {
 	type MaxAdditionalFields = MaxAdditionalFields;
 	type MaxRegistrars = MaxRegistrars;
 	type Slashed = ();
-	type ForceOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollectiveOrigin>>;
-	type RegistrarOrigin =
-		RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollectiveOrigin>>;
+	type ForceOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
+	type RegistrarOrigin = RootOr<EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>>;
 	type WeightInfo = pallet_identity::weights::SubstrateWeight<Self>;
 }
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -45,7 +45,7 @@ pub mod types {
 	use sp_runtime::traits::{BlakeTwo256, IdentifyAccount, Verify};
 	use sp_std::vec::Vec;
 
-	pub type RootOr<O> = EnsureOneOf<AccountId, EnsureRoot<AccountId>, O>;
+	pub type EnsureRootOr<O> = EnsureOneOf<AccountId, EnsureRoot<AccountId>, O>;
 
 	/// An index to a block.
 	pub type BlockNumber = u32;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -37,7 +37,6 @@ pub mod apis {
 
 /// Common types for all runtimes
 pub mod types {
-	use frame_support::traits::EnsureOrigin;
 	use frame_system::{EnsureOneOf, EnsureRoot};
 	use scale_info::TypeInfo;
 	#[cfg(feature = "std")]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -37,12 +37,16 @@ pub mod apis {
 
 /// Common types for all runtimes
 pub mod types {
+	use frame_support::traits::EnsureOrigin;
+	use frame_system::{EnsureOneOf, EnsureRoot};
 	use scale_info::TypeInfo;
 	#[cfg(feature = "std")]
 	use serde::{Deserialize, Serialize};
 	use sp_core::{H160, U256};
 	use sp_runtime::traits::{BlakeTwo256, IdentifyAccount, Verify};
 	use sp_std::vec::Vec;
+
+	pub type RootOr<O> = EnsureOneOf<AccountId, EnsureRoot<AccountId>, O>;
 
 	/// An index to a block.
 	pub type BlockNumber = u32;


### PR DESCRIPTION
This PR adds a type of `type RootOr<O>  = EnsureOneOf<EnsureRoot, O>`. When using this as the origin type for an admin Origin of `0`, this ensures, that root is always also able to call as admin.

I think as a general rule we should always use this type for any kind of admin origin. This ensures that democracy can always act as an admin.