### PR TITLE
Cap number of roles per location in permissions pallet

### DIFF
--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -237,6 +237,8 @@ parameter_types! {
 	pub const MaxTranches: TrancheId = 5;
 	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MinDelay: Moment = 0;
+
+	pub const MaxRoles: u32 = u32::MAX;
 }
 impl pallet_permissions::Config for MockRuntime {
 	type Event = Event;
@@ -246,6 +248,7 @@ impl pallet_permissions::Config for MockRuntime {
 		PermissionRoles<TimeProvider<Timestamp>, MaxTranches, MinDelay, TrancheId, Moment>;
 	type Editors = frame_support::traits::Everything;
 	type AdminOrigin = EnsureSignedBy<One, u64>;
+	type MaxRolesPerLocation = MaxRoles;
 	type WeightInfo = ();
 }
 

--- a/pallets/permissions/src/mock.rs
+++ b/pallets/permissions/src/mock.rs
@@ -267,6 +267,7 @@ impl frame_system::Config for MockRuntime {
 
 parameter_types! {
 	pub const One: u64 = 1;
+	pub const MaxRoles: u32 = 10;
 }
 
 impl pallet_permissions::Config for MockRuntime {
@@ -276,6 +277,7 @@ impl pallet_permissions::Config for MockRuntime {
 	type Storage = Storage;
 	type AdminOrigin = EnsureSignedBy<One, u64>;
 	type Editors = Editors;
+	type MaxRolesPerLocation = MaxRoles;
 	type WeightInfo = ();
 }
 

--- a/pallets/permissions/src/tests.rs
+++ b/pallets/permissions/src/tests.rs
@@ -377,3 +377,31 @@ fn trait_has_permission_permission_works() {
 			));
 		})
 }
+
+#[test]
+fn add_too_many_permissions_fails() {
+	TestExternalitiesBuilder::default()
+		.build(|| {})
+		.execute_with(|| {
+			for who in 0..MaxRoles::get() {
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+					Origin::signed(1),
+					Role::Organisation(OrganisationRole::HeadOfSaubermaching),
+					who.into(),
+					Location::PalletA,
+					Role::Organisation(OrganisationRole::SeniorExeutive)
+				));
+			}
+			let who = MaxRoles::get() + 1;
+			assert_noop!(
+				pallet_permissions::Pallet::<MockRuntime>::add_permission(
+					Origin::signed(1),
+					Role::Organisation(OrganisationRole::HeadOfSaubermaching),
+					who.into(),
+					Location::PalletA,
+					Role::Organisation(OrganisationRole::SeniorExeutive)
+				),
+				PermissionsError::<MockRuntime>::TooManyRoles
+			);
+		})
+}

--- a/pallets/permissions/src/tests.rs
+++ b/pallets/permissions/src/tests.rs
@@ -405,3 +405,62 @@ fn add_too_many_permissions_fails() {
 			);
 		})
 }
+
+#[test]
+fn permission_counting() {
+	TestExternalitiesBuilder::default()
+		.build(|| {})
+		.execute_with(|| {
+			assert!(
+				pallet_permissions::PermissionCount::<MockRuntime>::get(Location::PalletA,)
+					.is_none()
+			);
+
+			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
+				AccountId,
+			>>::add_permission(
+				Location::PalletA,
+				2,
+				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
+			));
+			assert_eq!(
+				pallet_permissions::PermissionCount::<MockRuntime>::get(Location::PalletA,),
+				Some(1)
+			);
+
+			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
+				AccountId,
+			>>::add_permission(
+				Location::PalletA,
+				3,
+				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
+			));
+			assert_eq!(
+				pallet_permissions::PermissionCount::<MockRuntime>::get(Location::PalletA,),
+				Some(2)
+			);
+
+			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
+				AccountId,
+			>>::rm_permission(
+				Location::PalletA,
+				3,
+				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
+			));
+			assert_eq!(
+				pallet_permissions::PermissionCount::<MockRuntime>::get(Location::PalletA,),
+				Some(1)
+			);
+			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
+				AccountId,
+			>>::rm_permission(
+				Location::PalletA,
+				2,
+				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
+			));
+			assert!(
+				pallet_permissions::PermissionCount::<MockRuntime>::get(Location::PalletA,)
+					.is_none(),
+			);
+		})
+}

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -98,6 +98,8 @@ parameter_types! {
 	pub const MaxTranches: TrancheId = 5;
 	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MinDelay: Moment = 0;
+
+	pub const MaxRoles: u32 = u32::MAX;
 }
 impl pallet_permissions::Config for Test {
 	type Event = Event;
@@ -107,6 +109,7 @@ impl pallet_permissions::Config for Test {
 		PermissionRoles<TimeProvider<Timestamp>, MaxTranches, MinDelay, TrancheId, Moment>;
 	type AdminOrigin = EnsureSignedBy<One, u64>;
 	type Editors = frame_support::traits::Everything;
+	type MaxRolesPerLocation = MaxRoles;
 	type WeightInfo = ();
 }
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -968,6 +968,9 @@ parameter_types! {
 	pub const MaxTranches: TrancheId = 5;
 	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MinDelay: Moment = 30 * SECONDS_PER_DAY;
+
+	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
+	pub const MaxRolesPerPool: u32 = 1_000;
 }
 
 impl pallet_permissions::Config for Runtime {
@@ -978,6 +981,7 @@ impl pallet_permissions::Config for Runtime {
 		PermissionRoles<TimeProvider<Timestamp>, MaxTranches, MinDelay, TrancheId, Moment>;
 	type Editors = Editors;
 	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
+	type MaxRolesPerLocation = MaxRolesPerPool;
 	type WeightInfo = weights::pallet_permissions::SubstrateWeight<Runtime>;
 }
 


### PR DESCRIPTION
Previously this was unbounded, which is a potential DOS vector against
the chain.

Rather than taking a deposit per-assigned-role, we instead set a
"sufficiently large" limit on the roles per location and expect that
the creation of that location will handle taking a deposit for the
entire thing.

In our current usage, a "location" is a pool, so this deposit needs to
be taken by the pool pallet.

This also refactors the permissions pallet slightly to avoid using a
`map_or` with a complex default. Instead we use the built-in substrate
`try_mutate` and take a more procedural code approach to the
permissions manipulation.