### PR TITLE
Remove unnescesary unstable feature

### DIFF
--- a/libs/common-traits/src/lib.rs
+++ b/libs/common-traits/src/lib.rs
@@ -17,10 +17,6 @@
 //! # A common trait for centrifuge
 //!
 //! This crate provides some common traits used by centrifuge.
-//! # Reward trait
-//! The trait does assume, that any call of reward has been
-//! checked for validity. I.e. there are not validation checks
-//! provided by the trait.
 
 // Ensure we're `no_std` when compiling for WebAssembly.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/libs/common-types/src/lib.rs
+++ b/libs/common-types/src/lib.rs
@@ -12,8 +12,6 @@
 
 // Ensure we're `no_std` when compiling for WebAssembly.
 #![cfg_attr(not(feature = "std"), no_std)]
-// We need this for the tests.
-#![feature(duration_consts_2)]
 
 use codec::{Decode, Encode};
 use common_traits::Properties;

--- a/libs/common-types/src/tests.rs
+++ b/libs/common-types/src/tests.rs
@@ -24,22 +24,22 @@ struct Now(core::time::Duration);
 impl Now {
 	fn pass(delta: u64) {
 		unsafe {
-			let current = NOW_HOLDER.0;
-			NOW_HOLDER = Now(current.checked_add(Duration::new(delta, 0)).unwrap());
+			let current = NOW_HOLDER;
+			NOW_HOLDER = current + delta;
 		};
 	}
 
 	fn set(now: u64) {
 		unsafe {
-			NOW_HOLDER = Now(Duration::new(now, 0));
+			NOW_HOLDER = now;
 		};
 	}
 }
 
-static mut NOW_HOLDER: Now = Now(Duration::new(0, 0));
+static mut NOW_HOLDER: u64 = 0;
 impl UnixTime for Now {
 	fn now() -> Duration {
-		unsafe { NOW_HOLDER.0 }
+		unsafe { Duration::new(NOW_HOLDER, 0) }
 	}
 }
 


### PR DESCRIPTION
The tests for previously required an unstable feature which made compiling the pallets or runtimes without a nighty compiler version impossible. 

This was not needed and this PR removes the unstable feature. 