### PR TITLE
Extend pool and loan pallet events

### DIFF
--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -348,7 +348,7 @@ benchmarks! {
 		let loan_id: T::LoanId = 1u128.into();
 	}:_(RawOrigin::Signed(loan_owner.clone()), pool_id, loan_id, rp, loan_type)
 	verify {
-		assert_last_event::<T, <T as LoanConfig>::Event>(LoanEvent::Priced(pool_id, loan_id).into());
+		assert_last_event::<T, <T as LoanConfig>::Event>(LoanEvent::Priced(pool_id, loan_id, rp, loan_type).into());
 		let loan = Loan::<T>::get(pool_id, loan_id).expect("loan info should be present");
 		assert_eq!(loan.loan_type, loan_type);
 		assert_eq!(loan.status, LoanStatus::Active);

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -431,7 +431,12 @@ pub mod pallet {
 			// ensure sender has the pricing admin role in the pool
 			ensure_role!(pool_id, origin, PoolRole::PricingAdmin);
 			Self::price_loan(pool_id, loan_id, interest_rate_per_sec, loan_type)?;
-			Self::deposit_event(Event::<T>::Priced(pool_id, loan_id));
+			Self::deposit_event(Event::<T>::Priced(
+				pool_id,
+				loan_id,
+				interest_rate_per_sec,
+				loan_type,
+			));
 			Ok(())
 		}
 

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -200,8 +200,13 @@ pub mod pallet {
 		Created(PoolIdOf<T>, T::LoanId, AssetOf<T>),
 		/// A loan was closed. [pool, loan, collateral]
 		Closed(PoolIdOf<T>, T::LoanId, AssetOf<T>),
-		/// A loan was priced. [pool, loan]
-		Priced(PoolIdOf<T>, T::LoanId),
+		/// A loan was priced. [pool, loan, interest_rate_per_sec, loan_type]
+		Priced(
+			PoolIdOf<T>,
+			T::LoanId,
+			T::Rate,
+			LoanType<T::Rate, T::Amount>,
+		),
 		/// An amount was borrowed for a loan. [pool, loan, amount]
 		Borrowed(PoolIdOf<T>, T::LoanId, T::Amount),
 		/// An amount was repaid for a loan. [pool, loan, amount]

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -194,7 +194,7 @@ fn price_test_loan<T>(
 	assert_ok!(res);
 	let loan_event = fetch_loan_event(last_event()).expect("should be a loan event");
 	let (got_pool_id, got_loan_id) = match loan_event {
-		LoanEvent::Priced(pool_id, loan_id) => Some((pool_id, loan_id)),
+		LoanEvent::Priced(pool_id, loan_id, _, _) => Some((pool_id, loan_id)),
 		_ => None,
 	}
 	.expect("must be a Loan issue priced event");

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-/// Edit this file to define custom logic or remove it if it is not needed.
-/// Learn more about FRAME and the core library of Substrate FRAME pallets:
-/// <https://substrate.dev/docs/en/knowledgebase/runtime/frame>
 pub use pallet::*;
 pub use solution::*;
 pub use tranche::*;
@@ -193,10 +190,8 @@ pub mod pallet {
 	use sp_runtime::ArithmeticError;
 	use sp_std::convert::TryInto;
 
-	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
 		type Balance: Member
@@ -354,8 +349,6 @@ pub mod pallet {
 	pub type EpochExecution<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::PoolId, EpochExecutionInfoOf<T>>;
 
-	// Pallets use events to inform users when important changes are made.
-	// https://substrate.dev/docs/en/knowledgebase/runtime/events
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
@@ -403,7 +396,6 @@ pub mod pallet {
 		),
 	}
 
-	// Errors inform users that something went wrong.
 	#[pallet::error]
 	pub enum Error<T> {
 		/// A pool with this ID is already in use

--- a/runtime/integration-tests/src/pools/pool_starts.rs
+++ b/runtime/integration-tests/src/pools/pool_starts.rs
@@ -68,6 +68,6 @@ async fn create_init_and_price() {
 		Event::Loans(pallet_loans::Event::PoolInitialised(id)) if [id == 0],
 		Event::Loans(pallet_loans::Event::Created(id, loan, asset))
 			if [id == 0 && loan == InstanceId(1) && asset == Asset(4294967296, InstanceId(1))],
-		Event::Loans(pallet_loans::Event::Priced(id, loan)) if [id == 0 && loan == InstanceId(1)],
+		Event::Loans(pallet_loans::Event::Priced(id, loan, ..)) if [id == 0 && loan == InstanceId(1)],
 	);
 }


### PR DESCRIPTION
- Extend order events to include old & new order amounts
- Add event on tranche rebalancing
- Extend loan pricing event with pricing info