### PR TITLE
[docker] Explicitly use compose file version 3.2

### DIFF
--- a/docker-compose-local-relay.yml
+++ b/docker-compose-local-relay.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 services:
   node_alice:
     container_name: alice


### PR DESCRIPTION
Newer versions of Docker interpret version `3` as `3.0`. This
causes loading of the file to fail, since we use features from
newer releases of the compose format. Explicitly setting it to
`3.2` allows the file to load.

`3.2` was chosen as it does not unnecessarily bump the minimum
Docker version required to run the compose file.