### PR TITLE
Switch TrancheId generator hash-algorithm

### DIFF
--- a/pallets/loans/src/test_utils.rs
+++ b/pallets/loans/src/test_utils.rs
@@ -22,7 +22,7 @@ use common_types::PoolRole;
 use frame_support::sp_runtime::traits::One;
 use frame_support::traits::fungibles::Transfer;
 use frame_support::traits::tokens::nonfungibles::{Create, Inspect, Mutate};
-use frame_support::{assert_ok, parameter_types, StorageHasher, Twox128};
+use frame_support::{assert_ok, parameter_types, Blake2_128, StorageHasher};
 use frame_system::RawOrigin;
 use pallet_pools::TrancheLoc;
 use pallet_pools::TrancheType;
@@ -45,7 +45,7 @@ pub(crate) fn set_role<T: pallet_loans::Config>(
 
 fn create_tranche_id(pool: u64, tranche: u64) -> [u8; 16] {
 	let hash_input = (tranche, pool).encode();
-	Twox128::hash(&hash_input)
+	Blake2_128::hash(&hash_input)
 }
 
 parameter_types! {

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::traits::SortedMembers;
 use frame_support::{
 	parameter_types,
 	traits::{GenesisBuild, Hooks},
-	StorageHasher, Twox128,
+	Blake2_128, StorageHasher,
 };
 use frame_system as system;
 use frame_system::{EnsureSigned, EnsureSignedBy};
@@ -312,7 +312,7 @@ pub const CURRENCY: Balance = 1_000_000_000_000_000_000;
 
 fn create_tranche_id(pool: u64, tranche: u64) -> [u8; 16] {
 	let hash_input = (tranche, pool).encode();
-	Twox128::hash(&hash_input)
+	Blake2_128::hash(&hash_input)
 }
 
 parameter_types! {

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -432,7 +432,7 @@ where
 	/// Defines how a given salt will be transformed into
 	/// a TrancheId.
 	fn id_from_salt(salt: TrancheSalt<PoolId>) -> TrancheId {
-		Twox128::hash(salt.encode().as_slice()).into()
+		Blake2_128::hash(salt.encode().as_slice()).into()
 	}
 
 	/// Generate ids after the following schema:


### PR DESCRIPTION
Currently we are planning to use `Twox128` in order to generate `TrancheIds`.  I think this is a problem. It's seems that it is trivially to generate collisions, especially for the input data that we have, which are deterministic. 
As we only generate `TranchIds` at the setup of pools and then sparsly from time to time when a tranche is replaced or added I think it is okay to use the slower `Blake_128`

### Attack scenario
* Off-chain: generate hashes with available pool-ids and increasing tranche-counters
* Compare the generated hashes with existing tranche-ids
* If one matches: create the respective pool and replace the senior-tranche with new tranches until the `TrancheId` matches the found collision

-> We then have two pools, one normal one, one controlled by the attacker, where we have a colliding `TranchId`. 

### Note
No migration needed as we don't have yet any pools. 