### PR TITLE
pallet-pools: Fix-rebalancing and introduce losses and recovery of losses

### DIFF
--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -115,6 +115,7 @@ pub struct Tranche<Balance, Rate, Weight, Currency> {
 
 	pub(super) debt: Balance,
 	pub(super) reserve: Balance,
+	pub(super) loss: Balance,
 	pub(super) ratio: Perquintill,
 	pub(super) last_updated_interest: Moment,
 
@@ -137,6 +138,7 @@ where
 			outstanding_redeem_orders: Zero::zero(),
 			debt: Zero::zero(),
 			reserve: Zero::zero(),
+			loss: Zero::zero(),
 			ratio: Perquintill::one(),
 			last_updated_interest: 0,
 			_phantom: PhantomData::default(),
@@ -171,6 +173,14 @@ where
 	pub fn balance(&self) -> Result<Balance, DispatchError> {
 		self.debt
 			.checked_add(&self.reserve)
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	pub fn expected_assets(&self) -> Result<Balance, DispatchError> {
+		self.debt
+			.checked_add(&self.reserve)
+			.ok_or(ArithmeticError::Overflow.into())
+			.checked_add(&self.loss)
 			.ok_or(ArithmeticError::Overflow.into())
 	}
 
@@ -479,6 +489,7 @@ where
 			outstanding_redeem_orders: Zero::zero(),
 			debt: Zero::zero(),
 			reserve: Zero::zero(),
+			loss: Zero::zero(),
 			ratio: Perquintill::zero(),
 			last_updated_interest: now,
 			_phantom: Default::default(),

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -777,8 +777,10 @@ where
 		let mut prices = self.combine_mut_non_residual_top(|tranche| {
 			let total_issuance = Tokens::total_issuance(tranche.currency);
 
-			if pool_is_zero || total_issuance == Zero::zero() {
-				Ok(One::one())
+			if total_issuance == Zero::zero() {
+				Ok(BalanceRatio::one())
+			} else if pool_is_zero {
+				Ok(BalanceRatio::zero())
 			} else if tranche.tranche_type == TrancheType::Residual {
 				BalanceRatio::checked_from_rational(remaining_assets, total_issuance)
 					.ok_or(ArithmeticError::Overflow.into())

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -170,6 +170,17 @@ where
 		Ok(orders)
 	}
 
+	pub fn claim(&self, from: Balance) -> Result<Balance, DispatchError> {
+		self.ratio
+			.mul_ceil(from)
+			.checked_add(&self.loss)
+			.ok_or(ArithmeticError::Overflow.into())
+	}
+
+	pub fn claim_with_losses(&self, from: Balance) -> Result<Balance, DispatchError> {
+		Ok(self.ratio.mul_ceil(from))
+	}
+
 	pub fn balance(&self) -> Result<Balance, DispatchError> {
 		self.debt
 			.checked_add(&self.reserve)


### PR DESCRIPTION
This PR is a draft-proposal that does
* Fix rebalancing issues when NAV drops
* Introduce losses 
* Introduce possibility to recover these losses and finally recover the pool.

Logic is based on this spec here: https://centrifuge.hackmd.io/w4MrddApTQykzBA8xh18RQ?both

### Notes
This PR does contain this logic but the pool will never reach this state as we currently simply block a pool once a tranche-price has gone to zero. Hence, this must be enabled afterwards. 

The pool-state PR  #695 was the PR that first brought up the problems with NAV drops and rebalancing and is a good starting-point for introducing the possibility for such states after this PR here. 