### PR TITLE
reverse tranche order

### DIFF
--- a/pallets/loans/src/test_utils.rs
+++ b/pallets/loans/src/test_utils.rs
@@ -45,8 +45,8 @@ pub(crate) fn set_role<T: pallet_loans::Config>(
 }
 
 parameter_types! {
-	pub const JuniorTrancheId: u8 = 1;
-	pub const SeniorTrancheId: u8 = 0;
+	pub const JuniorTrancheId: u8 = 0;
+	pub const SeniorTrancheId: u8 = 1;
 }
 
 pub(crate) fn create_nft_class<T>(
@@ -116,14 +116,12 @@ pub(crate) fn create<T>(
 		pool_id,
 		vec![
 			TrancheInput {
-				interest_per_sec: Some(One::one()),
-				min_risk_buffer: Some(Perquintill::from_percent(10)),
-				seniority: None,
-			},
-			TrancheInput {
 				interest_per_sec: None,
 				min_risk_buffer: None,
-				seniority: None,
+			},
+			TrancheInput {
+				interest_per_sec: Some(One::one()),
+				min_risk_buffer: Some(Perquintill::from_percent(10)),
 			}
 		],
 		currency_id.into(),

--- a/pallets/loans/src/test_utils.rs
+++ b/pallets/loans/src/test_utils.rs
@@ -118,10 +118,12 @@ pub(crate) fn create<T>(
 			TrancheInput {
 				interest_per_sec: None,
 				min_risk_buffer: None,
+				seniority: None
 			},
 			TrancheInput {
 				interest_per_sec: Some(One::one()),
 				min_risk_buffer: Some(Perquintill::from_percent(10)),
+				seniority: None
 			}
 		],
 		currency_id.into(),

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -204,8 +204,8 @@ impl fake_nav::Config for Test {
 
 pub const CURRENCY: Balance = 1_000_000_000_000_000_000;
 
-pub const JUNIOR_TRANCHE_ID: u8 = 1;
-pub const SENIOR_TRANCHE_ID: u8 = 0;
+pub const JUNIOR_TRANCHE_ID: u8 = 0;
+pub const SENIOR_TRANCHE_ID: u8 = 1;
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -176,11 +176,11 @@ fn pool_constraints_tranche_violates_risk_buffer() {
 			outstanding_redeem_orders: Zero::zero(),
 			..Default::default()
 		};
-		let tranches = vec![tranche_a, tranche_b, tranche_c, tranche_d];
+		let tranches = vec![tranche_d, tranche_c, tranche_b, tranche_a];
 
 		let epoch_tranches = tranches
 			.iter()
-			.zip(vec![80, 20, 5, 5]) // no IntoIterator for arrays, so we use a vec here. Meh.
+			.zip(vec![5, 5, 20, 80]) // no IntoIterator for arrays, so we use a vec here. Meh.
 			.map(|(tranche, value)| EpochExecutionTranche {
 				value,
 				price: One::one(),
@@ -235,35 +235,35 @@ fn pool_constraints_pass() {
 			min_risk_buffer: Perquintill::from_float(0.2),
 			outstanding_invest_orders: 100,
 			outstanding_redeem_orders: Zero::zero(),
-			seniority: 0,
+			seniority: 3,
 			..Default::default()
 		};
 		let tranche_b = Tranche {
 			min_risk_buffer: Perquintill::from_float(0.1),
 			outstanding_invest_orders: Zero::zero(),
 			outstanding_redeem_orders: 30,
-			seniority: 1,
+			seniority: 2,
 			..Default::default()
 		};
 		let tranche_c = Tranche {
 			min_risk_buffer: Perquintill::from_float(0.05),
 			outstanding_invest_orders: Zero::zero(),
 			outstanding_redeem_orders: Zero::zero(),
-			seniority: 2,
+			seniority: 1,
 			..Default::default()
 		};
 		let tranche_d = Tranche {
 			min_risk_buffer: Perquintill::zero(),
 			outstanding_invest_orders: Zero::zero(),
 			outstanding_redeem_orders: Zero::zero(),
-			seniority: 3,
+			seniority: 0,
 			..Default::default()
 		};
-		let tranches = vec![tranche_a, tranche_b, tranche_c, tranche_d];
+		let tranches = vec![tranche_d, tranche_c, tranche_b, tranche_a];
 
 		let epoch_tranches = tranches
 			.iter()
-			.zip(vec![20, 35, 70, 80]) // no IntoIterator for arrays, so we use a vec here. Meh.
+			.zip(vec![80, 70, 35, 20]) // no IntoIterator for arrays, so we use a vec here. Meh.
 			.map(|(tranche, value)| EpochExecutionTranche {
 				value,
 				price: One::one(),
@@ -350,14 +350,12 @@ fn epoch() {
 			0,
 			vec![
 				TrancheInput {
-					interest_per_sec: Some(senior_interest_rate),
-					min_risk_buffer: Some(Perquintill::from_percent(10)),
-					seniority: None,
-				},
-				TrancheInput {
 					interest_per_sec: None,
 					min_risk_buffer: None,
-					seniority: None,
+				},
+				TrancheInput {
+					interest_per_sec: Some(senior_interest_rate),
+					min_risk_buffer: Some(Perquintill::from_percent(10)),
 				}
 			],
 			CurrencyId::Usd,
@@ -535,14 +533,12 @@ fn collect_tranche_tokens() {
 			0,
 			vec![
 				TrancheInput {
-					interest_per_sec: Some(senior_interest_rate),
-					min_risk_buffer: Some(Perquintill::from_percent(10)),
-					seniority: None,
-				},
-				TrancheInput {
 					interest_per_sec: None,
 					min_risk_buffer: None,
-					seniority: None,
+				},
+				TrancheInput {
+					interest_per_sec: Some(senior_interest_rate),
+					min_risk_buffer: Some(Perquintill::from_percent(10)),
 				}
 			],
 			CurrencyId::Usd,
@@ -647,15 +643,13 @@ fn test_approve_and_remove_roles() {
 			0,
 			vec![
 				TrancheInput {
-					interest_per_sec: Some(senior_interest_rate),
-					min_risk_buffer: Some(Perquintill::from_percent(10)),
-					seniority: None,
-				},
-				TrancheInput {
 					interest_per_sec: None,
 					min_risk_buffer: None,
-					seniority: None,
-				}
+				},
+				TrancheInput {
+					interest_per_sec: Some(senior_interest_rate),
+					min_risk_buffer: Some(Perquintill::from_percent(10)),
+				},
 			],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
@@ -746,7 +740,6 @@ fn invalid_tranche_id_is_err() {
 			vec![TrancheInput {
 				interest_per_sec: None,
 				min_risk_buffer: None,
-				seniority: None,
 			},],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
@@ -783,7 +776,6 @@ fn updating_with_same_amount_is_err() {
 			vec![TrancheInput {
 				interest_per_sec: None,
 				min_risk_buffer: None,
-				seniority: None,
 			},],
 			CurrencyId::Usd,
 			10_000 * CURRENCY

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -352,10 +352,12 @@ fn epoch() {
 				TrancheInput {
 					interest_per_sec: None,
 					min_risk_buffer: None,
+					seniority: None
 				},
 				TrancheInput {
 					interest_per_sec: Some(senior_interest_rate),
 					min_risk_buffer: Some(Perquintill::from_percent(10)),
+					seniority: None
 				}
 			],
 			CurrencyId::Usd,
@@ -535,10 +537,12 @@ fn collect_tranche_tokens() {
 				TrancheInput {
 					interest_per_sec: None,
 					min_risk_buffer: None,
+					seniority: None
 				},
 				TrancheInput {
 					interest_per_sec: Some(senior_interest_rate),
 					min_risk_buffer: Some(Perquintill::from_percent(10)),
+					seniority: None
 				}
 			],
 			CurrencyId::Usd,
@@ -645,10 +649,12 @@ fn test_approve_and_remove_roles() {
 				TrancheInput {
 					interest_per_sec: None,
 					min_risk_buffer: None,
+					seniority: None
 				},
 				TrancheInput {
 					interest_per_sec: Some(senior_interest_rate),
 					min_risk_buffer: Some(Perquintill::from_percent(10)),
+					seniority: None
 				},
 			],
 			CurrencyId::Usd,
@@ -740,6 +746,7 @@ fn invalid_tranche_id_is_err() {
 			vec![TrancheInput {
 				interest_per_sec: None,
 				min_risk_buffer: None,
+				seniority: None
 			},],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
@@ -776,6 +783,7 @@ fn updating_with_same_amount_is_err() {
 			vec![TrancheInput {
 				interest_per_sec: None,
 				min_risk_buffer: None,
+				seniority: None
 			},],
 			CurrencyId::Usd,
 			10_000 * CURRENCY


### PR DESCRIPTION
This PR ensures that tranche order is from most junior to senior.

For easier calculations for rebalancing, price calculations etc... we reverse the order to go from most senior to junior. The reverse is applied on the results if necessary