### PR TITLE
integration-tests: Adapt structure

### DIFF
--- a/runtime/integration-tests/src/lib.rs
+++ b/runtime/integration-tests/src/lib.rs
@@ -16,43 +16,41 @@
 mod pools;
 mod xcm;
 
-/// Re-exports the correct runtimes that we run the integration tests with
-/// This allows all other modules to use the import of `crate::chain::{...}`
-/// in order to get the right stuff from the respective runtime.
-mod chain {
+/// Re-exports the correct runtimes that we run the integration tests with.
+/// This allows all other modules to use the import of `crate::parachain::{...}` and
+/// `crate::relay::{...}` in order to get the right stuff from the respective runtime.
+pub mod parachain {
+	#[cfg(feature = "runtime-altair")]
+	pub use altair::*;
+	#[cfg(feature = "runtime-centrifuge")]
+	pub use centrifuge::*;
+	#[cfg(feature = "runtime-development")]
+	pub use development::*;
+
+	#[cfg(feature = "runtime-centrifuge")]
 	pub mod centrifuge {
-		#[cfg(feature = "runtime-altair")]
-		pub use altair::*;
-		#[cfg(feature = "runtime-centrifuge")]
-		pub use centrifuge::*;
-		#[cfg(feature = "runtime-development")]
-		pub use development::*;
-
-		#[cfg(feature = "runtime-centrifuge")]
-		pub mod centrifuge {
-			pub use centrifuge_runtime::*;
-			pub const PARA_ID: u32 = 2031;
-		}
-
-		#[cfg(feature = "runtime-altair")]
-		pub mod altair {
-			pub use altair_runtime::*;
-			pub const PARA_ID: u32 = 2088;
-		}
-
-		#[cfg(feature = "runtime-development")]
-		pub mod development {
-			pub use development_runtime::*;
-			pub const PARA_ID: u32 = 2000;
-		}
+		pub use centrifuge_runtime::*;
+		pub const PARA_ID: u32 = 2031;
 	}
 
-	pub mod relay {
-		#[cfg(feature = "runtime-altair")]
-		pub use kusama_runtime::*;
-		#[cfg(feature = "runtime-centrifuge")]
-		pub use polkadot_runtime::*;
-		#[cfg(feature = "runtime-development")]
-		pub use rococo_runtime::*;
+	#[cfg(feature = "runtime-altair")]
+	pub mod altair {
+		pub use altair_runtime::*;
+		pub const PARA_ID: u32 = 2088;
 	}
+
+	#[cfg(feature = "runtime-development")]
+	pub mod development {
+		pub use development_runtime::*;
+		pub const PARA_ID: u32 = 2000;
+	}
+}
+
+pub mod relay {
+	#[cfg(feature = "runtime-altair")]
+	pub use kusama_runtime::*;
+	#[cfg(feature = "runtime-centrifuge")]
+	pub use polkadot_runtime::*;
+	#[cfg(feature = "runtime-development")]
+	pub use rococo_runtime::*;
 }

--- a/runtime/integration-tests/src/pools/env.rs
+++ b/runtime/integration-tests/src/pools/env.rs
@@ -9,8 +9,8 @@
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-use crate::chain::centrifuge;
-use crate::chain::centrifuge::{Runtime, PARA_ID};
+use crate::parachain;
+use crate::parachain::{Runtime, PARA_ID};
 use crate::pools::utils::accounts::Keyring;
 use crate::pools::utils::extrinsics::ext_centrifuge;
 use crate::pools::utils::*;
@@ -19,6 +19,7 @@ use fudge::primitives::Chain;
 use pallet_balances::Call as BalancesCall;
 use sp_runtime::Storage;
 use tokio::runtime::Handle;
+use runtime_common::CFG;
 
 #[tokio::test]
 async fn env_works() {
@@ -50,13 +51,13 @@ async fn extrinsics_works() {
 	env::default_balances::<Runtime>(&mut genesis);
 	let mut env = env::test_env_with_centrifuge_storage(&manager, genesis);
 
-	let to: centrifuge::Address = Keyring::Bob.into();
+	let to: parachain::Address = Keyring::Bob.into();
 	let xt = ext_centrifuge(
 		&env,
 		Keyring::Alice,
-		centrifuge::Call::Balances(BalancesCall::transfer {
+		parachain::Call::Balances(BalancesCall::transfer {
 			dest: to,
-			value: 100 * centrifuge::CFG,
+			value: 100 * CFG,
 		}),
 	)
 	.unwrap();
@@ -84,10 +85,10 @@ async fn extrinsics_works() {
 		.unwrap();
 
 	// Need to account for fees here
-	assert!(alice_after.data.free <= alice_before.data.free - 100 * centrifuge::CFG);
+	assert!(alice_after.data.free <= alice_before.data.free - 100 * CFG);
 	assert_eq!(
 		bob_after.data.free,
-		bob_before.data.free + 100 * centrifuge::CFG
+		bob_before.data.free + 100 * CFG
 	);
 
 	env.evolve().unwrap();
@@ -102,9 +103,9 @@ async fn extrinsics_works() {
 		.unwrap();
 
 	// Need to account for fees here
-	assert!(alice_after.data.free <= alice_before.data.free - 100 * centrifuge::CFG);
+	assert!(alice_after.data.free <= alice_before.data.free - 100 * CFG);
 	assert_eq!(
 		bob_after.data.free,
-		bob_before.data.free + 100 * centrifuge::CFG
+		bob_before.data.free + 100 * CFG
 	);
 }

--- a/runtime/integration-tests/src/pools/pool_starts.rs
+++ b/runtime/integration-tests/src/pools/pool_starts.rs
@@ -9,7 +9,7 @@
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-use crate::chain::centrifuge::Runtime;
+use crate::parachain::Runtime;
 use crate::pools::utils::*;
 use sp_runtime::Storage;
 use tokio::runtime::Handle;

--- a/runtime/integration-tests/src/pools/utils/env.rs
+++ b/runtime/integration-tests/src/pools/utils/env.rs
@@ -11,11 +11,11 @@
 // GNU General Public License for more details.
 
 //! Utilities to create a relay-chain-parachain setup
-use crate::chain::centrifuge::{
+use crate::parachain::{
 	Block as CentrifugeBlock, CurrencyId, RuntimeApi as CentrifugeRtApi, PARA_ID,
 	WASM_BINARY as CentrifugeCode,
 };
-use crate::chain::relay::{Runtime as RelayRt, RuntimeApi as RelayRtApi, WASM_BINARY as RelayCode};
+use crate::relay::{Runtime as RelayRt, RuntimeApi as RelayRtApi, WASM_BINARY as RelayCode};
 use crate::pools::utils::accounts::default_accounts;
 use crate::pools::utils::logs;
 use frame_support::traits::GenesisBuild;

--- a/runtime/integration-tests/src/pools/utils/env.rs
+++ b/runtime/integration-tests/src/pools/utils/env.rs
@@ -30,7 +30,6 @@ use fudge::{
 };
 use polkadot_core_primitives::{Block as RelayBlock, Header as RelayHeader};
 use polkadot_parachain::primitives::Id as ParaId;
-use sc_executor::sp_wasm_interface::ExtendedHostFunctions;
 use sc_executor::{WasmExecutionMethod, WasmExecutor};
 use sc_service::TaskManager;
 use sp_consensus_babe::digests::CompatibleDigestItem;
@@ -44,7 +43,7 @@ use tokio::runtime::Handle;
 type CentrifugeHF = sp_io::SubstrateHostFunctions;
 #[cfg(feature = "runtime-benchmarks")]
 /// Host functions that include benchmarking specific functionalities
-type CentrifugeHF = ExtendedHostFunctions<
+type CentrifugeHF = sc_executor::sp_wasm_interface::ExtendedHostFunctions<
 	sp_io::SubstrateHostFunctions,
 	frame_benchmarking::benchmarking::HostFunctions,
 >;

--- a/runtime/integration-tests/src/pools/utils/extrinsics.rs
+++ b/runtime/integration-tests/src/pools/utils/extrinsics.rs
@@ -13,15 +13,15 @@
 //! Utilities for creating extrinsics
 #![allow(unused)]
 
-use crate::chain::centrifuge::{
+use crate::parachain::{
 	Call as CentrifugeCall, Runtime as CentrifugeRuntime, SignedExtra as CentrifugeSignedExtra,
 	UncheckedExtrinsic as CentrifugeUnchecked,
 };
-use crate::chain::relay::{
+use crate::relay::{
 	Address as RelayAddress, Call as RelayCall, Runtime as RelayRuntime,
 	SignedExtra as RelaySignedExtra, UncheckedExtrinsic as RelayUnchecked,
 };
-use crate::chain::{centrifuge, relay};
+use crate::{parachain, relay};
 use crate::pools::utils::{accounts::Keyring, env::TestEnv};
 use codec::Encode;
 use node_primitives::Index as RelayIndex;
@@ -39,15 +39,15 @@ use sp_runtime::{
 pub fn ext_centrifuge(
 	env: &TestEnv,
 	who: Keyring,
-	call: centrifuge::Call,
-) -> Result<centrifuge::UncheckedExtrinsic, ()> {
+	call: parachain::Call,
+) -> Result<parachain::UncheckedExtrinsic, ()> {
 	let client = env.centrifuge.client();
 
 	let genesis_hash = client
 		.block_hash(0)
 		.expect("ESSENTIAL: Genesis MUST be avilable.")
 		.unwrap();
-	let best_block_id = centrifuge::BlockId::number(client.chain_info().best_number);
+	let best_block_id = parachain::BlockId::number(client.chain_info().best_number);
 	let (spec_version, tx_version) = {
 		let version = client.runtime_version_at(&best_block_id).unwrap();
 		(version.spec_version, version.transaction_version)

--- a/runtime/integration-tests/src/xcm/setup.rs
+++ b/runtime/integration-tests/src/xcm/setup.rs
@@ -10,7 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-pub use crate::chain::centrifuge::{AccountId, CurrencyId, Origin, Runtime, System, PARA_ID};
+pub use crate::parachain::{AccountId, CurrencyId, Origin, Runtime, System, PARA_ID};
 use common_traits::TokenMetadata;
 use frame_support::traits::GenesisBuild;
 use runtime_common::Balance;
@@ -109,15 +109,15 @@ pub fn dollar(currency_id: CurrencyId) -> Balance {
 }
 
 pub fn sibling_account() -> AccountId {
-	parachain_account(PARA_ID_SIBLING.into())
+	account_from(PARA_ID_SIBLING.into())
 }
 
-pub fn development_account() -> AccountId {
-	parachain_account(PARA_ID.into())
+pub fn parachain_account() -> AccountId {
+	account_from(PARA_ID.into())
 }
 
-fn parachain_account(id: u32) -> AccountId {
+fn account_from(para_id: u32) -> AccountId {
 	use sp_runtime::traits::AccountIdConversion;
 
-	polkadot_parachain::primitives::Sibling::from(id).into_account()
+	polkadot_parachain::primitives::Sibling::from(para_id).into_account()
 }

--- a/runtime/integration-tests/src/xcm/test_net.rs
+++ b/runtime/integration-tests/src/xcm/test_net.rs
@@ -23,25 +23,23 @@ use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain
 use development_runtime::CurrencyId;
 use runtime_common::AccountId;
 
-use crate::{
-	chain::centrifuge::PARA_ID,
-	xcm::setup::{native_amount, ExtBuilder, ALICE, BOB, PARA_ID_SIBLING},
-};
+use crate::parachain::PARA_ID;
+use crate::xcm::setup::{native_amount, ExtBuilder, ALICE, BOB, PARA_ID_SIBLING};
 
 decl_test_relay_chain! {
 	pub struct RelayChain {
-		Runtime = crate::chain::relay::Runtime,
-		XcmConfig = crate::chain::relay::xcm_config::XcmConfig,
+		Runtime = crate::relay::Runtime,
+		XcmConfig = crate::relay::xcm_config::XcmConfig,
 		new_ext = relay_ext(),
 	}
 }
 
 decl_test_parachain! {
-	pub struct Centrifuge {
-		Runtime = crate::chain::centrifuge::Runtime,
-		Origin = crate::chain::centrifuge::Origin,
-		XcmpMessageHandler = crate::chain::centrifuge::XcmpQueue,
-		DmpMessageHandler = crate::chain::centrifuge::DmpQueue,
+	pub struct Parachain {
+		Runtime = crate::parachain::Runtime,
+		Origin = crate::parachain::Origin,
+		XcmpMessageHandler = crate::parachain::XcmpQueue,
+		DmpMessageHandler = crate::parachain::DmpQueue,
 		new_ext = para_ext(PARA_ID),
 	}
 }
@@ -63,8 +61,9 @@ decl_test_network! {
 			// N.B: Ideally, we could use the defined para id constants but doing so
 			// fails with: "error: arbitrary expressions aren't allowed in patterns"
 
-			// Be sure to use `PARA_ID`
-			(2000, Centrifuge),
+			// Be sure to use the appropriate `PARA_ID`
+			(2000, Parachain),
+
 			// Be sure to use `PARA_ID_SIBLING`
 			(3000, Sibling),
 		],
@@ -72,7 +71,7 @@ decl_test_network! {
 }
 
 pub fn relay_ext() -> sp_io::TestExternalities {
-	use crate::chain::relay::{Runtime, System};
+	use crate::relay::{Runtime, System};
 
 	let mut t = frame_system::GenesisConfig::default()
 		.build_storage::<Runtime>()

--- a/runtime/integration-tests/src/xcm/test_net.rs
+++ b/runtime/integration-tests/src/xcm/test_net.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 decl_test_relay_chain! {
-	pub struct RelayNet {
+	pub struct RelayChain {
 		Runtime = crate::chain::relay::Runtime,
 		XcmConfig = crate::chain::relay::xcm_config::XcmConfig,
 		new_ext = relay_ext(),
@@ -58,7 +58,7 @@ decl_test_parachain! {
 
 decl_test_network! {
 	pub struct TestNet {
-		relay_chain = RelayNet,
+		relay_chain = RelayChain,
 		parachains = vec![
 			// N.B: Ideally, we could use the defined para id constants but doing so
 			// fails with: "error: arbitrary expressions aren't allowed in patterns"

--- a/xcm/README.md
+++ b/xcm/README.md
@@ -117,4 +117,4 @@ sender and receiver parachains respectively:
 ## Integration Tests
 
 In `runtime` > `integration-tests` > `xcm_transfers` we have our integrated tests covering the xcm transfers using an
-environment identical to the one described previously that you can setup on your machine but emulated instead.
+environment identical to the one described previously that you can set up on your machine but emulated instead.


### PR DESCRIPTION
With the latest changes to the integration tests, the new structure had us refer to whichever selected runtime (`altair`/`development`/`centrifuge`) as `::centrifuge::` which is confusing.

The main change is is going from:

``` rust
mod chain {
  mod centrifuge {
     // import actually selected runtime `altair`/`development`/`centrifuge`
  }

  mod relay {
     // import the right relay for the selected runtime `altair`/`development`/`centrifuge`
  }
}
```

to

``` rust
mod parachain {
  // import actually selected runtime `altair`/`development`/`centrifuge`
}

mod relay {
  // import the right relay for the selected runtime `altair`/`development`/`centrifuge`
}
```

The `chain::` prefix mod didn't seem to add any palpable value and this way we now refer to the selected parachain runtime as `::parachain::`, which is fitting to all usages.