### PR TITLE
Disallow updating orders during submission period

### DIFF
--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -834,6 +834,11 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
+			ensure!(
+				EpochExecution::<T>::try_get(pool_id).is_err(),
+				Error::<T>::InSubmissionPeriod
+			);
+
 			let (tranche_id, old_order) = Pool::<T>::try_mutate(
 				pool_id,
 				|pool| -> Result<(T::TrancheId, T::Balance), DispatchError> {
@@ -910,6 +915,11 @@ pub mod pallet {
 			new_order: T::Balance,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
+
+			ensure!(
+				EpochExecution::<T>::try_get(pool_id).is_err(),
+				Error::<T>::InSubmissionPeriod
+			);
 
 			let (tranche_id, old_order) = Pool::<T>::try_mutate(
 				pool_id,


### PR DESCRIPTION
Prevents panics in epoch execution due to the invest/redeem amount
changing during the submission period.

This is a temporary measure until the investments pallet can be
fully integrated.