### PR TITLE
Move back to `shaunxw/xcm-simulator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12659,7 +12659,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.1.0"
-source = "git+https://github.com/NunoAlexandre/xcm-simulator?rev=bb08aefda9cecd39814fba7abae7b7b1c69019f5#bb08aefda9cecd39814fba7abae7b7b1c69019f5"
+source = "git+https://github.com/shaunxw/xcm-simulator?rev=24ccbce563d1f99019b4cdfa2f3af4e99bac0dfc#24ccbce563d1f99019b4cdfa2f3af4e99bac0dfc"
 dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -37,7 +37,7 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "master" }
 
 # Misc
-xcm-emulator = { git = "https://github.com/NunoAlexandre/xcm-simulator", rev="bb08aefda9cecd39814fba7abae7b7b1c69019f5" }
+xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev="24ccbce563d1f99019b4cdfa2f3af4e99bac0dfc" }
 
 # Local
 runtime-common = { path = "../common" }


### PR DESCRIPTION
My pr updating that dependency to polkadot v17 has been merged so we can
move back to use the official project.