### PR TITLE
[HOLD] Adapt tx fees on both altair and centrifuge by aprox. factor of 33 and transfer some % to the treasury.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9007,6 +9007,7 @@ dependencies = [
  "pallet-collective",
  "pallet-permissions",
  "pallet-pools",
+ "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9016,6 +9016,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-consensus-aura",
  "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
  "xcm",

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
             };
 
             # This is a hash of all the Cargo dependencies, for reproducibility.
-            cargoSha256 = "0000000000000000000000";
+            cargoSha256 = "sha256-pausA0+qcM6PEH1fS9/3Dn0GWC5LBnQXX+W8UVDbCj4=";
 
             nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
             buildInputs = with pkgs; [ openssl ] ++ (

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
             };
 
             # This is a hash of all the Cargo dependencies, for reproducibility.
-            cargoSha256 = "sha256-5z7J2EThjg903NDQgQSvP/p2CEkL1JiSexkEtB7gdhQ=";
+            cargoSha256 = "0000000000000000000000";
 
             nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
             buildInputs = with pkgs; [ openssl ] ++ (

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -212,7 +212,7 @@ impl pallet_timestamp::Config for Runtime {
 
 // money stuff
 parameter_types! {
-	/// TransactionByteFee is set to 0.01 MicroCFG
+	/// TransactionByteFee is set to 0.01 MicroAIR
 	pub const TransactionByteFee: Balance = 1 * (MICRO_AIR / 100);
 	/// This value increases the priority of `Operational` transactions by adding
 	/// a "virtual tip" that's equal to the `OperationalFeeMultiplier * final_fee`.

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -212,7 +212,7 @@ impl pallet_timestamp::Config for Runtime {
 
 // money stuff
 parameter_types! {
-	/// TransactionByteFee is set to 0.01 MicroAIR
+	/// TransactionByteFee is set to 0.01 MicroCFG
 	pub const TransactionByteFee: Balance = 1 * (MICRO_AIR / 100);
 	/// This value increases the priority of `Operational` transactions by adding
 	/// a "virtual tip" that's equal to the `OperationalFeeMultiplier * final_fee`.

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -22,6 +22,7 @@ node-primitives = { git = "https://github.com/paritytech/substrate",  default-fe
 pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 pallet-collective = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24" }
 sp-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -43,6 +43,9 @@ pallet-pools = { path = "../../pallets/pools", default-features = false }
 common-types = { path = "../../libs/common-types", default-features = false }
 pallet-permissions = { path = "../../pallets/permissions", default-features = false }
 
+[dev-dependencies]
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24" }
+
 [features]
 default = ["std"]
 std = [

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -58,6 +58,7 @@ std = [
     "pallet-authorship/std",
     "pallet-balances/std",
     "pallet-collective/std",
+    "pallet-treasury/std",
     "pallet-permissions/std",
     "serde",
     "sp-core/std",

--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -7,7 +7,8 @@ use core::marker::PhantomData;
 use frame_support::sp_runtime::app_crypto::sp_core::U256;
 use frame_support::traits::{Currency, OnUnbalanced};
 use frame_support::weights::{
-	WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
+	constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients,
+	WeightToFeePolynomial,
 };
 use frame_system::pallet::Config as SystemConfig;
 use pallet_authorship::{Config as AuthorshipConfig, Pallet as Authorship};
@@ -47,46 +48,19 @@ where
 ///   - Setting it to `0` will essentially disable the weight fee.
 ///   - Setting it to `1` will cause the literal `#[weight = x]` values to be charged.
 ///
-/// Sample weight to Fee Calculation for 1 Rad Balance transfer:
-/// ```rust
-/// 	use node_primitives::Balance;
-/// 	let extrinsic_bytes: Balance = 92;
-/// 	let weight: Balance = 195000000;
-/// 	let weight_coefficient: Balance = 315000;
-/// 	let transaction_byte_fee: Balance = 10000000000; // 0.01 Micro RAD
-///		let maximum_block_weight: Balance = 2000000000000; // 2 * WEIGHT_PER_SECOND
-/// 	let extrinsic_base_weight: Balance = 125000000; // 125 * WEIGHT_PER_MICROS
-///
-/// 	// AIR token value
-///     //
-///     // FIXME (ToZ):
-///     // The following constants are copied verbatim from Altair runtime constants so
-///     // that to avoid a circular dependency between common runtime crate and Altair
-///     // runtime crate. Can we consider such token values as primitives much like
-///     // MILLISECONDS_PER_DAY constants, for instance, and extract them in a separate
-///     // library.
-/// 	let MICRO_AIR: Balance = runtime_common::constants::MICRO_CFG;
-/// 	let MILLI_AIR: Balance = runtime_common::constants::MILLI_CFG;
-/// 	let CENTI_AIR: Balance = runtime_common::constants::CENTI_CFG;
-/// 	let AIR: Balance = runtime_common::constants::CFG;
-///
-/// 	// Calculation:
-/// 	let base_fee: Balance = extrinsic_base_weight * weight_coefficient; // 39375000000000
-/// 	let length_fee: Balance = extrinsic_bytes * transaction_byte_fee; // 920000000000
-/// 	let weight_fee: Balance = weight * weight_coefficient; // 61425000000000
-/// 	let fee: Balance = base_fee + length_fee + weight_fee;
-/// 	assert_eq!(fee, 10172 * (MICRO_AIR / 100));
-/// ```
 pub struct WeightToFee;
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+		let p = super::CENTI_CFG;
+		let q = 10 * Balance::from(ExtrinsicBaseWeight::get());
+
 		smallvec!(WeightToFeeCoefficient {
-			coeff_integer: 315000,
-			coeff_frac: Perbill::zero(),
-			negative: false,
 			degree: 1,
+			negative: false,
+			coeff_frac: Perbill::from_rational(p % q, q),
+			coeff_integer: p / q,
 		})
 	}
 }

--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -43,8 +43,11 @@ where
 {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
 		if let Some(fees) = fees_then_tips.next() {
-			let trasury_amount = super::TREASURY_FEE_RATIO * fees.peek();
-			let mut split = fees.split(trasury_amount);
+			// for fees, split the destination
+			let mut split = fees.ration(
+				super::TREASURY_FEE_RATIO.deconstruct(),
+				(Perbill::one() - super::TREASURY_FEE_RATIO).deconstruct(),
+			);
 			if let Some(tips) = fees_then_tips.next() {
 				// for tips, if any, 100% to author
 				tips.merge_into(&mut split.1);
@@ -272,5 +275,162 @@ pub mod xcm {
 				.fee_per_second
 				.or_else(|| Some(default_per_second(metadata.decimals)))
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use frame_support::{parameter_types, traits::FindAuthor, weights::DispatchClass, PalletId};
+	use frame_system::limits;
+	use sp_core::H256;
+	use sp_runtime::{
+		testing::Header,
+		traits::{BlakeTwo256, IdentityLookup},
+		Perbill,
+	};
+	use sp_std::convert::TryFrom;
+
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
+	const TEST_ACCOUNT: AccountId = AccountId::new([1; 32]);
+
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+			Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
+			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+			Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>},
+		}
+	);
+
+	parameter_types! {
+		pub const BlockHashCount: u64 = 250;
+		pub BlockWeights: limits::BlockWeights = limits::BlockWeights::builder()
+			.base_block(10)
+			.for_class(DispatchClass::all(), |weight| {
+				weight.base_extrinsic = 100;
+			})
+			.for_class(DispatchClass::non_mandatory(), |weight| {
+				weight.max_total = Some(1024);
+			})
+			.build_or_panic();
+		pub BlockLength: limits::BlockLength = limits::BlockLength::max(2 * 1024);
+		pub const AvailableBlockRatio: Perbill = Perbill::one();
+	}
+
+	impl frame_system::Config for Test {
+		type BaseCallFilter = frame_support::traits::Everything;
+		type Origin = Origin;
+		type Index = u64;
+		type BlockNumber = u64;
+		type Call = Call;
+		type Hash = H256;
+		type Hashing = BlakeTwo256;
+		type AccountId = AccountId;
+		type Lookup = IdentityLookup<Self::AccountId>;
+		type Header = Header;
+		type Event = Event;
+		type BlockHashCount = BlockHashCount;
+		type BlockLength = BlockLength;
+		type BlockWeights = BlockWeights;
+		type DbWeight = ();
+		type Version = ();
+		type PalletInfo = PalletInfo;
+		type AccountData = pallet_balances::AccountData<u64>;
+		type OnNewAccount = ();
+		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
+		type SS58Prefix = ();
+		type OnSetCode = ();
+		type MaxConsumers = frame_support::traits::ConstU32<16>;
+	}
+
+	impl pallet_balances::Config for Test {
+		type Balance = u64;
+		type Event = Event;
+		type DustRemoval = ();
+		type ExistentialDeposit = ();
+		type AccountStore = System;
+		type MaxLocks = ();
+		type MaxReserves = ();
+		type ReserveIdentifier = [u8; 8];
+		type WeightInfo = ();
+	}
+
+	parameter_types! {
+		pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
+		pub const MaxApprovals: u32 = 100;
+	}
+
+	impl pallet_treasury::Config for Test {
+		type Currency = pallet_balances::Pallet<Test>;
+		type ApproveOrigin = frame_system::EnsureRoot<AccountId>;
+		type RejectOrigin = frame_system::EnsureRoot<AccountId>;
+		type Event = Event;
+		type OnSlash = ();
+		type ProposalBond = ();
+		type ProposalBondMinimum = ();
+		type ProposalBondMaximum = ();
+		type SpendPeriod = ();
+		type Burn = ();
+		type BurnDestination = ();
+		type PalletId = TreasuryPalletId;
+		type SpendFunds = ();
+		type MaxApprovals = MaxApprovals;
+		type WeightInfo = ();
+	}
+
+	pub struct OneAuthor;
+	impl FindAuthor<AccountId> for OneAuthor {
+		fn find_author<'a, I>(_: I) -> Option<AccountId>
+		where
+			I: 'a,
+		{
+			Some(TEST_ACCOUNT)
+		}
+	}
+	impl pallet_authorship::Config for Test {
+		type FindAuthor = OneAuthor;
+		type UncleGenerations = ();
+		type FilterUncle = ();
+		type EventHandler = ();
+	}
+
+	pub fn new_test_ext() -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Test>()
+			.unwrap();
+		// We use default for brevity, but you can configure as desired if needed.
+		pallet_balances::GenesisConfig::<Test>::default()
+			.assimilate_storage(&mut t)
+			.unwrap();
+		t.into()
+	}
+
+	#[test]
+	fn test_fees_and_tip_split() {
+		new_test_ext().execute_with(|| {
+			let fee = Balances::issue(10);
+			let tip = Balances::issue(20);
+
+			assert_eq!(Balances::free_balance(Treasury::account_id()), 0);
+			assert_eq!(Balances::free_balance(TEST_ACCOUNT), 0);
+
+			DealWithFees::on_unbalanceds(vec![fee, tip].into_iter());
+
+			assert_eq!(
+				Balances::free_balance(Treasury::account_id()),
+				super::TREASURY_FEE_RATIO * 10
+			);
+			assert_eq!(
+				Balances::free_balance(TEST_ACCOUNT),
+				20 + (Perbill::one() - super::TREASURY_FEE_RATIO) * 10
+			);
+		});
 	}
 }

--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -1,5 +1,6 @@
 //! Some configurable implementations as associated type for the substrate runtime.
 
+use super::constants::{CENTI_CFG, TREASURY_FEE_RATIO};
 use super::*;
 use codec::{Decode, Encode, MaxEncodedLen};
 use common_types::CurrencyId;
@@ -44,18 +45,18 @@ where
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
 		if let Some(fees) = fees_then_tips.next() {
 			// for fees, split the destination
-			let mut split = fees.ration(
-				super::TREASURY_FEE_RATIO.deconstruct(),
-				(Perbill::one() - super::TREASURY_FEE_RATIO).deconstruct(),
+			let (treasury_amount, mut author_amount) = fees.ration(
+				TREASURY_FEE_RATIO.deconstruct(),
+				(Perbill::one() - TREASURY_FEE_RATIO).deconstruct(),
 			);
 			if let Some(tips) = fees_then_tips.next() {
 				// for tips, if any, 100% to author
-				tips.merge_into(&mut split.1);
+				tips.merge_into(&mut author_amount);
 			}
 
 			use pallet_treasury::Pallet as Treasury;
-			<Treasury<R> as OnUnbalanced<_>>::on_unbalanced(split.0);
-			<ToAuthor<R> as OnUnbalanced<_>>::on_unbalanced(split.1);
+			<Treasury<R> as OnUnbalanced<_>>::on_unbalanced(treasury_amount);
+			<ToAuthor<R> as OnUnbalanced<_>>::on_unbalanced(author_amount);
 		}
 	}
 }
@@ -76,7 +77,7 @@ impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		let p = super::CENTI_CFG;
+		let p = CENTI_CFG;
 		let q = 10 * Balance::from(ExtrinsicBaseWeight::get());
 
 		smallvec!(WeightToFeeCoefficient {
@@ -281,156 +282,34 @@ pub mod xcm {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use frame_support::{parameter_types, traits::FindAuthor, weights::DispatchClass, PalletId};
-	use frame_system::limits;
-	use sp_core::H256;
-	use sp_runtime::{
-		testing::Header,
-		traits::{BlakeTwo256, IdentityLookup},
-		Perbill,
-	};
-	use sp_std::convert::TryFrom;
+	use mock::*;
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
-	type Block = frame_system::mocking::MockBlock<Test>;
 	const TEST_ACCOUNT: AccountId = AccountId::new([1; 32]);
-
-	frame_support::construct_runtime!(
-		pub enum Test where
-			Block = Block,
-			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
-		{
-			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-			Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
-			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-			Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>},
-		}
-	);
-
-	parameter_types! {
-		pub const BlockHashCount: u64 = 250;
-		pub BlockWeights: limits::BlockWeights = limits::BlockWeights::builder()
-			.base_block(10)
-			.for_class(DispatchClass::all(), |weight| {
-				weight.base_extrinsic = 100;
-			})
-			.for_class(DispatchClass::non_mandatory(), |weight| {
-				weight.max_total = Some(1024);
-			})
-			.build_or_panic();
-		pub BlockLength: limits::BlockLength = limits::BlockLength::max(2 * 1024);
-		pub const AvailableBlockRatio: Perbill = Perbill::one();
-	}
-
-	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::Everything;
-		type Origin = Origin;
-		type Index = u64;
-		type BlockNumber = u64;
-		type Call = Call;
-		type Hash = H256;
-		type Hashing = BlakeTwo256;
-		type AccountId = AccountId;
-		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
-		type Event = Event;
-		type BlockHashCount = BlockHashCount;
-		type BlockLength = BlockLength;
-		type BlockWeights = BlockWeights;
-		type DbWeight = ();
-		type Version = ();
-		type PalletInfo = PalletInfo;
-		type AccountData = pallet_balances::AccountData<u64>;
-		type OnNewAccount = ();
-		type OnKilledAccount = ();
-		type SystemWeightInfo = ();
-		type SS58Prefix = ();
-		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
-	}
-
-	impl pallet_balances::Config for Test {
-		type Balance = u64;
-		type Event = Event;
-		type DustRemoval = ();
-		type ExistentialDeposit = ();
-		type AccountStore = System;
-		type MaxLocks = ();
-		type MaxReserves = ();
-		type ReserveIdentifier = [u8; 8];
-		type WeightInfo = ();
-	}
-
-	parameter_types! {
-		pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
-		pub const MaxApprovals: u32 = 100;
-	}
-
-	impl pallet_treasury::Config for Test {
-		type Currency = pallet_balances::Pallet<Test>;
-		type ApproveOrigin = frame_system::EnsureRoot<AccountId>;
-		type RejectOrigin = frame_system::EnsureRoot<AccountId>;
-		type Event = Event;
-		type OnSlash = ();
-		type ProposalBond = ();
-		type ProposalBondMinimum = ();
-		type ProposalBondMaximum = ();
-		type SpendPeriod = ();
-		type Burn = ();
-		type BurnDestination = ();
-		type PalletId = TreasuryPalletId;
-		type SpendFunds = ();
-		type MaxApprovals = MaxApprovals;
-		type WeightInfo = ();
-	}
-
-	pub struct OneAuthor;
-	impl FindAuthor<AccountId> for OneAuthor {
-		fn find_author<'a, I>(_: I) -> Option<AccountId>
-		where
-			I: 'a,
-		{
-			Some(TEST_ACCOUNT)
-		}
-	}
-	impl pallet_authorship::Config for Test {
-		type FindAuthor = OneAuthor;
-		type UncleGenerations = ();
-		type FilterUncle = ();
-		type EventHandler = ();
-	}
-
-	pub fn new_test_ext() -> sp_io::TestExternalities {
-		let mut t = frame_system::GenesisConfig::default()
-			.build_storage::<Test>()
-			.unwrap();
-		// We use default for brevity, but you can configure as desired if needed.
-		pallet_balances::GenesisConfig::<Test>::default()
-			.assimilate_storage(&mut t)
-			.unwrap();
-		t.into()
-	}
 
 	#[test]
 	fn test_fees_and_tip_split() {
-		new_test_ext().execute_with(|| {
-			let fee = Balances::issue(10);
-			let tip = Balances::issue(20);
+		TestExternalitiesBuilder::default()
+			.build()
+			.execute_with(|| {
+				const FEE: u64 = 10;
+				const TIP: u64 = 20;
 
-			assert_eq!(Balances::free_balance(Treasury::account_id()), 0);
-			assert_eq!(Balances::free_balance(TEST_ACCOUNT), 0);
+				let fee = Balances::issue(FEE);
+				let tip = Balances::issue(TIP);
 
-			DealWithFees::on_unbalanceds(vec![fee, tip].into_iter());
+				assert_eq!(Balances::free_balance(Treasury::account_id()), 0);
+				assert_eq!(Balances::free_balance(TEST_ACCOUNT), 0);
 
-			assert_eq!(
-				Balances::free_balance(Treasury::account_id()),
-				super::TREASURY_FEE_RATIO * 10
-			);
-			assert_eq!(
-				Balances::free_balance(TEST_ACCOUNT),
-				20 + (Perbill::one() - super::TREASURY_FEE_RATIO) * 10
-			);
-		});
+				DealWithFees::on_unbalanceds(vec![fee, tip].into_iter());
+
+				assert_eq!(
+					Balances::free_balance(Treasury::account_id()),
+					TREASURY_FEE_RATIO * FEE
+				);
+				assert_eq!(
+					Balances::free_balance(TEST_ACCOUNT),
+					TIP + (Perbill::one() - TREASURY_FEE_RATIO) * FEE
+				);
+			});
 	}
 }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -25,6 +25,10 @@ pub mod apis;
 mod fixed_point;
 mod impls;
 
+// Pallet mock runtime
+#[cfg(test)]
+mod mock;
+
 /// Common types for all runtimes
 pub mod types {
 	use codec::{CompactAs, Decode, Encode, MaxEncodedLen};

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -280,6 +280,9 @@ pub mod constants {
 	/// Additional fee charged when validating NFT proofs
 	pub const NFT_PROOF_VALIDATION_FEE: Balance = 10 * CFG;
 
+	/// % of fee addressed to the Treasury. The reminder % will be for the block author.
+	pub const TREASURY_FEE_RATIO: Perbill = Perbill::from_percent(80);
+
 	// Represents the protobuf encoding - "NFTS". All Centrifuge documents are formatted in this way.
 	/// These are pre/appended to the registry id before being set as a [RegistryInfo] field in [create_registry].
 	pub const NFTS_PREFIX: &'static [u8] = &[1, 0, 0, 0, 0, 0, 0, 20];

--- a/runtime/common/src/mock.rs
+++ b/runtime/common/src/mock.rs
@@ -1,0 +1,142 @@
+use super::*;
+use frame_support::{parameter_types, traits::FindAuthor, weights::DispatchClass, PalletId};
+use frame_system::limits;
+use sp_core::H256;
+use sp_io::TestExternalities;
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+	Perbill,
+};
+use sp_std::convert::{TryFrom, TryInto};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+const TEST_ACCOUNT: AccountId = AccountId::new([1; 32]);
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>},
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub BlockWeights: limits::BlockWeights = limits::BlockWeights::builder()
+		.base_block(10)
+		.for_class(DispatchClass::all(), |weight| {
+			weight.base_extrinsic = 100;
+		})
+		.for_class(DispatchClass::non_mandatory(), |weight| {
+			weight.max_total = Some(1024);
+		})
+		.build_or_panic();
+	pub BlockLength: limits::BlockLength = limits::BlockLength::max(2 * 1024);
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Call = Call;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type BlockLength = BlockLength;
+	type BlockWeights = BlockWeights;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = u64;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ();
+	type AccountStore = System;
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
+	pub const MaxApprovals: u32 = 100;
+}
+
+impl pallet_treasury::Config for Test {
+	type Currency = pallet_balances::Pallet<Test>;
+	type ApproveOrigin = frame_system::EnsureRoot<AccountId>;
+	type RejectOrigin = frame_system::EnsureRoot<AccountId>;
+	type Event = Event;
+	type OnSlash = ();
+	type ProposalBond = ();
+	type ProposalBondMinimum = ();
+	type ProposalBondMaximum = ();
+	type SpendPeriod = ();
+	type Burn = ();
+	type BurnDestination = ();
+	type PalletId = TreasuryPalletId;
+	type SpendFunds = ();
+	type MaxApprovals = MaxApprovals;
+	type WeightInfo = ();
+}
+
+pub struct OneAuthor;
+impl FindAuthor<AccountId> for OneAuthor {
+	fn find_author<'a, I>(_: I) -> Option<AccountId>
+	where
+		I: 'a,
+	{
+		Some(TEST_ACCOUNT)
+	}
+}
+impl pallet_authorship::Config for Test {
+	type FindAuthor = OneAuthor;
+	type UncleGenerations = ();
+	type FilterUncle = ();
+	type EventHandler = ();
+}
+
+pub struct TestExternalitiesBuilder {}
+
+impl Default for TestExternalitiesBuilder {
+	fn default() -> Self {
+		Self {}
+	}
+}
+
+impl TestExternalitiesBuilder {
+	pub(crate) fn build(self) -> TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Test>()
+			.unwrap();
+
+		pallet_balances::GenesisConfig::<Test>::default()
+			.assimilate_storage(&mut t)
+			.unwrap();
+		t.into()
+	}
+}


### PR DESCRIPTION
Proposal to increment the tx fees:
https://gov.centrifuge.io/t/rfc-increase-transaction-fees-on-centrifuge-chain-by-100x-and-use-the-fees-towards-a-token-burn/3723?u=ash

Comparison of old vs new fee (around 33 times more):
 - Current balance transfer fee on a dev environment: **0.000099871597561621 CFG**
 - New balance transfer fee on same dev environment **0.003287559668446737 CFG** 

Pending before merging:
- [x] Implementation
- [x] Discuss the correct % of fees to the treasury: 80% treasury and 20% author.
- [x] Discuss the correct % to burn in the treasury: 0% by now
- [x] Unitary Tests.
- [x] ~~Integration Tests (blocked until [fudge](https://github.com/centrifuge/fudge) works with Polkadot 9.24).~~ (Can be updated in other PR)
- [x] Analyzing new fee values (Blocked until having the correct %).

Closes #809