### PR TITLE
Pool Refactor - Part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5825,6 +5825,7 @@ dependencies = [
  "pallet-restricted-tokens",
  "pallet-timestamp",
  "parity-scale-codec",
+ "rev_slice",
  "runtime-common",
  "scale-info",
  "serde",
@@ -8216,6 +8217,12 @@ name = "retain_mut"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11000e6ba5020e53e7cc26f73b91ae7d5496b4977851479edb66b694c0675c21"
+
+[[package]]
+name = "rev_slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed802e95a56a9f0cbc3687c0baf84bb0aa9c3af2fae758add8a07bbbc4e3954"
 
 [[package]]
 name = "ring"

--- a/libs/common-traits/src/lib.rs
+++ b/libs/common-traits/src/lib.rs
@@ -210,3 +210,16 @@ pub trait TokenMetadata {
 
 	fn decimals(&self) -> u8;
 }
+
+/// Trait for converting a pool+tranche ID pair to a CurrencyId
+///
+/// This should be implemented in the runtime to convert from the
+/// PoolId and TrancheId types to a CurrencyId that represents that
+/// tranche.
+///
+/// The pool epoch logic assumes that every tranche has a UNIQUE
+/// currency, but nothing enforces that. Failure to ensure currency
+/// uniqueness will almost certainly cause some wild bugs.
+pub trait TrancheToken<PoolId, TrancheId, CurrencyId> {
+	fn tranche_token(pool: PoolId, tranche: TrancheId) -> CurrencyId;
+}

--- a/libs/common-types/src/tokens.rs
+++ b/libs/common-types/src/tokens.rs
@@ -56,19 +56,21 @@ impl TokenMetadata for CurrencyId {
 #[macro_export]
 macro_rules! impl_tranche_token {
 	() => {
-		pub struct TrancheToken<T>(core::marker::PhantomData<T>);
+		pub struct TrancheToken<Config>(core::marker::PhantomData<(Config)>);
 
-		impl<T> pallet_pools::TrancheToken<T> for TrancheToken<T>
+		impl<Config>
+			common_traits::TrancheToken<Config::PoolId, Config::TrancheId, Config::CurrencyId>
+			for TrancheToken<Config>
 		where
-			T: Config,
-			<T as Config>::PoolId: Into<u64>,
-			<T as Config>::TrancheId: Into<u8>,
-			<T as Config>::CurrencyId: From<CurrencyId>,
+			Config: pallet_pools::Config,
+			Config::PoolId: Into<u64>,
+			Config::TrancheId: Into<u8>,
+			Config::CurrencyId: From<CurrencyId>,
 		{
 			fn tranche_token(
-				pool: <T as Config>::PoolId,
-				tranche: <T as Config>::TrancheId,
-			) -> <T as Config>::CurrencyId {
+				pool: Config::PoolId,
+				tranche: Config::TrancheId,
+			) -> Config::CurrencyId {
 				CurrencyId::Tranche(pool.into(), tranche.into()).into()
 			}
 		}

--- a/libs/proofs/Cargo.toml
+++ b/libs/proofs/Cargo.toml
@@ -17,7 +17,7 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.12" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.12" }
 
 [features]
 default = ['std']

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -939,7 +939,7 @@ macro_rules! test_pool_nav {
 					assert_err!(res, Error::<MockRuntime>::LoanCeilingReached);
 
 					// payback 50 and borrow more later
-					let repay_amount = Amount::from_inner(200 * USD);
+					let repay_amount = Amount::from_inner(50 * USD);
 					let res =
 						Loans::repay(Origin::signed(borrower), pool_id, loan_id, repay_amount);
 					assert_ok!(res);

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -939,7 +939,7 @@ macro_rules! test_pool_nav {
 					assert_err!(res, Error::<MockRuntime>::LoanCeilingReached);
 
 					// payback 50 and borrow more later
-					let repay_amount = Amount::from_inner(50 * USD);
+					let repay_amount = Amount::from_inner(200 * USD);
 					let res =
 						Loans::repay(Origin::signed(borrower), pool_id, loan_id, repay_amount);
 					assert_ok!(res);

--- a/pallets/pools/Cargo.toml
+++ b/pallets/pools/Cargo.toml
@@ -15,6 +15,7 @@ targets = ['x86_64-unknown-linux-gnu']
 serde = { version = "1.0.102" }
 codec = { package = 'parity-scale-codec', version = '2.0.0', features = ['derive'] , default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+rev_slice = { version = "0.1.5", default-features = false }
 
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true , branch = "polkadot-v0.9.12" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }

--- a/pallets/pools/src/benchmarking.rs
+++ b/pallets/pools/src/benchmarking.rs
@@ -155,7 +155,7 @@ benchmarks! {
 		assert_eq!(T::Tokens::balance(currency, &caller), expected);
 	}
 
-	close_epoch_no_investments {
+	close_epoch_no_orders{
 		let n in 1..T::MaxTranches::get(); // number of tranches
 
 		let admin: T::AccountId = account("admin", 0, 0);

--- a/pallets/pools/src/benchmarking.rs
+++ b/pallets/pools/src/benchmarking.rs
@@ -326,11 +326,27 @@ fn assert_tranches_match<T: Config>(
 ) {
 	assert!(chain.len() == target.len());
 	for (chain, target) in chain.iter().zip(target.iter()) {
-		if let Some(interest_per_sec) = target.interest_per_sec {
-			assert!(chain.interest_per_sec == interest_per_sec);
-		}
-		if let Some(min_risk_buffer) = target.min_risk_buffer {
-			assert!(chain.min_risk_buffer == min_risk_buffer);
+		match chain.tranche_type {
+			TrancheType::Residual => {
+				assert!(target.interest_per_sec.is_none() && target.min_risk_buffer.is_none())
+			}
+			TrancheType::NonResidual {
+				interest_per_sec,
+				min_risk_buffer,
+			} => {
+				assert_eq!(
+					interest_per_sec,
+					target
+						.interest_per_sec
+						.expect("Interest rate for non-residual tranches must be set.")
+				);
+				assert_eq!(
+					min_risk_buffer,
+					target
+						.min_risk_buffer
+						.expect("Min risk buffer for non-residual tranches must be set.")
+				);
+			}
 		}
 	}
 }

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -1905,7 +1905,7 @@ pub mod pallet {
 				.rev();
 			for (((tranche_id, tranche), ratio), value) in tranches_senior_to_junior
 				.zip(tranche_ratios.iter())
-				.zip(tranche_assets.iter())
+				.zip(tranche_assets.iter().rev())
 			{
 				tranche.ratio = *ratio;
 				if tranche_id == junior_tranche_id {

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -994,7 +994,8 @@ pub mod pallet {
 				let inspection_full_solution =
 					Self::inspect_solution(pool, &epoch, &full_execution_solution);
 				if inspection_full_solution.is_ok()
-					&& inspection_full_solution? == PoolState::Healthy
+					&& inspection_full_solution.expect("is_ok() == true. qed.")
+						== PoolState::Healthy
 				{
 					Self::do_execute_epoch(pool_id, pool, &epoch, &full_execution_solution)?;
 					Self::deposit_event(Event::EpochExecuted(pool_id, submission_period_epoch));

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -991,8 +991,10 @@ pub mod pallet {
 					})
 				})?;
 
-				if Self::inspect_solution(pool, &epoch, &full_execution_solution)?
-					== PoolState::Healthy
+				let inspection_full_solution =
+					Self::inspect_solution(pool, &epoch, &full_execution_solution);
+				if inspection_full_solution.is_ok()
+					&& inspection_full_solution? == PoolState::Healthy
 				{
 					Self::do_execute_epoch(pool_id, pool, &epoch, &full_execution_solution)?;
 					Self::deposit_event(Event::EpochExecuted(pool_id, submission_period_epoch));

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -1568,7 +1568,7 @@ pub mod pallet {
 			);
 
 			let mut prev_tranche_type = &TrancheType::Residual;
-			let mut prev_seniority = &Some(One::one());
+			let mut prev_seniority = &None;
 			let max_seniority = new_tranches
 				.len()
 				.try_into()
@@ -1579,6 +1579,7 @@ pub mod pallet {
 					prev_tranche_type.valid_next_tranche(tranche_type),
 					Error::<T>::InvalidTrancheStructure
 				);
+
 				ensure!(
 					prev_seniority <= seniority && seniority <= &Some(max_seniority),
 					Error::<T>::InvalidTrancheSeniority

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -1700,12 +1700,12 @@ pub mod pallet {
 					.reserve
 					.total_reserve
 					.checked_sub(&amount)
-					.ok_or(Error::<T>::Overflow)?;
+					.ok_or(ArithmeticError::Underflow)?;
 				pool.reserve.available_reserve = pool
 					.reserve
 					.available_reserve
 					.checked_sub(&amount)
-					.ok_or(Error::<T>::Overflow)?;
+					.ok_or(ArithmeticError::Underflow)?;
 
 				let mut remaining_amount = amount;
 				for tranche in pool.tranches.senior_to_junior_slice_mut() {

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -366,10 +366,10 @@ pub fn invest_close_and_collect(
 
 	let epoch = pallet_pools::Pool::<Test>::try_get(pool_id)
 		.map_err(|_| Error::<Test>::NoSuchPool)?
-		.last_epoch_closed;
+		.last_epoch_executed;
 
 	for (who, tranche_id, _) in investments {
-		Pools::collect(who, pool_id, tranche_id, epoch as u32).map_err(|e| e.error)?;
+		Pools::collect(who, pool_id, tranche_id, epoch).map_err(|e| e.error)?;
 	}
 
 	Ok(())

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -154,7 +154,7 @@ impl pallet_timestamp::Config for Test {
 	type WeightInfo = ();
 }
 
-type Balance = u128;
+pub type Balance = u128;
 
 parameter_type_with_key! {
 	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -337,12 +337,12 @@ pub fn next_block_after(seconds: u64) {
 
 pub fn test_borrow(borrower: u64, pool_id: u64, amount: Balance) -> DispatchResult {
 	test_nav_up(pool_id, amount);
-	Pools::do_borrow(borrower, pool_id, amount)
+	Pools::do_withdraw(borrower, pool_id, amount)
 }
 
 pub fn test_payback(borrower: u64, pool_id: u64, amount: Balance) -> DispatchResult {
 	test_nav_down(pool_id, amount);
-	Pools::do_payback(borrower, pool_id, amount)
+	Pools::do_deposit(borrower, pool_id, amount)
 }
 
 pub fn test_nav_up(pool_id: u64, amount: Balance) {

--- a/pallets/pools/src/solution.rs
+++ b/pallets/pools/src/solution.rs
@@ -97,24 +97,6 @@ pub enum EpochSolution<Balance> {
 }
 
 impl<Balance> EpochSolution<Balance> {
-	/// Scores a solution and returns a healthy solution as a result.
-	pub fn score_solution_healthy<BalanceRatio, Weight>(
-		solution: &[TrancheSolution],
-		tranches: &EpochExecutionTranches<Balance, BalanceRatio, Weight>,
-	) -> Result<EpochSolution<Balance>, DispatchError>
-	where
-		Balance: Zero + Copy + BaseArithmetic + Unsigned + From<u64>,
-		Weight: Copy + From<u128> + Convert<Weight, Balance>,
-		BalanceRatio: Copy,
-	{
-		let score = Self::calculate_score(solution, tranches)?;
-
-		Ok(EpochSolution::Healthy(HealthySolution {
-			solution: solution.to_vec(),
-			score,
-		}))
-	}
-
 	/// Calculates the score for a given solution. Should only be called inside the
 	/// `fn score_solution()` from the runtime, as there are no checks if solution
 	/// length matches tranche length.
@@ -171,6 +153,24 @@ impl<Balance> EpochSolution<Balance> {
 			.zip(redeem_score)
 			.and_then(|(invest_score, redeem_score)| invest_score.checked_add(&redeem_score))
 			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	/// Scores a solution and returns a healthy solution as a result.
+	pub fn score_solution_healthy<BalanceRatio, Weight>(
+		solution: &[TrancheSolution],
+		tranches: &EpochExecutionTranches<Balance, BalanceRatio, Weight>,
+	) -> Result<EpochSolution<Balance>, DispatchError>
+	where
+		Balance: Zero + Copy + BaseArithmetic + Unsigned + From<u64>,
+		Weight: Copy + From<u128> + Convert<Weight, Balance>,
+		BalanceRatio: Copy,
+	{
+		let score = Self::calculate_score(solution, tranches)?;
+
+		Ok(EpochSolution::Healthy(HealthySolution {
+			solution: solution.to_vec(),
+			score,
+		}))
 	}
 
 	/// Scores an solution, that would bring a pool into an unhealthy state.

--- a/pallets/pools/src/solution.rs
+++ b/pallets/pools/src/solution.rs
@@ -11,6 +11,9 @@
 // GNU General Public License for more details.
 
 use super::*;
+use frame_support::sp_runtime::traits::Convert;
+use sp_arithmetic::traits::Unsigned;
+use sp_runtime::ArithmeticError;
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum PoolState {
@@ -91,6 +94,181 @@ pub enum UnhealthyState {
 pub enum EpochSolution<Balance> {
 	Healthy(HealthySolution<Balance>),
 	Unhealthy(UnhealthySolution<Balance>),
+}
+
+impl<Balance> EpochSolution<Balance> {
+	/// Scores a solution and returns a healthy solution as a result.
+	pub fn score_solution_healthy<BalanceRatio, Weight>(
+		solution: &[TrancheSolution],
+		tranches: &EpochExecutionTranches<Balance, BalanceRatio, Weight>,
+	) -> Result<EpochSolution<Balance>, DispatchError>
+	where
+		Balance: Zero + Copy + BaseArithmetic + Unsigned + From<u64>,
+		Weight: Copy + From<u128> + Convert<Weight, Balance>,
+		BalanceRatio: Copy,
+	{
+		let score = Self::calculate_score(solution, tranches)?;
+
+		Ok(EpochSolution::Healthy(HealthySolution {
+			solution: solution.to_vec(),
+			score,
+		}))
+	}
+
+	/// Calculates the score for a given solution. Should only be called inside the
+	/// `fn score_solution()` from the runtime, as there are no checks if solution
+	/// length matches tranche length.
+	///
+	/// Scores are calculated with the following function
+	///
+	/// Notation:
+	///  * X(a) -> A vector of a's, where each element is associated with a tranche
+	///  * ||X(a)||1 -> 1-Norm of a vector, i.e. the absolute sum over all elements
+	///
+	///  X = X(%-invest-fulfillments) * X(investments) * X(invest_tranche_weights)
+	///            + X(%-redeem-fulfillments) * X(redemptions) * X(redeem_tranche_weights)
+	///
+	///  score = ||X||1
+	///
+	/// Returns error upon overflow of `Balances`.
+	pub fn calculate_score<BalanceRatio, Weight>(
+		solution: &[TrancheSolution],
+		tranches: &EpochExecutionTranches<Balance, BalanceRatio, Weight>,
+	) -> Result<Balance, DispatchError>
+	where
+		Balance: Zero + Copy + BaseArithmetic + Unsigned + From<u64>,
+		Weight: Copy + From<u128> + Convert<Weight, Balance>,
+		BalanceRatio: Copy,
+	{
+		let (invest_score, redeem_score) = solution
+			.iter()
+			.zip(tranches.junior_to_senior_slice())
+			.zip(tranches.calculate_weights())
+			.fold(
+				(Some(Balance::zero()), Some(Balance::zero())),
+				|(invest_score, redeem_score),
+				 ((solution, tranches), (invest_weight, redeem_weight))| {
+					(
+						invest_score.and_then(|score| {
+							solution
+								.invest_fulfillment
+								.mul_floor(tranches.invest)
+								.checked_mul(&Weight::convert(invest_weight))
+								.and_then(|score_tranche| score.checked_add(&score_tranche))
+						}),
+						redeem_score.and_then(|score| {
+							solution
+								.redeem_fulfillment
+								.mul_floor(tranches.redeem)
+								.checked_mul(&Weight::convert(redeem_weight))
+								.and_then(|score_tranche| score.checked_add(&score_tranche))
+						}),
+					)
+				},
+			);
+
+		invest_score
+			.zip(redeem_score)
+			.and_then(|(invest_score, redeem_score)| invest_score.checked_add(&redeem_score))
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	/// Scores an solution, that would bring a pool into an unhealthy state.
+	///
+	pub fn score_solution_unhealthy<BalanceRatio, Weight>(
+		solution: &[TrancheSolution],
+		tranches: &EpochExecutionTranches<Balance, BalanceRatio, Weight>,
+		reserve: Balance,
+		max_reserve: Balance,
+		state: &Vec<UnhealthyState>,
+	) -> Result<EpochSolution<Balance>, DispatchError>
+	where
+		Weight: Copy + From<u128>,
+		BalanceRatio: Copy + FixedPointNumber,
+		Balance: Copy + BaseArithmetic + FixedPointOperand + Unsigned + From<u64>,
+	{
+		let risk_buffer_improvement_scores = if state
+			.contains(&UnhealthyState::MinRiskBufferViolated)
+		{
+			let risk_buffers = calculate_risk_buffers(
+				&tranches.supplies_with_fulfillment(solution)?,
+				&tranches.prices(),
+			)?;
+
+			// Score: 1 / (min risk buffer - risk buffer)
+			// A higher score means the distance to the min risk buffer is smaller
+			let non_junior_tranches =
+				tranches
+					.non_residual_tranches()
+					.ok_or(DispatchError::Other(
+						"Corrupted PoolState. Getting NonResidualTranches infailable.",
+					))?;
+			Some(
+				non_junior_tranches
+					.iter()
+					.zip(risk_buffers)
+					.map(|(tranche, risk_buffer)| {
+						tranche.min_risk_buffer.checked_sub(&risk_buffer).and_then(
+							|div: Perquintill| Some(div.saturating_reciprocal_mul(Balance::one())),
+						)
+					})
+					.collect::<Option<Vec<_>>>()
+					.ok_or(ArithmeticError::Overflow)?,
+			)
+		} else {
+			None
+		};
+
+		let reserve_improvement_score = if state.contains(&UnhealthyState::MaxReserveViolated) {
+			let (acc_invest, acc_redeem) =
+				solution.iter().zip(tranches.junior_to_senior_slice()).fold(
+					(Some(Balance::zero()), Some(Balance::zero())),
+					|(acc_invest, acc_redeem), (solution, tranches)| {
+						(
+							acc_invest.and_then(|acc| {
+								solution
+									.invest_fulfillment
+									.mul_floor(tranches.invest)
+									.checked_add(&acc)
+							}),
+							acc_redeem.and_then(|acc| {
+								solution
+									.redeem_fulfillment
+									.mul_floor(tranches.redeem)
+									.checked_add(&acc)
+							}),
+						)
+					},
+				);
+
+			let acc_invest = acc_invest.ok_or(ArithmeticError::Overflow)?;
+			let acc_redeem = acc_redeem.ok_or(ArithmeticError::Overflow)?;
+
+			let new_reserve = reserve
+				.checked_add(&acc_invest)
+				.and_then(|value| value.checked_sub(&acc_redeem))
+				.and_then(|value| value.checked_sub(&max_reserve))
+				.ok_or(ArithmeticError::Overflow)?;
+
+			// Score: 1 / (new reserve - max reserve)
+			// A higher score means the distance to the max reserve is smaller
+			Some(
+				new_reserve
+					.checked_sub(&max_reserve)
+					.and_then(|reserve_diff| BalanceRatio::one().checked_div_int(reserve_diff))
+					.ok_or(ArithmeticError::Overflow)?,
+			)
+		} else {
+			None
+		};
+
+		Ok(EpochSolution::Unhealthy(UnhealthySolution {
+			state: state.to_vec(),
+			solution: solution.to_vec(),
+			risk_buffer_improvement_scores,
+			reserve_improvement_score,
+		}))
+	}
 }
 
 impl<Balance> EpochSolution<Balance>
@@ -214,6 +392,44 @@ where
 pub struct TrancheSolution {
 	pub invest_fulfillment: Perquintill,
 	pub redeem_fulfillment: Perquintill,
+}
+
+pub fn calculate_solution_parameters<Balance, BalanceRatio, Rate, Weight, Currency>(
+	epoch_tranches: &EpochExecutionTranches<Balance, BalanceRatio, Weight>,
+	solution: &[TrancheSolution],
+) -> Result<(Balance, Balance, Vec<Perquintill>), DispatchError>
+where
+	BalanceRatio: Copy + FixedPointNumber,
+	Balance: Copy + BaseArithmetic + FixedPointOperand + Unsigned + From<u64>,
+	Weight: Copy + From<u128>,
+{
+	let acc_invest: Balance = epoch_tranches
+		.junior_to_senior_slice()
+		.iter()
+		.zip(solution)
+		.fold(Some(Balance::zero()), |sum, (tranche, solution)| {
+			sum.and_then(|sum| {
+				sum.checked_add(&solution.invest_fulfillment.mul_floor(tranche.invest))
+			})
+		})
+		.ok_or(ArithmeticError::Overflow)?;
+
+	let acc_redeem: Balance = epoch_tranches
+		.junior_to_senior_slice()
+		.iter()
+		.zip(solution)
+		.fold(Some(Balance::zero()), |sum, (tranche, solution)| {
+			sum.and_then(|sum| {
+				sum.checked_add(&solution.redeem_fulfillment.mul_floor(tranche.redeem))
+			})
+		})
+		.ok_or(ArithmeticError::Overflow)?;
+
+	let new_tranche_supplies = epoch_tranches.supplies_with_fulfillment(solution)?;
+	let tranche_prices = epoch_tranches.prices();
+	let risk_buffers = calculate_risk_buffers(&new_tranche_supplies, &tranche_prices)?;
+
+	Ok((acc_invest, acc_redeem, risk_buffers))
 }
 
 #[cfg(test)]

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -23,7 +23,7 @@ fn core_constraints_currency_available_cant_cover_redemptions() {
 
 		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
-				.residual_slice()
+				.residual_top_slice()
 				.iter()
 				.zip(vec![80, 20, 5, 5]) // no IntoIterator for arrays, so we use a vec here. Meh.
 				.map(|(tranche, value)| EpochExecutionTranche {
@@ -66,7 +66,7 @@ fn core_constraints_currency_available_cant_cover_redemptions() {
 
 		let full_solution = pool
 			.tranches
-			.residual_slice()
+			.residual_top_slice()
 			.iter()
 			.map(|_| TrancheSolution {
 				invest_fulfillment: Perquintill::one(),
@@ -111,7 +111,7 @@ fn pool_constraints_pool_reserve_above_max_reserve() {
 		let tranches = Tranches::new(vec![tranche_a, tranche_b, tranche_c, tranche_d]);
 		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
-				.residual_slice()
+				.residual_top_slice()
 				.iter()
 				.zip(vec![80, 20, 15, 15]) // no IntoIterator for arrays, so we use a vec here. Meh.
 				.map(|(tranche, value)| EpochExecutionTranche {
@@ -154,7 +154,7 @@ fn pool_constraints_pool_reserve_above_max_reserve() {
 
 		let full_solution = pool
 			.tranches
-			.residual_slice()
+			.residual_top_slice()
 			.iter()
 			.map(|_| TrancheSolution {
 				invest_fulfillment: Perquintill::one(),
@@ -215,7 +215,7 @@ fn pool_constraints_tranche_violates_risk_buffer() {
 
 		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
-				.residual_slice()
+				.residual_top_slice()
 				.iter()
 				.zip(vec![5, 5, 20, 80]) // no IntoIterator for arrays, so we use a vec here. Meh.
 				.map(|(tranche, value)| EpochExecutionTranche {
@@ -258,7 +258,7 @@ fn pool_constraints_tranche_violates_risk_buffer() {
 
 		let full_solution = pool
 			.tranches
-			.residual_slice()
+			.residual_top_slice()
 			.iter()
 			.map(|_| TrancheSolution {
 				invest_fulfillment: Perquintill::one(),
@@ -322,7 +322,7 @@ fn pool_constraints_pass() {
 		let tranches = Tranches::new(vec![tranche_d, tranche_c, tranche_b, tranche_a]);
 		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
-				.residual_slice()
+				.residual_top_slice()
 				.iter()
 				.zip(vec![80, 70, 35, 20])
 				.enumerate() // no IntoIterator for arrays, so we use a vec here. Meh.
@@ -367,7 +367,7 @@ fn pool_constraints_pass() {
 
 		let full_solution = pool
 			.tranches
-			.residual_slice()
+			.residual_top_slice()
 			.iter()
 			.map(|_| TrancheSolution {
 				invest_fulfillment: Perquintill::one(),

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -378,7 +378,11 @@ fn pool_constraints_pass() {
 		assert_ok!(Pools::is_valid_solution(pool, &epoch, &full_solution));
 
 		assert_eq!(
-			Pools::calculate_risk_buffers(&vec![3, 1], &vec![One::one(), One::one()]).unwrap(),
+			crate::calculate_risk_buffers::<u128, runtime_common::Rate>(
+				&vec![3, 1],
+				&vec![One::one(), One::one()]
+			)
+			.unwrap(),
 			vec![Perquintill::zero(), Perquintill::from_float(0.75),]
 		);
 		assert_eq!(

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -3,8 +3,9 @@ use crate::mock::*;
 use common_traits::Permissions as PermissionsT;
 use common_types::CurrencyId;
 use frame_support::sp_std::convert::TryInto;
+use frame_support::traits::fungibles;
 use frame_support::{assert_err, assert_noop, assert_ok};
-use runtime_common::{Rate, TrancheWeight};
+use runtime_common::Rate;
 use sp_runtime::traits::{One, Zero};
 use sp_runtime::Perquintill;
 
@@ -462,6 +463,27 @@ fn epoch() {
 			SENIOR_TRANCHE_ID,
 			1
 		));
+		assert_ok!(Pools::collect(
+			junior_investor.clone(),
+			0,
+			JUNIOR_TRANCHE_ID,
+			1
+		));
+
+		assert_eq!(
+			<pallet_restricted_tokens::Pallet<Test> as fungibles::Inspect<u64>>::balance(
+				CurrencyId::Tranche(0, 0),
+				&0,
+			),
+			500 * CURRENCY,
+		);
+		assert_eq!(
+			<pallet_restricted_tokens::Pallet<Test> as fungibles::Inspect<u64>>::balance(
+				CurrencyId::Tranche(0, 1),
+				&1,
+			),
+			500 * CURRENCY,
+		);
 
 		let pool = Pools::pool(0).unwrap();
 		assert_eq!(

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -428,16 +428,14 @@ fn epoch() {
 			pool_owner.clone(),
 			0,
 			vec![
-				TrancheInput {
-					interest_per_sec: None,
-					min_risk_buffer: None,
-					seniority: None
-				},
-				TrancheInput {
-					interest_per_sec: Some(senior_interest_rate),
-					min_risk_buffer: Some(Perquintill::from_percent(10)),
-					seniority: None
-				}
+				(TrancheType::Residual, None),
+				(
+					TrancheType::NonResidual {
+						interest_per_sec: senior_interest_rate,
+						min_risk_buffer: Perquintill::from_percent(10),
+					},
+					None
+				)
 			],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
@@ -657,16 +655,14 @@ fn submission_period() {
 			pool_owner.clone(),
 			0,
 			vec![
-				TrancheInput {
-					interest_per_sec: None,
-					min_risk_buffer: None,
-					seniority: None,
-				},
-				TrancheInput {
-					interest_per_sec: Some(senior_interest_rate),
-					min_risk_buffer: Some(Perquintill::from_percent(10)),
-					seniority: None,
-				}
+				(TrancheType::Residual, None),
+				(
+					TrancheType::NonResidual {
+						interest_per_sec: senior_interest_rate,
+						min_risk_buffer: Perquintill::from_percent(10),
+					},
+					None
+				)
 			],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
@@ -858,16 +854,14 @@ fn execute_info_removed_after_epoch_execute() {
 			pool_owner.clone(),
 			0,
 			vec![
-				TrancheInput {
-					interest_per_sec: None,
-					min_risk_buffer: None,
-					seniority: None,
-				},
-				TrancheInput {
-					interest_per_sec: Some(senior_interest_rate),
-					min_risk_buffer: Some(Perquintill::from_percent(10)),
-					seniority: None,
-				}
+				(TrancheType::Residual, None),
+				(
+					TrancheType::NonResidual {
+						interest_per_sec: senior_interest_rate,
+						min_risk_buffer: Perquintill::from_percent(10),
+					},
+					None
+				)
 			],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
@@ -943,16 +937,14 @@ fn collect_tranche_tokens() {
 			pool_owner.clone(),
 			0,
 			vec![
-				TrancheInput {
-					interest_per_sec: None,
-					min_risk_buffer: None,
-					seniority: None
-				},
-				TrancheInput {
-					interest_per_sec: Some(senior_interest_rate),
-					min_risk_buffer: Some(Perquintill::from_percent(10)),
-					seniority: None
-				}
+				(TrancheType::Residual, None),
+				(
+					TrancheType::NonResidual {
+						interest_per_sec: senior_interest_rate,
+						min_risk_buffer: Perquintill::from_percent(10),
+					},
+					None
+				)
 			],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
@@ -1060,11 +1052,7 @@ fn invalid_tranche_id_is_err() {
 		assert_ok!(Pools::create(
 			senior_investor.clone(),
 			0,
-			vec![TrancheInput {
-				interest_per_sec: None,
-				min_risk_buffer: None,
-				seniority: None
-			},],
+			vec![(TrancheType::Residual, None)],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
 		));
@@ -1097,11 +1085,7 @@ fn updating_with_same_amount_is_err() {
 		assert_ok!(Pools::create(
 			senior_investor.clone(),
 			0,
-			vec![TrancheInput {
-				interest_per_sec: None,
-				min_risk_buffer: None,
-				seniority: None
-			},],
+			vec![(TrancheType::Residual, None)],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
 		));
@@ -1139,11 +1123,7 @@ fn updating_orders_updates_epoch() {
 		assert_ok!(Pools::create(
 			pool_admin.clone(),
 			pool_id,
-			vec![TrancheInput {
-				interest_per_sec: None,
-				min_risk_buffer: None,
-				seniority: None
-			},],
+			vec![(TrancheType::Residual, None)],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
 		));
@@ -1206,11 +1186,7 @@ fn no_order_is_err() {
 		assert_ok!(Pools::create(
 			pool_admin.clone(),
 			pool_id,
-			vec![TrancheInput {
-				interest_per_sec: None,
-				min_risk_buffer: None,
-				seniority: None
-			},],
+			vec![(TrancheType::Residual, None)],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
 		));
@@ -1245,11 +1221,7 @@ fn collecting_over_last_exec_epoch_is_err() {
 		assert_ok!(Pools::create(
 			pool_admin.clone(),
 			pool_id,
-			vec![TrancheInput {
-				interest_per_sec: None,
-				min_risk_buffer: None,
-				seniority: None
-			},],
+			vec![(TrancheType::Residual, None)],
 			CurrencyId::Usd,
 			10_000 * CURRENCY
 		));

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -23,7 +23,7 @@ fn core_constraints_currency_available_cant_cover_redemptions() {
 
 		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
-				.junior_to_senior_slice()
+				.residual_slice()
 				.iter()
 				.zip(vec![80, 20, 5, 5]) // no IntoIterator for arrays, so we use a vec here. Meh.
 				.map(|(tranche, value)| EpochExecutionTranche {
@@ -66,7 +66,7 @@ fn core_constraints_currency_available_cant_cover_redemptions() {
 
 		let full_solution = pool
 			.tranches
-			.junior_to_senior_slice()
+			.residual_slice()
 			.iter()
 			.map(|_| TrancheSolution {
 				invest_fulfillment: Perquintill::one(),
@@ -111,7 +111,7 @@ fn pool_constraints_pool_reserve_above_max_reserve() {
 		let tranches = Tranches::new(vec![tranche_a, tranche_b, tranche_c, tranche_d]);
 		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
-				.junior_to_senior_slice()
+				.residual_slice()
 				.iter()
 				.zip(vec![80, 20, 15, 15]) // no IntoIterator for arrays, so we use a vec here. Meh.
 				.map(|(tranche, value)| EpochExecutionTranche {
@@ -154,7 +154,7 @@ fn pool_constraints_pool_reserve_above_max_reserve() {
 
 		let full_solution = pool
 			.tranches
-			.junior_to_senior_slice()
+			.residual_slice()
 			.iter()
 			.map(|_| TrancheSolution {
 				invest_fulfillment: Perquintill::one(),
@@ -215,7 +215,7 @@ fn pool_constraints_tranche_violates_risk_buffer() {
 
 		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
-				.junior_to_senior_slice()
+				.residual_slice()
 				.iter()
 				.zip(vec![5, 5, 20, 80]) // no IntoIterator for arrays, so we use a vec here. Meh.
 				.map(|(tranche, value)| EpochExecutionTranche {
@@ -258,7 +258,7 @@ fn pool_constraints_tranche_violates_risk_buffer() {
 
 		let full_solution = pool
 			.tranches
-			.junior_to_senior_slice()
+			.residual_slice()
 			.iter()
 			.map(|_| TrancheSolution {
 				invest_fulfillment: Perquintill::one(),
@@ -322,7 +322,7 @@ fn pool_constraints_pass() {
 		let tranches = Tranches::new(vec![tranche_d, tranche_c, tranche_b, tranche_a]);
 		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
-				.junior_to_senior_slice()
+				.residual_slice()
 				.iter()
 				.zip(vec![80, 70, 35, 20])
 				.enumerate() // no IntoIterator for arrays, so we use a vec here. Meh.
@@ -367,7 +367,7 @@ fn pool_constraints_pass() {
 
 		let full_solution = pool
 			.tranches
-			.junior_to_senior_slice()
+			.residual_slice()
 			.iter()
 			.map(|_| TrancheSolution {
 				invest_fulfillment: Perquintill::one(),

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -21,7 +21,7 @@ fn core_constraints_currency_available_cant_cover_redemptions() {
 			.collect(),
 		};
 
-		let epoch_tranches = EpochExecutionTranches(
+		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
 				.as_tranche_slice()
 				.iter()
@@ -111,7 +111,7 @@ fn pool_constraints_pool_reserve_above_max_reserve() {
 		let tranches = Tranches {
 			tranches: vec![tranche_a, tranche_b, tranche_c, tranche_d],
 		};
-		let epoch_tranches = EpochExecutionTranches(
+		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
 				.as_tranche_slice()
 				.iter()
@@ -208,7 +208,7 @@ fn pool_constraints_tranche_violates_risk_buffer() {
 			tranches: vec![tranche_d, tranche_c, tranche_b, tranche_a],
 		};
 
-		let epoch_tranches = EpochExecutionTranches(
+		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
 				.as_tranche_slice()
 				.iter()
@@ -308,7 +308,7 @@ fn pool_constraints_pass() {
 		let tranches = Tranches {
 			tranches: vec![tranche_d, tranche_c, tranche_b, tranche_a],
 		};
-		let epoch_tranches = EpochExecutionTranches(
+		let epoch_tranches = EpochExecutionTranches::new(
 			tranches
 				.as_tranche_slice()
 				.iter()

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -501,33 +501,33 @@ fn epoch() {
 
 		let pool = Pools::pool(0).unwrap();
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].interest_per_sec(),
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].interest_per_sec(),
 			Rate::from_inner(1_000000003170979198376458650)
 		);
 		assert_eq!(pool.reserve.available_reserve, 1000 * CURRENCY);
 		assert_eq!(pool.reserve.total_reserve, 1000 * CURRENCY);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[JUNIOR_TRANCHE_ID as usize].debt,
+			pool.tranches.residual_top_slice()[JUNIOR_TRANCHE_ID as usize].debt,
 			0
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[JUNIOR_TRANCHE_ID as usize].reserve,
+			pool.tranches.residual_top_slice()[JUNIOR_TRANCHE_ID as usize].reserve,
 			500 * CURRENCY
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[JUNIOR_TRANCHE_ID as usize].ratio,
+			pool.tranches.residual_top_slice()[JUNIOR_TRANCHE_ID as usize].ratio,
 			Perquintill::from_float(0.5)
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].debt,
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].debt,
 			0
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].ratio,
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].ratio,
 			Perquintill::from_float(0.5)
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].reserve,
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].reserve,
 			500 * CURRENCY
 		);
 
@@ -537,19 +537,19 @@ fn epoch() {
 
 		let pool = Pools::pool(0).unwrap();
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[JUNIOR_TRANCHE_ID as usize].debt,
+			pool.tranches.residual_top_slice()[JUNIOR_TRANCHE_ID as usize].debt,
 			250 * CURRENCY
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[JUNIOR_TRANCHE_ID as usize].reserve,
+			pool.tranches.residual_top_slice()[JUNIOR_TRANCHE_ID as usize].reserve,
 			250 * CURRENCY
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].debt,
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].debt,
 			250 * CURRENCY
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].reserve,
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].reserve,
 			250 * CURRENCY
 		);
 		assert_eq!(pool.reserve.available_reserve, 500 * CURRENCY);
@@ -562,20 +562,19 @@ fn epoch() {
 
 		let pool = Pools::pool(0).unwrap();
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[JUNIOR_TRANCHE_ID as usize].debt,
+			pool.tranches.residual_top_slice()[JUNIOR_TRANCHE_ID as usize].debt,
 			0
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[JUNIOR_TRANCHE_ID as usize].reserve,
+			pool.tranches.residual_top_slice()[JUNIOR_TRANCHE_ID as usize].reserve,
 			500 * CURRENCY
 		); // not yet rebalanced
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].debt,
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].debt,
 			0
 		);
 		assert!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].reserve
-				> 500 * CURRENCY
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].reserve > 500 * CURRENCY
 		); // there's interest in here now
 		assert_eq!(pool.reserve.available_reserve, 500 * CURRENCY);
 		assert_eq!(pool.reserve.total_reserve, 1010 * CURRENCY);
@@ -602,20 +601,19 @@ fn epoch() {
 		assert_eq!(pool.tranches.residual_tranche().unwrap().debt, 0);
 		assert!(pool.tranches.residual_tranche().unwrap().reserve > 500 * CURRENCY);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize]
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize]
 				.outstanding_redeem_orders,
 			0
 		);
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].debt,
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].debt,
 			0
 		);
 		assert_eq!(pool.reserve.available_reserve, pool.reserve.total_reserve);
 		assert!(pool.reserve.total_reserve > 750 * CURRENCY);
 		assert!(pool.reserve.total_reserve < 800 * CURRENCY);
 		assert!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize].reserve
-				> 250 * CURRENCY
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize].reserve > 250 * CURRENCY
 		);
 		assert_eq!(
 			pool.reserve.total_reserve
@@ -979,7 +977,7 @@ fn collect_tranche_tokens() {
 
 		let pool = Pools::pool(0).unwrap();
 		assert_eq!(
-			pool.tranches.junior_to_senior_slice()[SENIOR_TRANCHE_ID as usize]
+			pool.tranches.residual_top_slice()[SENIOR_TRANCHE_ID as usize]
 				.outstanding_invest_orders,
 			0
 		);

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -28,13 +28,6 @@ use frame_support::sp_std::convert::TryInto;
 use rev_slice::{RevSlice, SliceExt};
 use sp_arithmetic::traits::{checked_pow, BaseArithmetic, Unsigned};
 
-/// Types alias for EpochExecutionTranches
-pub(super) type EpochExecutionTranchesOf<T> = EpochExecutionTranches<
-	<T as Config>::Balance,
-	<T as Config>::BalanceRatio,
-	<T as Config>::TrancheWeight,
->;
-
 /// Types alias for EpochExecutionTranche
 #[allow(dead_code)]
 pub(super) type EpochExecutionTrancheOf<T> = EpochExecutionTranche<

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -143,7 +143,7 @@ where
 
 impl<Balance, Rate, Weight, Currency> Tranche<Balance, Rate, Weight, Currency>
 where
-	Balance: Zero + Copy + BaseArithmetic + FixedPointOperand,
+	Balance: Zero + Copy + BaseArithmetic + FixedPointOperand + Unsigned + From<u64>,
 	Rate: FixedPointNumber<Inner = Balance> + One + Copy,
 	Balance: FixedPointOperand,
 	Weight: Copy + From<u128>,
@@ -235,7 +235,7 @@ where
 impl<Balance, Rate, Weight, CurrencyId> Tranches<Balance, Rate, Weight, CurrencyId>
 where
 	CurrencyId: Copy,
-	Balance: Zero + Copy + BaseArithmetic + FixedPointOperand,
+	Balance: Zero + Copy + BaseArithmetic + FixedPointOperand + Unsigned + From<u64>,
 	Weight: Copy + From<u128>,
 	Rate: One + Copy + FixedPointNumber<Inner = Balance>,
 {
@@ -670,6 +670,72 @@ where
 			.iter()
 			.map(|tranche| tranche.seniority)
 			.collect::<Vec<_>>()
+	}
+
+	pub fn rebalance_tranches(
+		&mut self,
+		now: Moment,
+		pool_total_reserve: Balance,
+		pool_nav: Balance,
+		tranche_ratios: &[Perquintill],
+		executed_amounts: &[(Balance, Balance)],
+	) -> DispatchResult {
+		// Calculate the new fraction of the total pool value that each tranche contains
+		// This is based on the tranche values at time of epoch close.
+		let total_assets = pool_total_reserve
+			.checked_add(&pool_nav)
+			.ok_or(ArithmeticError::Overflow)?;
+
+		// Calculate the new total asset value for each tranche
+		// This uses the current state of the tranches, rather than the cached epoch-close-time values.
+		let mut total_assets = total_assets;
+		let tranche_assets = self.combine_with_mut_rev(
+			executed_amounts.iter().rev(),
+			|tranche, (invest, redeem)| {
+				tranche.accrue(now)?;
+
+				tranche
+					.debt
+					.checked_add(&tranche.reserve)
+					.and_then(|value| value.checked_add(invest))
+					.and_then(|value| value.checked_sub(redeem))
+					.map(|value| {
+						if value > total_assets {
+							let assets = total_assets;
+							total_assets = Zero::zero();
+							assets
+						} else {
+							total_assets = total_assets.saturating_sub(value);
+							value
+						}
+					})
+					.ok_or(ArithmeticError::Overflow.into())
+			},
+		)?;
+
+		// Rebalance tranches based on the new tranche asset values and ratios
+		let mut remaining_nav = pool_nav;
+		let mut remaining_reserve = pool_total_reserve;
+		self.combine_with_mut_rev(
+			tranche_ratios.iter().rev().zip(tranche_assets.iter()),
+			|tranche, (ratio, value)| {
+				tranche.ratio = *ratio;
+				if tranche.tranche_type == TrancheType::Residual {
+					tranche.debt = remaining_nav;
+					tranche.reserve = remaining_reserve;
+				} else {
+					tranche.debt = ratio.mul_ceil(pool_nav);
+					if tranche.debt > *value {
+						tranche.debt = *value;
+					}
+					tranche.reserve = value.saturating_sub(tranche.debt);
+					remaining_nav -= tranche.debt;
+					remaining_reserve -= tranche.reserve;
+				}
+				Ok(())
+			},
+		)
+		.map(|_| ())
 	}
 }
 

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -1030,10 +1030,9 @@ where
 			tranche
 				.supply
 				.checked_add(&solution.invest_fulfillment.mul_floor(tranche.invest))
-				.and_then(|value| {
-					value.checked_sub(&solution.redeem_fulfillment.mul_floor(tranche.redeem))
-				})
-				.ok_or(ArithmeticError::Overflow.into())
+				.ok_or(ArithmeticError::Overflow)?
+				.checked_sub(&solution.redeem_fulfillment.mul_floor(tranche.redeem))
+				.ok_or(ArithmeticError::Underflow.into())
 		})
 	}
 
@@ -1166,11 +1165,12 @@ where
 
 #[cfg(test)]
 pub mod test {
-	use super::*;
-
 	#[test]
 	fn reverse_slice_panics_on_out_of_bounds() {}
 
 	#[test]
 	fn reverse_works_for_both_tranches() {}
+
+	#[test]
+	fn accrue_overflows_safely() {}
 }

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -452,19 +452,19 @@ where
 					.ok_or(ArithmeticError::Overflow.into())
 			} else {
 				tranche.accrue(now)?;
-				let tranche_value = tranche.balance()?;
+				let tranche_balance = tranche.balance()?;
 
 				// Indicates that a tranche has been wiped out and/or a tranche has
 				// lost value due to defaults.
-				let tranche_value = if tranche_value > remaining_assets {
+				let tranche_value = if tranche_balance > remaining_assets {
 					let left_over_assets = remaining_assets;
 					remaining_assets = Zero::zero();
 					left_over_assets
 				} else {
 					remaining_assets = remaining_assets
-						.checked_sub(&tranche_value)
+						.checked_sub(&tranche_balance)
 						.expect("Tranche value smaller equal remaining assets. qed.");
-					tranche_value
+					tranche_balance
 				};
 				BalanceRatio::checked_from_rational(tranche_value, total_issuance)
 					.ok_or(ArithmeticError::Overflow.into())
@@ -575,14 +575,14 @@ where
 			.ok_or(ArithmeticError::Overflow.into())
 	}
 
-	pub fn oustanding_redemptions(&self) -> Vec<Balance> {
+	pub fn outstanding_redemptions(&self) -> Vec<Balance> {
 		self.tranches
 			.iter()
 			.map(|tranche| tranche.outstanding_redeem_orders)
 			.collect()
 	}
 
-	pub fn acc_oustanding_redemptions(&self) -> Result<Balance, DispatchError> {
+	pub fn acc_outstanding_redemptions(&self) -> Result<Balance, DispatchError> {
 		self.tranches
 			.iter()
 			.fold(Some(Balance::zero()), |sum, tranche| {
@@ -631,7 +631,7 @@ where
 			.collect()
 	}
 
-	pub fn senorities(&self) -> Vec<Seniority> {
+	pub fn seniorities(&self) -> Vec<Seniority> {
 		self.tranches
 			.iter()
 			.map(|tranche| tranche.seniority)

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -283,23 +283,6 @@ where
 		Self { tranches }
 	}
 
-	pub fn fold<R, F>(&self, start: R, mut f: F) -> Result<R, DispatchError>
-	where
-		F: FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>, R) -> Result<R, DispatchError>,
-	{
-		let mut iter = self.tranches.iter();
-		let mut r = if let Some(tranche) = iter.next() {
-			f(tranche, start)?
-		} else {
-			return Ok(start);
-		};
-
-		while let Some(tranche) = iter.next() {
-			r = f(tranche, r)?;
-		}
-		Ok(r)
-	}
-
 	pub fn combine<R, F>(&self, mut f: F) -> Result<Vec<R>, DispatchError>
 	where
 		F: FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>) -> Result<R, DispatchError>,
@@ -360,23 +343,6 @@ where
 		}
 
 		Ok(res)
-	}
-
-	pub fn fold_rev<R, F>(&self, start: R, mut f: F) -> Result<R, DispatchError>
-	where
-		F: FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>, R) -> Result<R, DispatchError>,
-	{
-		let mut iter = self.tranches.iter().rev();
-		let mut r = if let Some(tranche) = iter.next() {
-			f(tranche, start)?
-		} else {
-			return Ok(start);
-		};
-
-		while let Some(tranche) = iter.next() {
-			r = f(tranche, r)?;
-		}
-		Ok(r)
 	}
 
 	pub fn combine_rev<R, F>(&self, mut f: F) -> Result<Vec<R>, DispatchError>
@@ -830,26 +796,6 @@ where
 		self.tranches.as_mut_slice()
 	}
 
-	pub fn fold<R, F>(&self, start: R, mut f: F) -> Result<R, DispatchError>
-	where
-		F: FnMut(
-			&EpochExecutionTranche<Balance, BalanceRatio, Weight>,
-			R,
-		) -> Result<R, DispatchError>,
-	{
-		let mut iter = self.tranches.iter();
-		let mut r = if let Some(tranche) = iter.next() {
-			f(tranche, start)?
-		} else {
-			return Ok(start);
-		};
-
-		while let Some(tranche) = iter.next() {
-			r = f(tranche, r)?;
-		}
-		Ok(r)
-	}
-
 	pub fn combine<R, F>(&self, mut f: F) -> Result<Vec<R>, DispatchError>
 	where
 		F: FnMut(&EpochExecutionTranche<Balance, BalanceRatio, Weight>) -> Result<R, DispatchError>,
@@ -918,26 +864,6 @@ where
 		}
 
 		Ok(res)
-	}
-
-	pub fn fold_rev<R, F>(&self, start: R, mut f: F) -> Result<R, DispatchError>
-	where
-		F: FnMut(
-			&EpochExecutionTranche<Balance, BalanceRatio, Weight>,
-			R,
-		) -> Result<R, DispatchError>,
-	{
-		let mut iter = self.tranches.iter().rev();
-		let mut r = if let Some(tranche) = iter.next() {
-			f(tranche, start)?
-		} else {
-			return Ok(start);
-		};
-
-		while let Some(tranche) = iter.next() {
-			r = f(tranche, r)?;
-		}
-		Ok(r)
 	}
 
 	pub fn combine_rev<R, F>(&self, mut f: F) -> Result<Vec<R>, DispatchError>

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -595,6 +595,14 @@ where
 		let n_tranches: u32 = self.tranches.len().try_into().expect("MaxTranches is u32");
 		let redeem_starts = 10u128.checked_pow(n_tranches).unwrap_or(u128::MAX);
 
+		// The desired order priority is:
+		// - Senior redemptions
+		// - Junior redemptions
+		// - Junior investments
+		// - Senior investments
+		// We ensure this by having a higher base weight for redemptions,
+		// increasing the redemption weights by seniority,
+		// and decreasing the investment weight by seniority.
 		self.tranches
 			.iter()
 			.map(|tranche| {
@@ -1025,6 +1033,14 @@ where
 		let n_tranches: u32 = self.tranches.len().try_into().expect("MaxTranches is u32");
 		let redeem_starts = 10u128.checked_pow(n_tranches).unwrap_or(u128::MAX);
 
+		// The desired order priority is:
+		// - Senior redemptions
+		// - Junior redemptions
+		// - Junior investments
+		// - Senior investments
+		// We ensure this by having a higher base weight for redemptions,
+		// increasing the redemption weights by seniority,
+		// and decreasing the investment weight by seniority.
 		self.tranches
 			.iter()
 			.map(|tranche| {

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -246,11 +246,10 @@ where
 		Ok(Self { tranches })
 	}
 
-	pub fn fold<R>(
-		&self,
-		start: R,
-		mut f: impl FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>, R) -> Result<R, DispatchError>,
-	) -> Result<R, DispatchError> {
+	pub fn fold<R, F>(&self, start: R, mut f: F) -> Result<R, DispatchError>
+	where
+		F: FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>, R) -> Result<R, DispatchError>,
+	{
 		let mut iter = self.tranches.iter();
 		let mut r = if let Some(tranche) = iter.next() {
 			f(tranche, start)?
@@ -264,10 +263,10 @@ where
 		Ok(r)
 	}
 
-	pub fn combine<R>(
-		&self,
-		mut f: impl FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>) -> Result<R, DispatchError>,
-	) -> Result<Vec<R>, DispatchError> {
+	pub fn combine<R, F>(&self, mut f: F) -> Result<Vec<R>, DispatchError>
+	where
+		F: FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>) -> Result<R, DispatchError>,
+	{
 		let mut res = Vec::with_capacity(self.tranches.len());
 		for tranche in &self.tranches {
 			let r = f(tranche)?;
@@ -276,10 +275,10 @@ where
 		Ok(res)
 	}
 
-	pub fn combine_mut<R>(
-		&mut self,
-		mut f: impl FnMut(&mut Tranche<Balance, Rate, Weight, CurrencyId>) -> Result<R, DispatchError>,
-	) -> Result<Vec<R>, DispatchError> {
+	pub fn combine_mut<R, F>(&mut self, mut f: F) -> Result<Vec<R>, DispatchError>
+	where
+		F: FnMut(&mut Tranche<Balance, Rate, Weight, CurrencyId>) -> Result<R, DispatchError>,
+	{
 		let mut res = Vec::with_capacity(self.tranches.len());
 		for tranche in &mut self.tranches {
 			let r = f(tranche)?;
@@ -288,11 +287,11 @@ where
 		Ok(res)
 	}
 
-	pub fn combine_with<R, W>(
-		&self,
-		with: impl IntoIterator<Item = W>,
-		mut f: impl FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>, W) -> Result<R, DispatchError>,
-	) -> Result<Vec<R>, DispatchError> {
+	pub fn combine_with<R, I, W, F>(&self, with: I, mut f: F) -> Result<Vec<R>, DispatchError>
+	where
+		F: FnMut(&Tranche<Balance, Rate, Weight, CurrencyId>, W) -> Result<R, DispatchError>,
+		I: IntoIterator<Item = W>,
+	{
 		let mut res = Vec::with_capacity(self.tranches.len());
 		// TODO: Would be nice to error out when with is larger than tranches...
 		let iter = self.tranches.iter().zip(with.into_iter());

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -150,11 +150,8 @@ where
 {
 	fn default() -> Self {
 		Self {
-			tranche_type: TrancheType::NonResidual {
-				interest_per_sec: One::one(),
-				min_risk_buffer: Perquintill::zero(),
-			},
-			seniority: 0,
+			tranche_type: TrancheType::Residual,
+			seniority: 1,
 			currency: CurrencyId::Tranche(0, 0),
 			outstanding_invest_orders: Zero::zero(),
 			outstanding_redeem_orders: Zero::zero(),

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -114,11 +114,7 @@ where
 }
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
-pub struct Tranche<Balance, Rate, Weight, Currency>
-where
-	Rate: FixedPointNumber<Inner = Balance>,
-	Balance: FixedPointOperand,
-{
+pub struct Tranche<Balance, Rate, Weight, Currency> {
 	pub(super) tranche_type: TrancheType<Rate>,
 	pub(super) seniority: Seniority,
 	pub(super) currency: Currency,
@@ -236,11 +232,7 @@ where
 }
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
-pub struct Tranches<Balance, Rate, Weight, Currency>
-where
-	Rate: FixedPointNumber<Inner = Balance>,
-	Balance: FixedPointOperand,
-{
+pub struct Tranches<Balance, Rate, Weight, Currency> {
 	tranches: Vec<Tranche<Balance, Rate, Weight, Currency>>,
 }
 

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -531,7 +531,7 @@ where
 		self.tranches.rev_mut()
 	}
 
-	pub fn residual_slice(&self) -> &[Tranche<Balance, Rate, Weight, CurrencyId>] {
+	pub fn residual_top_slice(&self) -> &[Tranche<Balance, Rate, Weight, CurrencyId>] {
 		self.tranches.as_slice()
 	}
 

--- a/pallets/pools/src/weights.rs
+++ b/pallets/pools/src/weights.rs
@@ -44,7 +44,7 @@ pub trait WeightInfo {
 	fn update_invest_order() -> Weight;
 	fn update_redeem_order() -> Weight;
 	fn collect(n: u32) -> Weight;
-	fn close_epoch_no_investments(n: u32) -> Weight;
+	fn close_epoch_no_orders(n: u32) -> Weight;
 	fn close_epoch_no_execution(n: u32) -> Weight;
 	fn close_epoch_execute(n: u32) -> Weight;
 	fn submit_solution(n: u32) -> Weight;
@@ -103,7 +103,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(n as Weight)))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
-	fn close_epoch_no_investments(n: u32) -> Weight {
+	fn close_epoch_no_orders(n: u32) -> Weight {
 		(95_307_000 as Weight)
 			// Standard Error: 2_725_000
 			.saturating_add((11_842_000 as Weight).saturating_mul(n as Weight))
@@ -208,7 +208,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(n as Weight)))
 			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
-	fn close_epoch_no_investments(n: u32) -> Weight {
+	fn close_epoch_no_orders(n: u32) -> Weight {
 		(95_307_000 as Weight)
 			// Standard Error: 2_725_000
 			.saturating_add((11_842_000 as Weight).saturating_mul(n as Weight))

--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -12,7 +12,6 @@ use frame_support::weights::{
 use frame_system::pallet::Config as SystemConfig;
 use pallet_authorship::{Config as AuthorshipConfig, Pallet as Authorship};
 use pallet_balances::{Config as BalancesConfig, Pallet as Balances};
-use pallet_pools::Config;
 use scale_info::TypeInfo;
 use smallvec::smallvec;
 use sp_arithmetic::Perbill;


### PR DESCRIPTION
I will split this refactoring into multiple smaller chunks. Although this will duplicate a little work, I hope that the reviewing process will be better and we can follow more on the changes and discuss them.

This part does:
* Remove implicit behaviour for `pool::collect` calls, where `last_epoch_executed` is used as a maximum for the n_epoch that are collected over. Instead now it errors out. #618
* Enforce sane tranche structure #631
* Wrap bookkeeping into methods or trait #633
* Unifiy interface of reserve trait #642
* Adjust calculation of total reserve #599