### PR TITLE
deps: Move back to official orml repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5783,7 +5783,7 @@ dependencies = [
 [[package]]
 name = "orml-tokens"
 version = "0.4.1-dev"
-source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.4.1-dev"
-source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -5816,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "0.4.1-dev"
-source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5830,7 +5830,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm-support"
 version = "0.4.1-dev"
-source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "frame-support",
  "orml-traits",
@@ -5844,7 +5844,7 @@ dependencies = [
 [[package]]
 name = "orml-xtokens"
 version = "0.4.1-dev"
-source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5783,7 +5783,7 @@ dependencies = [
 [[package]]
 name = "orml-tokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/NunoAlexandre/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.4.1-dev"
-source = "git+https://github.com/NunoAlexandre/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -5816,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "0.4.1-dev"
-source = "git+https://github.com/NunoAlexandre/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5830,7 +5830,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm-support"
 version = "0.4.1-dev"
-source = "git+https://github.com/NunoAlexandre/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "frame-support",
  "orml-traits",
@@ -5844,7 +5844,7 @@ dependencies = [
 [[package]]
 name = "orml-xtokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/NunoAlexandre/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
+source = "git+https://github.com//open-web3-stack/open-runtime-module-library?branch=polkadot-v0.9.24#29442c0a2f8ec8d76dc2287afc977e608cbcf7c2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/pallets/loans/Cargo.toml
+++ b/pallets/loans/Cargo.toml
@@ -34,9 +34,9 @@ pallet-balances = { git = "https://github.com/paritytech/substrate",  default-fe
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.24" }
 pallet-pools = { path = "../pools", optional = true, default-features = false}
 
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false, optional = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", default-features =  false, branch = "polkadot-v0.9.24" }
@@ -44,8 +44,8 @@ pallet-balances = { git = "https://github.com/paritytech/substrate",  default-fe
 runtime-common = { path = "../../runtime/common", default-features = true }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 pallet-pools = { path = "../pools", default-features = false}

--- a/pallets/loans/Cargo.toml
+++ b/pallets/loans/Cargo.toml
@@ -34,9 +34,9 @@ pallet-balances = { git = "https://github.com/paritytech/substrate",  default-fe
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.24" }
 pallet-pools = { path = "../pools", optional = true, default-features = false}
 
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false, optional = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", default-features =  false, branch = "polkadot-v0.9.24" }
@@ -44,8 +44,8 @@ pallet-balances = { git = "https://github.com/paritytech/substrate",  default-fe
 runtime-common = { path = "../../runtime/common", default-features = true }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 pallet-pools = { path = "../pools", default-features = false}

--- a/pallets/nft-sales/Cargo.toml
+++ b/pallets/nft-sales/Cargo.toml
@@ -22,8 +22,8 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", default-features
 frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.24" }
 pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.24" }
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.24" }
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 common-types = { path = "../../libs/common-types", default-features = false, optional = true }
 runtime-common = { path = "../../runtime/common", default-features = false, optional = true }
 
@@ -35,8 +35,8 @@ pallet-balances = { git = "https://github.com/paritytech/substrate",  default-fe
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
 # Orml crates
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 # Local crates
 runtime-common = { path = "../../runtime/common", default-features = true }

--- a/pallets/nft-sales/Cargo.toml
+++ b/pallets/nft-sales/Cargo.toml
@@ -22,8 +22,8 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", default-features
 frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.24" }
 pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.24" }
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.24" }
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 common-types = { path = "../../libs/common-types", default-features = false, optional = true }
 runtime-common = { path = "../../runtime/common", default-features = false, optional = true }
 
@@ -35,8 +35,8 @@ pallet-balances = { git = "https://github.com/paritytech/substrate",  default-fe
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
 # Orml crates
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 # Local crates
 runtime-common = { path = "../../runtime/common", default-features = true }

--- a/pallets/pools/Cargo.toml
+++ b/pallets/pools/Cargo.toml
@@ -24,7 +24,7 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-fe
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 common-traits = { path = "../../libs/common-traits", default-features = false }
 common-types = { path = "../../libs/common-types", default-features = false }
 pallet-permissions = { path = "../../pallets/permissions", default-features = false}
@@ -32,7 +32,7 @@ pallet-permissions = { path = "../../pallets/permissions", default-features = fa
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 runtime-common = { path = "../../runtime/common", default-features = true }
 pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = true}
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.24" }

--- a/pallets/pools/Cargo.toml
+++ b/pallets/pools/Cargo.toml
@@ -24,7 +24,7 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-fe
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 common-traits = { path = "../../libs/common-traits", default-features = false }
 common-types = { path = "../../libs/common-types", default-features = false }
 pallet-permissions = { path = "../../pallets/permissions", default-features = false}
@@ -32,7 +32,7 @@ pallet-permissions = { path = "../../pallets/permissions", default-features = fa
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 runtime-common = { path = "../../runtime/common", default-features = true }
 pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = true}
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.24" }

--- a/pallets/restricted-tokens/Cargo.toml
+++ b/pallets/restricted-tokens/Cargo.toml
@@ -26,14 +26,14 @@ common-types = { path = "../../libs/common-types", default-features = false }
 
 ## Benchmarkind dependencies
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 pallet-permissions = { path = "../permissions", default-features = false, optional = true }
 runtime-common = { path = "../../runtime/common", default-features = false, optional = true }
 
 [dev-dependencies]
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.24" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.24" }
 

--- a/pallets/restricted-tokens/Cargo.toml
+++ b/pallets/restricted-tokens/Cargo.toml
@@ -26,14 +26,14 @@ common-types = { path = "../../libs/common-types", default-features = false }
 
 ## Benchmarkind dependencies
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.24" }
 pallet-permissions = { path = "../permissions", default-features = false, optional = true }
 runtime-common = { path = "../../runtime/common", default-features = false, optional = true }
 
 [dev-dependencies]
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.24" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.24" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.24" }
 

--- a/runtime/altair/Cargo.toml
+++ b/runtime/altair/Cargo.toml
@@ -99,10 +99,10 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
 # orml pallets
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xcm-support = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xtokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 # our custom pallets
 runtime-common = { path = "../common", default-features = false }

--- a/runtime/altair/Cargo.toml
+++ b/runtime/altair/Cargo.toml
@@ -99,10 +99,10 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
 # orml pallets
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xcm-support = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xtokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xcm-support = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xtokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 # our custom pallets
 runtime-common = { path = "../common", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -28,7 +28,7 @@ sp-consensus-aura = { git = "https://github.com/paritytech/substrate",  default-
 sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
 # ORML dependencies
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 # Local Dependencies
 common-traits = { path = "../../libs/common-traits", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -28,7 +28,7 @@ sp-consensus-aura = { git = "https://github.com/paritytech/substrate",  default-
 sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.24" }
 
 # ORML dependencies
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 # Local Dependencies
 common-traits = { path = "../../libs/common-traits", default-features = false }

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -99,10 +99,10 @@ pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-fea
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24" }
 
 # orml pallets
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xcm-support = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xtokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xcm-support = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xtokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 runtime-common = { path = "../common", default-features = false }
 common-types = { path = "../../libs/common-types", default-features = false }

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -99,10 +99,10 @@ pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-fea
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24" }
 
 # orml pallets
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xcm-support = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
-orml-xtokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.24" }
 
 runtime-common = { path = "../common", default-features = false }
 common-types = { path = "../../libs/common-types", default-features = false }

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -60,10 +60,10 @@ cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branc
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24" }
 
 # Orml pallets
-orml-tokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", branch = "polkadot-v0.9.24" }
-orml-xcm-support = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", branch = "polkadot-v0.9.24" }
-orml-xtokens = { git = "https://github.com/NunoAlexandre/open-runtime-module-library", branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
+orml-xcm-support = { git = "https://github.com//open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
+orml-xtokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
 
 # Misc
 xcm-emulator = { git = "https://github.com/NunoAlexandre/xcm-simulator", branch = "polkadot-v0.9.24" }

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -60,10 +60,10 @@ cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branc
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24" }
 
 # Orml pallets
-orml-tokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
-orml-traits = { git = "https://github.com//open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
-orml-xcm-support = { git = "https://github.com//open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
-orml-xtokens = { git = "https://github.com//open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
 
 # Misc
 xcm-emulator = { git = "https://github.com/NunoAlexandre/xcm-simulator", branch = "polkadot-v0.9.24" }


### PR DESCRIPTION
The fork updating to polkadot v0.9.24 [has been merged](https://github.com/open-web3-stack/open-runtime-module-library/pull/773) so we move back to using the official repo.