### PR TITLE
Version in flake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,9 @@ jobs:
         with:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v16
         with:
-          install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          install_url: https://releases.nixos.org/nix/nix-2.6.0/install
       - uses: cachix/cachix-action@v10
         with:
           name: centrifuge-chain

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           name: centrifuge-chain
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix build -L .#dockerContainer
+      - run: nix build -L .#dockerImage
       - name: Load built image into Docker
         run: docker load -i result
       - name: Login to Docker Hub

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,32 @@
 {
   "nodes": {
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1635165013,
+        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1611179033,
-        "narHash": "sha256-NMepSdxJt8mFfgWHUT2o7u2yKZ8l2KD+FWbNDiR8Ufk=",
+        "lastModified": 1635350005,
+        "narHash": "sha256-tAMJnUwfaDEB2aa31jGcu7R7bzGELM9noc91L2PbVjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da3378c4aaf2ed350ad14552558fa55bb68d96d3",
+        "rev": "1c1f5649bb9c1b0d98637c8c365228f57126f361",
         "type": "github"
       },
       "original": {
@@ -18,6 +38,7 @@
     },
     "root": {
       "inputs": {
+        "gitignore": "gitignore",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -68,11 +68,10 @@
 
           doCheck = false;
         };
-
       defaultPackage.x86_64-linux = inputs.self.packages.x86_64-linux.centrifuge-chain;
 
       packages.x86_64-linux.dockerContainer =
-        pkgs.dockerTools.buildImage {
+        pkgs.dockerTools.buildLayeredImage {
           name = "centrifugeio/${name}";
           tag = version;
 

--- a/flake.nix
+++ b/flake.nix
@@ -78,9 +78,6 @@
           contents = inputs.self.defaultPackage.x86_64-linux;
 
           config = {
-            Env = [
-              "PATH=/bin:$PATH"
-            ];
             ExposedPorts = {
               "30333/tcp" = { };
               "9933/tcp" = { };

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
             filter = srcFilter;
             name = "centrifuge-chain-source";
           };
-          cargoSha256 = "sha256-52CN7N9FQiJSODloo0VZGPNw4P5XsaWfaQxEf6Nm2gI=";
+          cargoSha256 = "sha256-ulzzofKBqw4RUwwBmFKvgfCZ1ZeuULvCHLEQVzZrKBk=";
 
           nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
           buildInputs = [ pkgs.openssl ];

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,10 @@
           name = "centrifugeio/${name}";
           tag = version;
 
-          contents = inputs.self.defaultPackage.${system};
+          contents = [
+            pkgs.busybox
+            inputs.self.defaultPackage.${system}
+          ];
 
           config = {
             ExposedPorts = {

--- a/flake.nix
+++ b/flake.nix
@@ -10,8 +10,9 @@
       name = "centrifuge-chain";
       major = "2.0.0";
       version = "${major}-${commit-substr}";
+      system = [ "x86_64-linux" ];
 
-      pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
+      pkgs = inputs.nixpkgs.legacyPackages.${system};
 
       # This evaluates to the first 6 digits of the git hash of this repo's HEAD
       # commit, or to "dirty" if there are uncommitted changes.
@@ -47,7 +48,7 @@
 
     in
     {
-      packages.x86_64-linux.centrifuge-chain =
+      packages.${system}.centrifuge-chain =
         pkgs.rustPlatform.buildRustPackage {
           pname = name;
           inherit version;
@@ -68,14 +69,14 @@
 
           doCheck = false;
         };
-      defaultPackage.x86_64-linux = inputs.self.packages.x86_64-linux.centrifuge-chain;
+      defaultPackage.${system} = inputs.self.packages.${system}.centrifuge-chain;
 
-      packages.x86_64-linux.dockerContainer =
+      packages.${system}.dockerContainer =
         pkgs.dockerTools.buildLayeredImage {
           name = "centrifugeio/${name}";
           tag = version;
 
-          contents = inputs.self.defaultPackage.x86_64-linux;
+          contents = inputs.self.defaultPackage.${system};
 
           config = {
             ExposedPorts = {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       name = "centrifuge-chain";
       major = "2.0.0";
       version = "${major}-${commit-substr}";
-      system = [ "x86_64-linux" ];
+      system = "x86_64-linux";
 
       pkgs = inputs.nixpkgs.legacyPackages.${system};
 

--- a/flake.nix
+++ b/flake.nix
@@ -54,11 +54,14 @@
             pname = name;
             inherit version;
 
+            # This applies the srcFilter function to the current directory, so
+            # we don't include unnecessary files in the package.
             src = pkgs.lib.cleanSourceWith {
               src = ./.;
               filter = srcFilter;
-              name = "centrifuge-chain-source";
+              name = "${name}-source";
             };
+            # This is a hash of all the Cargo dependencies.
             cargoSha256 = "sha256-ulzzofKBqw4RUwwBmFKvgfCZ1ZeuULvCHLEQVzZrKBk=";
 
             nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];

--- a/flake.nix
+++ b/flake.nix
@@ -10,13 +10,15 @@
       name = "centrifuge-chain";
       major = "2.0.0";
       version = "${major}-${commit-substr}";
-      system = "x86_64-linux";
-
-      pkgs = inputs.nixpkgs.legacyPackages.${system};
 
       # This evaluates to the first 6 digits of the git hash of this repo's HEAD
       # commit, or to "dirty" if there are uncommitted changes.
       commit-substr = builtins.substring 0 6 (inputs.self.rev or "dirty");
+
+      # This could be made into a list, to support multiple platforms
+      system = "x86_64-linux";
+
+      pkgs = inputs.nixpkgs.legacyPackages.${system};
 
       # This is a mock git program, which just returns the commit-substr value.
       # It is called when the build process calls git. Instead of the real git,

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,11 @@
       version = "2.0.0";
       pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
 
+      # this mocks git to return the truncated SHA hash we get from Nix
+      git-mock = pkgs.writeShellScriptBin "git" ''
+        echo ${builtins.substring 0 6 (inputs.self.rev or "dirty")}
+      '';
+
       # srcFilter is used to keep out of the build non-source files,
       # so that we only trigger a rebuild when necessary.
       srcFilter = path: type:
@@ -44,7 +49,7 @@
           };
           cargoSha256 = "sha256-52CN7N9FQiJSODloo0VZGPNw4P5XsaWfaQxEf6Nm2gI=";
 
-          nativeBuildInputs = with pkgs; [ clang pkg-config ];
+          nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
           buildInputs = with pkgs; [ openssl ];
 
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";

--- a/flake.nix
+++ b/flake.nix
@@ -51,48 +51,48 @@
       packages.${system} = {
         # This is the native package.
         centrifuge-chain = pkgs.rustPlatform.buildRustPackage {
-            pname = name;
-            inherit version;
+          pname = name;
+          inherit version;
 
-            # This applies the srcFilter function to the current directory, so
-            # we don't include unnecessary files in the package.
-            src = pkgs.lib.cleanSourceWith {
-              src = ./.;
-              filter = srcFilter;
-              name = "${name}-source";
-            };
-            # This is a hash of all the Cargo dependencies.
-            cargoSha256 = "sha256-ulzzofKBqw4RUwwBmFKvgfCZ1ZeuULvCHLEQVzZrKBk=";
-
-            nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
-            buildInputs = [ pkgs.openssl ];
-
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
-            PROTOC = "${pkgs.protobuf}/bin/protoc";
-            BUILD_DUMMY_WASM_BINARY = 1;
-
-            doCheck = false;
+          # This applies the srcFilter function to the current directory, so
+          # we don't include unnecessary files in the package.
+          src = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            filter = srcFilter;
+            name = "${name}-source";
           };
+          # This is a hash of all the Cargo dependencies.
+          cargoSha256 = "sha256-ulzzofKBqw4RUwwBmFKvgfCZ1ZeuULvCHLEQVzZrKBk=";
+
+          nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
+          buildInputs = [ pkgs.openssl ];
+
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
+          PROTOC = "${pkgs.protobuf}/bin/protoc";
+          BUILD_DUMMY_WASM_BINARY = 1;
+
+          doCheck = false;
+        };
 
         # This is the Docker container.
         dockerContainer = pkgs.dockerTools.buildLayeredImage {
-            name = "centrifugeio/${name}";
-            tag = version;
+          name = "centrifugeio/${name}";
+          tag = version;
 
-            contents = inputs.self.defaultPackage.${system};
+          contents = inputs.self.defaultPackage.${system};
 
-            config = {
-              ExposedPorts = {
-                "30333/tcp" = { };
-                "9933/tcp" = { };
-                "9944/tcp" = { };
-              };
-              Volumes = {
-                "/data" = { };
-              };
-              Entrypoint = [ "centrifuge-chain" ];
+          config = {
+            ExposedPorts = {
+              "30333/tcp" = { };
+              "9933/tcp" = { };
+              "9944/tcp" = { };
             };
+            Volumes = {
+              "/data" = { };
+            };
+            Entrypoint = [ "centrifuge-chain" ];
           };
+        };
       };
 
       defaultPackage.${system} = inputs.self.packages.${system}.centrifuge-chain;

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
             # ignore CI directories
             (type == "directory" && (p == ".github" || p == "ci")) ||
             # ignore cargo files
-            (type == "directory" && (p == "target")) || p == ".cargo" ||
+            (type == "directory" && (p == "target" || p == ".cargo")) ||
             # ignore CI files
             p == ".travis.yml" || p == "cloudbuild.yaml" ||
             # ignore flake.(nix|lock)

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
       packages.x86_64-linux.dockerContainer =
         pkgs.dockerTools.buildImage {
           name = "centrifugeio/${name}";
-          tag = "latest";
+          tag = version;
 
           contents = inputs.self.defaultPackage.x86_64-linux;
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,8 @@
           !(
             # ignore CI directories
             (type == "directory" && (p == ".github" || p == "ci")) ||
+            # ignore cargo files
+            (type == "directory" && (p == "target")) || p == ".cargo" ||
             # ignore CI files
             p == ".travis.yml" || p == "cloudbuild.yaml" ||
             # ignore flake.(nix|lock)
@@ -32,7 +34,7 @@
             # ignore docker files
             p == ".dockerignore" || p == "docker-compose.yml" ||
             # ignore misc
-            p == "rustfmt.toml"
+            p == "rustfmt.toml" || p == ".idea" || p == ".vscode"
           );
 
     in

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
           src = pkgs.lib.cleanSourceWith {
             src = ./.;
             filter = srcFilter;
-            name = "${name}-source";
+            name = "${name}-${version}-source";
           };
           # This is a hash of all the Cargo dependencies.
           cargoSha256 = "sha256-ulzzofKBqw4RUwwBmFKvgfCZ1ZeuULvCHLEQVzZrKBk=";

--- a/flake.nix
+++ b/flake.nix
@@ -74,8 +74,8 @@
           doCheck = false;
         };
 
-        # This is the Docker container.
-        dockerContainer = pkgs.dockerTools.buildLayeredImage {
+        # This is the Docker image.
+        dockerImage = pkgs.dockerTools.buildLayeredImage {
           name = "centrifugeio/${name}";
           tag = version;
 


### PR DESCRIPTION
This PR adds a substring of the commit hash to a few places:

- output of `centrifuge-chain --version`
- docker image tag
- nix package version

The substring is formaed by the first 6 characters of the `HEAD`, or by the word `dirty`, in case there are uncommitted changes.

Examples:

```
❯ result/bin/centrifuge-chain --version
centrifuge-chain 2.0.0-dirty-x86_64-linux-gnu
```

