### PR TITLE
Remove use of borrow/payback in Pools pallet

### DIFF
--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -2225,7 +2225,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		pub(crate) fn do_payback(
+		pub(crate) fn do_deposit(
 			who: T::AccountId,
 			pool_id: T::PoolId,
 			amount: T::Balance,
@@ -2270,7 +2270,7 @@ pub mod pallet {
 			})
 		}
 
-		pub(crate) fn do_borrow(
+		pub(crate) fn do_withdraw(
 			who: T::AccountId,
 			pool_id: T::PoolId,
 			amount: T::Balance,
@@ -2333,10 +2333,10 @@ impl<T: Config> PoolReserve<T::AccountId> for Pallet<T> {
 	type Balance = T::Balance;
 
 	fn withdraw(pool_id: Self::PoolId, to: T::AccountId, amount: Self::Balance) -> DispatchResult {
-		Self::do_borrow(to, pool_id, amount)
+		Self::do_withdraw(to, pool_id, amount)
 	}
 
 	fn deposit(pool_id: Self::PoolId, from: T::AccountId, amount: Self::Balance) -> DispatchResult {
-		Self::do_payback(from, pool_id, amount)
+		Self::do_deposit(from, pool_id, amount)
 	}
 }

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -350,12 +350,12 @@ pub fn next_block_after(seconds: u64) {
 
 pub fn test_borrow(borrower: u64, pool_id: u64, amount: Balance) -> DispatchResult {
 	test_nav_up(pool_id, amount);
-	Pools::do_borrow(borrower, pool_id, amount)
+	Pools::do_withdraw(borrower, pool_id, amount)
 }
 
 pub fn test_payback(borrower: u64, pool_id: u64, amount: Balance) -> DispatchResult {
 	test_nav_down(pool_id, amount);
-	Pools::do_payback(borrower, pool_id, amount)
+	Pools::do_deposit(borrower, pool_id, amount)
 }
 
 pub fn test_nav_up(pool_id: u64, amount: Balance) {


### PR DESCRIPTION
For consistency, use withdraw/deposit internally as well as externally

Fixes #642