### PR TITLE
Pool Refactor - Part 1 - Move tranche related structures

### DIFF
--- a/libs/common-traits/src/lib.rs
+++ b/libs/common-traits/src/lib.rs
@@ -21,12 +21,11 @@
 use codec::{Decode, Encode};
 use frame_support::dispatch::{Codec, DispatchResult, DispatchResultWithPostInfo};
 use frame_support::scale_info::TypeInfo;
-use frame_support::sp_runtime::ArithmeticError;
 use frame_support::Parameter;
 use frame_support::RuntimeDebug;
 use impl_trait_for_tuples::impl_for_tuples;
 use sp_runtime::traits::{
-	AtLeast32BitUnsigned, Bounded, CheckedAdd, MaybeDisplay, MaybeMallocSizeOf, MaybeSerialize,
+	AtLeast32BitUnsigned, Bounded, MaybeDisplay, MaybeMallocSizeOf, MaybeSerialize,
 	MaybeSerializeDeserialize, Member, Zero,
 };
 use sp_runtime::DispatchError;
@@ -210,94 +209,4 @@ pub trait TokenMetadata {
 	fn symbol(&self) -> Vec<u8>;
 
 	fn decimals(&self) -> u8;
-}
-
-/// A means of weighting a tranche. This can be used
-/// in order to determine how much importance a tranche has
-pub trait TrancheWeigher {
-	type External;
-	type Weight;
-
-	fn calculate_weight(&self, input: Self::External) -> Self::Weight;
-}
-
-/// Implementation for a vec of TrancheWeigher
-impl<T: TrancheWeigher> TrancheWeigher for Vec<T>
-where
-	T::External: Clone,
-{
-	type Weight = Vec<T::Weight>;
-	type External = T::External;
-
-	fn calculate_weight(&self, input: Self::External) -> Self::Weight {
-		let mut weights = Vec::with_capacity(self.len());
-		self.iter()
-			.for_each(|tranche| weights.push(tranche.calculate_weight(input.clone())));
-
-		weights
-	}
-}
-
-/// Implementation for a vec of TrancheWeigher
-impl<T: TrancheWeigher> TrancheWeigher for &[T]
-where
-	T::External: Clone,
-{
-	type Weight = Vec<T::Weight>;
-	type External = T::External;
-
-	fn calculate_weight(&self, input: Self::External) -> Self::Weight {
-		let mut weights = Vec::with_capacity(self.len());
-		self.iter()
-			.for_each(|tranche| weights.push(tranche.calculate_weight(input.clone())));
-
-		weights
-	}
-}
-
-pub trait Tranche {
-	type Supply;
-	type Value;
-	type Price;
-
-	fn supply(&self) -> Self::Supply;
-
-	fn value(&self) -> Self::Value;
-
-	fn price(&self) -> Self::Price;
-}
-
-impl<T: Tranche> Tranche for Vec<T>
-where
-	T::Value: Zero + CheckedAdd,
-{
-	type Supply = Vec<T::Supply>;
-	type Value = Result<T::Value, ArithmeticError>;
-	type Price = Vec<T::Price>;
-
-	fn supply(&self) -> Self::Supply {
-		let mut supplies = Vec::with_capacity(self.len());
-
-		self.iter()
-			.for_each(|tranche| supplies.push(tranche.supply()));
-
-		supplies
-	}
-
-	fn price(&self) -> Self::Price {
-		let mut prices = Vec::with_capacity(self.len());
-
-		self.iter().for_each(|tranche| prices.push(tranche.price()));
-
-		prices
-	}
-
-	fn value(&self) -> Self::Value {
-		self.iter().fold(Ok(Zero::zero()), |sum, tranche| {
-			sum.and_then(|sum| {
-				sum.checked_add(&tranche.value())
-					.ok_or(ArithmeticError::Overflow)
-			})
-		})
-	}
 }

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -26,7 +26,6 @@ use crate::test_utils::{
 use common_types::CurrencyId;
 use frame_support::traits::fungibles::Inspect;
 use frame_support::{assert_err, assert_ok};
-use frame_system::RawOrigin;
 use loan_type::{BulletLoan, LoanType};
 use pallet_loans::Event as LoanEvent;
 use pallet_pools::PoolLocator;
@@ -69,8 +68,9 @@ where
 			TrancheId = u8,
 			EpochId = u32,
 		> + pallet_loans::Config<ClassId = ClassId, LoanId = InstanceId>
-		+ frame_system::Config<AccountId = u64>
-		+ pallet_uniques::Config<ClassId = ClassId, InstanceId = InstanceId>,
+		+ frame_system::Config<AccountId = u64, Origin = Origin>
+		+ pallet_uniques::Config<ClassId = ClassId, InstanceId = InstanceId>
+		+ pallet_permissions::Config<Location = PoolId, Role = PoolRole>,
 	PoolIdOf<T>: From<<T as pallet_pools::Config>::PoolId>,
 {
 	let pool_admin = PoolAdmin::get();
@@ -83,17 +83,19 @@ where
 		CurrencyId::Usd,
 	);
 	// add borrower role and price admin role
-	assert_ok!(pallet_pools::Pallet::<T>::approve_role_for(
-		RawOrigin::Signed(pool_admin).into(),
+	assert_ok!(pallet_permissions::Pallet::<T>::add_permission(
+		Origin::signed(pool_admin),
+		PoolRole::PoolAdmin,
+		borrower,
 		pool_id,
 		PoolRole::Borrower,
-		vec![<T::Lookup as StaticLookup>::unlookup(borrower)]
 	));
-	assert_ok!(pallet_pools::Pallet::<T>::approve_role_for(
-		RawOrigin::Signed(pool_admin).into(),
+	assert_ok!(pallet_permissions::Pallet::<T>::add_permission(
+		Origin::signed(pool_admin),
+		PoolRole::PoolAdmin,
+		borrower,
 		pool_id,
 		PoolRole::PricingAdmin,
-		vec![<T::Lookup as StaticLookup>::unlookup(borrower)]
 	));
 	let pr_pool_id: PoolIdOf<T> = pool_id.into();
 	let loan_nft_class_id =
@@ -509,6 +511,7 @@ macro_rules! test_borrow_loan {
 		TestExternalitiesBuilder::default()
 			.build()
 			.execute_with(|| {
+				let pool_admin = PoolAdmin::get();
 				let borrower = Borrower::get();
 				// successful issue
 				let (pool_id, loan, _asset) = issue_test_loan::<MockRuntime>(0, borrower);
@@ -607,15 +610,12 @@ macro_rules! test_borrow_loan {
 				// written off loan cannot borrow
 				// add write off groups
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
-					RawOrigin::Signed(PoolAdmin::get()).into(),
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+					Origin::signed(pool_admin),
+					PoolRole::PoolAdmin,
+					risk_admin,
 					pool_id,
 					PoolRole::RiskAdmin,
-					vec![
-						<<MockRuntime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
-							risk_admin
-						)
-					]
 				));
 				for group in vec![(3, 0), (5, 15), (7, 20), (20, 30), (120, 100)] {
 					let res = Loans::add_write_off_group(
@@ -875,6 +875,7 @@ macro_rules! test_pool_nav {
 		TestExternalitiesBuilder::default()
 			.build()
 			.execute_with(|| {
+				let pool_admin: u64 = PoolAdmin::get();
 				let borrower: u64 = Borrower::get();
 				// successful issue
 				let (pool_id, loan, _asset) = issue_test_loan::<MockRuntime>(0, borrower);
@@ -999,15 +1000,12 @@ macro_rules! test_pool_nav {
 				assert_eq!(updated_nav, nav);
 
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
-					RawOrigin::Signed(PoolAdmin::get()).into(),
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+					Origin::signed(pool_admin),
+					PoolRole::PoolAdmin,
+					risk_admin,
 					pool_id,
 					PoolRole::RiskAdmin,
-					vec![
-						<<MockRuntime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
-							risk_admin
-						)
-					]
 				));
 				// write off the loan and check for updated nav
 				for group in vec![(3, 10), (5, 15), (7, 20), (20, 30)] {
@@ -1123,15 +1121,12 @@ fn test_add_write_off_groups() {
 			);
 			let pr_pool_id: PoolIdOf<MockRuntime> = pool_id.into();
 			initialise_test_pool::<MockRuntime>(pr_pool_id, 1, pool_admin, None);
-			assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
-				RawOrigin::Signed(pool_admin).into(),
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				Origin::signed(pool_admin),
+				PoolRole::PoolAdmin,
+				risk_admin,
 				pool_id,
 				PoolRole::RiskAdmin,
-				vec![
-					<<MockRuntime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
-						risk_admin
-					)
-				]
 			));
 
 			// fetch write off groups
@@ -1210,15 +1205,12 @@ macro_rules! test_write_off_maturity_loan {
 
 				// add write off groups
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
-					RawOrigin::Signed(pool_admin).into(),
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+					Origin::signed(pool_admin),
+					PoolRole::PoolAdmin,
+					risk_admin,
 					pool_id,
 					PoolRole::RiskAdmin,
-					vec![
-						<<MockRuntime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
-							risk_admin
-						)
-					]
 				));
 				for group in vec![(3, 10), (5, 15), (7, 20), (20, 30)] {
 					let res = Loans::add_write_off_group(
@@ -1305,15 +1297,12 @@ macro_rules! test_admin_write_off_loan_type {
 				// after one year
 				// caller should be admin, can write off before maturity
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
-					RawOrigin::Signed(pool_admin).into(),
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+					Origin::signed(pool_admin),
+					PoolRole::PoolAdmin,
+					risk_admin,
 					pool_id,
 					PoolRole::RiskAdmin,
-					vec![
-						<<MockRuntime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
-							risk_admin
-						)
-					]
 				));
 
 				Timestamp::set_timestamp(math::seconds_per_year() * 1000);
@@ -1429,15 +1418,12 @@ macro_rules! test_close_written_off_loan_type {
 
 				// add write off groups
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
-					RawOrigin::Signed(pool_admin).into(),
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+					Origin::signed(pool_admin),
+					PoolRole::PoolAdmin,
+					risk_admin,
 					pool_id,
 					PoolRole::RiskAdmin,
-					vec![
-						<<MockRuntime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
-							risk_admin
-						)
-					]
 				));
 				for group in vec![(3, 10), (5, 15), (7, 20), (20, 30), (120, 100)] {
 					let res = Loans::add_write_off_group(
@@ -1611,15 +1597,12 @@ macro_rules! write_off_overflow {
 				let caller = 42;
 				// add write off groups
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
-					RawOrigin::Signed(pool_admin).into(),
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+					Origin::signed(pool_admin),
+					PoolRole::PoolAdmin,
+					risk_admin,
 					pool_id,
 					PoolRole::RiskAdmin,
-					vec![
-						<<MockRuntime as frame_system::Config>::Lookup as StaticLookup>::unlookup(
-							risk_admin
-						)
-					]
 				));
 				//for group in vec![(3, 10), (313503982334601, 20)] {
 				for group in vec![(3, 10), (313503982334601, 15), (10, 20), (10, 30)] {

--- a/pallets/permissions/src/lib.rs
+++ b/pallets/permissions/src/lib.rs
@@ -11,8 +11,6 @@
 // GNU General Public License for more details.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate frame_system;
-
 ///! A crate that defines a simple permissions logic for our infrastructure.
 pub use pallet::*;
 

--- a/pallets/pools/Cargo.toml
+++ b/pallets/pools/Cargo.toml
@@ -21,6 +21,7 @@ frame-support = { git = "https://github.com/paritytech/substrate", default-featu
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.12" }
 common-traits = { path = "../../libs/common-traits", default-features = false }

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -318,10 +318,6 @@ pub mod pallet {
 		InvestOrderUpdated(T::PoolId, T::AccountId),
 		/// A redeem order was updated. [pool, account]
 		RedeemOrderUpdated(T::PoolId, T::AccountId),
-		/// A role was approved for an account in a pool. [pool, role, account]
-		RoleApproved(T::PoolId, PoolRole<Moment, T::TrancheId>, T::AccountId),
-		// A role was revoked for an account in a pool. [pool, role, account]
-		RoleRevoked(T::PoolId, PoolRole<Moment, T::TrancheId>, T::AccountId),
 	}
 
 	// Errors inform users that something went wrong.
@@ -903,7 +899,7 @@ pub mod pallet {
 					.map(|tranche| tranche.seniority)
 					.collect::<Vec<_>>();
 
-				let tranche_min_risk_buffs = pool.tranches.risk_buffers();
+				let tranche_min_risk_buffs = pool.tranches.min_risk_buffers();
 
 				let epoch_tranches: Vec<_> = orders
 					.iter()

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -1,0 +1,262 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+/// Trait for converting a pool+tranche ID pair to a CurrencyId
+///
+/// This should be implemented in the runtime to convert from the
+/// PoolId and TrancheId types to a CurrencyId that represents that
+/// tranche.
+///
+/// The pool epoch logic assumes that every tranche has a UNIQUE
+/// currency, but nothing enforces that. Failure to ensure currency
+/// uniqueness will almost certainly cause some wild bugs.
+use super::*;
+use common_traits::{Combinator, Tranche as TrancheT};
+use frame_support::sp_runtime::ArithmeticError;
+
+// Types alias for EpochExecutionTranche
+pub(super) type EpochExecutionTrancheOf<T> = EpochExecutionTranche<
+	<T as Config>::Balance,
+	<T as Config>::BalanceRatio,
+	<T as Config>::TrancheWeight,
+>;
+
+// Types alias for Tranche
+pub(super) type TrancheOf<T> =
+	Tranche<<T as Config>::Balance, <T as Config>::InterestRate, <T as Config>::TrancheWeight>;
+
+/// Trait for converting a pool+tranche ID pair to a CurrencyId
+///
+/// This should be implemented in the runtime to convert from the
+/// PoolId and TrancheId types to a CurrencyId that represents that
+/// tranche.
+///
+/// The pool epoch logic assumes that every tranche has a UNIQUE
+/// currency, but nothing enforces that. Failure to ensure currency
+/// uniqueness will almost certainly cause some wild bugs.
+pub trait TrancheToken<T: Config> {
+	fn tranche_token(pool: T::PoolId, tranche: T::TrancheId) -> T::CurrencyId;
+}
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, Default, TypeInfo)]
+pub struct TrancheInput<Rate> {
+	pub interest_per_sec: Option<Rate>,
+	pub min_risk_buffer: Option<Perquintill>,
+	pub seniority: Option<Seniority>,
+}
+
+/// A representation of a tranche identifier that can be used as a storage key
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+pub struct TrancheLocator<PoolId, TrancheId> {
+	pub pool_id: PoolId,
+	pub tranche_id: TrancheId,
+}
+
+impl<PoolId, TrancheId> TrancheLocator<PoolId, TrancheId> {
+	pub(super) fn new(pool_id: PoolId, tranche_id: TrancheId) -> Self {
+		TrancheLocator {
+			pool_id,
+			tranche_id,
+		}
+	}
+}
+
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, TypeInfo)]
+pub struct Tranches<T: Config>(Vec<TrancheOf<T>>);
+
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, TypeInfo)]
+pub struct Tranche<Balance, Rate, Weight> {
+	pub(super) interest_per_sec: Rate,
+	pub(super) min_risk_buffer: Perquintill,
+	pub(super) seniority: Seniority,
+
+	pub(super) outstanding_invest_orders: Balance,
+	pub(super) outstanding_redeem_orders: Balance,
+
+	pub(super) debt: Balance,
+	pub(super) reserve: Balance,
+	pub(super) ratio: Perquintill,
+	pub(super) last_updated_interest: Moment,
+
+	pub(super) _phantom: PhantomData<Weight>,
+}
+
+impl<T: Config> Tranches<T> {
+	fn supply(&self) -> Vec<Option<T::Balance>> {
+		self.0
+			.iter()
+			.map(|tranche| tranche.debt.checked_add(&tranche.reserve))
+			.collect()
+	}
+
+	fn acc_supply(&self) -> Result<T::Balance, DispatchError> {
+		self.0
+			.iter()
+			.fold(Some(T::Balance::zero()), |sum, tranche| {
+				sum.and_then(|acc| {
+					acc.checked_add(&tranche.debt)
+						.and_then(|acc| acc.checked_add(&tranche.reserve))
+				})
+			})
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	fn investments(&self) -> Vec<T::Balance> {
+		self.0
+			.iter()
+			.map(|tranche| tranche.outstanding_invest_orders)
+			.collect()
+	}
+
+	fn acc_investments(&self) -> Result<T::Balance, DispatchError> {
+		self.0
+			.iter()
+			.fold(Some(T::Balance::zero()), |sum, tranche| {
+				sum.and_then(|acc| acc.checked_add(&tranche.outstanding_invest_orders))
+			})
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	fn redemptions(&self) -> Vec<T::Balance> {
+		self.0
+			.iter()
+			.map(|tranche| tranche.outstanding_redeem_orders)
+			.collect()
+	}
+
+	fn acc_redemptions(&self) -> Result<T::Balance, DispatchError> {
+		self.0
+			.iter()
+			.fold(Some(T::Balance::zero()), |sum, tranche| {
+				sum.and_then(|acc| acc.checked_add(&tranche.outstanding_redeem_orders))
+			})
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	fn calculate_weight(&self) -> Vec<(T::TrancheWeight, T::TrancheWeight)> {
+		let redeem_starts = 10u128.checked_pow(self.0.len()).unwrap_or(u128::MAX);
+
+		self.0
+			.iter()
+			.map(|tranche| {
+				(
+					10u128
+						.checked_pow(
+							n_tranches
+								.checked_sub(&tranche.seniority)
+								.unwrap_or(u32::MAX),
+						)
+						.unwrap_or(u128::MAX)
+						.into(),
+					redeem_starts
+						.checked_mul(10u128.pow(&tranche.seniority.saturating_add(1)).into())
+						.unwrap_or(u128::MAX)
+						.into(),
+				)
+			})
+			.collect()
+	}
+
+	fn risk_buffers(&self) -> Vec<Perquintill> {
+		self.0
+			.iter()
+			.map(|tranche| tranche.min_risk_buffer)
+			.collect()
+	}
+}
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, Default, TypeInfo)]
+pub struct EpochExecutionTranches<T: Config>(Vec<EpochExecutionTrancheOf<T>>);
+
+impl<T: Config> EpochExecutionTranches<T> {
+	fn supply(&self) -> Vec<T::Balance> {
+		self.0.iter().map(|tranche| tranche.supply).collect()
+	}
+
+	fn acc_supply(&self) -> Result<T::Balance, DispatchError> {
+		self.0
+			.iter()
+			.fold(Some(T::Balance::zero()), |sum, tranche| {
+				sum.and_then(|acc| acc.checked_add(&tranche.supply))
+			})
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	fn investments(&self) -> Vec<T::Balance> {
+		self.0.iter().map(|tranche| tranche.invest).collect()
+	}
+
+	fn acc_investments(&self) -> Result<T::Balance, DispatchError> {
+		self.0
+			.iter()
+			.fold(Some(T::Balance::zero()), |sum, tranche| {
+				sum.and_then(|acc| acc.checked_add(&tranche.invest))
+			})
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	fn redemptions(&self) -> Vec<T::Balance> {
+		self.0.iter().map(|tranche| tranche.redeem).collect()
+	}
+
+	fn acc_redemptions(&self) -> Result<T::Balance, DispatchError> {
+		self.0
+			.iter()
+			.fold(Some(T::Balance::zero()), |sum, tranche| {
+				sum.and_then(|acc| acc.checked_add(&tranche.redeem))
+			})
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	fn calculate_weight(&self) -> Vec<(T::TrancheWeight, T::TrancheWeight)> {
+		let redeem_starts = 10u128.checked_pow(self.0.len()).unwrap_or(u128::MAX);
+
+		self.0
+			.iter()
+			.map(|tranche| {
+				(
+					10u128
+						.checked_pow(
+							n_tranches
+								.checked_sub(&tranche.seniority)
+								.unwrap_or(u32::MAX),
+						)
+						.unwrap_or(u128::MAX)
+						.into(),
+					redeem_starts
+						.checked_mul(10u128.pow(&tranche.seniority.saturating_add(1)).into())
+						.unwrap_or(u128::MAX)
+						.into(),
+				)
+			})
+			.collect()
+	}
+
+	fn risk_buffers(&self) -> Vec<Perquintill> {
+		self.0
+			.iter()
+			.map(|tranche| tranche.min_risk_buffer)
+			.collect()
+	}
+}
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, Default, TypeInfo)]
+pub struct EpochExecutionTranche<Balance, BalanceRatio, Weight> {
+	pub(super) supply: Balance,
+	pub(super) price: BalanceRatio,
+	pub(super) invest: Balance,
+	pub(super) redeem: Balance,
+	pub(super) min_risk_buffer: Perquintill,
+	pub(super) seniority: Seniority,
+
+	pub(super) _phantom: PhantomData<Weight>,
+}

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -47,7 +47,7 @@ pub(super) type TranchesOf<T> =
 pub(super) type TrancheOf<T> =
 	Tranche<<T as Config>::Balance, <T as Config>::InterestRate, <T as Config>::TrancheWeight>;
 
-/// Type that indicates the senority of a tranche
+/// Type that indicates the seniority of a tranche
 type Seniority = u32;
 
 /// Trait for converting a pool+tranche ID pair to a CurrencyId
@@ -229,7 +229,7 @@ where
 			.collect()
 	}
 
-	pub fn risk_buffers(&self) -> Vec<Perquintill> {
+	pub fn min_risk_buffers(&self) -> Vec<Perquintill> {
 		self.0
 			.iter()
 			.map(|tranche| tranche.min_risk_buffer)
@@ -365,7 +365,7 @@ where
 			.collect()
 	}
 
-	pub fn risk_buffers(&self) -> Vec<Perquintill> {
+	pub fn min_risk_buffers(&self) -> Vec<Perquintill> {
 		self.0
 			.iter()
 			.map(|tranche| tranche.min_risk_buffer)


### PR DESCRIPTION
I will split this refactoring into multiple smaller chunks. Although, this will duplicate a little work, I hope that the reviewing process will be better and we can follow more on the changes and discuss them. 

This part does:
* Move all tranche related structures into the tranche.rs file
* Wrap the two `Vec<Tranche>` & `Vec<EpochExecutionTranche>` structs into new types
* Implement some logic like the accumulation of supplies of all pools in methods of the new types
* Remove the role approval logic from the pool api
* Adapt tests and mocks accordingly
* Makes `Order` an `OptionQuery`