### PR TITLE
Rename permission extrinsic names

### DIFF
--- a/libs/common-traits/src/lib.rs
+++ b/libs/common-traits/src/lib.rs
@@ -132,15 +132,15 @@ pub trait Permissions<AccountId> {
 	type Error;
 	type Ok;
 
-	fn has_permission(location: Self::Location, who: AccountId, role: Self::Role) -> bool;
+	fn has(location: Self::Location, who: AccountId, role: Self::Role) -> bool;
 
-	fn add_permission(
+	fn add(
 		location: Self::Location,
 		who: AccountId,
 		role: Self::Role,
 	) -> Result<Self::Ok, Self::Error>;
 
-	fn rm_permission(
+	fn remove(
 		location: Self::Location,
 		who: AccountId,
 		role: Self::Role,

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -600,7 +600,7 @@ macro_rules! ensure_role {
 	( $pool_id:expr, $origin:expr, $role:expr $(,)? ) => {{
 		let sender = ensure_signed($origin)?;
 		ensure!(
-			T::Permission::has_permission($pool_id, sender.clone(), $role),
+			T::Permission::has($pool_id, sender.clone(), $role),
 			BadOrigin
 		);
 		sender

--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -255,7 +255,7 @@ impl pallet_permissions::Config for MockRuntime {
 parameter_types! {
 	pub const LoansPalletId: PalletId = PalletId(*b"roc/loan");
 	pub const MaxLoansPerPool: u64 = 200;
-	pub const MaxWriteOffgroups: u32 = 10;
+	pub const MaxWriteOffGroups: u32 = 10;
 }
 
 impl pallet_loans::Config for MockRuntime {
@@ -271,7 +271,7 @@ impl pallet_loans::Config for MockRuntime {
 	type Permission = Permissions;
 	type WeightInfo = ();
 	type MaxLoansPerPool = MaxLoansPerPool;
-	type MaxWriteOffGroups = MaxWriteOffgroups;
+	type MaxWriteOffGroups = MaxWriteOffGroups;
 }
 
 // USD currencyId

--- a/pallets/loans/src/test_utils.rs
+++ b/pallets/loans/src/test_utils.rs
@@ -38,7 +38,7 @@ pub(crate) fn set_role<T: pallet_loans::Config>(
 	who: T::AccountId,
 	role: PoolRole,
 ) {
-	PermissionsOf::<T>::add_permission(location, who, role)
+	PermissionsOf::<T>::add(location, who, role)
 		.expect("adding permissions should not fail");
 }
 

--- a/pallets/loans/src/test_utils.rs
+++ b/pallets/loans/src/test_utils.rs
@@ -38,8 +38,7 @@ pub(crate) fn set_role<T: pallet_loans::Config>(
 	who: T::AccountId,
 	role: PoolRole,
 ) {
-	PermissionsOf::<T>::add(location, who, role)
-		.expect("adding permissions should not fail");
+	PermissionsOf::<T>::add(location, who, role).expect("adding permissions should not fail");
 }
 
 parameter_types! {

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -83,14 +83,14 @@ where
 		CurrencyId::Usd,
 	);
 	// add borrower role and price admin role
-	assert_ok!(pallet_permissions::Pallet::<T>::add_permission(
+	assert_ok!(pallet_permissions::Pallet::<T>::add(
 		Origin::signed(pool_admin),
 		PoolRole::PoolAdmin,
 		borrower,
 		pool_id,
 		PoolRole::Borrower,
 	));
-	assert_ok!(pallet_permissions::Pallet::<T>::add_permission(
+	assert_ok!(pallet_permissions::Pallet::<T>::add(
 		Origin::signed(pool_admin),
 		PoolRole::PoolAdmin,
 		borrower,
@@ -610,7 +610,7 @@ macro_rules! test_borrow_loan {
 				// written off loan cannot borrow
 				// add write off groups
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(pool_admin),
 					PoolRole::PoolAdmin,
 					risk_admin,
@@ -1003,7 +1003,7 @@ macro_rules! test_pool_nav {
 				assert_eq!(exact, NAVUpdateType::Exact);
 
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(pool_admin),
 					PoolRole::PoolAdmin,
 					risk_admin,
@@ -1127,7 +1127,7 @@ fn test_add_write_off_groups() {
 			);
 			let pr_pool_id: PoolIdOf<MockRuntime> = pool_id.into();
 			initialise_test_pool::<MockRuntime>(pr_pool_id, 1, pool_admin, None);
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(pool_admin),
 				PoolRole::PoolAdmin,
 				risk_admin,
@@ -1211,7 +1211,7 @@ macro_rules! test_write_off_maturity_loan {
 
 				// add write off groups
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(pool_admin),
 					PoolRole::PoolAdmin,
 					risk_admin,
@@ -1303,7 +1303,7 @@ macro_rules! test_admin_write_off_loan_type {
 				// after one year
 				// caller should be admin, can write off before maturity
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(pool_admin),
 					PoolRole::PoolAdmin,
 					risk_admin,
@@ -1424,7 +1424,7 @@ macro_rules! test_close_written_off_loan_type {
 
 				// add write off groups
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(pool_admin),
 					PoolRole::PoolAdmin,
 					risk_admin,
@@ -1606,7 +1606,7 @@ macro_rules! write_off_overflow {
 				let caller = 42;
 				// add write off groups
 				let risk_admin = RiskAdmin::get();
-				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(pool_admin),
 					PoolRole::PoolAdmin,
 					risk_admin,

--- a/pallets/permissions/src/benchmarking.rs
+++ b/pallets/permissions/src/benchmarking.rs
@@ -38,95 +38,95 @@ benchmarks! {
 		<T as pallet_permissions::Config>::Location: From<u64>,
 	}
 
-	add_permission_admin {
+	add_as_admin {
 		let acc = admin::<T>(0);
 		let with_role = PoolRole::PoolAdmin;
 		let role = PoolRole::PoolAdmin;
 		let pool_id = 0;
-	}:add_permission(RawOrigin::Root, with_role.into(), acc.clone(), pool_id.into(), role.into())
+	}:add(RawOrigin::Root, with_role.into(), acc.clone(), pool_id.into(), role.into())
 	verify {
-		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc, role.into()));
+		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc, role.into()));
 	}
 
-	add_permission_editor {
+	add_as_editor {
 		// setup pool admin
 		let acc = admin::<T>(0);
 		let with_role = PoolRole::PoolAdmin;
 		let role = PoolRole::PoolAdmin;
 		let pool_id = 0;
-		let res = PermissionsPallet::<T>::add_permission(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
+		let res = PermissionsPallet::<T>::add(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
 		assert_ok!(res);
-		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc.clone(), role.into()));
+		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc.clone(), role.into()));
 
 		// setup borrower through pool admin
 		let acc2 = admin::<T>(1);
 		let role = PoolRole::Borrower;
-	}:add_permission(RawOrigin::Signed(acc.clone()), with_role.into(), acc2.clone(), pool_id.into(), role.into())
+	}:add(RawOrigin::Signed(acc.clone()), with_role.into(), acc2.clone(), pool_id.into(), role.into())
 	verify {
-		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc2, role.into()));
+		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc2, role.into()));
 	}
 
-	rm_permission_admin {
+	remove_as_admin {
 		// setup pool admin
 		let acc = admin::<T>(0);
 		let with_role = PoolRole::PoolAdmin;
 		let role = PoolRole::PoolAdmin;
 		let pool_id = 0;
-		let res = PermissionsPallet::<T>::add_permission(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
+		let res = PermissionsPallet::<T>::add(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
 		assert_ok!(res);
-		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc.clone(), role.into()));
-	}:rm_permission(RawOrigin::Root, with_role.into(), acc.clone(), pool_id.into(), role.into())
+		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc.clone(), role.into()));
+	}:remove(RawOrigin::Root, with_role.into(), acc.clone(), pool_id.into(), role.into())
 	verify {
-		assert!(!<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc, role.into()));
+		assert!(!<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc, role.into()));
 	}
 
-	rm_permission_editor {
+	remove_as_editor {
 		// setup pool admin
 		let acc = admin::<T>(0);
 		let with_role = PoolRole::PoolAdmin;
 		let role = PoolRole::PoolAdmin;
 		let pool_id = 0;
-		let res = PermissionsPallet::<T>::add_permission(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
+		let res = PermissionsPallet::<T>::add(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
 		assert_ok!(res);
-		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc.clone(), role.into()));
+		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc.clone(), role.into()));
 
 		// setup borrower through pool admin
 		let acc2 = admin::<T>(1);
 		let role = PoolRole::Borrower;
-		let res = PermissionsPallet::<T>::add_permission(RawOrigin::Signed(acc.clone()).into(), with_role.into(), acc2.clone(), pool_id.into(), role.into());
+		let res = PermissionsPallet::<T>::add(RawOrigin::Signed(acc.clone()).into(), with_role.into(), acc2.clone(), pool_id.into(), role.into());
 		assert_ok!(res);
-		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc2.clone(), role.into()));
-	}:rm_permission(RawOrigin::Signed(acc), with_role.into(), acc2.clone(), pool_id.into(), role.into())
+		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc2.clone(), role.into()));
+	}:remove(RawOrigin::Signed(acc), with_role.into(), acc2.clone(), pool_id.into(), role.into())
 	verify {
-		assert!(!<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc2, role.into()));
+		assert!(!<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc2, role.into()));
 	}
 
-	purge_permissions {
+	purge {
 		// setup pool admin
 		let acc = admin::<T>(0);
 		let with_role = PoolRole::PoolAdmin;
 		let role = PoolRole::PoolAdmin;
 		let pool_id = 0;
-		let res = PermissionsPallet::<T>::add_permission(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
+		let res = PermissionsPallet::<T>::add(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
 		assert_ok!(res);
-		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc.clone(), role.into()));
+		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc.clone(), role.into()));
 	}:_(RawOrigin::Signed(acc.clone()), pool_id.into())
 	verify {
-		assert!(!<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc, role.into()));
+		assert!(!<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc, role.into()));
 	}
 
-	admin_purge_permissions {
+	admin_purge {
 		// setup pool admin
 		let acc = admin::<T>(0);
 		let with_role = PoolRole::PoolAdmin;
 		let role = PoolRole::PoolAdmin;
 		let pool_id = 0;
-		let res = PermissionsPallet::<T>::add_permission(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
+		let res = PermissionsPallet::<T>::add(RawOrigin::Root.into(), with_role.into(), acc.clone(), pool_id.into(), role.into());
 		assert_ok!(res);
-		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc.clone(), role.into()));
+		assert!(<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc.clone(), role.into()));
 	}:_(RawOrigin::Root, acc.clone(), pool_id.into())
 	verify {
-		assert!(!<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has_permission(pool_id.into(), acc, role.into()));
+		assert!(!<PermissionsPallet::<T> as TPermissions<T::AccountId>>::has(pool_id.into(), acc, role.into()));
 	}
 }
 

--- a/pallets/permissions/src/lib.rs
+++ b/pallets/permissions/src/lib.rs
@@ -284,11 +284,7 @@ impl<T: Config> Permissions<T::AccountId> for Pallet<T> {
 		Permission::<T>::get(who, location).map_or(false, |roles| roles.exists(role))
 	}
 
-	fn add(
-		location: T::Location,
-		who: T::AccountId,
-		role: T::Role,
-	) -> Result<(), DispatchError> {
+	fn add(location: T::Location, who: T::AccountId, role: T::Role) -> Result<(), DispatchError> {
 		Pallet::<T>::do_add(location, who, role)
 	}
 

--- a/pallets/permissions/src/mock.rs
+++ b/pallets/permissions/src/mock.rs
@@ -184,11 +184,11 @@ mod dummy {
 				let who = ensure_signed(origin)?;
 
 				ensure!(
-					!T::Permission::has_permission(location.clone(), who.clone(), role.clone()),
+					!T::Permission::has(location.clone(), who.clone(), role.clone()),
 					Error::<T>::AlreadyCleared
 				);
 
-				T::Permission::add_permission(location, who, role)?;
+				T::Permission::add(location, who, role)?;
 
 				Ok(())
 			}
@@ -202,11 +202,11 @@ mod dummy {
 				let who = ensure_signed(origin)?;
 
 				ensure!(
-					T::Permission::has_permission(location.clone(), who.clone(), role.clone()),
+					T::Permission::has(location.clone(), who.clone(), role.clone()),
 					Error::<T>::NotCleared
 				);
 
-				T::Permission::rm_permission(location, who, role)?;
+				T::Permission::remove(location, who, role)?;
 
 				Ok(())
 			}

--- a/pallets/permissions/src/tests.rs
+++ b/pallets/permissions/src/tests.rs
@@ -177,12 +177,10 @@ fn user_purge_permission_ext_works() {
 				Role::Organisation(OrganisationRole::SeniorExeutive)
 			));
 
-			assert_ok!(
-				pallet_permissions::Pallet::<MockRuntime>::purge(
-					Origin::signed(2),
-					Location::PalletA
-				)
-			);
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::purge(
+				Origin::signed(2),
+				Location::PalletA
+			));
 
 			assert!(
 				pallet_permissions::Permission::<MockRuntime>::get(2, Location::PalletA).is_none()
@@ -230,13 +228,11 @@ fn admin_purge_permission_ext_works() {
 				Role::Organisation(OrganisationRole::SeniorExeutive)
 			));
 
-			assert_ok!(
-				pallet_permissions::Pallet::<MockRuntime>::admin_purge(
-					Origin::signed(1),
-					2,
-					Location::PalletA,
-				)
-			);
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::admin_purge(
+				Origin::signed(1),
+				2,
+				Location::PalletA,
+			));
 
 			assert!(
 				pallet_permissions::Permission::<MockRuntime>::get(2, Location::PalletA,).is_none()

--- a/pallets/permissions/src/tests.rs
+++ b/pallets/permissions/src/tests.rs
@@ -18,11 +18,11 @@ use frame_support::{assert_noop, assert_ok};
 use pallet_permissions::{Permissions, Properties};
 
 #[test]
-fn add_permission_ext_works() {
+fn add_ext_works() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -30,7 +30,7 @@ fn add_permission_ext_works() {
 				Role::Organisation(OrganisationRole::SeniorExeutive)
 			));
 
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -38,7 +38,7 @@ fn add_permission_ext_works() {
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
 			));
 
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -61,11 +61,11 @@ fn add_permission_ext_works() {
 }
 
 #[test]
-fn add_permission_ext_fails() {
+fn add_ext_fails() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -74,7 +74,7 @@ fn add_permission_ext_fails() {
 			));
 
 			assert_noop!(
-				pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(1),
 					Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 					2,
@@ -87,11 +87,11 @@ fn add_permission_ext_fails() {
 }
 
 #[test]
-fn rm_permission_ext_works() {
+fn remove_ext_works() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -99,7 +99,7 @@ fn rm_permission_ext_works() {
 				Role::Xcm(XcmRole::Sender)
 			));
 
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::rm_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::remove(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -114,12 +114,12 @@ fn rm_permission_ext_works() {
 }
 
 #[test]
-fn rm_permission_ext_fails() {
+fn remove_ext_fails() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
 			assert_noop!(
-				pallet_permissions::Pallet::<MockRuntime>::rm_permission(
+				pallet_permissions::Pallet::<MockRuntime>::remove(
 					Origin::signed(1),
 					Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 					2,
@@ -129,7 +129,7 @@ fn rm_permission_ext_fails() {
 				PermissionsError::<MockRuntime>::NoRoles
 			);
 
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -138,7 +138,7 @@ fn rm_permission_ext_fails() {
 			));
 
 			assert_noop!(
-				pallet_permissions::Pallet::<MockRuntime>::rm_permission(
+				pallet_permissions::Pallet::<MockRuntime>::remove(
 					Origin::signed(1),
 					Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 					2,
@@ -161,7 +161,7 @@ fn user_purge_permission_ext_works() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -169,7 +169,7 @@ fn user_purge_permission_ext_works() {
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
 			));
 
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -178,7 +178,7 @@ fn user_purge_permission_ext_works() {
 			));
 
 			assert_ok!(
-				pallet_permissions::Pallet::<MockRuntime>::purge_permissions(
+				pallet_permissions::Pallet::<MockRuntime>::purge(
 					Origin::signed(2),
 					Location::PalletA
 				)
@@ -196,7 +196,7 @@ fn user_purge_permission_ext_fails() {
 		.build(|| {})
 		.execute_with(|| {
 			assert_noop!(
-				pallet_permissions::Pallet::<MockRuntime>::purge_permissions(
+				pallet_permissions::Pallet::<MockRuntime>::purge(
 					Origin::signed(2),
 					Location::PalletA
 				),
@@ -214,7 +214,7 @@ fn admin_purge_permission_ext_works() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -222,7 +222,7 @@ fn admin_purge_permission_ext_works() {
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
 			));
 
-			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+			assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 				Origin::signed(1),
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 				2,
@@ -231,7 +231,7 @@ fn admin_purge_permission_ext_works() {
 			));
 
 			assert_ok!(
-				pallet_permissions::Pallet::<MockRuntime>::admin_purge_permissions(
+				pallet_permissions::Pallet::<MockRuntime>::admin_purge(
 					Origin::signed(1),
 					2,
 					Location::PalletA,
@@ -250,7 +250,7 @@ fn admin_purge_permission_ext_fails() {
 		.build(|| {})
 		.execute_with(|| {
 			assert_noop!(
-				pallet_permissions::Pallet::<MockRuntime>::admin_purge_permissions(
+				pallet_permissions::Pallet::<MockRuntime>::admin_purge(
 					Origin::signed(1),
 					2,
 					Location::PalletA,
@@ -265,20 +265,20 @@ fn admin_purge_permission_ext_fails() {
 }
 
 #[test]
-fn trait_add_permission_fails() {
+fn trait_add_fails() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
 			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::add_permission(
+			>>::add(
 				Location::PalletA,
 				2,
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
 			));
 
 			assert_noop!(
-				<pallet_permissions::Pallet<MockRuntime> as Permissions<AccountId>>::add_permission(
+				<pallet_permissions::Pallet<MockRuntime> as Permissions<AccountId>>::add(
 					Location::PalletA,
 					2,
 					Role::Organisation(OrganisationRole::HeadOfSaubermaching)
@@ -289,7 +289,7 @@ fn trait_add_permission_fails() {
 }
 
 #[test]
-fn trait_add_permission_works() {
+fn trait_add_works() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
@@ -300,7 +300,7 @@ fn trait_add_permission_works() {
 			));
 
 			assert_noop!(
-				<pallet_permissions::Pallet<MockRuntime> as Permissions<AccountId>>::add_permission(
+				<pallet_permissions::Pallet<MockRuntime> as Permissions<AccountId>>::add(
 					Location::PalletA,
 					2,
 					Role::Organisation(OrganisationRole::HeadOfSaubermaching)
@@ -311,7 +311,7 @@ fn trait_add_permission_works() {
 }
 
 #[test]
-fn trait_rm_permission_fails() {
+fn trait_remove_fails() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
@@ -327,13 +327,13 @@ fn trait_rm_permission_fails() {
 }
 
 #[test]
-fn trait_rm_permission_works() {
+fn trait_remove_works() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
 			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::add_permission(
+			>>::add(
 				Location::PalletA,
 				2,
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
@@ -348,13 +348,13 @@ fn trait_rm_permission_works() {
 }
 
 #[test]
-fn trait_has_permission_permission_works() {
+fn trait_has_permission_works() {
 	TestExternalitiesBuilder::default()
 		.build(|| {})
 		.execute_with(|| {
 			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::add_permission(
+			>>::add(
 				Location::PalletA,
 				2,
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
@@ -362,7 +362,7 @@ fn trait_has_permission_permission_works() {
 
 			assert!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::has_permission(
+			>>::has(
 				Location::PalletA,
 				2,
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
@@ -370,7 +370,7 @@ fn trait_has_permission_permission_works() {
 
 			assert!(!<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::has_permission(
+			>>::has(
 				Location::PalletA,
 				2,
 				Role::Organisation(OrganisationRole::SeniorExeutive)
@@ -384,7 +384,7 @@ fn add_too_many_permissions_fails() {
 		.build(|| {})
 		.execute_with(|| {
 			for who in 0..MaxRoles::get() {
-				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				assert_ok!(pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(1),
 					Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 					who.into(),
@@ -394,7 +394,7 @@ fn add_too_many_permissions_fails() {
 			}
 			let who = MaxRoles::get() + 1;
 			assert_noop!(
-				pallet_permissions::Pallet::<MockRuntime>::add_permission(
+				pallet_permissions::Pallet::<MockRuntime>::add(
 					Origin::signed(1),
 					Role::Organisation(OrganisationRole::HeadOfSaubermaching),
 					who.into(),
@@ -418,7 +418,7 @@ fn permission_counting() {
 
 			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::add_permission(
+			>>::add(
 				Location::PalletA,
 				2,
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
@@ -430,7 +430,7 @@ fn permission_counting() {
 
 			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::add_permission(
+			>>::add(
 				Location::PalletA,
 				3,
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
@@ -442,7 +442,7 @@ fn permission_counting() {
 
 			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::rm_permission(
+			>>::remove(
 				Location::PalletA,
 				3,
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)
@@ -453,7 +453,7 @@ fn permission_counting() {
 			);
 			assert_ok!(<pallet_permissions::Pallet<MockRuntime> as Permissions<
 				AccountId,
-			>>::rm_permission(
+			>>::remove(
 				Location::PalletA,
 				2,
 				Role::Organisation(OrganisationRole::HeadOfSaubermaching)

--- a/pallets/permissions/src/weights.rs
+++ b/pallets/permissions/src/weights.rs
@@ -29,43 +29,43 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_permissions.
 pub trait WeightInfo {
-	fn add_permission_admin() -> Weight;
-	fn add_permission_editor() -> Weight;
-	fn rm_permission_admin() -> Weight;
-	fn rm_permission_editor() -> Weight;
-	fn purge_permissions() -> Weight;
-	fn admin_purge_permissions() -> Weight;
+	fn add_as_admin() -> Weight;
+	fn add_as_editor() -> Weight;
+	fn remove_as_admin() -> Weight;
+	fn remove_as_editor() -> Weight;
+	fn purge() -> Weight;
+	fn admin_purge() -> Weight;
 }
 
 /// Weights for pallet_permissions using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn add_permission_admin() -> Weight {
+	fn add_as_admin() -> Weight {
 		(85_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn add_permission_editor() -> Weight {
+	fn add_as_editor() -> Weight {
 		(106_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn rm_permission_admin() -> Weight {
+	fn remove_as_admin() -> Weight {
 		(90_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn rm_permission_editor() -> Weight {
+	fn remove_as_editor() -> Weight {
 		(109_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn purge_permissions() -> Weight {
+	fn purge() -> Weight {
 		(86_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn admin_purge_permissions() -> Weight {
+	fn admin_purge() -> Weight {
 		(86_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
@@ -74,32 +74,32 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn add_permission_admin() -> Weight {
+	fn add_as_admin() -> Weight {
 		(85_000_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
-	fn add_permission_editor() -> Weight {
+	fn add_as_editor() -> Weight {
 		(106_000_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
-	fn rm_permission_admin() -> Weight {
+	fn remove_as_admin() -> Weight {
 		(90_000_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
-	fn rm_permission_editor() -> Weight {
+	fn remove_as_editor() -> Weight {
 		(109_000_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
-	fn purge_permissions() -> Weight {
+	fn purge() -> Weight {
 		(86_000_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
-	fn admin_purge_permissions() -> Weight {
+	fn admin_purge() -> Weight {
 		(86_000_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))

--- a/pallets/pools/src/benchmarking.rs
+++ b/pallets/pools/src/benchmarking.rs
@@ -268,7 +268,7 @@ benchmarks! {
 	}: approve_role_for(RawOrigin::Signed(admin), POOL, role.clone(), account_lookups)
 	verify {
 		for account in accounts {
-			assert!(T::Permission::has_permission(POOL, account.into(), role.clone()));
+			assert!(T::Permission::has(POOL, account.into(), role.clone()));
 		}
 	}
 
@@ -280,7 +280,7 @@ benchmarks! {
 		Pallet::<T>::approve_role_for(RawOrigin::Signed(admin.clone()).into(), POOL, role.clone(), vec![account.clone().into()])?;
 	}: revoke_role_for(RawOrigin::Signed(admin), POOL, role.clone(), account.clone().into())
 	verify {
-		assert!(!T::Permission::has_permission(POOL, account.into(), role));
+		assert!(!T::Permission::has(POOL, account.into(), role));
 	}
 }
 

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -504,7 +504,7 @@ pub mod pallet {
 					metadata: None,
 				},
 			);
-			T::Permission::add_permission(pool_id, admin.clone(), PoolRole::PoolAdmin)?;
+			T::Permission::add(pool_id, admin.clone(), PoolRole::PoolAdmin)?;
 			Self::deposit_event(Event::Created(pool_id, admin));
 			Ok(())
 		}
@@ -526,7 +526,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(
-				T::Permission::has_permission(pool_id, who.clone(), PoolRole::PoolAdmin),
+				T::Permission::has(pool_id, who.clone(), PoolRole::PoolAdmin),
 				BadOrigin
 			);
 
@@ -560,7 +560,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(
-				T::Permission::has_permission(pool_id, who.clone(), PoolRole::PoolAdmin),
+				T::Permission::has(pool_id, who.clone(), PoolRole::PoolAdmin),
 				BadOrigin
 			);
 
@@ -592,7 +592,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(
-				T::Permission::has_permission(pool_id, who.clone(), PoolRole::LiquidityAdmin),
+				T::Permission::has(pool_id, who.clone(), PoolRole::LiquidityAdmin),
 				BadOrigin
 			);
 
@@ -620,7 +620,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(
-				T::Permission::has_permission(pool_id, who.clone(), PoolRole::PoolAdmin),
+				T::Permission::has(pool_id, who.clone(), PoolRole::PoolAdmin),
 				BadOrigin
 			);
 
@@ -676,7 +676,7 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 
 			ensure!(
-				T::Permission::has_permission(
+				T::Permission::has(
 					pool_id,
 					who.clone(),
 					PoolRole::TrancheInvestor(tranche_id, Self::now())
@@ -738,7 +738,7 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 
 			ensure!(
-				T::Permission::has_permission(
+				T::Permission::has(
 					pool_id,
 					who.clone(),
 					PoolRole::TrancheInvestor(tranche_id, Self::now())

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -363,10 +363,10 @@ pub mod pallet {
 			T::AccountId,
 			OutstandingCollections<T::Balance>,
 		),
-		/// An invest order was updated. [pool, account]
-		InvestOrderUpdated(T::PoolId, T::AccountId),
-		/// A redeem order was updated. [pool, account]
-		RedeemOrderUpdated(T::PoolId, T::AccountId),
+		/// An invest order was updated. [pool, tranche, account]
+		InvestOrderUpdated(T::PoolId, T::TrancheId, T::AccountId),
+		/// A redeem order was updated. [pool, tranche, account]
+		RedeemOrderUpdated(T::PoolId, T::TrancheId, T::AccountId),
 	}
 
 	// Errors inform users that something went wrong.
@@ -709,7 +709,7 @@ pub mod pallet {
 				)
 			})?;
 
-			Self::deposit_event(Event::InvestOrderUpdated(pool_id, who));
+			Self::deposit_event(Event::InvestOrderUpdated(pool_id, tranche_id, who));
 			Ok(())
 		}
 
@@ -771,7 +771,7 @@ pub mod pallet {
 				)
 			})?;
 
-			Self::deposit_event(Event::RedeemOrderUpdated(pool_id, who));
+			Self::deposit_event(Event::RedeemOrderUpdated(pool_id, tranche_id, who));
 			Ok(())
 		}
 

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -250,8 +250,8 @@ where
 		match id {
 			CurrencyId::Usd => true,
 			CurrencyId::Tranche(pool_id, tranche_id) => {
-				P::has_permission(pool_id, send, PoolRole::TrancheInvestor(tranche_id, UNION))
-					&& P::has_permission(
+				P::has(pool_id, send, PoolRole::TrancheInvestor(tranche_id, UNION))
+					&& P::has(
 						pool_id,
 						recv,
 						PoolRole::TrancheInvestor(tranche_id, UNION),

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -251,11 +251,7 @@ where
 			CurrencyId::Usd => true,
 			CurrencyId::Tranche(pool_id, tranche_id) => {
 				P::has(pool_id, send, PoolRole::TrancheInvestor(tranche_id, UNION))
-					&& P::has(
-						pool_id,
-						recv,
-						PoolRole::TrancheInvestor(tranche_id, UNION),
-					)
+					&& P::has(pool_id, recv, PoolRole::TrancheInvestor(tranche_id, UNION))
 			}
 			CurrencyId::Native => true,
 		}

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -403,14 +403,14 @@ fn epoch() {
 		let pool_owner_origin = Origin::signed(pool_owner);
 		let borrower = 3;
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(JUNIOR_TRANCHE_ID, u64::MAX),
 		)
 		.unwrap();
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(senior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(SENIOR_TRANCHE_ID, u64::MAX),
@@ -645,14 +645,14 @@ fn submission_period() {
 		let pool_owner = 2_u64;
 		let pool_owner_origin = Origin::signed(pool_owner);
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(JUNIOR_TRANCHE_ID, u64::MAX),
 		)
 		.unwrap();
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(senior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(SENIOR_TRANCHE_ID, u64::MAX),
@@ -854,14 +854,14 @@ fn execute_info_removed_after_epoch_execute() {
 		let pool_owner = 2_u64;
 		let pool_owner_origin = Origin::signed(pool_owner);
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(JUNIOR_TRANCHE_ID, u64::MAX),
 		)
 		.unwrap();
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(senior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(SENIOR_TRANCHE_ID, u64::MAX),
@@ -951,14 +951,14 @@ fn collect_tranche_tokens() {
 		let pool_owner = 2_u64;
 		let pool_owner_origin = Origin::signed(pool_owner);
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(JUNIOR_TRANCHE_ID, u64::MAX),
 		)
 		.unwrap();
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(senior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(SENIOR_TRANCHE_ID, u64::MAX),
@@ -1091,7 +1091,7 @@ fn invalid_tranche_id_is_err() {
 		let junior_investor = Origin::signed(0);
 		let senior_investor = Origin::signed(1);
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(1, u64::MAX),
@@ -1125,7 +1125,7 @@ fn updating_with_same_amount_is_err() {
 		let junior_investor = Origin::signed(0);
 		let senior_investor = Origin::signed(1);
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			0,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(0, u64::MAX),
@@ -1226,7 +1226,7 @@ fn updating_orders_updates_epoch() {
 		let pool_id = 0;
 		let jun_tranche_id = 0;
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			pool_id,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(jun_tranche_id, u64::MAX),
@@ -1292,7 +1292,7 @@ fn no_order_is_err() {
 		let pool_id = 0;
 		let jun_tranche_id = 0;
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			pool_id,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(jun_tranche_id, u64::MAX),
@@ -1330,7 +1330,7 @@ fn collecting_over_last_exec_epoch_is_err() {
 		let pool_id = 0;
 		let jun_tranche_id = 0;
 
-		<<Test as Config>::Permission as PermissionsT<u64>>::add_permission(
+		<<Test as Config>::Permission as PermissionsT<u64>>::add(
 			pool_id,
 			ensure_signed(junior_investor.clone()).unwrap(),
 			PoolRole::TrancheInvestor(jun_tranche_id, u64::MAX),

--- a/pallets/restricted-tokens/src/benchmarking.rs
+++ b/pallets/restricted-tokens/src/benchmarking.rs
@@ -105,7 +105,7 @@ fn permission_for_tranche<T>(acc: T::AccountId, pool_id: PoolId, tranche_id: Tra
 where
 	T: frame_system::Config + pallet_permissions::Config<Location = PoolId, Role = PoolRole>,
 {
-	<pallet_permissions::Pallet<T> as Permissions<T::AccountId>>::add_permission(
+	<pallet_permissions::Pallet<T> as Permissions<T::AccountId>>::add(
 		pool_id,
 		acc,
 		PoolRole::TrancheInvestor(tranche_id, u64::MAX),

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1039,11 +1039,7 @@ where
 			CurrencyId::Usd | CurrencyId::Native => true,
 			CurrencyId::Tranche(pool_id, tranche_id) => {
 				P::has(pool_id, send, PoolRole::TrancheInvestor(tranche_id, UNION))
-					&& P::has(
-						pool_id,
-						recv,
-						PoolRole::TrancheInvestor(tranche_id, UNION),
-					)
+					&& P::has(pool_id, recv, PoolRole::TrancheInvestor(tranche_id, UNION))
 			}
 		}
 	}

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -944,7 +944,7 @@ impl pallet_collator_selection::Config for Runtime {
 parameter_types! {
 	pub const LoansPalletId: PalletId = PalletId(*b"roc/loan");
 	pub const MaxLoansPerPool: u64 = 50;
-	pub const MaxWriteOffgroups: u32 = 10;
+	pub const MaxWriteOffGroups: u32 = 10;
 }
 
 impl pallet_loans::Config for Runtime {
@@ -960,14 +960,16 @@ impl pallet_loans::Config for Runtime {
 	type Permission = Permissions;
 	type WeightInfo = pallet_loans::weights::SubstrateWeight<Self>;
 	type MaxLoansPerPool = MaxLoansPerPool;
-	type MaxWriteOffGroups = MaxWriteOffgroups;
+	type MaxWriteOffGroups = MaxWriteOffGroups;
 }
 
 parameter_types! {
 	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MaxTranches: TrancheId = 5;
+
+	// How much time should lapse before a tranche investor can be removed
 	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
-	pub const MinDelay: Moment = 30 * SECONDS_PER_DAY;
+	pub const MinDelay: Moment = 7 * SECONDS_PER_DAY;
 
 	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MaxRolesPerPool: u32 = 1_000;
@@ -1036,8 +1038,8 @@ where
 		match id {
 			CurrencyId::Usd | CurrencyId::Native => true,
 			CurrencyId::Tranche(pool_id, tranche_id) => {
-				P::has_permission(pool_id, send, PoolRole::TrancheInvestor(tranche_id, UNION))
-					&& P::has_permission(
+				P::has(pool_id, send, PoolRole::TrancheInvestor(tranche_id, UNION))
+					&& P::has(
 						pool_id,
 						recv,
 						PoolRole::TrancheInvestor(tranche_id, UNION),

--- a/runtime/development/src/weights/pallet_permissions.rs
+++ b/runtime/development/src/weights/pallet_permissions.rs
@@ -31,32 +31,32 @@ use sp_std::marker::PhantomData;
 /// Weights for pallet_permissions using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn add_permission_admin() -> Weight {
+	fn add_as_admin() -> Weight {
 		(70_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn add_permission_editor() -> Weight {
+	fn add_as_editor() -> Weight {
 		(55_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn rm_permission_admin() -> Weight {
+	fn remove_as_admin() -> Weight {
 		(45_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn rm_permission_editor() -> Weight {
+	fn remove_as_editor() -> Weight {
 		(56_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn purge_permissions() -> Weight {
+	fn purge() -> Weight {
 		(41_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn admin_purge_permissions() -> Weight {
+	fn admin_purge() -> Weight {
 		(41_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))


### PR DESCRIPTION
- Closes #691
- Fixes a casing typo in the runtime
- Adds `tranche_id` to the `InvestOrderUpdated` and `RedeemOrderUpdated` events, as without this, the client does not know which tranche the order was updated for, and they need to check orders for all tranches of the pool.