### PR TITLE
dev: Add `orml_asset_registry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-process",
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.9",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1640,12 +1640,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.9",
 ]
 
 [[package]]
@@ -1656,20 +1656,20 @@ checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.9",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.8",
- "lazy_static",
+ "crossbeam-utils 0.8.9",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
@@ -1680,7 +1680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.9",
 ]
 
 [[package]]
@@ -1696,12 +1696,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -2354,6 +2354,7 @@ dependencies = [
  "hex-literal 0.2.2",
  "integer-sqrt",
  "node-primitives",
+ "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
  "orml-xcm-support",
@@ -5781,9 +5782,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "orml-asset-registry"
+version = "0.4.1-dev"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#41dddc878ecef961b9b20207713abdcb8d84ae53"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "orml-traits",
+ "pallet-xcm",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
+]
+
+[[package]]
 name = "orml-tokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#41dddc878ecef961b9b20207713abdcb8d84ae53"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5798,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#41dddc878ecef961b9b20207713abdcb8d84ae53"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -5816,7 +5836,7 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#41dddc878ecef961b9b20207713abdcb8d84ae53"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5830,7 +5850,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm-support"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#41dddc878ecef961b9b20207713abdcb8d84ae53"
 dependencies = [
  "frame-support",
  "orml-traits",
@@ -5844,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "orml-xtokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#41dddc878ecef961b9b20207713abdcb8d84ae53"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9113,7 +9133,7 @@ checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.8",
+ "crossbeam-utils 0.8.9",
  "num_cpus",
 ]
 
@@ -9442,6 +9462,7 @@ dependencies = [
  "pallet-anchors",
  "pallet-authorship",
  "pallet-balances",
+ "pallet-collective",
  "pallet-permissions",
  "pallet-pools",
  "parity-scale-codec",
@@ -9454,6 +9475,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
+ "xcm",
 ]
 
 [[package]]
@@ -11986,7 +12008,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros 0.24.1",
+ "strum_macros 0.24.0",
 ]
 
 [[package]]
@@ -12004,9 +12026,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.24.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9550962e7cf70d9980392878dfaf1dcc3ece024f4cf3bf3c46b978d0bad61d6c"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,9 +177,11 @@ std = [
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
 	"altair-runtime/runtime-benchmarks",
 	"centrifuge-runtime/runtime-benchmarks",
 	"development-runtime/runtime-benchmarks",
+	"runtime-common/runtime-benchmarks",
 ]
 test-benchmarks = [
 	"runtime-benchmarks",

--- a/libs/common-traits/src/lib.rs
+++ b/libs/common-traits/src/lib.rs
@@ -32,7 +32,6 @@ use sp_runtime::DispatchError;
 use sp_std::fmt::Debug;
 use sp_std::hash::Hash;
 use sp_std::str::FromStr;
-use sp_std::vec::Vec;
 
 /// A trait used for loosely coupling the claim pallet with a reward mechanism.
 ///
@@ -206,16 +205,6 @@ impl<T> PreConditions<T> for Never {
 	fn check(_t: T) -> bool {
 		false
 	}
-}
-
-/// A trait that Assets or Tokens can implement so that pallets
-/// can easily use the trait `InspectMetadata` with them.
-pub trait TokenMetadata {
-	fn name(&self) -> Vec<u8>;
-
-	fn symbol(&self) -> Vec<u8>;
-
-	fn decimals(&self) -> u8;
 }
 
 /// Trait for converting a pool+tranche ID pair to a CurrencyId

--- a/libs/common-types/src/lib.rs
+++ b/libs/common-types/src/lib.rs
@@ -40,6 +40,9 @@ mod tokens;
 /// PoolId type we use.
 pub type PoolId = u64;
 
+/// A representation of a tranche identifier
+pub type TrancheId = [u8; 16];
+
 /// PoolRole can hold any type of role specific functions a user can do on a given pool.
 // NOTE: In order to not carry around the TrancheId and Moment types all the time, we give it a default.
 //       In case the Role we provide does not match what we expect. I.e. if we change the Moment

--- a/libs/common-types/src/tokens.rs
+++ b/libs/common-types/src/tokens.rs
@@ -1,19 +1,9 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
-use common_traits::TokenMetadata;
+use crate::{PoolId, TrancheId};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use sp_runtime::format_runtime_string;
-use sp_std::vec::Vec;
-
-#[derive(
-	Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
-)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum PermissionedCurrency {
-	// TODO: Tranche variant from CurrencyId should be moved in here.
-}
 
 #[derive(
 	Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
@@ -22,61 +12,29 @@ pub enum PermissionedCurrency {
 pub enum CurrencyId {
 	// The Native token, representing AIR in Altair and CFG in Centrifuge.
 	Native,
+
 	// A Tranche token
-	Tranche(u64, [u8; 16]),
+	Tranche(PoolId, TrancheId),
 
 	/// Karura KSM
 	KSM,
 
 	/// Karura Dollar
 	KUSD,
+
 	/// Acala Dollar
 	/// Note: KUSD and AUSD will be merged into a single token, AUSD.
 	AUSD,
 
-	Permissioned(PermissionedCurrency),
+	/// A foreign asset
+	ForeignAsset(ForeignAssetId),
 }
 
-impl TokenMetadata for CurrencyId {
-	fn name(&self) -> Vec<u8> {
-		match self {
-			CurrencyId::Native => b"Native currency".to_vec(),
-			CurrencyId::Permissioned(_) => b"Permissioned currency".to_vec(),
-			CurrencyId::Tranche(pool_id, tranche_id) => format_runtime_string!(
-				"Tranche token of pool {} and tranche {:?}",
-				pool_id,
-				tranche_id,
-			)
-			.as_ref()
-			.to_vec(),
-			CurrencyId::KUSD => b"Karura Dollar".to_vec(),
-			CurrencyId::AUSD => b"Acala Dollar".to_vec(),
-			CurrencyId::KSM => b"Kusama".to_vec(),
-		}
-	}
+pub type ForeignAssetId = u32;
 
-	fn symbol(&self) -> Vec<u8> {
-		match self {
-			CurrencyId::Native => b"CFG".to_vec(),
-			CurrencyId::Permissioned(_) => b"PERM".to_vec(),
-			CurrencyId::Tranche(pool_id, tranche_id) => {
-				format_runtime_string!("TT:{}:{:?}", pool_id, tranche_id)
-					.as_ref()
-					.to_vec()
-			}
-			CurrencyId::KUSD => b"KUSD".to_vec(),
-			CurrencyId::AUSD => b"AUSD".to_vec(),
-			CurrencyId::KSM => b"KSM".to_vec(),
-		}
-	}
-
-	fn decimals(&self) -> u8 {
-		match self {
-			CurrencyId::Native => 18,
-			CurrencyId::Permissioned(_) => 12,
-			CurrencyId::Tranche(_, _) => 27,
-			CurrencyId::KUSD | CurrencyId::AUSD | CurrencyId::KSM => 12,
-		}
+impl Default for CurrencyId {
+	fn default() -> Self {
+		CurrencyId::Native
 	}
 }
 

--- a/pallets/pools/Cargo.toml
+++ b/pallets/pools/Cargo.toml
@@ -33,6 +33,7 @@ pallet-permissions = { path = "../../pallets/permissions", default-features = fa
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+
 runtime-common = { path = "../../runtime/common", default-features = true }
 pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = true}
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.24" }

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -331,11 +331,8 @@ pub struct PoolCurrency;
 impl Contains<CurrencyId> for PoolCurrency {
 	fn contains(id: &CurrencyId) -> bool {
 		match id {
-			CurrencyId::Tranche(_, _)
-			| CurrencyId::Native
-			| CurrencyId::KSM
-			| CurrencyId::Permissioned(_) => false,
-			CurrencyId::KUSD | CurrencyId::AUSD => true,
+			CurrencyId::Tranche(_, _) | CurrencyId::Native | CurrencyId::KSM => false,
+			_ => true,
 		}
 	}
 }

--- a/pallets/restricted-tokens/Cargo.toml
+++ b/pallets/restricted-tokens/Cargo.toml
@@ -28,6 +28,7 @@ common-types = { path = "../../libs/common-types", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+
 pallet-permissions = { path = "../permissions", default-features = false, optional = true }
 runtime-common = { path = "../../runtime/common", default-features = false, optional = true }
 

--- a/pallets/restricted-tokens/src/impl_fungibles.rs
+++ b/pallets/restricted-tokens/src/impl_fungibles.rs
@@ -12,27 +12,11 @@
 
 use super::*;
 use common_traits::PreConditions;
-use common_traits::TokenMetadata;
 use frame_support::traits::{
 	fungible,
-	fungibles::{Inspect, InspectHold, InspectMetadata, Mutate, MutateHold, Transfer},
+	fungibles::{Inspect, InspectHold, Mutate, MutateHold, Transfer},
 	tokens::{DepositConsequence, WithdrawConsequence},
 };
-use sp_std::vec::Vec;
-
-impl<T: Config> InspectMetadata<T::AccountId> for Pallet<T> {
-	fn name(asset: &Self::AssetId) -> Vec<u8> {
-		asset.name()
-	}
-
-	fn symbol(asset: &Self::AssetId) -> Vec<u8> {
-		asset.symbol()
-	}
-
-	fn decimals(asset: &Self::AssetId) -> u8 {
-		asset.decimals()
-	}
-}
 
 /// Represents the trait `fungibles::Inspect` effects that are called via
 /// the pallet-restricted-tokens.

--- a/pallets/restricted-tokens/src/lib.rs
+++ b/pallets/restricted-tokens/src/lib.rs
@@ -71,7 +71,7 @@ pub mod pallet {
 		FungiblesInspectEffects, FungiblesInspectHoldEffects, FungiblesMutateEffects,
 		FungiblesMutateHoldEffects, FungiblesTransferEffects,
 	};
-	use common_traits::{PreConditions, TokenMetadata};
+	use common_traits::PreConditions;
 	use frame_support::scale_info::TypeInfo;
 	use frame_support::sp_runtime::traits::{AtLeast32BitUnsigned, CheckedAdd, StaticLookup};
 	use frame_support::sp_runtime::ArithmeticError;
@@ -94,13 +94,7 @@ pub mod pallet {
 			+ MaxEncodedLen;
 
 		/// The currency-id of this pallet
-		type CurrencyId: Parameter
-			+ Member
-			+ Copy
-			+ MaybeSerializeDeserialize
-			+ Ord
-			+ TypeInfo
-			+ TokenMetadata;
+		type CurrencyId: Parameter + Member + Copy + MaybeSerializeDeserialize + Ord + TypeInfo;
 
 		/// Checks the pre conditions for every transfer via the user api (i.e. extrinsics)
 		type PreExtrTransfer: PreConditions<

--- a/pallets/restricted-tokens/src/mock.rs
+++ b/pallets/restricted-tokens/src/mock.rs
@@ -11,7 +11,7 @@
 // GNU General Public License for more details.
 
 pub use crate as pallet_restricted_tokens;
-use common_traits::{PreConditions, TokenMetadata};
+use common_traits::PreConditions;
 use common_types::Moment;
 use frame_support::parameter_types;
 use frame_support::sp_io::TestExternalities;
@@ -315,35 +315,6 @@ pub enum CurrencyId {
 	KUSD,
 	AUSD,
 	RestrictedCoin,
-}
-
-impl TokenMetadata for CurrencyId {
-	fn name(&self) -> Vec<u8> {
-		match self {
-			CurrencyId::Cfg => b"Centrifuge".to_vec(),
-			CurrencyId::AUSD => b"Acala USD".to_vec(),
-			CurrencyId::KUSD => b"Karura USD".to_vec(),
-			CurrencyId::RestrictedCoin => b"Restricted Token".to_vec(),
-		}
-	}
-
-	fn symbol(&self) -> Vec<u8> {
-		match self {
-			CurrencyId::Cfg => b"CFG".to_vec(),
-			CurrencyId::AUSD => b"AUSD".to_vec(),
-			CurrencyId::KUSD => b"KUSD".to_vec(),
-			CurrencyId::RestrictedCoin => b"RST".to_vec(),
-		}
-	}
-
-	fn decimals(&self) -> u8 {
-		match self {
-			CurrencyId::Cfg => 18,
-			CurrencyId::AUSD => 12,
-			CurrencyId::KUSD => 12,
-			CurrencyId::RestrictedCoin => 27,
-		}
-	}
 }
 
 // Build mock runtime

--- a/runtime/altair/Cargo.toml
+++ b/runtime/altair/Cargo.toml
@@ -237,6 +237,7 @@ runtime-benchmarks = [
     "pallet-permissions/runtime-benchmarks",
     "pallet-restricted-tokens/runtime-benchmarks",
     "pallet-nft-sales/runtime-benchmarks",
+    "runtime-common/runtime-benchmarks",
 ]
 
 # A feature that should be enabled when the runtime should be build for on-chain

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -25,7 +25,7 @@ use orml_traits::parameter_type_with_key;
 
 use pallet_anchors::AnchorData;
 pub use pallet_balances::Call as BalancesCall;
-use pallet_collective::{EnsureMember, EnsureProportionAtLeast, EnsureProportionMoreThan};
+use pallet_collective::{EnsureMember, EnsureProportionMoreThan};
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo};
@@ -450,21 +450,6 @@ parameter_types! {
 	pub const CouncilMaxProposals: u32 = 100;
 	pub const CouncilMaxMembers: u32 = 100;
 }
-
-/// The council
-type CouncilCollective = pallet_collective::Instance1;
-
-/// All council members must vote yes to create this origin.
-type AllOfCouncil = EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 1>;
-
-/// 1/2 of all council members must vote yes to create this origin.
-type HalfOfCouncil = EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 2>;
-
-/// 2/3 of all council members must vote yes to create this origin.
-type TwoThirdOfCouncil = EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>;
-
-/// 3/4 of all council members must vote yes to create this origin.
-type ThreeFourthOfCouncil = EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 4>;
 
 impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type Origin = Origin;

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -220,6 +220,7 @@ runtime-benchmarks = [
     "pallet-migration-manager/runtime-benchmarks",
     "pallet-crowdloan-claim/runtime-benchmarks",
     "pallet-crowdloan-reward/runtime-benchmarks",
+    "runtime-common/runtime-benchmarks",
 ]
 
 try-runtime = [

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -444,18 +444,6 @@ parameter_types! {
 	pub const CouncilMaxMembers: u32 = 100;
 }
 
-/// The council
-type CouncilCollective = pallet_collective::Instance1;
-
-/// All council members must vote yes to create this origin.
-type AllOfCouncil = EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 1>;
-
-/// 1/2 of all council members must vote yes to create this origin.
-type HalfOfCouncil = EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 2>;
-
-/// 2/3 of all council members must vote yes to create this origin.
-type TwoThirdOfCouncil = EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>;
-
 impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type Origin = Origin;
 	type Proposal = Call;

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -15,11 +15,13 @@ smallvec = "1.4.0"
 # Substrate dependencies
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+
 frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 node-primitives = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
+pallet-collective = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 sp-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
@@ -27,8 +29,11 @@ sp-core = { git = "https://github.com/paritytech/substrate",  default-features =
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
+# Polkadot dependencies
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.24" }
+
 # ORML dependencies
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 # Local Dependencies
 common-traits = { path = "../../libs/common-traits", default-features = false }
@@ -48,6 +53,7 @@ std = [
     "node-primitives/std",
     "pallet-authorship/std",
     "pallet-balances/std",
+    "pallet-collective/std",
     "pallet-permissions/std",
     "serde",
     "sp-core/std",
@@ -59,7 +65,13 @@ std = [
     "sp-runtime/std",
     "common-types/std",
     "pallet-anchors/std",
-    "common-traits/std"
+    "common-traits/std",
+    "frame-support/std",
+    "frame-system/std",
+]
+runtime-benchmarks = [
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
 ]
 
 on-chain-release-build = [

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -99,10 +99,11 @@ pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-fea
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24" }
 
 # orml pallets
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-asset-registry = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xcm-support = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xtokens = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 runtime-common = { path = "../common", default-features = false }
 common-types = { path = "../../libs/common-types", default-features = false }
@@ -208,6 +209,7 @@ std = [
     "runtime-common/std",
     "orml-tokens/std",
     "orml-xtokens/std",
+    "orml-asset-registry/std",
     "pallet-loans/std",
     "pallet-uniques/std",
     "pallet-treasury/std",
@@ -244,6 +246,7 @@ runtime-benchmarks = [
     "pallet-loans/runtime-benchmarks",
     "chainbridge/runtime-benchmarks",
     "pallet-uniques/runtime-benchmarks",
+    "runtime-common/runtime-benchmarks",
 ]
 
 # A feature that should be enabled when the runtime should be build for on-chain

--- a/runtime/integration-tests/src/xcm/setup.rs
+++ b/runtime/integration-tests/src/xcm/setup.rs
@@ -10,10 +10,11 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+use altair_runtime::CustomMetadata;
 pub use altair_runtime::{AccountId, CurrencyId, Origin, Runtime, System};
-use common_traits::TokenMetadata;
 use frame_support::traits::GenesisBuild;
-use runtime_common::{parachains, Balance};
+use orml_traits::asset_registry::AssetMetadata;
+use runtime_common::{decimals, parachains, Balance};
 
 /// Accounts
 pub const ALICE: [u8; 32] = [4u8; 32];
@@ -22,6 +23,7 @@ pub const BOB: [u8; 32] = [5u8; 32];
 /// A PARA ID used for a sibling parachain.
 /// It must be one that doesn't collide with any other in use.
 pub const PARA_ID_SIBLING: u32 = 3000;
+pub const PARA_ID_DEVELOPMENT: u32 = 3001;
 
 pub struct ExtBuilder {
 	balances: Vec<(AccountId, CurrencyId, Balance)>,
@@ -97,20 +99,24 @@ impl ExtBuilder {
 	}
 }
 
-pub fn air_amount(amount: Balance) -> Balance {
-	amount * dollar(CurrencyId::Native)
+pub fn air(amount: Balance) -> Balance {
+	amount * dollar(decimals::NATIVE)
 }
 
-pub fn kusd_amount(amount: Balance) -> Balance {
-	amount * dollar(CurrencyId::KUSD)
+pub fn ausd(amount: Balance) -> Balance {
+	amount * dollar(decimals::AUSD)
 }
 
-pub fn ksm_amount(amount: Balance) -> Balance {
-	amount * dollar(CurrencyId::KSM)
+pub fn ksm(amount: Balance) -> Balance {
+	amount * dollar(decimals::KSM)
 }
 
-pub fn dollar(currency_id: CurrencyId) -> Balance {
-	10u128.saturating_pow(currency_id.decimals().into())
+pub fn foreign(amount: Balance, decimals: u32) -> Balance {
+	amount * dollar(decimals)
+}
+
+pub fn dollar(decimals: u32) -> Balance {
+	10u128.saturating_pow(decimals.into())
 }
 
 pub fn sibling_account() -> AccountId {

--- a/runtime/integration-tests/src/xcm/test_net.rs
+++ b/runtime/integration-tests/src/xcm/test_net.rs
@@ -23,7 +23,7 @@ use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain
 use altair_runtime::CurrencyId;
 use runtime_common::{parachains, AccountId};
 
-use crate::xcm::setup::{air_amount, ksm_amount, ExtBuilder, ALICE, BOB, PARA_ID_SIBLING};
+use crate::xcm::setup::{air, ksm, ExtBuilder, ALICE, BOB, PARA_ID_DEVELOPMENT, PARA_ID_SIBLING};
 
 decl_test_relay_chain! {
 	pub struct KusamaNet {
@@ -63,6 +63,16 @@ decl_test_parachain! {
 	}
 }
 
+decl_test_parachain! {
+	pub struct Development {
+		Runtime = development_runtime::Runtime,
+		Origin = development_runtime::Origin,
+		XcmpMessageHandler = development_runtime::XcmpQueue,
+		DmpMessageHandler = development_runtime::DmpQueue,
+		new_ext = para_ext(PARA_ID_DEVELOPMENT),
+	}
+}
+
 decl_test_network! {
 	pub struct TestNet {
 		relay_chain = KusamaNet,
@@ -76,6 +86,9 @@ decl_test_network! {
 			(3000, Sibling),
 			// Be sure to use `parachains::karura::ID`
 			(2000, Karura),
+
+			// Be sure to use `PARA_ID_DEVELOPMENT`
+			(3001, Development),
 		],
 	}
 }
@@ -89,14 +102,14 @@ pub fn relay_ext() -> sp_io::TestExternalities {
 
 	pallet_balances::GenesisConfig::<Runtime> {
 		balances: vec![
-			(AccountId::from(ALICE), air_amount(2002)),
+			(AccountId::from(ALICE), air(2002)),
 			(
 				ParaId::from(parachains::altair::ID).into_account_truncating(),
-				air_amount(7),
+				air(7),
 			),
 			(
 				ParaId::from(PARA_ID_SIBLING).into_account_truncating(),
-				air_amount(7),
+				air(7),
 			),
 		],
 	}
@@ -125,13 +138,13 @@ pub fn relay_ext() -> sp_io::TestExternalities {
 pub fn para_ext(parachain_id: u32) -> sp_io::TestExternalities {
 	ExtBuilder::default()
 		.balances(vec![
-			(AccountId::from(ALICE), CurrencyId::Native, air_amount(10)),
-			(AccountId::from(BOB), CurrencyId::Native, air_amount(10)),
-			(AccountId::from(ALICE), CurrencyId::KSM, ksm_amount(10)),
+			(AccountId::from(ALICE), CurrencyId::Native, air(10)),
+			(AccountId::from(BOB), CurrencyId::Native, air(10)),
+			(AccountId::from(ALICE), CurrencyId::KSM, ksm(10)),
 			(
 				altair_runtime::TreasuryAccount::get(),
 				CurrencyId::KSM,
-				ksm_amount(1),
+				ksm(1),
 			),
 		])
 		.parachain_id(parachain_id)

--- a/runtime/integration-tests/src/xcm/xcm_transfers.rs
+++ b/runtime/integration-tests/src/xcm/xcm_transfers.rs
@@ -10,31 +10,42 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+// Copyright 2021 Centrifuge GmbH (centrifuge.io).
+// This file is part of Centrifuge chain project.
+//
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
 use frame_support::assert_ok;
+use xcm::latest::{Junction, Junction::*, Junctions::*, MultiLocation, NetworkId};
 use xcm_emulator::TestExt;
 
-use xcm::latest::{Junction, Junction::*, Junctions::*, MultiLocation, NetworkId};
-
-use orml_traits::MultiCurrency;
+use orml_traits::{FixedConversionRateProvider, MultiCurrency};
+use xcm::VersionedMultiLocation;
 
 use crate::xcm::setup::{
-	air_amount, altair_account, karura_account, ksm_amount, kusd_amount, sibling_account,
-	CurrencyId, ALICE, BOB, PARA_ID_SIBLING,
+	air, altair_account, ausd, foreign, karura_account, ksm, sibling_account, CurrencyId, ALICE,
+	BOB, PARA_ID_SIBLING,
 };
 use crate::xcm::test_net::{Altair, Karura, KusamaNet, Sibling, TestNet};
 
-use altair_runtime::{
-	AirPerSecond, Balances, KUsdPerSecond, KsmPerSecond, Origin, OrmlTokens, XTokens,
-};
-use runtime_common::{parachains, Balance};
+use altair_runtime::{Balances, Origin, OrmlTokens, XTokens};
+use runtime_common::xcm_fees::{default_per_second, ksm_per_second};
+use runtime_common::{decimals, parachains, Balance};
 
 #[test]
 fn transfer_air_to_sibling() {
 	TestNet::reset();
 
-	let alice_initial_balance = air_amount(10);
-	let bob_initial_balance = air_amount(10);
-	let transfer_amount = air_amount(1);
+	let alice_initial_balance = air(10);
+	let bob_initial_balance = air(10);
+	let transfer_amount = air(1);
 
 	Altair::execute_with(|| {
 		assert_eq!(Balances::free_balance(&ALICE.into()), alice_initial_balance);
@@ -80,7 +91,7 @@ fn transfer_air_to_sibling() {
 		// Verify that BOB now has initial balance + amount transferred - fee
 		assert_eq!(
 			Balances::free_balance(&BOB.into()),
-			bob_initial_balance + transfer_amount - air_fee(),
+			bob_initial_balance + transfer_amount - fee(decimals::NATIVE),
 		);
 	});
 }
@@ -94,9 +105,9 @@ fn transfer_air_sibling_to_altair() {
 	// AIR on their side.
 	transfer_air_to_sibling();
 
-	let alice_initial_balance = air_amount(10);
-	let bob_initial_balance = air_amount(10);
-	let transfer_amount = air_amount(1);
+	let alice_initial_balance = air(10);
+	let bob_initial_balance = air(10);
+	let transfer_amount = air(1);
 
 	Sibling::execute_with(|| {
 		assert_eq!(Balances::free_balance(&ALICE.into()), alice_initial_balance);
@@ -140,18 +151,18 @@ fn transfer_air_sibling_to_altair() {
 		// Verify that BOB now has initial balance + amount transferred - fee
 		assert_eq!(
 			Balances::free_balance(&BOB.into()),
-			bob_initial_balance + transfer_amount - air_fee(),
+			bob_initial_balance + transfer_amount - fee(decimals::NATIVE),
 		);
 	});
 }
 
 #[test]
-fn transfer_kusd_to_development() {
+fn transfer_kusd_to_altair() {
 	TestNet::reset();
 
-	let alice_initial_balance = kusd_amount(10);
-	let bob_initial_balance = kusd_amount(10);
-	let transfer_amount = kusd_amount(7);
+	let alice_initial_balance = ausd(10);
+	let bob_initial_balance = ausd(10);
+	let transfer_amount = ausd(7);
 
 	Karura::execute_with(|| {
 		assert_ok!(OrmlTokens::deposit(
@@ -223,12 +234,18 @@ fn transfer_kusd_to_development() {
 			OrmlTokens::free_balance(CurrencyId::KUSD, &BOB.into()),
 			bob_initial_balance + transfer_amount - kusd_fee()
 		);
+
+		// Sanity check the actual balance
+		assert_eq!(
+			OrmlTokens::free_balance(CurrencyId::KUSD, &BOB.into()),
+			16925408000000
+		);
 	});
 }
 
 #[test]
 fn transfer_from_relay_chain() {
-	let transfer_amount: Balance = ksm_amount(1);
+	let transfer_amount: Balance = ksm(1);
 
 	KusamaNet::execute_with(|| {
 		assert_ok!(kusama_runtime::XcmPallet::reserve_transfer_assets(
@@ -261,7 +278,7 @@ fn transfer_ksm_to_relay_chain() {
 		assert_ok!(XTokens::transfer(
 			Origin::signed(ALICE.into()),
 			CurrencyId::KSM,
-			ksm_amount(1),
+			ksm(1),
 			Box::new(
 				MultiLocation::new(
 					1,
@@ -282,6 +299,98 @@ fn transfer_ksm_to_relay_chain() {
 			999988476752
 		);
 	});
+}
+
+pub mod asset_registry {
+	use super::{assert_ok, parachains, GeneralKey, MultiLocation, X1};
+	use crate::xcm::test_net::{Development, TestNet};
+	use development_runtime::{Balance, CurrencyId, CustomMetadata, Origin, OrmlAssetRegistry};
+	use frame_support::assert_noop;
+	use orml_traits::asset_registry::AssetMetadata;
+	use orml_traits::currency::MultiCurrency;
+	use sp_runtime::traits::BadOrigin;
+	use xcm::prelude::{Parachain, X2};
+	use xcm::VersionedMultiLocation;
+	use xcm_emulator::TestExt;
+
+	#[test]
+	fn register_air_works() {
+		Development::execute_with(|| {
+			let meta: AssetMetadata<Balance, CustomMetadata> = AssetMetadata {
+				decimals: 18,
+				name: "Altair".into(),
+				symbol: "AIR".into(),
+				existential_deposit: 1_000_000_000_000,
+				location: Some(VersionedMultiLocation::V1(MultiLocation::new(
+					0,
+					X1(GeneralKey(parachains::altair::AIR_KEY.to_vec())),
+				))),
+				additional: CustomMetadata::default(),
+			};
+
+			assert_ok!(OrmlAssetRegistry::register_asset(
+				Origin::root(),
+				meta,
+				Some(CurrencyId::Native)
+			));
+		});
+	}
+
+	#[test]
+	fn register_foreign_asset_works() {
+		Development::execute_with(|| {
+			let meta: AssetMetadata<Balance, CustomMetadata> = AssetMetadata {
+				decimals: 12,
+				name: "Acala Dollar".into(),
+				symbol: "AUSD".into(),
+				existential_deposit: 1_000_000_000_000,
+				location: Some(VersionedMultiLocation::V1(MultiLocation::new(
+					1,
+					X2(
+						Parachain(2000),
+						GeneralKey(parachains::altair::AIR_KEY.to_vec()),
+					),
+				))),
+				additional: CustomMetadata::default(),
+			};
+
+			assert_ok!(OrmlAssetRegistry::register_asset(
+				Origin::root(),
+				meta,
+				Some(CurrencyId::ForeignAsset(42))
+			));
+		});
+	}
+
+	#[test]
+	// Verify that registering tranche tokens is not allowed through extrinsics
+	fn register_tranche_asset_blocked() {
+		Development::execute_with(|| {
+			let meta: AssetMetadata<Balance, CustomMetadata> = AssetMetadata {
+				decimals: 12,
+				name: "Tranche Token 1".into(),
+				symbol: "TRNCH".into(),
+				existential_deposit: 1_000_000_000_000,
+				location: Some(VersionedMultiLocation::V1(MultiLocation::new(
+					1,
+					X2(Parachain(2000), GeneralKey(vec![42])),
+				))),
+				additional: CustomMetadata::default(),
+			};
+
+			// It fails with `BadOrigin` even when submitted with `Origin::root` since we only
+			// allow for tranche tokens to be registered through the pools pallet.
+			let asset_id = CurrencyId::Tranche(42, [42u8; 16]);
+			assert_noop!(
+				OrmlAssetRegistry::register_asset(
+					Origin::root(),
+					meta.clone(),
+					Some(asset_id.clone())
+				),
+				BadOrigin
+			);
+		});
+	}
 }
 
 pub mod currency_id_convert {
@@ -321,7 +430,7 @@ pub mod currency_id_convert {
 	}
 
 	#[test]
-	fn convert_kusd() {
+	fn convert_ausd() {
 		assert_eq!(parachains::karura::KUSD_KEY.to_vec(), vec![0, 129]);
 
 		let kusd_location: MultiLocation = MultiLocation::new(
@@ -386,27 +495,22 @@ pub mod currency_id_convert {
 	}
 }
 
-// The fee associated with transferring AIR tokens
-fn air_fee() -> Balance {
-	let (_asset, fee) = AirPerSecond::get();
-	// We divide the fee to align its unit and multiply by 4 as that seems to be the unit of
-	// time the transfers take.
-	// NOTE: it is possible that in different machines this value may differ. We shall see.
-	fee.div_euclid(10_000) * 8
+fn fee(decimals: u32) -> Balance {
+	calc_fee(default_per_second(decimals))
 }
 
-// The fee associated with transferring KUSD tokens
 fn kusd_fee() -> Balance {
-	let (_asset, fee) = KUsdPerSecond::get();
-	// We divide the fee to align its unit and multiply by 4 as that seems to be the unit of
-	// time the transfers take.
-	fee.div_euclid(10_000) * 8
+	ksm_fee() * 400
 }
 
 // The fee associated with transferring KSM tokens
 fn ksm_fee() -> Balance {
-	let (_asset, fee) = KsmPerSecond::get();
-	// We divide the fee to align its unit and multiply by 8 as that seems to be the unit of
+	calc_fee(ksm_per_second())
+}
+
+fn calc_fee(fee_per_second: Balance) -> Balance {
+	// We divide the fee to align its unit and multiply by 4 as that seems to be the unit of
 	// time the transfers take.
-	fee.div_euclid(10_000) * 8
+	// NOTE: it is possible that in different machines this value may differ. We shall see.
+	fee_per_second.div_euclid(10_000) * 8
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -23,7 +23,7 @@ use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 use altair_runtime::constants::currency::AIR;
-use runtime_common::CFG;
+use runtime_common::{decimals, CFG};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use serde::{Deserialize, Serialize};
 
@@ -94,7 +94,7 @@ pub fn centrifuge_config() -> CentrifugeChainSpec {
 pub fn centrifuge_staging(para_id: ParaId) -> CentrifugeChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "CFG".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	CentrifugeChainSpec::from_genesis(
 		"Centrifuge",
@@ -148,7 +148,7 @@ pub fn centrifuge_staging(para_id: ParaId) -> CentrifugeChainSpec {
 pub fn centrifuge_dev(para_id: ParaId) -> CentrifugeChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "DCFG".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	CentrifugeChainSpec::from_genesis(
 		"Centrifuge Dev",
@@ -188,7 +188,7 @@ pub fn centrifuge_dev(para_id: ParaId) -> CentrifugeChainSpec {
 pub fn centrifuge_local(para_id: ParaId) -> CentrifugeChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "DCFG".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	CentrifugeChainSpec::from_genesis(
 		"Centrifuge Local",
@@ -223,7 +223,7 @@ pub fn catalyst_config() -> CentrifugeChainSpec {
 pub fn catalyst_staging(para_id: ParaId) -> CentrifugeChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "NCFG".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	CentrifugeChainSpec::from_genesis(
 		"Catalyst Testnet",
@@ -280,7 +280,7 @@ pub fn catalyst_staging(para_id: ParaId) -> CentrifugeChainSpec {
 pub fn catalyst_local(para_id: ParaId) -> CentrifugeChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "NCFG".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	CentrifugeChainSpec::from_genesis(
 		"Catalyst Local",
@@ -317,7 +317,7 @@ pub fn altair_config() -> AltairChainSpec {
 pub fn altair_staging(para_id: ParaId) -> AltairChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "AIR".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	AltairChainSpec::from_genesis(
 		"Altair",
@@ -369,7 +369,7 @@ pub fn altair_staging(para_id: ParaId) -> AltairChainSpec {
 pub fn altair_dev(para_id: ParaId) -> AltairChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "DAIR".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	AltairChainSpec::from_genesis(
 		"Altair Dev",
@@ -409,7 +409,7 @@ pub fn altair_dev(para_id: ParaId) -> AltairChainSpec {
 pub fn altair_local(para_id: ParaId) -> AltairChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "DAIR".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	AltairChainSpec::from_genesis(
 		"Altair Local",
@@ -443,7 +443,7 @@ pub fn antares_config() -> AltairChainSpec {
 pub fn antares_staging(para_id: ParaId) -> AltairChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "NAIR".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	AltairChainSpec::from_genesis(
 		"Antares Testnet",
@@ -501,7 +501,7 @@ pub fn antares_staging(para_id: ParaId) -> AltairChainSpec {
 pub fn antares_local(para_id: ParaId) -> AltairChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "NAIR".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	AltairChainSpec::from_genesis(
 		"Antares Local",
@@ -535,7 +535,7 @@ pub fn charcoal_config() -> AltairChainSpec {
 pub fn charcoal_staging(para_id: ParaId) -> AltairChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "CAIR".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	AltairChainSpec::from_genesis(
 		"Charcoal Testnet",
@@ -587,7 +587,7 @@ pub fn charcoal_staging(para_id: ParaId) -> AltairChainSpec {
 pub fn charcoal_local(para_id: ParaId) -> AltairChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "CAIR".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	AltairChainSpec::from_genesis(
 		"Charcoal Local",
@@ -617,7 +617,7 @@ pub fn charcoal_local(para_id: ParaId) -> AltairChainSpec {
 pub fn development(para_id: ParaId) -> DevelopmentChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "DEVEL".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	DevelopmentChainSpec::from_genesis(
 		"Dev Live",
@@ -657,7 +657,7 @@ pub fn development(para_id: ParaId) -> DevelopmentChainSpec {
 pub fn development_local(para_id: ParaId) -> DevelopmentChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "DEVEL".into());
-	properties.insert("tokenDecimals".into(), 18.into());
+	properties.insert("tokenDecimals".into(), decimals::NATIVE.into());
 
 	DevelopmentChainSpec::from_genesis(
 		"Dev Local",
@@ -928,6 +928,7 @@ fn development_genesis(
 				.to_vec(),
 		},
 		balances: development_runtime::BalancesConfig { balances },
+		orml_asset_registry: Default::default(),
 		orml_tokens: development_runtime::OrmlTokensConfig {
 			balances: token_balances,
 		},


### PR DESCRIPTION
Part 1/2 of #825 


##### development
- [x] Add `orml-asset-registry` pallet to dependencies
- [x] Add `orml_asset_registry` pallet to the development runtime
- [x] Try and use `CurrencyId` as the `AssetId` type of this pallet
- [x] Implement mock `AssetProcessor`
- [x] Add `CurrencyId::ForeignAsset` variant
- [x] Test that we can register the native as well as new foreign asset tokens
- [x] Adapt the XCM config to make use of this registry

##### general
- [x] Extend dependency to allow for origin checks based on the asset id 
https://github.com/open-web3-stack/open-runtime-module-library/pull/762
- [x] Extend orml to allow for AssetRegistry to be passed as a trait to pools later on 
https://github.com/open-web3-stack/open-runtime-module-library/pull/767
- [x] Drop our custom `TokenMetadata` trait
    See [commit description](https://github.com/centrifuge/centrifuge-chain/pull/829/commits/0f561c11cdacb2d6e890ade1ed8681ff45420df7)
- [x] Define  `CustomMetadata` 
   See https://github.com/centrifuge/centrifuge-chain/pull/829#discussion_r896056172
- [x] Drop `CurrencyId::Permissioned` 
- [x] Fine tune values and configs (see the comments I left on my self-review)
