### PR TITLE
Emit NAVUpdated event on borrow, repay, writeoff

### DIFF
--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -583,7 +583,7 @@ benchmarks! {
 		assert!(pool_nav.latest_nav > amount);
 		// updated time should be after_one_years
 		assert_eq!(pool_nav.last_updated, after_one_year/1000);
-		assert_last_event::<T, <T as LoanConfig>::Event>(LoanEvent::NAVUpdated(pool_id, pool_nav.latest_nav, true).into());
+		assert_last_event::<T, <T as LoanConfig>::Event>(LoanEvent::NAVUpdated(pool_id, pool_nav.latest_nav, NAVUpdateType::Exact).into());
 	}
 }
 

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -583,7 +583,7 @@ benchmarks! {
 		assert!(pool_nav.latest_nav > amount);
 		// updated time should be after_one_years
 		assert_eq!(pool_nav.last_updated, after_one_year/1000);
-		assert_last_event::<T, <T as LoanConfig>::Event>(LoanEvent::NAVUpdated(pool_id, pool_nav.latest_nav).into());
+		assert_last_event::<T, <T as LoanConfig>::Event>(LoanEvent::NAVUpdated(pool_id, pool_nav.latest_nav, true).into());
 	}
 }
 

--- a/pallets/loans/src/functions.rs
+++ b/pallets/loans/src/functions.rs
@@ -322,6 +322,7 @@ impl<T: Config> Pallet<T> {
 			}?;
 			nav.latest_nav = new_nav;
 			*maybe_nav_details = Some(nav);
+			Self::deposit_event(Event::<T>::NAVUpdated(pool_id, new_nav, false));
 			Ok(())
 		})
 	}

--- a/pallets/loans/src/functions.rs
+++ b/pallets/loans/src/functions.rs
@@ -322,7 +322,11 @@ impl<T: Config> Pallet<T> {
 			}?;
 			nav.latest_nav = new_nav;
 			*maybe_nav_details = Some(nav);
-			Self::deposit_event(Event::<T>::NAVUpdated(pool_id, new_nav, false));
+			Self::deposit_event(Event::<T>::NAVUpdated(
+				pool_id,
+				new_nav,
+				NAVUpdateType::Inexact,
+			));
 			Ok(())
 		})
 	}

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -212,8 +212,8 @@ pub mod pallet {
 		/// An amount was repaid for a loan. [pool, loan, amount]
 		Repaid(PoolIdOf<T>, T::LoanId, T::Amount),
 
-		/// The NAV for a pool was updated. [pool, nav, exact]
-		NAVUpdated(PoolIdOf<T>, T::Amount, bool),
+		/// The NAV for a pool was updated. [pool, nav, update_type]
+		NAVUpdated(PoolIdOf<T>, T::Amount, NAVUpdateType),
 
 		/// A write-off group was added to a pool. [pool, write_off_group]
 		WriteOffGroupAdded(PoolIdOf<T>, u32),
@@ -476,7 +476,11 @@ pub mod pallet {
 			// ensure signed so that caller pays for the update fees
 			ensure_signed(origin)?;
 			let (updated_nav, updated_loans) = Self::update_nav_of_pool(pool_id)?;
-			Self::deposit_event(Event::<T>::NAVUpdated(pool_id, updated_nav, true));
+			Self::deposit_event(Event::<T>::NAVUpdated(
+				pool_id,
+				updated_nav,
+				NAVUpdateType::Exact,
+			));
 
 			// if the total loans updated are more than max loans, we are charging lower txn fees for this pool nav calculation.
 			// there is nothing we can do right now. return Ok

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -212,8 +212,8 @@ pub mod pallet {
 		/// An amount was repaid for a loan. [pool, loan, amount]
 		Repaid(PoolIdOf<T>, T::LoanId, T::Amount),
 
-		/// The NAV for a pool was updated. [pool, nav]
-		NAVUpdated(PoolIdOf<T>, T::Amount),
+		/// The NAV for a pool was updated. [pool, nav, exact]
+		NAVUpdated(PoolIdOf<T>, T::Amount, bool),
 
 		/// A write-off group was added to a pool. [pool, write_off_group]
 		WriteOffGroupAdded(PoolIdOf<T>, u32),
@@ -476,7 +476,7 @@ pub mod pallet {
 			// ensure signed so that caller pays for the update fees
 			ensure_signed(origin)?;
 			let (updated_nav, updated_loans) = Self::update_nav_of_pool(pool_id)?;
-			Self::deposit_event(Event::<T>::NAVUpdated(pool_id, updated_nav));
+			Self::deposit_event(Event::<T>::NAVUpdated(pool_id, updated_nav, true));
 
 			// if the total loans updated are more than max loans, we are charging lower txn fees for this pool nav calculation.
 			// there is nothing we can do right now. return Ok

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -990,13 +990,16 @@ macro_rules! test_pool_nav {
 				let res = Loans::update_nav(Origin::signed(borrower), pool_id);
 				assert_ok!(res);
 				let loan_event = fetch_loan_event(last_event()).expect("should be a loan event");
-				let (got_pool_id, updated_nav) = match loan_event {
-					LoanEvent::NAVUpdated(pool_id, update_nav) => Some((pool_id, update_nav)),
+				let (got_pool_id, updated_nav, exact) = match loan_event {
+					LoanEvent::NAVUpdated(pool_id, update_nav, exact) => {
+						Some((pool_id, update_nav, exact))
+					}
 					_ => None,
 				}
 				.expect("must be a Nav updated event");
 				assert_eq!(pool_id, got_pool_id);
 				assert_eq!(updated_nav, nav);
+				assert_eq!(exact, true);
 
 				let risk_admin = RiskAdmin::get();
 				assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
@@ -1044,8 +1047,10 @@ macro_rules! test_pool_nav {
 				let res = Loans::update_nav(Origin::signed(borrower), pool_id);
 				assert_ok!(res);
 				let loan_event = fetch_loan_event(last_event()).expect("should be a loan event");
-				let (_pool_id, updated_nav) = match loan_event {
-					LoanEvent::NAVUpdated(pool_id, update_nav) => Some((pool_id, update_nav)),
+				let (_pool_id, updated_nav, exact) = match loan_event {
+					LoanEvent::NAVUpdated(pool_id, update_nav, exact) => {
+						Some((pool_id, update_nav, exact))
+					}
 					_ => None,
 				}
 				.expect("must be a Nav updated event");
@@ -1057,6 +1062,7 @@ macro_rules! test_pool_nav {
 						.and_then(|written_off_amount| debt.checked_sub(&written_off_amount))
 						.unwrap();
 				assert_eq!(expected_nav, updated_nav);
+				assert_eq!(exact, true);
 			})
 	};
 }
@@ -1495,13 +1501,16 @@ macro_rules! test_close_written_off_loan_type {
 				let res = Loans::update_nav(Origin::signed(borrower), pool_id);
 				assert_ok!(res);
 				let loan_event = fetch_loan_event(last_event()).expect("should be a loan event");
-				let (got_pool_id, updated_nav) = match loan_event {
-					LoanEvent::NAVUpdated(pool_id, update_nav) => Some((pool_id, update_nav)),
+				let (got_pool_id, updated_nav, exact) = match loan_event {
+					LoanEvent::NAVUpdated(pool_id, update_nav, exact) => {
+						Some((pool_id, update_nav, exact))
+					}
 					_ => None,
 				}
 				.expect("must be a Nav updated event");
 				assert_eq!(pool_id, got_pool_id);
 				assert_eq!(updated_nav, Zero::zero());
+				assert_eq!(exact, true);
 
 				// close loan now
 				close_test_loan::<MockRuntime>(borrower, pool_id, loan, asset);

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -999,7 +999,7 @@ macro_rules! test_pool_nav {
 				.expect("must be a Nav updated event");
 				assert_eq!(pool_id, got_pool_id);
 				assert_eq!(updated_nav, nav);
-				assert_eq!(exact, true);
+				assert_eq!(exact, NAVUpdateType::Exact);
 
 				let risk_admin = RiskAdmin::get();
 				assert_ok!(pallet_pools::Pallet::<MockRuntime>::approve_role_for(
@@ -1062,7 +1062,7 @@ macro_rules! test_pool_nav {
 						.and_then(|written_off_amount| debt.checked_sub(&written_off_amount))
 						.unwrap();
 				assert_eq!(expected_nav, updated_nav);
-				assert_eq!(exact, true);
+				assert_eq!(exact, NAVUpdateType::Exact);
 			})
 	};
 }
@@ -1510,7 +1510,7 @@ macro_rules! test_close_written_off_loan_type {
 				.expect("must be a Nav updated event");
 				assert_eq!(pool_id, got_pool_id);
 				assert_eq!(updated_nav, Zero::zero());
-				assert_eq!(exact, true);
+				assert_eq!(exact, NAVUpdateType::Exact);
 
 				// close loan now
 				close_test_loan::<MockRuntime>(borrower, pool_id, loan, asset);

--- a/pallets/loans/src/types.rs
+++ b/pallets/loans/src/types.rs
@@ -76,6 +76,17 @@ pub enum LoanStatus {
 	Closed,
 }
 
+/// Information about how the nav was updated
+#[derive(Encode, Decode, Copy, Clone, PartialEq, TypeInfo)]
+#[cfg_attr(any(feature = "std", feature = "runtime-benchmarks"), derive(Debug))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum NAVUpdateType {
+	/// NAV was fully recomputed to an exact value
+	Exact,
+	/// NAV was updated inexactly based on loan status changes
+	Inexact,
+}
+
 /// The data structure for storing loan info
 #[derive(Encode, Decode, Copy, Clone, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]


### PR DESCRIPTION
This changes the NAVUpdated event to have an `exact` parameter, and
adds inexact NAVUpdated events for loan actions which modify the NAV.

Closes #641