### PR TITLE
ci: Fix rust_toolchain version to 1.60.0

### DIFF
--- a/.github/workflows/build-matrix.json
+++ b/.github/workflows/build-matrix.json
@@ -11,7 +11,7 @@
     "target": "build-runtime",
     "package": "altair-runtime",
     "run_on_event": "push",
-    "rust_toolchain": "1.62.0"
+    "rust_toolchain": "1.60.0"
   },
 
   {
@@ -19,6 +19,6 @@
     "target": "build-runtime",
     "package": "centrifuge-runtime",
     "run_on_event": "push",
-    "rust_toolchain": "1.62.0"
+    "rust_toolchain": "1.60.0"
   }
 ]


### PR DESCRIPTION
When upgrading to polkadot v0.9.24 I bumped the rust_toolchain version to 1.62.0 but that version is not published as stable yet so the CI is failing with a 404 error when trying to download that toolchain's version.

~~We fix this by moving to 1.61.0, the [latest published release](https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html).~~
-> paritytech/srtool v1.61.0 is not available yet

We fix this by moving to rust_toolchain v1.60.0.
