### PR TITLE
claim root hashes value instead of map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,7 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
  "tempfile",
+ "try-runtime-cli",
  "url 2.2.2",
  "vergen",
 ]
@@ -1230,6 +1231,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal 0.2.2",
  "integer-sqrt",
  "node-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = 
 
 # Cli specific
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", optional = true }
 node-inspect = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
 
 # local dependencies
@@ -171,7 +172,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
 
 [features]
-default = [ "std" ]
+default = [ "std", "cli" ]
 std = [
 	"sc-service/db",
 	"substrate-build-script-utils",
@@ -186,4 +187,11 @@ runtime-benchmarks = [
 test-benchmarks = [
 	"runtime-benchmarks",
 	"runtime-integration-tests/runtime-benchmarks",
+]
+cli = [
+	'try-runtime-cli',
+]
+try-runtime = [
+	"centrifuge-runtime/try-runtime",
+	"try-runtime-cli"
 ]

--- a/pallets/claims/Cargo.toml
+++ b/pallets/claims/Cargo.toml
@@ -39,3 +39,5 @@ std = [
   'pallet-balances/std',
   'sp-std/std',
 ]
+
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/claims/src/lib.rs
+++ b/pallets/claims/src/lib.rs
@@ -120,6 +120,8 @@ pub use crate::traits::WeightInfo as PalletWeightInfo;
 // Re-export in crate namespace (for runtime construction)
 pub use pallet::*;
 
+mod migration;
+
 // ----------------------------------------------------------------------------
 // Traits and types declaration
 // ----------------------------------------------------------------------------
@@ -273,7 +275,21 @@ pub mod pallet {
 	// ----------------------------------------------------------------------------
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			migration::root_hashes::migrate::<T>()
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<(), &'static str> {
+			migration::root_hashes::pre_migrate::<T>()
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade() -> Result<(), &'static str> {
+			migration::root_hashes::post_migrate::<T>()
+		}
+	}
 
 	// ------------------------------------------------------------------------
 	// Pallet errors

--- a/pallets/claims/src/lib.rs
+++ b/pallets/claims/src/lib.rs
@@ -230,11 +230,10 @@ pub mod pallet {
 	pub(super) type ClaimedAmounts<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, T::Balance, ValueQuery>;
 
-	/// Map of root hashes that correspond to lists of reward claim amounts per account.
+	/// Root hash that correspond to lists of reward claim amounts per account.
 	#[pallet::storage]
 	#[pallet::getter(fn get_root_hash)]
-	pub(super) type RootHashes<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::Hash, bool, ValueQuery>;
+	pub(super) type RootHash<T: Config> = StorageValue<_, T::Hash, OptionQuery>;
 
 	/// Account that is allowed to upload new root hashes.
 	#[pallet::storage]
@@ -392,7 +391,7 @@ pub mod pallet {
 				Error::<T>::MustBeAdmin
 			);
 
-			<RootHashes<T>>::insert(root_hash, true);
+			<RootHash<T>>::put(root_hash);
 
 			Self::deposit_event(Event::RootHashStored(root_hash));
 
@@ -483,6 +482,6 @@ impl<T: Config> Pallet<T> {
 			root_hash = leaf_hash;
 		}
 
-		Self::get_root_hash(root_hash)
+		Self::get_root_hash() == Some(root_hash)
 	}
 }

--- a/pallets/claims/src/migration.rs
+++ b/pallets/claims/src/migration.rs
@@ -38,7 +38,7 @@ pub mod root_hashes {
 	}
 
 	pub fn migrate<T: Config>() -> Weight {
-		RootHashes::<T>::remove_all(Some(1000)); // large enough number in case we enable the tree update job before this upgrade goes through
+		RootHashes::<T>::remove_all(None); // All keys should be deleted
 		log::info!(target: "runtime::claims::migrate", "Done Migrating");
 		T::DbWeight::get().reads_writes(1, 1)
 	}

--- a/pallets/claims/src/migration.rs
+++ b/pallets/claims/src/migration.rs
@@ -1,0 +1,81 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+// This file is part of Centrifuge (centrifuge.io) parachain.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+use frame_support::{generate_storage_alias, log, traits::Get, weights::Weight, Blake2_128Concat};
+
+generate_storage_alias!(
+	Claims,
+	RootHashes<T: Config> => Map<(Blake2_128Concat, T::Hash), bool>
+);
+
+pub mod root_hashes {
+	use super::*;
+
+	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
+		let count = RootHashes::<T>::iter_values().count();
+		ensure!(count != 0, "RootHashes storage items not found!");
+		log::info!(
+				target: "runtime::claims::pre-migrate",
+				"Pre Migrate check passed with count {:?}",
+				count,
+		);
+		Ok(())
+	}
+
+	pub fn migrate<T: Config>() -> Weight {
+		RootHashes::<T>::remove_all(Some(1000)); // large enough number in case we enable the tree update job before this upgrade goes through
+		log::info!(target: "runtime::claims::migrate", "Done Migrating");
+		T::DbWeight::get().reads_writes(1, 1)
+	}
+
+	pub fn post_migrate<T: Config>() -> Result<(), &'static str> {
+		ensure!(
+			RootHashes::<T>::iter_values().count() == 0,
+			"RootHashes storage should be empty!"
+		);
+		log::info!(target: "runtime::claims::post-migrate", "Post Migrate check passed");
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::{MockRuntime as T, TestExternalitiesBuilder};
+	use frame_support::assert_ok;
+	use sp_core::H256;
+
+	#[test]
+	fn should_kill_root_hashes() {
+		TestExternalitiesBuilder::default()
+			.build()
+			.execute_with(|| {
+				assert_eq!(RootHashes::<T>::iter_values().count(), 0);
+				let root_hash: H256 = [1; 32].into();
+				RootHashes::<T>::insert(root_hash, true);
+				assert_eq!(RootHashes::<T>::iter_values().count(), 1);
+				assert_ok!(root_hashes::pre_migrate::<T>());
+				root_hashes::migrate::<T>();
+				assert_eq!(RootHashes::<T>::iter_values().count(), 0);
+				assert_eq!(
+					root_hashes::pre_migrate::<T>(),
+					Err("RootHashes storage items not found!")
+				);
+			});
+	}
+}

--- a/pallets/claims/src/tests.rs
+++ b/pallets/claims/src/tests.rs
@@ -183,7 +183,7 @@ fn store_root_hash() {
 			assert_ok!(Claims::set_upload_account(Origin::signed(ADMIN), ADMIN));
 			assert_eq!(Claims::get_upload_account(), Some(ADMIN));
 			assert_ok!(Claims::store_root_hash(Origin::signed(ADMIN), root_hash));
-			assert_eq!(Claims::get_root_hash(root_hash), true);
+			assert_eq!(Claims::get_root_hash(), Some(root_hash));
 		});
 }
 

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -87,6 +87,7 @@ pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate",
 pallet-staking = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.20" }
 pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.20" }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", default-features = false, optional = true }
 pallet-utility = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.20" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.20" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.20" }
@@ -189,6 +190,7 @@ std = [
     "pallet-crowdloan-claim/std",
     "pallet-crowdloan-reward/std",
     "pallet-treasury/std",
+    "frame-try-runtime/std",
 ]
 
 runtime-benchmarks = [
@@ -218,6 +220,14 @@ runtime-benchmarks = [
     "pallet-migration-manager/runtime-benchmarks",
     "pallet-crowdloan-claim/runtime-benchmarks",
     "pallet-crowdloan-reward/runtime-benchmarks",
+]
+
+try-runtime = [
+    "frame-executive/try-runtime",
+    "frame-try-runtime",
+    "frame-system/try-runtime",
+    "pallet-scheduler/try-runtime",
+    "pallet-claims/try-runtime"
 ]
 
 # A feature that should be enabled when the runtime should be build for on-chain

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1065,6 +1065,17 @@ impl_runtime_apis! {
 			Ok(batches)
 		}
 	}
+
+	#[cfg(feature = "try-runtime")]
+	impl frame_try_runtime::TryRuntime<Block> for Runtime {
+		fn on_runtime_upgrade() -> (Weight, Weight) {
+			let weight = Executive::try_runtime_upgrade().unwrap();
+			(weight, RuntimeBlockWeights::get().max_block)
+		}
+		fn execute_block_no_check(block: Block) -> Weight {
+			Executive::execute_block_no_check(block)
+		}
+	}
 }
 struct CheckInherents;
 

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -65,7 +65,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge"),
 	impl_name: create_runtime_str!("centrifuge"),
 	authoring_version: 1,
-	spec_version: 1006,
+	spec_version: 1007,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,6 +53,11 @@ pub enum Subcommand {
 	/// The pallet benchmarking moved to the `pallet` sub-command.
 	#[clap(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
+
+	/// Try some experimental command on the runtime. This includes migration and runtime-upgrade
+	/// testing.
+	#[cfg(feature = "try-runtime")]
+	TryRuntime(try_runtime_cli::TryRuntimeCmd),
 }
 
 /// Command for exporting the genesis state of the parachain

--- a/src/command.rs
+++ b/src/command.rs
@@ -202,6 +202,25 @@ fn extract_genesis_wasm(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Result<V
 		.ok_or_else(|| "Could not find wasm file in genesis state!".into())
 }
 
+macro_rules! with_runtime {
+	($chain_spec:expr, { $( $code:tt )* }) => {
+		match $chain_spec.identify() {
+			ChainIdentity::Altair => {
+				use AltairRuntimeExecutor as Executor;
+				$( $code )*
+			}
+			ChainIdentity::Centrifuge => {
+				use CentrifugeRuntimeExecutor as Executor;
+				$( $code )*
+			}
+			ChainIdentity::Development => {
+				use DevelopmentRuntimeExecutor as Executor;
+				$( $code )*
+			}
+		}
+	}
+}
+
 macro_rules! construct_async_run {
 	(|$components:ident, $cli:ident, $cmd:ident, $config:ident| $( $code:tt )* ) => {{
 	    let runner = $cli.create_runner($cmd)?;
@@ -346,6 +365,25 @@ pub fn run() -> Result<()> {
 
 			Ok(())
 		}
+
+		#[cfg(feature = "try-runtime")]
+		Some(Subcommand::TryRuntime(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			let chain_spec = &runner.config().chain_spec;
+
+			with_runtime!(chain_spec, {
+				return runner.async_run(|config| {
+					let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
+					let task_manager =
+						sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
+							.map_err(|e| {
+								sc_cli::Error::Service(sc_service::Error::Prometheus(e))
+							})?;
+					Ok((cmd.run::<Block, Executor>(config), task_manager))
+				});
+			})
+		}
+
 		Some(Subcommand::Benchmark(cmd)) => {
 			if cfg!(feature = "runtime-benchmarks") {
 				let runner = cli.create_runner(cmd)?;


### PR DESCRIPTION
Potential change (pending agreement) to change root hashes storage from a map to single value.

In addition adding try-runtime to verify upgrades against a live chain data. To execute:
```
cargo build --release --features=try-runtime

RUST_LOG=runtime=trace,try-runtime::cli=trace,executor=trace ./target/release/centrifuge-chain try-runtime --execution Native --chain centrifuge-local --no-spec-name-check on-runtime-upgrade live --uri wss://fullnode.parachain.centrifuge.io:443
```