### PR TITLE
Drop CurrencyId::Usd in favour of AUSD

### DIFF
--- a/libs/common-types/src/tokens.rs
+++ b/libs/common-types/src/tokens.rs
@@ -30,6 +30,9 @@ pub enum CurrencyId {
 
 	/// Karura Dollar
 	KUSD,
+	/// Acala Dollar
+	/// Note: KUSD and AUSD will be merged into a single token, AUSD.
+	AUSD,
 
 	Permissioned(PermissionedCurrency),
 }
@@ -47,6 +50,7 @@ impl TokenMetadata for CurrencyId {
 			.as_ref()
 			.to_vec(),
 			CurrencyId::KUSD => b"Karura Dollar".to_vec(),
+			CurrencyId::AUSD => b"Acala Dollar".to_vec(),
 			CurrencyId::KSM => b"Kusama".to_vec(),
 		}
 	}
@@ -61,6 +65,7 @@ impl TokenMetadata for CurrencyId {
 					.to_vec()
 			}
 			CurrencyId::KUSD => b"KUSD".to_vec(),
+			CurrencyId::AUSD => b"AUSD".to_vec(),
 			CurrencyId::KSM => b"KSM".to_vec(),
 		}
 	}
@@ -70,7 +75,7 @@ impl TokenMetadata for CurrencyId {
 			CurrencyId::Native => 18,
 			CurrencyId::Permissioned(_) => 12,
 			CurrencyId::Tranche(_, _) => 27,
-			CurrencyId::KUSD | CurrencyId::KSM => 12,
+			CurrencyId::KUSD | CurrencyId::AUSD | CurrencyId::KSM => 12,
 		}
 	}
 }

--- a/libs/common-types/src/tokens.rs
+++ b/libs/common-types/src/tokens.rs
@@ -20,8 +20,9 @@ pub enum PermissionedCurrency {
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum CurrencyId {
+	// The Native token, representing AIR in Altair and CFG in Centrifuge.
 	Native,
-	Usd,
+	// A Tranche token
 	Tranche(u64, [u8; 16]),
 
 	/// Karura KSM
@@ -37,7 +38,6 @@ impl TokenMetadata for CurrencyId {
 	fn name(&self) -> Vec<u8> {
 		match self {
 			CurrencyId::Native => b"Native currency".to_vec(),
-			CurrencyId::Usd => b"USD stable coin".to_vec(),
 			CurrencyId::Permissioned(_) => b"Permissioned currency".to_vec(),
 			CurrencyId::Tranche(pool_id, tranche_id) => format_runtime_string!(
 				"Tranche token of pool {} and tranche {:?}",
@@ -54,7 +54,6 @@ impl TokenMetadata for CurrencyId {
 	fn symbol(&self) -> Vec<u8> {
 		match self {
 			CurrencyId::Native => b"CFG".to_vec(),
-			CurrencyId::Usd => b"USD".to_vec(),
 			CurrencyId::Permissioned(_) => b"PERM".to_vec(),
 			CurrencyId::Tranche(pool_id, tranche_id) => {
 				format_runtime_string!("TT:{}:{:?}", pool_id, tranche_id)
@@ -71,7 +70,7 @@ impl TokenMetadata for CurrencyId {
 			CurrencyId::Native => 18,
 			CurrencyId::Permissioned(_) => 12,
 			CurrencyId::Tranche(_, _) => 27,
-			CurrencyId::Usd | CurrencyId::KUSD | CurrencyId::KSM => 12,
+			CurrencyId::KUSD | CurrencyId::KSM => 12,
 		}
 	}
 }

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -149,8 +149,8 @@ where
 	let (senior_inv, junior_inv) = investors::<T>();
 	make_free_cfg_balance::<T>(senior_inv.clone());
 	make_free_cfg_balance::<T>(junior_inv.clone());
-	make_free_token_balance::<T>(CurrencyId::KUSD, &senior_inv, (500 * CURRENCY).into());
-	make_free_token_balance::<T>(CurrencyId::KUSD, &junior_inv, (500 * CURRENCY).into());
+	make_free_token_balance::<T>(CurrencyId::AUSD, &senior_inv, (500 * CURRENCY).into());
+	make_free_token_balance::<T>(CurrencyId::AUSD, &junior_inv, (500 * CURRENCY).into());
 	let pool_id: PoolIdOf<T> = Default::default();
 	let pool_account = pool_account::<T>(pool_id.into());
 	let pal_pool_id: T::PoolId = pool_id.into();
@@ -159,7 +159,7 @@ where
 		pool_owner.clone(),
 		junior_inv,
 		senior_inv,
-		CurrencyId::KUSD,
+		CurrencyId::AUSD,
 	);
 	let tranche_id = get_tranche_id::<T>(pool_id.into(), 0);
 	make_free_token_balance::<T>(
@@ -383,11 +383,11 @@ benchmarks! {
 		// pool reserve should have 100 USD less = 900 USD
 		let pool_reserve_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (900 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::KUSD, &pool_reserve_account, pool_reserve_balance);
+		check_free_token_balance::<T>(CurrencyId::AUSD, &pool_reserve_account, pool_reserve_balance);
 
 		// loan owner should have 100 USD
 		let loan_owner_balance: <T as ORMLConfig>::Balance = (100 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::KUSD, &loan_owner, loan_owner_balance);
+		check_free_token_balance::<T>(CurrencyId::AUSD, &loan_owner, loan_owner_balance);
 	}
 
 	further_borrows {
@@ -409,11 +409,11 @@ benchmarks! {
 		// pool reserve should have 100 USD less = 900 USD
 		let pool_reserve_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (910 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::KUSD, &pool_reserve_account, pool_reserve_balance);
+		check_free_token_balance::<T>(CurrencyId::AUSD, &pool_reserve_account, pool_reserve_balance);
 
 		// loan owner should have 100 USD
 		let loan_owner_balance: <T as ORMLConfig>::Balance = (90 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::KUSD, &loan_owner, loan_owner_balance);
+		check_free_token_balance::<T>(CurrencyId::AUSD, &loan_owner, loan_owner_balance);
 	}
 
 	repay {
@@ -435,11 +435,11 @@ benchmarks! {
 		// pool reserve should have 1000 USD
 		let pool_reserve_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (1000 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::KUSD, &pool_reserve_account, pool_reserve_balance);
+		check_free_token_balance::<T>(CurrencyId::AUSD, &pool_reserve_account, pool_reserve_balance);
 
 		// loan owner should have 0 USD
 		let loan_owner_balance: <T as ORMLConfig>::Balance = (0 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::KUSD, &loan_owner, loan_owner_balance);
+		check_free_token_balance::<T>(CurrencyId::AUSD, &loan_owner, loan_owner_balance);
 
 		// current debt should not be zero
 		let loan = Loan::<T>::get(pool_id, loan_id).expect("loan info should be present");
@@ -507,7 +507,7 @@ benchmarks! {
 		TimestampPallet::<T>::set(RawOrigin::None.into(), after_two_years.into()).expect("timestamp set should not fail");
 		// repay all. sent more than current debt
 		let owner_balance: <T as ORMLConfig>::Balance = (1000 * CURRENCY).into();
-		make_free_token_balance::<T>(CurrencyId::KUSD, &loan_owner, owner_balance);
+		make_free_token_balance::<T>(CurrencyId::AUSD, &loan_owner, owner_balance);
 		let amount = Amount::from_inner(200 * CURRENCY).into();
 		LoansPallet::<T>::repay(RawOrigin::Signed(loan_owner.clone()).into(), pool_id, loan_id, amount).expect("repay should not fail");
 	}:close(RawOrigin::Signed(loan_owner.clone()), pool_id, loan_id)
@@ -516,7 +516,7 @@ benchmarks! {
 		// pool reserve should have more 1000 USD. this is with interest
 		let pool_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (1000 * CURRENCY).into();
-		assert!(get_free_token_balance::<T>(CurrencyId::KUSD, &pool_account) > pool_reserve_balance);
+		assert!(get_free_token_balance::<T>(CurrencyId::AUSD, &pool_account) > pool_reserve_balance);
 
 		// Loan should be closed
 		let loan = Loan::<T>::get(pool_id, loan_id).expect("loan info should be present");
@@ -552,7 +552,7 @@ benchmarks! {
 		// pool reserve should have 900 USD since loan is written off 100%
 		let pool_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (900 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::KUSD, &pool_account, pool_reserve_balance);
+		check_free_token_balance::<T>(CurrencyId::AUSD, &pool_account, pool_reserve_balance);
 
 		// Loan should be closed
 		let loan = Loan::<T>::get(pool_id, loan_id).expect("loan info should be present");

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -149,8 +149,8 @@ where
 	let (senior_inv, junior_inv) = investors::<T>();
 	make_free_cfg_balance::<T>(senior_inv.clone());
 	make_free_cfg_balance::<T>(junior_inv.clone());
-	make_free_token_balance::<T>(CurrencyId::Usd, &senior_inv, (500 * CURRENCY).into());
-	make_free_token_balance::<T>(CurrencyId::Usd, &junior_inv, (500 * CURRENCY).into());
+	make_free_token_balance::<T>(CurrencyId::KUSD, &senior_inv, (500 * CURRENCY).into());
+	make_free_token_balance::<T>(CurrencyId::KUSD, &junior_inv, (500 * CURRENCY).into());
 	let pool_id: PoolIdOf<T> = Default::default();
 	let pool_account = pool_account::<T>(pool_id.into());
 	let pal_pool_id: T::PoolId = pool_id.into();
@@ -159,7 +159,7 @@ where
 		pool_owner.clone(),
 		junior_inv,
 		senior_inv,
-		CurrencyId::Usd,
+		CurrencyId::KUSD,
 	);
 	let tranche_id = get_tranche_id::<T>(pool_id.into(), 0);
 	make_free_token_balance::<T>(
@@ -383,11 +383,11 @@ benchmarks! {
 		// pool reserve should have 100 USD less = 900 USD
 		let pool_reserve_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (900 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::Usd, &pool_reserve_account, pool_reserve_balance);
+		check_free_token_balance::<T>(CurrencyId::KUSD, &pool_reserve_account, pool_reserve_balance);
 
 		// loan owner should have 100 USD
 		let loan_owner_balance: <T as ORMLConfig>::Balance = (100 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::Usd, &loan_owner, loan_owner_balance);
+		check_free_token_balance::<T>(CurrencyId::KUSD, &loan_owner, loan_owner_balance);
 	}
 
 	further_borrows {
@@ -409,11 +409,11 @@ benchmarks! {
 		// pool reserve should have 100 USD less = 900 USD
 		let pool_reserve_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (910 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::Usd, &pool_reserve_account, pool_reserve_balance);
+		check_free_token_balance::<T>(CurrencyId::KUSD, &pool_reserve_account, pool_reserve_balance);
 
 		// loan owner should have 100 USD
 		let loan_owner_balance: <T as ORMLConfig>::Balance = (90 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::Usd, &loan_owner, loan_owner_balance);
+		check_free_token_balance::<T>(CurrencyId::KUSD, &loan_owner, loan_owner_balance);
 	}
 
 	repay {
@@ -435,11 +435,11 @@ benchmarks! {
 		// pool reserve should have 1000 USD
 		let pool_reserve_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (1000 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::Usd, &pool_reserve_account, pool_reserve_balance);
+		check_free_token_balance::<T>(CurrencyId::KUSD, &pool_reserve_account, pool_reserve_balance);
 
 		// loan owner should have 0 USD
 		let loan_owner_balance: <T as ORMLConfig>::Balance = (0 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::Usd, &loan_owner, loan_owner_balance);
+		check_free_token_balance::<T>(CurrencyId::KUSD, &loan_owner, loan_owner_balance);
 
 		// current debt should not be zero
 		let loan = Loan::<T>::get(pool_id, loan_id).expect("loan info should be present");
@@ -507,7 +507,7 @@ benchmarks! {
 		TimestampPallet::<T>::set(RawOrigin::None.into(), after_two_years.into()).expect("timestamp set should not fail");
 		// repay all. sent more than current debt
 		let owner_balance: <T as ORMLConfig>::Balance = (1000 * CURRENCY).into();
-		make_free_token_balance::<T>(CurrencyId::Usd, &loan_owner, owner_balance);
+		make_free_token_balance::<T>(CurrencyId::KUSD, &loan_owner, owner_balance);
 		let amount = Amount::from_inner(200 * CURRENCY).into();
 		LoansPallet::<T>::repay(RawOrigin::Signed(loan_owner.clone()).into(), pool_id, loan_id, amount).expect("repay should not fail");
 	}:close(RawOrigin::Signed(loan_owner.clone()), pool_id, loan_id)
@@ -516,7 +516,7 @@ benchmarks! {
 		// pool reserve should have more 1000 USD. this is with interest
 		let pool_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (1000 * CURRENCY).into();
-		assert!(get_free_token_balance::<T>(CurrencyId::Usd, &pool_account) > pool_reserve_balance);
+		assert!(get_free_token_balance::<T>(CurrencyId::KUSD, &pool_account) > pool_reserve_balance);
 
 		// Loan should be closed
 		let loan = Loan::<T>::get(pool_id, loan_id).expect("loan info should be present");
@@ -552,7 +552,7 @@ benchmarks! {
 		// pool reserve should have 900 USD since loan is written off 100%
 		let pool_account = pool_account::<T>(pool_id.into());
 		let pool_reserve_balance: <T as ORMLConfig>::Balance = (900 * CURRENCY).into();
-		check_free_token_balance::<T>(CurrencyId::Usd, &pool_account, pool_reserve_balance);
+		check_free_token_balance::<T>(CurrencyId::KUSD, &pool_account, pool_reserve_balance);
 
 		// Loan should be closed
 		let loan = Loan::<T>::get(pool_id, loan_id).expect("loan info should be present");

--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -318,7 +318,7 @@ impl pallet_loans::Config for MockRuntime {
 }
 
 // USD currencyId
-pub const USD: CurrencyId = CurrencyId::KUSD;
+pub const USD: CurrencyId = CurrencyId::AUSD;
 
 // Test externalities builder
 //

--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -318,7 +318,7 @@ impl pallet_loans::Config for MockRuntime {
 }
 
 // USD currencyId
-pub const USD: CurrencyId = CurrencyId::Usd;
+pub const USD: CurrencyId = CurrencyId::KUSD;
 
 // Test externalities builder
 //

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -80,7 +80,7 @@ where
 		pool_admin,
 		JuniorInvestor::get(),
 		SeniorInvestor::get(),
-		CurrencyId::Usd,
+		CurrencyId::KUSD,
 	);
 	// add borrower role and price admin role
 	assert_ok!(pallet_permissions::Pallet::<T>::add(
@@ -523,10 +523,10 @@ macro_rules! test_borrow_loan {
 				// successful issue
 				let (pool_id, loan, _collateral) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				// successful pricing
@@ -563,9 +563,9 @@ macro_rules! test_borrow_loan {
 					.unwrap();
 				assert_eq!(loan.principal_debt, p_debt);
 				// pool should have 50 less token
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 950 * USD);
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, 50 * USD);
 				// nav should be updated to latest present value
 				let current_nav = <Loans as TPoolNav<PoolId, Amount>>::nav(pool_id).unwrap().0;
@@ -595,9 +595,9 @@ macro_rules! test_borrow_loan {
 					.unwrap();
 				assert_eq!(loan.principal_debt, p_debt);
 
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 930 * USD);
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, 70 * USD);
 				let current_nav = <Loans as TPoolNav<PoolId, Amount>>::nav(pool_id).unwrap().0;
 				let pv = loan.present_value(&vec![]).unwrap();
@@ -687,10 +687,10 @@ macro_rules! test_repay_loan {
 				let (pool_id, loan_nft, collateral_nft) =
 					issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 				let loan_id = loan_nft.1;
 
@@ -715,9 +715,9 @@ macro_rules! test_repay_loan {
 					.unwrap();
 				assert_eq!(loan.principal_debt, p_debt);
 				// pool should have 50 less token
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 950 * USD);
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, 50 * USD);
 				// nav should be updated to latest present value
 				let current_nav = <Loans as TPoolNav<PoolId, Amount>>::nav(pool_id).unwrap().0;
@@ -745,9 +745,9 @@ macro_rules! test_repay_loan {
 				// principal debt should still be more than 30 due to interest
 				assert!(loan.principal_debt > Amount::from_inner(30 * USD));
 				// pool should have 30 less token
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 970 * USD);
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, 30 * USD);
 				// nav should be updated to latest present value
 				let current_nav = <Loans as TPoolNav<PoolId, Amount>>::nav(pool_id).unwrap().0;
@@ -820,7 +820,7 @@ macro_rules! test_repay_loan {
 				let res = Tokens::transfer(
 					Origin::signed(dummy),
 					dest,
-					CurrencyId::Usd,
+					CurrencyId::KUSD,
 					transfer_amount,
 				);
 				assert_ok!(res);
@@ -857,12 +857,12 @@ macro_rules! test_repay_loan {
 				assert_eq!(current_nav, Zero::zero());
 
 				// pool balance should be 1000 + interest
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				let expected_balance = 1000 * USD + transfer_amount;
 				assert_eq!(pool_balance, expected_balance);
 
 				// owner balance should be zero
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				// owner account should own the collateral NFT
@@ -906,10 +906,10 @@ macro_rules! test_pool_nav {
 				// successful issue
 				let (pool_id, loan, _collateral) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 				let loan_id = loan.1;
 
@@ -1149,7 +1149,7 @@ fn test_add_write_off_groups() {
 				pool_admin,
 				JuniorInvestor::get(),
 				SeniorInvestor::get(),
-				CurrencyId::Usd,
+				CurrencyId::KUSD,
 			);
 			let pr_pool_id: PoolIdOf<MockRuntime> = pool_id.into();
 			initialise_test_pool::<MockRuntime>(pr_pool_id, 1, pool_admin, None);
@@ -1206,10 +1206,10 @@ macro_rules! test_write_off_maturity_loan {
 				// successful issue
 				let (pool_id, loan, _collateral) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 				let loan_id = loan.1;
 
@@ -1309,10 +1309,10 @@ macro_rules! test_admin_write_off_loan_type {
 				// successful issue
 				let (pool_id, loan, _asset) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				let loan_id = loan.1;
@@ -1424,10 +1424,10 @@ macro_rules! test_close_written_off_loan_type {
 				// successful issue
 				let (pool_id, loan, asset) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				let loan_id = loan.1;
@@ -1555,10 +1555,10 @@ macro_rules! repay_too_early {
 				// successful issue
 				let (pool_id, loan, _asset) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				let loan_id = loan.1;
@@ -1572,10 +1572,10 @@ macro_rules! repay_too_early {
 				assert_ok!(res);
 
 				// check balances
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 900 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, 100 * USD);
 
 				// repay in the same instant
@@ -1588,10 +1588,10 @@ macro_rules! repay_too_early {
 				assert_ok!(res);
 
 				// check balances
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				// close loan
@@ -1618,10 +1618,10 @@ macro_rules! write_off_overflow {
 				// successful issue
 				let (pool_id, loan, _asset) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::Usd, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 				let loan_id = loan.1;
 

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -80,7 +80,7 @@ where
 		pool_admin,
 		JuniorInvestor::get(),
 		SeniorInvestor::get(),
-		CurrencyId::KUSD,
+		CurrencyId::AUSD,
 	);
 	// add borrower role and price admin role
 	assert_ok!(pallet_permissions::Pallet::<T>::add(
@@ -523,10 +523,10 @@ macro_rules! test_borrow_loan {
 				// successful issue
 				let (pool_id, loan, _collateral) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				// successful pricing
@@ -563,9 +563,9 @@ macro_rules! test_borrow_loan {
 					.unwrap();
 				assert_eq!(loan.principal_debt, p_debt);
 				// pool should have 50 less token
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 950 * USD);
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, 50 * USD);
 				// nav should be updated to latest present value
 				let current_nav = <Loans as TPoolNav<PoolId, Amount>>::nav(pool_id).unwrap().0;
@@ -595,9 +595,9 @@ macro_rules! test_borrow_loan {
 					.unwrap();
 				assert_eq!(loan.principal_debt, p_debt);
 
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 930 * USD);
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, 70 * USD);
 				let current_nav = <Loans as TPoolNav<PoolId, Amount>>::nav(pool_id).unwrap().0;
 				let pv = loan.present_value(&vec![]).unwrap();
@@ -687,10 +687,10 @@ macro_rules! test_repay_loan {
 				let (pool_id, loan_nft, collateral_nft) =
 					issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 				let loan_id = loan_nft.1;
 
@@ -715,9 +715,9 @@ macro_rules! test_repay_loan {
 					.unwrap();
 				assert_eq!(loan.principal_debt, p_debt);
 				// pool should have 50 less token
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 950 * USD);
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, 50 * USD);
 				// nav should be updated to latest present value
 				let current_nav = <Loans as TPoolNav<PoolId, Amount>>::nav(pool_id).unwrap().0;
@@ -745,9 +745,9 @@ macro_rules! test_repay_loan {
 				// principal debt should still be more than 30 due to interest
 				assert!(loan.principal_debt > Amount::from_inner(30 * USD));
 				// pool should have 30 less token
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 970 * USD);
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, 30 * USD);
 				// nav should be updated to latest present value
 				let current_nav = <Loans as TPoolNav<PoolId, Amount>>::nav(pool_id).unwrap().0;
@@ -820,7 +820,7 @@ macro_rules! test_repay_loan {
 				let res = Tokens::transfer(
 					Origin::signed(dummy),
 					dest,
-					CurrencyId::KUSD,
+					CurrencyId::AUSD,
 					transfer_amount,
 				);
 				assert_ok!(res);
@@ -857,12 +857,12 @@ macro_rules! test_repay_loan {
 				assert_eq!(current_nav, Zero::zero());
 
 				// pool balance should be 1000 + interest
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				let expected_balance = 1000 * USD + transfer_amount;
 				assert_eq!(pool_balance, expected_balance);
 
 				// owner balance should be zero
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				// owner account should own the collateral NFT
@@ -906,10 +906,10 @@ macro_rules! test_pool_nav {
 				// successful issue
 				let (pool_id, loan, _collateral) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 				let loan_id = loan.1;
 
@@ -1149,7 +1149,7 @@ fn test_add_write_off_groups() {
 				pool_admin,
 				JuniorInvestor::get(),
 				SeniorInvestor::get(),
-				CurrencyId::KUSD,
+				CurrencyId::AUSD,
 			);
 			let pr_pool_id: PoolIdOf<MockRuntime> = pool_id.into();
 			initialise_test_pool::<MockRuntime>(pr_pool_id, 1, pool_admin, None);
@@ -1206,10 +1206,10 @@ macro_rules! test_write_off_maturity_loan {
 				// successful issue
 				let (pool_id, loan, _collateral) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 				let loan_id = loan.1;
 
@@ -1309,10 +1309,10 @@ macro_rules! test_admin_write_off_loan_type {
 				// successful issue
 				let (pool_id, loan, _asset) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				let loan_id = loan.1;
@@ -1424,10 +1424,10 @@ macro_rules! test_close_written_off_loan_type {
 				// successful issue
 				let (pool_id, loan, asset) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				let loan_id = loan.1;
@@ -1555,10 +1555,10 @@ macro_rules! repay_too_early {
 				// successful issue
 				let (pool_id, loan, _asset) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				let loan_id = loan.1;
@@ -1572,10 +1572,10 @@ macro_rules! repay_too_early {
 				assert_ok!(res);
 
 				// check balances
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 900 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, 100 * USD);
 
 				// repay in the same instant
@@ -1588,10 +1588,10 @@ macro_rules! repay_too_early {
 				assert_ok!(res);
 
 				// check balances
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 
 				// close loan
@@ -1618,10 +1618,10 @@ macro_rules! write_off_overflow {
 				// successful issue
 				let (pool_id, loan, _asset) = issue_test_loan::<MockRuntime>(0, borrower);
 				let pool_account = PoolLocator { pool_id }.into_account();
-				let pool_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &pool_account);
+				let pool_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &pool_account);
 				assert_eq!(pool_balance, 1000 * USD);
 
-				let owner_balance = balance_of::<MockRuntime>(CurrencyId::KUSD, &borrower);
+				let owner_balance = balance_of::<MockRuntime>(CurrencyId::AUSD, &borrower);
 				assert_eq!(owner_balance, Zero::zero());
 				let loan_id = loan.1;
 

--- a/pallets/nft-sales/src/benchmarking.rs
+++ b/pallets/nft-sales/src/benchmarking.rs
@@ -36,7 +36,7 @@ benchmarks! {
 		// We need the NFT to exist in the pallet-uniques before we can put it for sale
 		let (class_id, instance_id) = mint_nft::<T>(0, 1, &seller_account);
 		// Define the price
-		let price: Price<crate::CurrencyOf<T>, crate::BalanceOf<T>> = Price { currency: CurrencyId::Usd.into(), amount: 10_000u128.into() };
+		let price: Price<crate::CurrencyOf<T>, crate::BalanceOf<T>> = Price { currency: CurrencyId::KUSD.into(), amount: 10_000u128.into() };
 
 	}: _(seller_origin, class_id, instance_id, price)
 	verify {
@@ -52,7 +52,7 @@ benchmarks! {
 		// We need the NFT to exist in the pallet-uniques before we can put it for sale
 		let (class_id, instance_id) = mint_nft::<T>(0, 1, &seller_account);
 		// Define the price
-		let price: Price<crate::CurrencyOf<T>, crate::BalanceOf<T>> = Price { currency: CurrencyId::Usd.into(), amount: 10_000u128.into() };
+		let price: Price<crate::CurrencyOf<T>, crate::BalanceOf<T>> = Price { currency: CurrencyId::KUSD.into(), amount: 10_000u128.into() };
 
 		// We need the nft in the storage beforehand to be able to remove it
 		<Sales<T>>::insert(class_id.clone(), instance_id.clone(), Sale { seller: seller_account, price});
@@ -71,7 +71,7 @@ benchmarks! {
 		// We need the NFT to exist in the pallet-uniques before we can put it for sale
 		let (class_id, instance_id) = mint_nft::<T>(0, 1, &seller_account);
 		// Define the price
-		let price: Price<crate::CurrencyOf<T>, crate::BalanceOf<T>> = Price { currency: CurrencyId::Usd.into(), amount: 10_000u128.into() };
+		let price: Price<crate::CurrencyOf<T>, crate::BalanceOf<T>> = Price { currency: CurrencyId::KUSD.into(), amount: 10_000u128.into() };
 
 		// We need the nft in the storage beforehand to be able to remove it
 		<Sales<T>>::insert(class_id.clone(), instance_id.clone(), Sale { seller: seller_account, price: price.clone()});
@@ -79,7 +79,7 @@ benchmarks! {
 		// We need the buyer to have enough balance to pay for the NFT
 		let buyer_account = account::<T::AccountId>("buyer", 0, 0);
 		let buyer_origin: RawOrigin<T::AccountId> = RawOrigin::Signed(buyer_account.clone()).into();
-		deposit_token_balance::<T>(&buyer_account, CurrencyId::Usd, 100_000u128.into());
+		deposit_token_balance::<T>(&buyer_account, CurrencyId::KUSD, 100_000u128.into());
 
 	}: _(buyer_origin, class_id, instance_id, price)
 	verify {

--- a/pallets/nft-sales/src/benchmarking.rs
+++ b/pallets/nft-sales/src/benchmarking.rs
@@ -36,7 +36,7 @@ benchmarks! {
 		// We need the NFT to exist in the pallet-uniques before we can put it for sale
 		let (class_id, instance_id) = mint_nft::<T>(0, 1, &seller_account);
 		// Define the price
-		let price: Price<crate::CurrencyOf<T>, crate::BalanceOf<T>> = Price { currency: CurrencyId::KUSD.into(), amount: 10_000u128.into() };
+		let price: Price<crate::CurrencyOf<T>, crate::BalanceOf<T>> = Price { currency: CurrencyId::AUSD.into(), amount: 10_000u128.into() };
 
 	}: _(seller_origin, class_id, instance_id, price)
 	verify {

--- a/pallets/nft-sales/src/mock.rs
+++ b/pallets/nft-sales/src/mock.rs
@@ -203,7 +203,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	orml_tokens::GenesisConfig::<Test> {
 		balances: (0..10)
 			.into_iter()
-			.map(|idx| (idx, CurrencyId::Usd, 1000 * CURRENCY))
+			.map(|idx| (idx, CurrencyId::KUSD, 1000 * CURRENCY))
 			.collect(),
 	}
 	.assimilate_storage(&mut t)

--- a/pallets/nft-sales/src/tests.rs
+++ b/pallets/nft-sales/src/tests.rs
@@ -33,7 +33,7 @@ fn add_nft_not_found() {
 				unknown_nft.0,
 				unknown_nft.1,
 				Price {
-					currency: CurrencyId::Usd,
+					currency: CurrencyId::KUSD,
 					amount: 3
 				}
 			),
@@ -56,7 +56,7 @@ fn add_nft_not_owner() {
 				class_id,
 				instance_id,
 				Price {
-					currency: CurrencyId::Usd,
+					currency: CurrencyId::KUSD,
 					amount: 3
 				}
 			),
@@ -78,7 +78,7 @@ fn add_nft_works() {
 		let seller: Origin = Origin::signed(SELLER);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let price = Price {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			amount: 10_000,
 		};
 
@@ -120,7 +120,7 @@ fn remove_nft_bad_actor() {
 		let seller: Origin = Origin::signed(SELLER);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let price = Price {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			amount: 10_000,
 		};
 
@@ -156,7 +156,7 @@ fn remove_nft_works() {
 		let seller: Origin = Origin::signed(SELLER);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let price = Price {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			amount: 10_000,
 		};
 
@@ -194,7 +194,7 @@ fn buy_nft_seller() {
 		let seller: Origin = Origin::signed(SELLER);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let price = Price {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			amount: 10_000,
 		};
 		// Set it for sale in the NftSales
@@ -215,7 +215,7 @@ fn buy_nft_not_for_sale() {
 		let seller: Origin = Origin::signed(SELLER);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let offer = Price {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			amount: 10_000,
 		};
 
@@ -234,8 +234,8 @@ fn buy_nft_insufficient_balance() {
 		let seller: Origin = Origin::signed(SELLER);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let price = Price {
-			currency: CurrencyId::Usd,
-			amount: OrmlTokens::balance(CurrencyId::Usd, &1) + 1,
+			currency: CurrencyId::KUSD,
+			amount: OrmlTokens::balance(CurrencyId::KUSD, &1) + 1,
 		};
 
 		// Set it for sale in the NftSales
@@ -260,10 +260,10 @@ fn buy_nft_insufficient_balance() {
 fn buy_nft_works() {
 	new_test_ext().execute_with(|| {
 		let seller: Origin = Origin::signed(SELLER);
-		let seller_initial_balance = OrmlTokens::balance(CurrencyId::Usd, &1);
+		let seller_initial_balance = OrmlTokens::balance(CurrencyId::KUSD, &1);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let price = Price {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			amount: 10_000,
 		};
 
@@ -284,7 +284,7 @@ fn buy_nft_works() {
 
 		// Verify that the buyer can buy the nft
 		let buyer: Origin = Origin::signed(BUYER);
-		let buyer_initial_balance = OrmlTokens::balance(CurrencyId::Usd, &BUYER);
+		let buyer_initial_balance = OrmlTokens::balance(CurrencyId::KUSD, &BUYER);
 		assert_ok!(NftSales::buy(
 			buyer.clone(),
 			class_id,
@@ -330,7 +330,7 @@ fn buy_nft_respects_max_offer_amount() {
 		let seller: Origin = Origin::signed(SELLER);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let price = Price {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			amount: 10_000,
 		};
 
@@ -362,7 +362,7 @@ fn buy_nft_respects_max_offer_currency() {
 		let seller: Origin = Origin::signed(SELLER);
 		let (class_id, instance_id) = prepared_nft(&seller);
 		let price = Price {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			amount: 10_000,
 		};
 

--- a/pallets/pools/src/benchmarking.rs
+++ b/pallets/pools/src/benchmarking.rs
@@ -55,7 +55,7 @@ benchmarks! {
 		let caller: T::AccountId = create_admin::<T>(0);
 		let tranches = build_bench_tranches::<T>(n);
 		let origin = RawOrigin::Signed(caller.clone());
-	}: create(origin, caller, POOL, tranches.clone(), CurrencyId::Usd, MAX_RESERVE)
+	}: create(origin, caller, POOL, tranches.clone(), CurrencyId::KUSD, MAX_RESERVE)
 	verify {
 		let pool = get_pool::<T>();
 		assert_tranches_match::<T>(pool.tranches.residual_top_slice(), &tranches);
@@ -412,7 +412,7 @@ where
 		investor.clone(),
 		Role::PoolRole(PoolRole::TrancheInvestor(tranche_id, 0x0FFF_FFFF_FFFF_FFFF)),
 	)?;
-	T::Tokens::mint_into(CurrencyId::Usd, &investor.clone().into(), MINT_AMOUNT)?;
+	T::Tokens::mint_into(CurrencyId::KUSD, &investor.clone().into(), MINT_AMOUNT)?;
 	T::Tokens::mint_into(
 		CurrencyId::Tranche(POOL, tranche_id),
 		&investor.clone().into(),
@@ -453,7 +453,7 @@ fn create_pool<T: Config<PoolId = u64, Balance = u128, CurrencyId = CurrencyId>>
 		caller,
 		POOL,
 		tranches,
-		CurrencyId::Usd,
+		CurrencyId::KUSD,
 		MAX_RESERVE,
 	)
 }

--- a/pallets/pools/src/benchmarking.rs
+++ b/pallets/pools/src/benchmarking.rs
@@ -55,7 +55,7 @@ benchmarks! {
 		let caller: T::AccountId = create_admin::<T>(0);
 		let tranches = build_bench_tranches::<T>(n);
 		let origin = RawOrigin::Signed(caller.clone());
-	}: create(origin, caller, POOL, tranches.clone(), CurrencyId::KUSD, MAX_RESERVE)
+	}: create(origin, caller, POOL, tranches.clone(), CurrencyId::AUSD, MAX_RESERVE)
 	verify {
 		let pool = get_pool::<T>();
 		assert_tranches_match::<T>(pool.tranches.residual_top_slice(), &tranches);
@@ -412,7 +412,7 @@ where
 		investor.clone(),
 		Role::PoolRole(PoolRole::TrancheInvestor(tranche_id, 0x0FFF_FFFF_FFFF_FFFF)),
 	)?;
-	T::Tokens::mint_into(CurrencyId::KUSD, &investor.clone().into(), MINT_AMOUNT)?;
+	T::Tokens::mint_into(CurrencyId::AUSD, &investor.clone().into(), MINT_AMOUNT)?;
 	T::Tokens::mint_into(
 		CurrencyId::Tranche(POOL, tranche_id),
 		&investor.clone().into(),
@@ -453,7 +453,7 @@ fn create_pool<T: Config<PoolId = u64, Balance = u128, CurrencyId = CurrencyId>>
 		caller,
 		POOL,
 		tranches,
-		CurrencyId::KUSD,
+		CurrencyId::AUSD,
 		MAX_RESERVE,
 	)
 }

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -333,7 +333,7 @@ impl Contains<CurrencyId> for PoolCurrency {
 			| CurrencyId::Native
 			| CurrencyId::KSM
 			| CurrencyId::Permissioned(_) => false,
-			CurrencyId::KUSD => true,
+			CurrencyId::KUSD | CurrencyId::AUSD => true,
 		}
 	}
 }
@@ -404,7 +404,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	orml_tokens::GenesisConfig::<Test> {
 		balances: (0..10)
 			.into_iter()
-			.map(|idx| (idx, CurrencyId::KUSD, 1000 * CURRENCY))
+			.map(|idx| (idx, CurrencyId::AUSD, 1000 * CURRENCY))
 			.collect(),
 	}
 	.assimilate_storage(&mut t)

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -333,7 +333,7 @@ impl Contains<CurrencyId> for PoolCurrency {
 			| CurrencyId::Native
 			| CurrencyId::KSM
 			| CurrencyId::Permissioned(_) => false,
-			CurrencyId::Usd | CurrencyId::KUSD => true,
+			CurrencyId::KUSD => true,
 		}
 	}
 }
@@ -404,7 +404,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	orml_tokens::GenesisConfig::<Test> {
 		balances: (0..10)
 			.into_iter()
-			.map(|idx| (idx, CurrencyId::Usd, 1000 * CURRENCY))
+			.map(|idx| (idx, CurrencyId::KUSD, 1000 * CURRENCY))
 			.collect(),
 	}
 	.assimilate_storage(&mut t)

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -42,7 +42,7 @@ fn core_constraints_currency_available_cant_cover_redemptions() {
 		);
 
 		let pool = &PoolDetails {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			tranches,
 			status: PoolStatus::Open,
 			epoch: EpochState {
@@ -134,7 +134,7 @@ fn pool_constraints_pool_reserve_above_max_reserve() {
 		);
 
 		let pool = &PoolDetails {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			tranches,
 			status: PoolStatus::Open,
 			epoch: EpochState {
@@ -235,7 +235,7 @@ fn pool_constraints_tranche_violates_risk_buffer() {
 		);
 
 		let pool = &PoolDetails {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			tranches,
 			status: PoolStatus::Open,
 			epoch: EpochState {
@@ -348,7 +348,7 @@ fn pool_constraints_pass() {
 		);
 
 		let pool = &PoolDetails {
-			currency: CurrencyId::Usd,
+			currency: CurrencyId::KUSD,
 			tranches,
 			status: PoolStatus::Open,
 			epoch: EpochState {
@@ -452,7 +452,7 @@ fn epoch() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 		assert_ok!(Pools::set_metadata(
@@ -695,7 +695,7 @@ fn submission_period() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 		assert_ok!(Pools::update_invest_order(
@@ -901,7 +901,7 @@ fn execute_info_removed_after_epoch_execute() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1004,7 +1004,7 @@ fn collect_tranche_tokens() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1113,7 +1113,7 @@ fn invalid_tranche_id_is_err() {
 			1_u64,
 			0,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1157,7 +1157,7 @@ fn updating_with_same_amount_is_err() {
 			1_u64,
 			0,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1194,7 +1194,7 @@ fn pool_updates_should_be_constrained() {
 			pool_owner.clone(),
 			pool_id,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1327,7 +1327,7 @@ fn updating_orders_updates_epoch() {
 			pool_owner,
 			pool_id,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1377,7 +1377,7 @@ fn no_order_is_err() {
 			pool_owner,
 			pool_id,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1419,7 +1419,7 @@ fn collecting_over_last_exec_epoch_is_err() {
 			pool_owner,
 			pool_id,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1502,7 +1502,7 @@ fn tranche_ids_are_unique() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1534,7 +1534,7 @@ fn tranche_ids_are_unique() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1559,7 +1559,7 @@ fn same_pool_id_not_possible() {
 			0,
 			pool_id_1,
 			vec![(TrancheType::Residual, None),],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1569,7 +1569,7 @@ fn same_pool_id_not_possible() {
 				0,
 				pool_id_1,
 				vec![(TrancheType::Residual, None),],
-				CurrencyId::Usd,
+				CurrencyId::KUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::PoolInUse
@@ -1615,7 +1615,7 @@ fn valid_tranche_structure_is_enforced() {
 						None
 					)
 				],
-				CurrencyId::Usd,
+				CurrencyId::KUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::InvalidTrancheStructure
@@ -1651,7 +1651,7 @@ fn valid_tranche_structure_is_enforced() {
 						None
 					)
 				],
-				CurrencyId::Usd,
+				CurrencyId::KUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::InvalidTrancheStructure
@@ -1686,7 +1686,7 @@ fn valid_tranche_structure_is_enforced() {
 						None
 					)
 				],
-				CurrencyId::Usd,
+				CurrencyId::KUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::InvalidJuniorTranche
@@ -1715,7 +1715,7 @@ fn valid_tranche_structure_is_enforced() {
 						None
 					),
 				],
-				CurrencyId::Usd,
+				CurrencyId::KUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::InvalidTrancheStructure
@@ -1765,7 +1765,7 @@ fn triger_challange_period_with_zero_solution() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1874,7 +1874,7 @@ fn min_challenge_time_is_respected() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1986,7 +1986,7 @@ fn only_zero_solution_is_accepted_max_reserve_violated() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			200 * CURRENCY
 		));
 
@@ -2203,7 +2203,7 @@ fn only_zero_solution_is_accepted_when_risk_buff_violated_else() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			200 * CURRENCY
 		));
 
@@ -2437,7 +2437,7 @@ fn only_usd_as_pool_currency_allowed() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			200 * CURRENCY
 		));
 	});
@@ -2470,7 +2470,7 @@ fn creation_takes_deposit() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			200 * CURRENCY
 		));
 		let pool = crate::PoolDeposit::<Test>::get(0).unwrap();
@@ -2496,7 +2496,7 @@ fn creation_takes_deposit() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			200 * CURRENCY
 		));
 		let pool = crate::PoolDeposit::<Test>::get(1).unwrap();
@@ -2524,7 +2524,7 @@ fn creation_takes_deposit() {
 					None
 				)
 			],
-			CurrencyId::Usd,
+			CurrencyId::KUSD,
 			200 * CURRENCY
 		));
 

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -42,7 +42,7 @@ fn core_constraints_currency_available_cant_cover_redemptions() {
 		);
 
 		let pool = &PoolDetails {
-			currency: CurrencyId::KUSD,
+			currency: CurrencyId::AUSD,
 			tranches,
 			status: PoolStatus::Open,
 			epoch: EpochState {
@@ -134,7 +134,7 @@ fn pool_constraints_pool_reserve_above_max_reserve() {
 		);
 
 		let pool = &PoolDetails {
-			currency: CurrencyId::KUSD,
+			currency: CurrencyId::AUSD,
 			tranches,
 			status: PoolStatus::Open,
 			epoch: EpochState {
@@ -235,7 +235,7 @@ fn pool_constraints_tranche_violates_risk_buffer() {
 		);
 
 		let pool = &PoolDetails {
-			currency: CurrencyId::KUSD,
+			currency: CurrencyId::AUSD,
 			tranches,
 			status: PoolStatus::Open,
 			epoch: EpochState {
@@ -348,7 +348,7 @@ fn pool_constraints_pass() {
 		);
 
 		let pool = &PoolDetails {
-			currency: CurrencyId::KUSD,
+			currency: CurrencyId::AUSD,
 			tranches,
 			status: PoolStatus::Open,
 			epoch: EpochState {
@@ -452,7 +452,7 @@ fn epoch() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 		assert_ok!(Pools::set_metadata(
@@ -695,7 +695,7 @@ fn submission_period() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 		assert_ok!(Pools::update_invest_order(
@@ -901,7 +901,7 @@ fn execute_info_removed_after_epoch_execute() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1004,7 +1004,7 @@ fn collect_tranche_tokens() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1113,7 +1113,7 @@ fn invalid_tranche_id_is_err() {
 			1_u64,
 			0,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1157,7 +1157,7 @@ fn updating_with_same_amount_is_err() {
 			1_u64,
 			0,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1194,7 +1194,7 @@ fn pool_updates_should_be_constrained() {
 			pool_owner.clone(),
 			pool_id,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1327,7 +1327,7 @@ fn updating_orders_updates_epoch() {
 			pool_owner,
 			pool_id,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1377,7 +1377,7 @@ fn no_order_is_err() {
 			pool_owner,
 			pool_id,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1419,7 +1419,7 @@ fn collecting_over_last_exec_epoch_is_err() {
 			pool_owner,
 			pool_id,
 			vec![(TrancheType::Residual, None)],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1502,7 +1502,7 @@ fn tranche_ids_are_unique() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1534,7 +1534,7 @@ fn tranche_ids_are_unique() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1559,7 +1559,7 @@ fn same_pool_id_not_possible() {
 			0,
 			pool_id_1,
 			vec![(TrancheType::Residual, None),],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1569,7 +1569,7 @@ fn same_pool_id_not_possible() {
 				0,
 				pool_id_1,
 				vec![(TrancheType::Residual, None),],
-				CurrencyId::KUSD,
+				CurrencyId::AUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::PoolInUse
@@ -1615,7 +1615,7 @@ fn valid_tranche_structure_is_enforced() {
 						None
 					)
 				],
-				CurrencyId::KUSD,
+				CurrencyId::AUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::InvalidTrancheStructure
@@ -1651,7 +1651,7 @@ fn valid_tranche_structure_is_enforced() {
 						None
 					)
 				],
-				CurrencyId::KUSD,
+				CurrencyId::AUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::InvalidTrancheStructure
@@ -1686,7 +1686,7 @@ fn valid_tranche_structure_is_enforced() {
 						None
 					)
 				],
-				CurrencyId::KUSD,
+				CurrencyId::AUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::InvalidJuniorTranche
@@ -1715,7 +1715,7 @@ fn valid_tranche_structure_is_enforced() {
 						None
 					),
 				],
-				CurrencyId::KUSD,
+				CurrencyId::AUSD,
 				10_000 * CURRENCY
 			),
 			Error::<Test>::InvalidTrancheStructure
@@ -1765,7 +1765,7 @@ fn triger_challange_period_with_zero_solution() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1874,7 +1874,7 @@ fn min_challenge_time_is_respected() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			10_000 * CURRENCY
 		));
 
@@ -1986,7 +1986,7 @@ fn only_zero_solution_is_accepted_max_reserve_violated() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			200 * CURRENCY
 		));
 
@@ -2203,7 +2203,7 @@ fn only_zero_solution_is_accepted_when_risk_buff_violated_else() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			200 * CURRENCY
 		));
 
@@ -2437,7 +2437,7 @@ fn only_usd_as_pool_currency_allowed() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			200 * CURRENCY
 		));
 	});
@@ -2470,7 +2470,7 @@ fn creation_takes_deposit() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			200 * CURRENCY
 		));
 		let pool = crate::PoolDeposit::<Test>::get(0).unwrap();
@@ -2496,7 +2496,7 @@ fn creation_takes_deposit() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			200 * CURRENCY
 		));
 		let pool = crate::PoolDeposit::<Test>::get(1).unwrap();
@@ -2524,7 +2524,7 @@ fn creation_takes_deposit() {
 					None
 				)
 			],
-			CurrencyId::KUSD,
+			CurrencyId::AUSD,
 			200 * CURRENCY
 		));
 

--- a/pallets/restricted-tokens/src/mock.rs
+++ b/pallets/restricted-tokens/src/mock.rs
@@ -112,8 +112,8 @@ mod filter {
 			}
 		}
 
-		/// Dummmy filter for InspectHold, that does not allow any holding periods on KUSD or USDT and
-		/// forwards the result of the acutal holding period otherwise.
+		/// Dummmy filter for InspectHold, that does not allow any holding periods on KUSD or AUSD and
+		/// forwards the result of the actual holding period otherwise.
 		pub struct InspectHoldFilter;
 		impl PreConditions<FungiblesInspectHoldEffects<CurrencyId, AccountId, Balance>>
 			for InspectHoldFilter
@@ -130,7 +130,7 @@ mod filter {
 						_amount,
 						can_actually_hold,
 					) => match asset {
-						CurrencyId::KUSD | CurrencyId::USDT => false,
+						CurrencyId::KUSD | CurrencyId::AUSD => false,
 						_ => can_actually_hold,
 					},
 				}
@@ -313,7 +313,7 @@ mod filter {
 pub enum CurrencyId {
 	Cfg,
 	KUSD,
-	USDT,
+	AUSD,
 	RestrictedCoin,
 }
 
@@ -321,8 +321,8 @@ impl TokenMetadata for CurrencyId {
 	fn name(&self) -> Vec<u8> {
 		match self {
 			CurrencyId::Cfg => b"Centrifuge".to_vec(),
-			CurrencyId::USDT => b"USD Tether".to_vec(),
-			CurrencyId::KUSD => b"Acala USD".to_vec(),
+			CurrencyId::AUSD => b"Acala USD".to_vec(),
+			CurrencyId::KUSD => b"Karura USD".to_vec(),
 			CurrencyId::RestrictedCoin => b"Restricted Token".to_vec(),
 		}
 	}
@@ -330,7 +330,7 @@ impl TokenMetadata for CurrencyId {
 	fn symbol(&self) -> Vec<u8> {
 		match self {
 			CurrencyId::Cfg => b"CFG".to_vec(),
-			CurrencyId::USDT => b"USDT".to_vec(),
+			CurrencyId::AUSD => b"AUSD".to_vec(),
 			CurrencyId::KUSD => b"KUSD".to_vec(),
 			CurrencyId::RestrictedCoin => b"RST".to_vec(),
 		}
@@ -339,7 +339,7 @@ impl TokenMetadata for CurrencyId {
 	fn decimals(&self) -> u8 {
 		match self {
 			CurrencyId::Cfg => 18,
-			CurrencyId::USDT => 12,
+			CurrencyId::AUSD => 12,
 			CurrencyId::KUSD => 12,
 			CurrencyId::RestrictedCoin => 27,
 		}
@@ -471,7 +471,7 @@ impl PreConditions<TransferDetails<AccountId, CurrencyId, Balance>> for Restrict
 
 	fn check(t: TransferDetails<AccountId, CurrencyId, Balance>) -> bool {
 		match t.id {
-			CurrencyId::KUSD | CurrencyId::USDT => true,
+			CurrencyId::KUSD | CurrencyId::AUSD => true,
 			CurrencyId::RestrictedCoin => t.recv >= 100 && t.send >= 100,
 			CurrencyId::Cfg => true,
 		}
@@ -499,7 +499,7 @@ impl TestExternalitiesBuilder {
 			.collect::<Vec<(AccountId, CurrencyId, Balance)>>();
 		let usdt = (0..10)
 			.into_iter()
-			.map(|idx| (idx, CurrencyId::USDT, DISTR_PER_ACCOUNT))
+			.map(|idx| (idx, CurrencyId::AUSD, DISTR_PER_ACCOUNT))
 			.collect::<Vec<(AccountId, CurrencyId, Balance)>>();
 		let restric_1 = (0..10)
 			.into_iter()

--- a/pallets/restricted-tokens/src/tests.rs
+++ b/pallets/restricted-tokens/src/tests.rs
@@ -34,7 +34,7 @@ fn transfer_works() {
 			assert_ok!(pallet_restricted_tokens::Pallet::<MockRuntime>::transfer(
 				Origin::signed(1),
 				2,
-				CurrencyId::USDT,
+				CurrencyId::AUSD,
 				DISTR_PER_ACCOUNT
 			));
 			assert_ok!(pallet_restricted_tokens::Pallet::<MockRuntime>::transfer(
@@ -64,7 +64,7 @@ fn transfer_fails() {
 				pallet_restricted_tokens::Pallet::<MockRuntime>::transfer(
 					Origin::signed(10),
 					2,
-					CurrencyId::USDT,
+					CurrencyId::AUSD,
 					100
 				),
 				orml_tokens::Error::<MockRuntime>::BalanceTooLow
@@ -108,7 +108,7 @@ fn transfer_keep_alive_fails() {
 				pallet_restricted_tokens::Pallet::<MockRuntime>::transfer_keep_alive(
 					Origin::signed(1),
 					2,
-					CurrencyId::USDT,
+					CurrencyId::AUSD,
 					DISTR_PER_ACCOUNT
 				),
 				orml_tokens::Error::<MockRuntime>::KeepAlive
@@ -142,7 +142,7 @@ fn transfer_keep_alive_works() {
 				pallet_restricted_tokens::Pallet::<MockRuntime>::transfer_keep_alive(
 					Origin::signed(1),
 					2,
-					CurrencyId::USDT,
+					CurrencyId::AUSD,
 					DISTR_PER_ACCOUNT - 1
 				)
 			);
@@ -175,11 +175,11 @@ fn transfer_all_works() {
 				pallet_restricted_tokens::Pallet::<MockRuntime>::transfer_all(
 					Origin::signed(1),
 					2,
-					CurrencyId::USDT,
+					CurrencyId::AUSD,
 					false
 				)
 			);
-			assert!(orml_tokens::Pallet::<MockRuntime>::accounts(2, CurrencyId::USDT).free == 2000);
+			assert!(orml_tokens::Pallet::<MockRuntime>::accounts(2, CurrencyId::AUSD).free == 2000);
 			assert_ok!(
 				pallet_restricted_tokens::Pallet::<MockRuntime>::transfer_all(
 					Origin::signed(100),
@@ -214,7 +214,7 @@ fn force_transfer_works() {
 					Origin::root(),
 					1,
 					2,
-					CurrencyId::USDT,
+					CurrencyId::AUSD,
 					DISTR_PER_ACCOUNT
 				)
 			);
@@ -250,7 +250,7 @@ fn force_transfer_fails() {
 					Origin::signed(1),
 					1,
 					2,
-					CurrencyId::USDT,
+					CurrencyId::AUSD,
 					DISTR_PER_ACCOUNT
 				)
 				.is_err()
@@ -291,14 +291,14 @@ fn set_balance_works() {
 				pallet_restricted_tokens::Pallet::<MockRuntime>::set_balance(
 					Origin::root(),
 					1,
-					CurrencyId::USDT,
+					CurrencyId::AUSD,
 					400,
 					200
 				)
 			);
-			assert!(orml_tokens::Pallet::<MockRuntime>::accounts(1, CurrencyId::USDT).free == 400);
+			assert!(orml_tokens::Pallet::<MockRuntime>::accounts(1, CurrencyId::AUSD).free == 400);
 			assert!(
-				orml_tokens::Pallet::<MockRuntime>::accounts(1, CurrencyId::USDT).reserved == 200
+				orml_tokens::Pallet::<MockRuntime>::accounts(1, CurrencyId::AUSD).reserved == 200
 			);
 
 			assert_ok!(
@@ -655,7 +655,7 @@ fn fungibles_balance_on_hold() {
 			assert_eq!(
 				<pallet_restricted_tokens::Pallet::<MockRuntime> as fungibles::InspectHold<
 					AccountId,
-				>>::balance_on_hold(CurrencyId::USDT, &1,),
+				>>::balance_on_hold(CurrencyId::AUSD, &1,),
 				0
 			);
 		})
@@ -679,7 +679,7 @@ fn fungibles_can_hold() {
 			assert!(
 				!<pallet_restricted_tokens::Pallet::<MockRuntime> as fungibles::InspectHold<
 					AccountId,
-				>>::can_hold(CurrencyId::USDT, &1, 0)
+				>>::can_hold(CurrencyId::AUSD, &1, 0)
 			);
 		})
 }
@@ -734,7 +734,7 @@ fn fungibles_hold() {
 			assert_noop!(
 				<pallet_restricted_tokens::Pallet::<MockRuntime> as fungibles::MutateHold<
 					AccountId,
-				>>::hold(CurrencyId::USDT, &1, 1),
+				>>::hold(CurrencyId::AUSD, &1, 1),
 				Error::<MockRuntime>::PreConditionsNotMet,
 			);
 		})
@@ -766,7 +766,7 @@ fn fungibles_release() {
 			assert_noop!(
 				<pallet_restricted_tokens::Pallet::<MockRuntime> as fungibles::MutateHold<
 					AccountId,
-				>>::hold(CurrencyId::USDT, &1, DISTR_PER_ACCOUNT),
+				>>::hold(CurrencyId::AUSD, &1, DISTR_PER_ACCOUNT),
 				Error::<MockRuntime>::PreConditionsNotMet
 			);
 		})

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -878,7 +878,7 @@ impl Contains<CurrencyId> for PoolCurrency {
 			| CurrencyId::Native
 			| CurrencyId::KSM
 			| CurrencyId::Permissioned(_) => false,
-			CurrencyId::KUSD => true,
+			CurrencyId::AUSD | CurrencyId::KUSD => true,
 		}
 	}
 }
@@ -1128,7 +1128,7 @@ where
 		} = details.clone();
 
 		match id {
-			CurrencyId::Native | CurrencyId::KUSD | CurrencyId::KSM => true,
+			CurrencyId::Native | CurrencyId::KUSD | CurrencyId::AUSD | CurrencyId::KSM => true,
 			CurrencyId::Tranche(pool_id, tranche_id) => {
 				P::has(
 					PermissionScope::Pool(pool_id),

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -878,7 +878,7 @@ impl Contains<CurrencyId> for PoolCurrency {
 			| CurrencyId::Native
 			| CurrencyId::KSM
 			| CurrencyId::Permissioned(_) => false,
-			CurrencyId::Usd | CurrencyId::KUSD => true,
+			CurrencyId::KUSD => true,
 		}
 	}
 }
@@ -1128,7 +1128,7 @@ where
 		} = details.clone();
 
 		match id {
-			CurrencyId::Usd | CurrencyId::Native | CurrencyId::KUSD | CurrencyId::KSM => true,
+			CurrencyId::Native | CurrencyId::KUSD | CurrencyId::KSM => true,
 			CurrencyId::Tranche(pool_id, tranche_id) => {
 				P::has(
 					PermissionScope::Pool(pool_id),

--- a/runtime/integration-tests/src/lib.rs
+++ b/runtime/integration-tests/src/lib.rs
@@ -1,6 +1,4 @@
 #![feature(stmt_expr_attributes)]
-//TODO(nuno): re-enable this line below once pools are re-enabled
-// #![feature(destructuring_assignment)]
 // Copyright 2021 Centrifuge GmbH (centrifuge.io).
 // This file is part of Centrifuge chain project.
 

--- a/runtime/integration-tests/src/pools/utils/genesis.rs
+++ b/runtime/integration-tests/src/pools/utils/genesis.rs
@@ -41,7 +41,7 @@ where
 	.expect("ESSENTIAL: Genesisbuild is not allowed to fail.");
 }
 
-/// Provides 100_000 * DECIMAL_BASE_12 CurrencyId::Usd tokens to the `accounts::default_accounts()`
+/// Provides 100_000 * DECIMAL_BASE_12 CurrencyId::KUSD tokens to the `accounts::default_accounts()`
 pub fn default_usd_balances<Runtime>(storage: &mut Storage)
 where
 	Runtime: orml_tokens::Config,
@@ -55,7 +55,7 @@ where
 			.map(|acc| {
 				(
 					AccountId32::from(acc).into(),
-					CurrencyId::Usd.into(),
+					CurrencyId::KUSD.into(),
 					(100_000 * DECIMAL_BASE_12).into(),
 				)
 			})
@@ -65,7 +65,7 @@ where
 	.expect("ESSENTIAL: Genesisbuild is not allowed to fail.");
 }
 
-/// Provides 100_000 * DECIMAL_BASE_18 and Provides 100_000 * DECIMAL_BASE_12 CurrencyId::Usd
+/// Provides 100_000 * DECIMAL_BASE_18 and Provides 100_000 * DECIMAL_BASE_12 CurrencyId::KUSD
 /// tokens to the `accounts::default_accounts()`
 pub fn default_balances<Runtime>(storage: &mut Storage)
 where

--- a/runtime/integration-tests/src/pools/utils/pools.rs
+++ b/runtime/integration-tests/src/pools/utils/pools.rs
@@ -109,13 +109,13 @@ pub fn custom_pool(
 /// 	* Keyring::TrancheInvestor(index) accounts with index 20 - 29 for tranche with id 2
 /// 	* Keyring::TrancheInvestor(index) accounts with index 30 - 39 for tranche with id 3
 /// 	* Keyring::TrancheInvestor(index) accounts with index 40 - 49 for tranche with id 4
-/// * Currency: CurrencyId::Usd,
-/// * MaxReserve: 100_000 Usd
+/// * Currency: CurrencyId::KUSD,
+/// * MaxReserve: 100_000 KUSD
 pub fn default_pool_calls(admin: AccountId, pool_id: PoolId, nfts: &mut NftManager) -> Vec<Call> {
 	pool_setup_calls(
 		admin,
 		pool_id,
-		CurrencyId::Usd,
+		CurrencyId::KUSD,
 		100_000 * DECIMAL_BASE_12,
 		create_tranche_input(
 			vec![None, Some(10), Some(7), Some(5), Some(3)],

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -808,25 +808,18 @@ fn altair_genesis(
 	council_members: Vec<altair_runtime::AccountId>,
 ) -> altair_runtime::GenesisConfig {
 	let num_endowed_accounts = endowed_accounts.len();
-	let (balances, token_balances) = match total_issuance {
+	let balances = match total_issuance {
 		Some(total_issuance) => {
 			let balance_per_endowed = total_issuance
 				.checked_div(num_endowed_accounts as altair_runtime::Balance)
 				.unwrap_or(0 as altair_runtime::Balance);
-			(
-				endowed_accounts
-					.iter()
-					.cloned()
-					.map(|k| (k, balance_per_endowed))
-					.collect(),
-				endowed_accounts
-					.iter()
-					.cloned()
-					.map(|k| (k, altair_runtime::CurrencyId::Usd, balance_per_endowed))
-					.collect(),
-			)
+			endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, balance_per_endowed))
+				.collect()
 		}
-		None => (vec![], vec![]),
+		None => (vec![]),
 	};
 
 	altair_runtime::GenesisConfig {
@@ -836,9 +829,7 @@ fn altair_genesis(
 				.to_vec(),
 		},
 		balances: altair_runtime::BalancesConfig { balances },
-		orml_tokens: altair_runtime::OrmlTokensConfig {
-			balances: token_balances,
-		},
+		orml_tokens: altair_runtime::OrmlTokensConfig { balances: vec![] },
 		elections: altair_runtime::ElectionsConfig { members: vec![] },
 		council: altair_runtime::CouncilConfig {
 			members: council_members,
@@ -913,10 +904,17 @@ fn development_genesis(
 					.cloned()
 					.map(|k| (k, balance_per_endowed))
 					.collect(),
+				// We can only mint kUSD in development
 				endowed_accounts
 					.iter()
 					.cloned()
-					.map(|k| (k, development_runtime::CurrencyId::Usd, balance_per_endowed))
+					.map(|k| {
+						(
+							k,
+							development_runtime::CurrencyId::KUSD,
+							balance_per_endowed,
+						)
+					})
 					.collect(),
 			)
 		}

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -911,7 +911,7 @@ fn development_genesis(
 					.map(|k| {
 						(
 							k,
-							development_runtime::CurrencyId::KUSD,
+							development_runtime::CurrencyId::AUSD,
 							balance_per_endowed,
 						)
 					})


### PR DESCRIPTION
The `CurrencyId::Usd` variant served as a placeholder for a dollar stable coin. With the introduction of the `KUSD` variant, we drop the placeholder `Usd` and use `KUSD` instead.