### PR TITLE
Add missing `[cfg(feature = "runtime-benchmarks")]`

### DIFF
--- a/pallets/collator-allowlist/src/lib.rs
+++ b/pallets/collator-allowlist/src/lib.rs
@@ -19,6 +19,7 @@ mod tests;
 #[cfg(test)]
 mod mock;
 
+#[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
 use frame_support::{dispatch::DispatchResult, traits::ValidatorRegistration};

--- a/pallets/fees/src/lib.rs
+++ b/pallets/fees/src/lib.rs
@@ -14,7 +14,9 @@ pub use pallet::*;
 #[cfg(test)]
 mod mock;
 
+#[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
Quick one, just adding `[cfg(feature = "runtime-benchmarks")]` where it's currently missing and deload the main build from including benchmarking-related stuff.