### PR TITLE
common-types: Test CurrencyId variants encoding

### DIFF
--- a/libs/common-types/src/tests.rs
+++ b/libs/common-types/src/tests.rs
@@ -200,3 +200,21 @@ fn permission_roles_work() {
 	assert!(!roles.exists(Role::PoolRole(PoolRole::LiquidityAdmin)));
 	assert!(!roles.exists(Role::PoolRole(PoolRole::MemberListAdmin)));
 }
+
+/// Sanity check for every CurrencyId variant's encoding value.
+/// This will stop us from accidentally moving or dropping variants
+/// around which could have silent but serious negative consequences.
+#[test]
+fn currency_id_encode_sanity() {
+	assert_eq!(CurrencyId::Native.encode(), vec![0]);
+	assert_eq!(
+		CurrencyId::Tranche(42, [42; 16]).encode(),
+		[
+			1, 42, 0, 0, 0, 0, 0, 0, 0, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
+			42
+		]
+	);
+	assert_eq!(CurrencyId::KSM.encode(), vec![2]);
+	assert_eq!(CurrencyId::KUSD.encode(), vec![3]);
+	assert_eq!(CurrencyId::AUSD.encode(), vec![4]);
+}


### PR DESCRIPTION
### Context

<blockquote>
🤯  **PLUS**, I jus realised this, if we choose this option I am pretty certain that we won't need to concern ourselves with the balances migration step because by dropping `CurrencyId::KUSD`, `CurrencyId::AUSD` will automatically be encoded to the value that `CurrencyId::KUSD` was, so the migration is essentially automatically done for free. I need to verify this tho!

In any case, we need to find a way of not breaking the balances when messing around with `CurrencyId` variants. Pehraps we need to implement a custom `Encode`/`Decode` impl for `CurrencyId`.
</blockquote>

_Originally posted by @NunoAlexandre in https://github.com/centrifuge/centrifuge-chain/issues/836#issuecomment-1157606927_

### Purpose

Whatever route we choose to we proceed with on the linked issue, it's important to have a sanity test verifying the values that each `CurrencyId` variant `codec::Encode` to.

This will alert us for any change we make to `CurrencyId` and avoids us from making a serious mistake which would, for instance, mess up with the balances indexing in `OrmlTokens` which I believe (*) encodes `CurrencyId`.

(*) busy verifying this