### PR TITLE
Add missing mandatory calls

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 246,
+    spec_version: 247,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -161,16 +161,19 @@ pub struct BaseFilter;
 impl frame_support::traits::Filter<Call> for BaseFilter {
     fn filter(c: &Call) -> bool {
         matches!(
-			c,
-			// Calls for runtime upgrade
-			Call::System(frame_system::Call::set_code{..}) |
-			Call::System(frame_system::Call::set_code_without_checks{..}) |
-      // Council-related calls
-      Call::Council(..) |
-      // Democracy-related calls
-      Call::Democracy(..) |
-			// Calls that are present in each block
-			Call::Timestamp(pallet_timestamp::Call::set{..})
+            c,
+            // Calls for runtime upgrade
+            Call::System(frame_system::Call::set_code{..}) |
+            Call::System(frame_system::Call::set_code_without_checks{..}) |
+            // Council-related calls
+            Call::Council(..) |
+            // Democracy-related calls
+            Call::Democracy(..) |
+            // Calls that are present in each block
+            Call::Timestamp(pallet_timestamp::Call::set{..}) |
+            // Mandatory Extrinsics
+            Call::FinalityTracker(..) |
+            Call::Authorship(..)
 		)
     }
 }


### PR DESCRIPTION
While testing found an error with the new code that had missing some mandatory calls:
```
2022-03-30 00:06:42.010 tokio-runtime-worker WARN slots  Encountered consensus error: ClientImport("ApplyExtrinsicFailed(Validity(TransactionValidityError::Invalid(InvalidTransaction::BadMandatory)))")
2022-03-30 00:06:45.553 tokio-runtime-worker INFO substrate  💤 Idle (0 peers), best: #123 (0xef70…4cf5), finalized #121 (0x74b9…6dba), ⬇ 0 ⬆ 0
2022-03-30 00:06:48.003 tokio-runtime-worker INFO sc_basic_authorship::basic_authorship  🙌 Starting consensus session on top of parent 0xef7097ec8015aa6bbca70791c75211ca293230ad3235c0440198711853064cf5
2022-03-30 00:06:48.022 tokio-blocking-driver ERROR sc_basic_authorship::basic_authorship  ❌️ Mandatory inherent extrinsic returned error. Block cannot be produced.
```
This was halting block production so just had to allow a few extra calls.