### PR TITLE
wip: Emulate statemine's XCM config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-ping"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
+dependencies = [
+ "cumulus-pallet-xcm",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+]
+
+[[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
@@ -2008,6 +2025,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
+ "cumulus-ping",
  "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",

--- a/primitives/tokens/src/lib.rs
+++ b/primitives/tokens/src/lib.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use core::convert::TryFrom;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
+
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -11,6 +13,29 @@ use serde::{Deserialize, Serialize};
 pub enum CurrencyId {
 	Usd,
 	Tranche(u64, u8),
+}
+
+
+impl TryFrom<CurrencyId> for u128 {
+	type Error = &'static str;
+
+	fn try_from(value: CurrencyId) -> Result<Self, Self::Error> {
+		match value {
+			CurrencyId::Usd => Ok(0),
+			CurrencyId::Tranche(_,_) => Err("CurrencyId::Tranche cannot be converted")
+		}
+	}
+}
+
+impl TryFrom<u128> for CurrencyId {
+	type Error = &'static str;
+
+	fn try_from(value: u128) -> Result<Self, Self::Error> {
+		match value {
+			0 => Ok(CurrencyId::Usd),
+			_ => Err("Unsupported u128 representation of CurrencyId")
+		}
+	}
 }
 
 #[macro_export]

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -30,6 +30,7 @@ cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", defa
 cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.12" }
 cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.12" }
 cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.12" }
+cumulus-ping = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.12" }
 
 # polkadot dependencies
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.12" }
@@ -177,6 +178,7 @@ std = [
     "xcm-builder/std",
     "cumulus-pallet-xcm/std",
     "cumulus-pallet-aura-ext/std",
+    "cumulus-ping/std",
     "pallet-aura/std",
     "sp-consensus-aura/std",
     "orml-tokens/std",

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1086,7 +1086,7 @@ pub type CurrencyTransactor = xcm_builder::CurrencyAdapter<
 	(),
 >;
 
-pub type AssetId = u32;
+// pub type AssetId = u32;
 
 /// Means for transacting assets besides the native currency on this chain.
 pub type FungiblesTransactor = FungiblesAdapter<
@@ -1094,9 +1094,9 @@ pub type FungiblesTransactor = FungiblesAdapter<
 	Tokens,
 	// Use this currency when it is a fungible asset matching the given location or name:
 	ConvertedConcreteAssetId<
-		AssetId,
+		CurrencyId,
 		Balance,
-		AsPrefixedGeneralIndex<Local, AssetId, JustTry>,
+		AsPrefixedGeneralIndex<Local, CurrencyId, JustTry>,
 		JustTry,
 	>,
 	// Convert an XCM MultiLocation into a local account id:

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -6,11 +6,11 @@
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{Contains, Everything, InstanceFilter, LockIdentifier, U128CurrencyToVote},
+	construct_runtime, match_type, parameter_types,
+	traits::{Contains, Everything, InstanceFilter, LockIdentifier, U128CurrencyToVote, Nothing},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight},
-		DispatchClass, Weight,
+		DispatchClass, IdentityFee, Weight,
 	},
 	PalletId, RuntimeDebug,
 };
@@ -50,7 +50,22 @@ use static_assertions::const_assert;
 pub use primitives_tokens::CurrencyId;
 
 /// common types for the runtime.
-pub use runtime_common::*;
+pub use runtime_common::{*, Index};
+
+// XCM imports
+use pallet_xcm::{EnsureXcm, IsMajorityOfBody, XcmPassthrough};
+use polkadot_parachain::primitives::Sibling;
+use xcm::latest::prelude::*;
+use xcm_builder::{
+	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom,
+	AsPrefixedGeneralIndex, ConvertedConcreteAssetId, EnsureXcmOrigin,
+	FixedWeightBounds, FungiblesAdapter, IsConcrete, LocationInverter, NativeAsset,
+	ParentAsSuperuser, ParentIsDefault, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SovereignSignedViaLocation,
+	TakeWeightCredit, UsingComponents,
+};
+use xcm_executor::{traits::JustTry, Config, XcmExecutor};
+
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -897,6 +912,12 @@ construct_runtime!(
 		InvestorPool: pallet_tinlake_investor_pool::{Pallet, Call, Storage, Event<T>} = 95,
 		Loan: pallet_loan::{Pallet, Call, Storage, Event<T>} = 96,
 
+		// XCM
+		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 120,
+        PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin} = 121,
+        CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 122,
+        DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 123,
+
 		// 3rd party pallets
 		Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>} = 150,
 
@@ -906,6 +927,188 @@ construct_runtime!(
 		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>} = 200,
 	}
 );
+
+
+// XCM stuff
+
+pub struct XcmConfig;
+impl Config for XcmConfig {
+	type Call = Call;
+	type XcmSender = XcmRouter;
+	// How to withdraw and deposit an asset.
+	type AssetTransactor = AssetTransactors;
+	type OriginConverter = XcmOriginToTransactDispatchOrigin;
+	type IsReserve = NativeAsset;
+	type IsTeleporter = NativeAsset; // <- should be enough to allow teleportation of KSM
+	type LocationInverter = LocationInverter<Ancestry>;
+	type Barrier = Barrier;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type Trader = UsingComponents<IdentityFee<Balance>, KsmLocation, AccountId, Balances, ()>;
+	type ResponseHandler = PolkadotXcm;
+	type AssetTrap = PolkadotXcm;
+	type AssetClaims = PolkadotXcm;
+	type SubscriptionService = PolkadotXcm;
+}
+
+pub type Barrier = (
+	TakeWeightCredit,
+	AllowTopLevelPaidExecutionFrom<Everything>,
+	AllowUnpaidExecutionFrom<ParentOrParentsExecutivePlurality>,
+	// ^^^ Parent and its exec plurality get free execution
+);
+
+impl cumulus_pallet_dmp_queue::Config for Runtime {
+	type Event = Event;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+}
+
+/// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
+/// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can
+/// biases the kind of local `Origin` it will become.
+pub type XcmOriginToTransactDispatchOrigin = (
+	// Sovereign account converter; this attempts to derive an `AccountId` from the origin location
+	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
+	// foreign chains who want to have a local sovereign account on this chain which they control.
+	SovereignSignedViaLocation<LocationToAccountId, Origin>,
+	// Native converter for Relay-chain (Parent) location; will converts to a `Relay` origin when
+	// recognized.
+	RelayChainAsNative<RelayChainOrigin, Origin>,
+	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
+	// recognized.
+	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, Origin>,
+	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
+	// transaction from the Root origin.
+	ParentAsSuperuser<Origin>,
+	// Native signed account converter; this just converts an `AccountId32` origin into a normal
+	// `Origin::Signed` origin of the same 32-byte value.
+	SignedAccountId32AsNative<RelayNetwork, Origin>,
+	// Xcm origins can be represented natively under the Xcm pallet's Xcm origin.
+	XcmPassthrough<Origin>,
+);
+
+
+impl pallet_xcm::Config for Runtime {
+	type Event = Event;
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmRouter = XcmRouter;
+	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmExecuteFilter = Nothing;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type XcmTeleportFilter = Everything;
+	type XcmReserveTransferFilter = Everything;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type Origin = Origin;
+	type Call = Call;
+
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	// Override for AdvertisedXcmVersion default
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+}
+
+parameter_types! {
+	pub const KsmLocation: MultiLocation = MultiLocation::parent();
+	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
+	pub RelayChainOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
+	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
+	pub const Local: MultiLocation = Here.into();
+	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
+}
+
+impl cumulus_pallet_xcm::Config for Runtime {
+	type Event = Event;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+impl cumulus_pallet_xcmp_queue::Config for Runtime {
+	type Event = Event;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type ChannelInfo = ParachainSystem;
+	type VersionWrapper = ();
+}
+
+parameter_types! {
+	// One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
+	pub UnitWeightCost: Weight = 1_000_000_000;
+	pub const MaxInstructions: u32 = 100;
+}
+
+match_type! {
+	pub type ParentOrParentsExecutivePlurality: impl Contains<MultiLocation> = {
+		MultiLocation { parents: 1, interior: Here } |
+		MultiLocation { parents: 1, interior: X1(Plurality { id: BodyId::Executive, .. }) }
+	};
+}
+
+/// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
+/// when determining ownership of accounts for asset transacting and when attempting to use XCM
+/// `Transact` in order to determine the dispatch Origin.
+pub type LocationToAccountId = (
+	// The parent (Relay-chain) origin converts to the default `AccountId`.
+	ParentIsDefault<AccountId>,
+	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
+	SiblingParachainConvertsVia<Sibling, AccountId>,
+	// Straight up local `AccountId32` origins just alias directly to `AccountId`.
+	AccountId32Aliases<RelayNetwork, AccountId>,
+);
+
+parameter_types! {
+	pub const MaxDownwardMessageWeight: Weight = MAXIMUM_BLOCK_WEIGHT / 10;
+}
+
+/// No local origins on this chain are allowed to dispatch XCM sends/executions.
+pub type LocalOriginToLocation = ();
+
+/// The means for routing XCM messages which are not for local execution into the right message
+/// queues.
+pub type XcmRouter = (
+	// Two routers - use UMP to communicate with the relay chain:
+	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, ()>,
+	// ..and XCMP to communicate with the sibling chains.
+	XcmpQueue,
+);
+
+/// Means for transacting assets on this chain.
+pub type AssetTransactors = (CurrencyTransactor, FungiblesTransactor);
+
+/// Means for transacting the native currency on this chain.
+pub type CurrencyTransactor = xcm_builder::CurrencyAdapter<
+	// Use this currency:
+	Balances,
+	// Use this currency when it is a fungible asset matching the given location or name:
+	IsConcrete<KsmLocation>,
+	// Convert an XCM MultiLocation into a local account id:
+	LocationToAccountId,
+	// Our chain's account ID type (we can't get away without mentioning it explicitly):
+	AccountId,
+	// We don't track any teleports of `Balances`.
+	(),
+>;
+
+/// Means for transacting assets besides the native currency on this chain.
+pub type FungiblesTransactor = FungiblesAdapter<
+	// Use this fungibles implementation:
+	Uniques,
+	// Use this currency when it is a fungible asset matching the given location or name:
+	ConvertedConcreteAssetId<
+		AssetId,
+		Balance,
+		AsPrefixedGeneralIndex<Local, AssetId, JustTry>,
+		JustTry,
+	>,
+	// Convert an XCM MultiLocation into a local account id:
+	LocationToAccountId,
+	// Our chain's account ID type (we can't get away without mentioning it explicitly):
+	AccountId,
+	// We only want to allow teleports of known assets. We use non-zero issuance as an indication
+	// that this asset is known.
+	(), //NonZeroIssuance<AccountId, Assets>,
+	// The account to use for tracking teleports.
+	CheckingAccount,
+>;
+
+// END XCM stuff
 
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1070,7 +1070,7 @@ pub type XcmRouter = (
 );
 
 /// Means for transacting assets on this chain.
-pub type AssetTransactors = (CurrencyTransactor, FungiblesTransactor);
+pub type AssetTransactors = (CurrencyTransactor);
 
 /// Means for transacting the native currency on this chain.
 pub type CurrencyTransactor = xcm_builder::CurrencyAdapter<
@@ -1089,7 +1089,7 @@ pub type CurrencyTransactor = xcm_builder::CurrencyAdapter<
 /// Means for transacting assets besides the native currency on this chain.
 pub type FungiblesTransactor = FungiblesAdapter<
 	// Use this fungibles implementation:
-	Uniques,
+	Balances,
 	// Use this currency when it is a fungible asset matching the given location or name:
 	ConvertedConcreteAssetId<
 		AssetId,

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -42,6 +42,7 @@ start-parachain)
     --rpc-cors all \
     --ws-external \
     --rpc-methods=Unsafe \
+    --state-cache-size 0 \
     --log="main,debug" \
   ;;
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -22,7 +22,7 @@ stop-relay-chain)
   ;;
 
 start-parachain)
-  echo "Building parachain..."
+  echo "Building parachain $parachain ..."
   cargo build --release
   if [ "$2" == "purge" ]; then
     echo "purging parachain..."

--- a/scripts/run_collator.sh
+++ b/scripts/run_collator.sh
@@ -52,5 +52,7 @@ bootnode () {
 
 args+=( "--" "--wasm-execution=compiled" "--no-beefy" "--execution=wasm" "--chain=${chain}" "--bootnodes=$(bootnode "$alice" "$alice_p2p_port" "$alice_rpc_port")" "--bootnodes=$(bootnode "$bob" "$bob_p2p_port" "$bob_rpc_port")" )
 
+echo "--bootnodes=$(bootnode "$alice" "$alice_p2p_port" "$alice_rpc_port")" "--bootnodes=$(bootnode "$bob" "$bob_p2p_port" "$bob_rpc_port")" > ./xcm/bootnodes
+
 set -x
 "$ctpc" "${args[@]}"

--- a/xcm/.gitignore
+++ b/xcm/.gitignore
@@ -1,0 +1,10 @@
+
+# Bin executables
+bin/
+
+# Statemine-local files
+statemine-local-genesis-state
+statemine-local-genesis-wasm
+
+# Bootnodes files
+bootnodes

--- a/xcm/README.md
+++ b/xcm/README.md
@@ -1,0 +1,65 @@
+# XCM Research
+
+This directory contains the artefacts necessary for the research and development
+of XCM features in the Centrifuge chain.
+
+
+## Local environment
+
+The local environment we setup is composed of:
+
+`Relay-Chain`
+	`|——>` `Statemine-local Parachain`
+	`|——>` `Cfg Development Parachain`
+
+### Start 
+
+To start the local environment, follow these steps.
+
+0. Copy Cumulus' `polkadot-collator` to `xcm/bin`
+
+    You will need to clone and build cumulus and copy the `polkadot-collator`
+    executable.
+
+    NOTE: we use cumulus' revision `c02514d8` for now.
+
+   ``` bash
+   git clone https://github.com/paritytech/cumulus
+   cd cumulus
+   git checkout c02514d8
+   cargo build --release
+
+   cp ./target/release/polkadot-collator ../xcm/bim
+   ```
+
+1. Start the relay chain
+   `./scripts/init.sh start-relay-chain`
+
+2. Start the cfg parachain
+    `./scripts/init.sh start-parachain purge`
+
+3. Start the `statemine-local` parachain
+
+    Copy the content of the `./xcm/bootnodes` file and replace the `<bootnodes>` bit below with said contents.
+
+    ``` bash
+    ./xcm/bin/polkadot-collator \
+    --collator --alice --force-authoring --tmp \
+    --chain statemine-local --parachain-id 42 \
+    --port 40335 --ws-port 9947 \
+    -- \
+    --execution wasm \
+    --chain ./res/rococo-local.json \
+    --port 30335 \
+    <bootnodes>
+    ```
+
+4. Onboard the cfg parachain
+
+5. Onboard the `statemine-local` parachain
+
+   5.1 Export the genesis state 
+   `./bin/polkadot-collator export-genesis-state --chain statemine-local --parachain-id 42 > statemine-local-genesis-state`
+
+   5.2 Export the genesis wasm
+   `./bin/target/release/polkadot-collator export-genesis-wasm --chain statemine-local  > statemine-local-genesis-wasm`

--- a/xcm/bootnodes
+++ b/xcm/bootnodes
@@ -1,0 +1,1 @@
+--bootnodes=/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWFv9j8AyUKuVFpq8wR1dprEzx7jnP6QzuvoNWwrWu9v8A --bootnodes=/ip4/127.0.0.1/tcp/30344/p2p/12D3KooWFRN2a4gPvhHgVcceXhQpCuCF6TzX6jh8fbXMMSTsq8Vn


### PR DESCRIPTION
Our first use case for XCM is to allow bridging NFTs from Statemine into our parachain.

Here, we start by emulating (aka copy-paste) Statemine's XCM config.