### PR TITLE
deps: Move back to official xcm-simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13643,7 +13643,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.1.0"
-source = "git+https://github.com/NunoAlexandre/xcm-simulator?branch=polkadot-v0.9.24#d21c372306f1cbf6a3b521d8b41e172587ae45e0"
+source = "git+https://github.com/shaunxw/xcm-simulator?branch=master#651af78d6d7521dc76e1f6bb257af485f8a454c7"
 dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -66,7 +66,7 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.24" }
 
 # Misc
-xcm-emulator = { git = "https://github.com/NunoAlexandre/xcm-simulator", branch = "polkadot-v0.9.24" }
+xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", branch = "master" }
 
 # Local
 runtime-common = { path = "../common" }


### PR DESCRIPTION
My [fork's PR](https://github.com/shaunxw/xcm-simulator/pull/32#event-6824800660) has been merged to we can got back to the official repo.