### PR TITLE
centrifuge: Add chainbridge pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
 name = "centrifuge-runtime"
 version = "0.10.1"
 dependencies = [
+ "chainbridge",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -1024,6 +1025,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-babe",
  "pallet-balances",
+ "pallet-bridge",
  "pallet-claims",
  "pallet-collective",
  "pallet-democracy",
@@ -1035,6 +1037,7 @@ dependencies = [
  "pallet-indices",
  "pallet-membership",
  "pallet-multisig",
+ "pallet-nft",
  "pallet-offences",
  "pallet-preimage",
  "pallet-proxy",

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -96,11 +96,17 @@ pallet-sudo = { git = "https://github.com/paritytech/substrate",  default-featur
 pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.17" }
 pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.17" }
 
-runtime-common = { path = "../common", default-features = false }
 
+# Our pallets and modules
+runtime-common = { path = "../common", default-features = false }
 pallet-anchors = { path = "../../pallets/anchors", default-features = false }
 pallet-fees = { path = "../../pallets/fees", default-features = false }
 pallet-claims = { path = "../../pallets/claims", default-features = false }
+pallet-bridge = { path = "../../pallets/bridge", default-features = false }
+pallet-nft = { path = "../../pallets/nft", default-features = false }
+
+# bridge pallets
+chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = false, branch = "polkadot-v0.9.17" }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
@@ -175,6 +181,9 @@ std = [
     "runtime-common/std",
     "polkadot-runtime-common/std",
     "pallet-preimage/std",
+    "chainbridge/std",
+    "pallet-bridge/std",
+    "pallet-nft/std",
 ]
 
 runtime-benchmarks = [
@@ -188,7 +197,8 @@ runtime-benchmarks = [
     "xcm-builder/runtime-benchmarks",
     "pallet-collective/runtime-benchmarks",
     "pallet-society/runtime-benchmarks",
-    "pallet-balances/runtime-benchmarks"
+    "pallet-balances/runtime-benchmarks",
+    "chainbridge/runtime-benchmarks",
 ]
 
 # A feature that should be enabled when the runtime should be build for on-chain

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -654,6 +654,62 @@ impl pallet_anchors::Config for Runtime {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub const NftProofValidationFee: u128 = NFT_PROOF_VALIDATION_FEE;
+}
+
+impl pallet_nft::Config for Runtime {
+	type Event = Event;
+	type ChainId = chainbridge::ChainId;
+	type ResourceId = chainbridge::ResourceId;
+	type HashId = HashId;
+	type NftProofValidationFee = NftProofValidationFee;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const BridgePalletId: PalletId = PalletId(*b"c/bridge");
+	pub HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(b"cent_nft_hash"));
+	//TODO create new mapping (< copied from 'development', need to figure out what this means)
+	pub NativeTokenId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(b"xCFG"));
+	pub const NativeTokenTransferFee: u128 = NATIVE_TOKEN_TRANSFER_FEE;
+	pub const NftTransferFee: u128 = NFT_TOKEN_TRANSFER_FEE;
+}
+
+impl pallet_bridge::Config for Runtime {
+	type BridgePalletId = BridgePalletId;
+	type BridgeOrigin = chainbridge::EnsureBridge<Runtime>;
+	type AdminOrigin =
+	pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
+	type Currency = Balances;
+	type Event = Event;
+	type NativeTokenId = NativeTokenId;
+	type NativeTokenTransferFee = NativeTokenTransferFee;
+	type NftTokenTransferFee = NftTransferFee;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const ChainId: chainbridge::ChainId = 1;
+	pub const ProposalLifetime: u32 = 500;
+	pub const ChainBridgePalletId: PalletId = PalletId(*b"chnbrdge");
+	pub const RelayerVoteThreshold: u32 = chainbridge::constants::DEFAULT_RELAYER_VOTE_THRESHOLD;
+}
+
+impl chainbridge::Config for Runtime {
+	type Event = Event;
+	type AdminOrigin =
+	pallet_collective::EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollective>;
+	type Proposal = Call;
+	type ChainId = ChainId;
+	type PalletId = ChainBridgePalletId;
+	type ProposalLifetime = ProposalLifetime;
+	type RelayerVoteThreshold = RelayerVoteThreshold;
+	/// A 75% majority of the council can update bridge settings.
+	type WeightInfo = ();
+}
+
+
 // Parameterize claims pallet
 parameter_types! {
 	pub const ClaimsPalletId: PalletId = PalletId(*b"p/claims");
@@ -722,6 +778,11 @@ construct_runtime!(
 		Fees: pallet_fees::{Pallet, Call, Storage, Config<T>, Event<T>} = 90,
 		Anchor: pallet_anchors::{Pallet, Call, Storage} = 91,
 		Claims: pallet_claims::{Pallet, Call, Storage, Event<T>, ValidateUnsigned} = 92,
+		Nfts: pallet_nft::{Pallet, Call, Event<T>} = 93,
+		Bridge: pallet_bridge::{Pallet, Call, Storage, Config<T>, Event<T>} = 94,
+
+		// 3rd party pallets
+		ChainBridge: chainbridge::{Pallet, Call, Storage, Event<T>} = 150,
 
 		// admin stuff
 		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>} = 200,

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -680,7 +680,7 @@ impl pallet_bridge::Config for Runtime {
 	type BridgePalletId = BridgePalletId;
 	type BridgeOrigin = chainbridge::EnsureBridge<Runtime>;
 	type AdminOrigin =
-	pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
+		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
 	type Currency = Balances;
 	type Event = Event;
 	type NativeTokenId = NativeTokenId;
@@ -698,17 +698,16 @@ parameter_types! {
 
 impl chainbridge::Config for Runtime {
 	type Event = Event;
+	/// A 75% majority of the council can update bridge settings.
 	type AdminOrigin =
-	pallet_collective::EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollective>;
+		pallet_collective::EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollective>;
 	type Proposal = Call;
 	type ChainId = ChainId;
 	type PalletId = ChainBridgePalletId;
 	type ProposalLifetime = ProposalLifetime;
 	type RelayerVoteThreshold = RelayerVoteThreshold;
-	/// A 75% majority of the council can update bridge settings.
 	type WeightInfo = ();
 }
-
 
 // Parameterize claims pallet
 parameter_types! {

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1154,6 +1154,7 @@ parameter_types! {
 
 impl chainbridge::Config for Runtime {
 	type Event = Event;
+	/// A 75% majority of the council can update bridge settings.
 	type AdminOrigin =
 		pallet_collective::EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollective>;
 	type Proposal = Call;
@@ -1161,7 +1162,6 @@ impl chainbridge::Config for Runtime {
 	type PalletId = ChainBridgePalletId;
 	type ProposalLifetime = ProposalLifetime;
 	type RelayerVoteThreshold = RelayerVoteThreshold;
-	/// A 75% majority of the council can update bridge settings.
 	type WeightInfo = ();
 }
 

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -775,7 +775,6 @@ fn centrifuge_genesis(
 			resources: vec![
 				// xCFG ResourceID to PalletBridge.transfer method (for incoming txs)
 				(
-					// TODO(all): Adapt these values
 					hex!["00000000000000000000000000000009e974040e705c10fb4de576d6cc261900"],
 					hex!["50616c6c65744272696467652e7472616e73666572"]
 						.iter()

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -768,6 +768,30 @@ fn centrifuge_genesis(
 		aura: Default::default(),
 		democracy: Default::default(),
 		parachain_system: Default::default(),
+		bridge: centrifuge_runtime::BridgeConfig {
+			// Whitelist chains Ethereum - 0
+			chains: vec![0],
+			// Register resourceIDs
+			resources: vec![
+				// xCFG ResourceID to PalletBridge.transfer method (for incoming txs)
+				(
+					// TODO(all): Adapt these values
+					hex!["00000000000000000000000000000009e974040e705c10fb4de576d6cc261900"],
+					hex!["50616c6c65744272696467652e7472616e73666572"]
+						.iter()
+						.cloned()
+						.collect(),
+				),
+			],
+			// TODO(all): Adapt these values
+			// Dev Alice - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+			// Sample Endowed1 - 5GVimUaccBq1XbjZ99Zmm8aytG6HaPCjkZGKSHC1vgrsQsLQ
+			relayers: vec![
+				hex!["d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"].into(),
+				hex!["c405224448dcd4259816b09cfedbd8df0e6796b16286ea18efa2d6343da5992e"].into(),
+			],
+			threshold: 1,
+		},
 	}
 }
 

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -782,7 +782,6 @@ fn centrifuge_genesis(
 						.collect(),
 				),
 			],
-			// TODO(all): Adapt these values
 			// Dev Alice - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 			// Sample Endowed1 - 5GVimUaccBq1XbjZ99Zmm8aytG6HaPCjkZGKSHC1vgrsQsLQ
 			relayers: vec![


### PR DESCRIPTION
Along with it, we also add `pallet_nfts` and `pallet_bridge` as they are both dependencies of chainbridge.