### PR TITLE
Remove -p centrifuge-runtime parameter

### DIFF
--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -11,7 +11,7 @@ if [  -z "${output}" ]; then
 fi
 
 echo "Benchmarking ${pallet} for runtime $chain..."
-cargo run --release -p centrifuge-runtime --features runtime-benchmarks -- benchmark \
+cargo run --release --features runtime-benchmarks -- benchmark \
   --chain="${chain}" \
   --steps=50 \
   --repeat=20 \


### PR DESCRIPTION
Removes the deprecated parameter as we now have multiple runtimes.