### PR TITLE
Include fast-runtime feature flag with some defaults

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: docker
 on:
   push:
-    branches: [master, parachain]
+    branches: [master, parachain, fast-runtime-flag]
   workflow_dispatch:
     inputs:
       docker_tag:
@@ -12,7 +12,11 @@ env:
   RUST_TOOLCHAIN: "nightly-2022-05-09"
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        target: [ release, test ]
+    runs-on: ${{ matrix.os }}
     env:
       WORKFLOW_TAG: ${{ github.event.inputs.docker_tag }}
     steps:
@@ -43,15 +47,23 @@ jobs:
           else
             echo "DOCKER_TAG=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
           fi
-      - name: Build docker
+      - if: matrix.target == 'release'
+        name: Build docker release
         run: docker build --build-arg RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }} -t centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-latest .
+      - if: matrix.target == 'test'
+        name: Build docker test
+        run: docker build --build-arg RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }} --build-arg OPTS="--features=fast-runtime" -t centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-test-latest .
       - name: Login to Docker Hub
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Tag image
+      - if: matrix.target == 'release'
+        name: Tag image release
         run: docker tag centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-latest "centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-$(date -u +%Y%m%d%H%M%S)-$(git rev-parse --short HEAD)"
+      - if: matrix.target == 'test'
+        name: Tag image test
+        run: docker tag centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-test-latest "centrifugeio/centrifuge-chain:test-${{ env.DOCKER_TAG }}-$(date -u +%Y%m%d%H%M%S)-$(git rev-parse --short HEAD)"
       - name: List images
         run: docker images
       - name: Push image to Docker Hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: docker
 on:
   push:
-    branches: [master, parachain, fast-runtime-flag]
+    branches: [master, parachain]
   workflow_dispatch:
     inputs:
       docker_tag:
@@ -52,7 +52,7 @@ jobs:
         run: docker build --build-arg RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }} -t centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-latest .
       - if: matrix.target == 'test'
         name: Build docker test
-        run: docker build --build-arg RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }} --build-arg OPTS="--features=fast-runtime" -t centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-test-latest .
+        run: docker build --build-arg RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }} --build-arg OPTS="--features=fast-runtime" -t centrifugeio/centrifuge-chain:test-${{ env.DOCKER_TAG }}-latest .
       - name: Login to Docker Hub
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
@@ -63,7 +63,7 @@ jobs:
         run: docker tag centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-latest "centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-$(date -u +%Y%m%d%H%M%S)-$(git rev-parse --short HEAD)"
       - if: matrix.target == 'test'
         name: Tag image test
-        run: docker tag centrifugeio/centrifuge-chain:${{ env.DOCKER_TAG }}-test-latest "centrifugeio/centrifuge-chain:test-${{ env.DOCKER_TAG }}-$(date -u +%Y%m%d%H%M%S)-$(git rev-parse --short HEAD)"
+        run: docker tag centrifugeio/centrifuge-chain:test-${{ env.DOCKER_TAG }}-latest "centrifugeio/centrifuge-chain:test-${{ env.DOCKER_TAG }}-$(date -u +%Y%m%d%H%M%S)-$(git rev-parse --short HEAD)"
       - name: List images
         run: docker images
       - name: Push image to Docker Hub

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,3 +192,10 @@ try-runtime = [
 	"centrifuge-runtime/try-runtime",
 	"try-runtime-cli"
 ]
+
+fast-runtime = [
+	"altair-runtime/fast-runtime",
+	"centrifuge-runtime/fast-runtime"
+]
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,5 +197,3 @@ fast-runtime = [
 	"altair-runtime/fast-runtime",
 	"centrifuge-runtime/fast-runtime"
 ]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV RUST_TOOLCHAIN=$RUST_TOOLCHAIN
 
 ARG PROFILE=release
+ARG OPTS
 WORKDIR /centrifuge-chain
 
 COPY . /centrifuge-chain
@@ -21,7 +22,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 	export PATH="$PATH:$HOME/.cargo/bin" && \
 	rustup default $RUST_TOOLCHAIN && \
 	rustup target add wasm32-unknown-unknown --toolchain $RUST_TOOLCHAIN && \
-	cargo build "--$PROFILE"
+	cargo build "--$PROFILE" "$OPTS"
 
 # ===== SECOND STAGE ======
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 	export PATH="$PATH:$HOME/.cargo/bin" && \
 	rustup default $RUST_TOOLCHAIN && \
 	rustup target add wasm32-unknown-unknown --toolchain $RUST_TOOLCHAIN && \
-	cargo build "--$PROFILE" "$OPTS"
+	cargo build "--$PROFILE" $OPTS
 
 # ===== SECOND STAGE ======
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV RUST_TOOLCHAIN=$RUST_TOOLCHAIN
 
 ARG PROFILE=release
-ARG OPTS
+ARG OPTS=""
 WORKDIR /centrifuge-chain
 
 COPY . /centrifuge-chain

--- a/docker-compose-local-chain.yml
+++ b/docker-compose-local-chain.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   cc_alice:
     container_name: cc-alice
-    image: "centrifugeio/centrifuge-chain:${CC_DOCKER_TAG:-parachain-latest}"
+    image: "centrifugeio/centrifuge-chain:${CC_DOCKER_TAG:-test-parachain-latest}"
     ports:
       - "30355:30333"
       - "9936:9933"
@@ -13,7 +13,7 @@ services:
         target: /chainspec.json
         read_only: true
     command: >
-      --chain="${PARA_CHAIN_SPEC:-development-local}" 
+      --chain="${PARA_CHAIN_SPEC:-altair-local}" 
       --alice
       --parachain-id="2000"
       --wasm-execution=compiled

--- a/runtime/altair/Cargo.toml
+++ b/runtime/altair/Cargo.toml
@@ -245,3 +245,6 @@ runtime-benchmarks = [
 on-chain-release-build = [
     "sp-api/disable-logging",
 ]
+
+# Set timing constants (e.g. session period) to faster versions to speed up testing.
+fast-runtime = []

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -29,7 +29,7 @@ use pallet_collective::{EnsureMember, EnsureProportionAtLeast, EnsureProportionM
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo};
-use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate, prod_or_fast};
+use polkadot_runtime_common::{prod_or_fast, BlockHashCount, SlowAdjustingFeeUpdate};
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -29,7 +29,7 @@ use pallet_collective::{EnsureMember, EnsureProportionAtLeast, EnsureProportionM
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo};
-use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
+use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate, prod_or_fast};
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
@@ -446,7 +446,7 @@ impl pallet_preimage::Config for Runtime {
 }
 
 parameter_types! {
-	pub const CouncilMotionDuration: BlockNumber = 5 * DAYS;
+	pub CouncilMotionDuration: BlockNumber = prod_or_fast!(5 * DAYS, 1 * MINUTES, "AIR_MOTION_DURATION");
 	pub const CouncilMaxProposals: u32 = 100;
 	pub const CouncilMaxMembers: u32 = 100;
 }
@@ -481,7 +481,7 @@ parameter_types! {
 	pub const CandidacyBond: Balance = 500 * AIR;
 	pub const VotingBond: Balance = 50 * CENTI_AIR;
 	pub const VotingBondBase: Balance = 50 * CENTI_AIR;
-	pub const TermDuration: BlockNumber = 7 * DAYS;
+	pub TermDuration: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_TERM_DURATION");
 	pub const DesiredMembers: u32 = 9;
 	pub const DesiredRunnersUp: u32 = 9;
 	pub const ElectionsPhragmenModuleId: LockIdentifier = *b"phrelect";
@@ -524,13 +524,13 @@ impl pallet_elections_phragmen::Config for Runtime {
 }
 
 parameter_types! {
-	pub const LaunchPeriod: BlockNumber = 7 * DAYS;
-	pub const VotingPeriod: BlockNumber = 7 * DAYS;
-	pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
+	pub LaunchPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_LAUNCH_PERIOD");
+	pub VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_LAUNCH_PERIOD");
+	pub FastTrackVotingPeriod: BlockNumber = prod_or_fast!(3 * HOURS, 1 * MINUTES, "AIR_FAST_TRACK_VOTING_PERIOD");
 	pub const InstantAllowed: bool = false;
 	pub const MinimumDeposit: Balance = 500 * AIR;
-	pub const EnactmentPeriod: BlockNumber = 8 * DAYS;
-	pub const CooloffPeriod: BlockNumber = 7 * DAYS;
+	pub EnactmentPeriod: BlockNumber = prod_or_fast!(8 * DAYS, 1 * MINUTES, "AIR_ENACTMENT_PERIOD");
+	pub CooloffPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_ENACTMENT_PERIOD");
 	pub const MaxProposals: u32 = 100;
 	pub const MaxVotes: u32 = 100;
 }

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -525,12 +525,12 @@ impl pallet_elections_phragmen::Config for Runtime {
 
 parameter_types! {
 	pub LaunchPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_LAUNCH_PERIOD");
-	pub VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_LAUNCH_PERIOD");
+	pub VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_VOTING_PERIOD");
 	pub FastTrackVotingPeriod: BlockNumber = prod_or_fast!(3 * HOURS, 1 * MINUTES, "AIR_FAST_TRACK_VOTING_PERIOD");
 	pub const InstantAllowed: bool = false;
 	pub const MinimumDeposit: Balance = 500 * AIR;
 	pub EnactmentPeriod: BlockNumber = prod_or_fast!(8 * DAYS, 1 * MINUTES, "AIR_ENACTMENT_PERIOD");
-	pub CooloffPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_ENACTMENT_PERIOD");
+	pub CooloffPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "AIR_COOLOFF_PERIOD");
 	pub const MaxProposals: u32 = 100;
 	pub const MaxVotes: u32 = 100;
 }

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -236,3 +236,6 @@ try-runtime = [
 on-chain-release-build = [
     "sp-api/disable-logging",
 ]
+
+# Set timing constants (e.g. session period) to faster versions to speed up testing.
+fast-runtime = []

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -25,7 +25,7 @@ use pallet_collective::{EnsureMember, EnsureProportionAtLeast, EnsureProportionM
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo};
-use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate, prod_or_fast};
+use polkadot_runtime_common::{prod_or_fast, BlockHashCount, SlowAdjustingFeeUpdate};
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -25,7 +25,7 @@ use pallet_collective::{EnsureMember, EnsureProportionAtLeast, EnsureProportionM
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo};
-use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
+use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate, prod_or_fast};
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
@@ -439,7 +439,7 @@ impl pallet_preimage::Config for Runtime {
 }
 
 parameter_types! {
-	pub const CouncilMotionDuration: BlockNumber = 5 * DAYS;
+	pub CouncilMotionDuration: BlockNumber = prod_or_fast!(5 * DAYS, 1 * MINUTES, "CFG_MOTION_DURATION");
 	pub const CouncilMaxProposals: u32 = 100;
 	pub const CouncilMaxMembers: u32 = 100;
 }
@@ -471,7 +471,7 @@ parameter_types! {
 	pub const CandidacyBond: Balance = 1000 * CFG;
 	pub const VotingBond: Balance = 50 * CENTI_CFG;
 	pub const VotingBondBase: Balance = 50 * CENTI_CFG;
-	pub const TermDuration: BlockNumber = 7 * DAYS;
+	pub TermDuration: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_TERM_DURATION");
 	pub const DesiredMembers: u32 = 9;
 	pub const DesiredRunnersUp: u32 = 9;
 	pub const ElectionsPhragmenModuleId: LockIdentifier = *b"phrelect";
@@ -514,13 +514,13 @@ impl pallet_elections_phragmen::Config for Runtime {
 }
 
 parameter_types! {
-	pub const LaunchPeriod: BlockNumber = 7 * DAYS;
-	pub const VotingPeriod: BlockNumber = 7 * DAYS;
-	pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
+	pub  LaunchPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_LAUNCH_PERIOD");
+	pub  VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_LAUNCH_PERIOD");
+	pub  FastTrackVotingPeriod: BlockNumber = prod_or_fast!(3 * HOURS, 1 * MINUTES, "CFG_FAST_TRACK_VOTING_PERIOD");
 	pub const InstantAllowed: bool = false;
 	pub const MinimumDeposit: Balance = 1000 * CFG;
-	pub const EnactmentPeriod: BlockNumber = 8 * DAYS;
-	pub const CooloffPeriod: BlockNumber = 7 * DAYS;
+	pub  EnactmentPeriod: BlockNumber = prod_or_fast!(8 * DAYS, 1 * MINUTES, "CFG_ENACTMENT_PERIOD");
+	pub  CooloffPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_ENACTMENT_PERIOD");
 	pub const MaxProposals: u32 = 100;
 	pub const MaxVotes: u32 = 100;
 }

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -515,12 +515,12 @@ impl pallet_elections_phragmen::Config for Runtime {
 
 parameter_types! {
 	pub  LaunchPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_LAUNCH_PERIOD");
-	pub  VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_LAUNCH_PERIOD");
+	pub  VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_VOTING_PERIOD");
 	pub  FastTrackVotingPeriod: BlockNumber = prod_or_fast!(3 * HOURS, 1 * MINUTES, "CFG_FAST_TRACK_VOTING_PERIOD");
 	pub const InstantAllowed: bool = false;
 	pub const MinimumDeposit: Balance = 1000 * CFG;
 	pub  EnactmentPeriod: BlockNumber = prod_or_fast!(8 * DAYS, 1 * MINUTES, "CFG_ENACTMENT_PERIOD");
-	pub  CooloffPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_ENACTMENT_PERIOD");
+	pub  CooloffPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES, "CFG_COOLOFF_PERIOD");
 	pub const MaxProposals: u32 = 100;
 	pub const MaxVotes: u32 = 100;
 }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -40,7 +40,7 @@ stop-parachain-docker)
 
 start-parachain)
   printf "\nBuilding parachain with runtime '$parachain' and id '$para_id'...\n"
-  cargo build --release
+  cargo build --release --features=fast-runtime
 
   parachain_dir=$base_dir/parachain/${para_id}
   mkdir -p $parachain_dir;

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -11,7 +11,7 @@ para_id="${PARA_ID:-2000}"
 base_dir=/tmp/centrifuge-chain
 # Option to use the Docker image to export state & wasm
 docker_onboard="${DOCKER_ONBOARD:-false}"
-cc_docker_image_tag="${PARA_DOCKER_IMAGE_TAG:-parachain-latest}"
+cc_docker_image_tag="${PARA_DOCKER_IMAGE_TAG:-test-parachain-latest}"
 
 case $cmd in
 install-toolchain)


### PR DESCRIPTION
**Context:**
The feedback loop of testing upgrades locally (or just some operations that require Council or Democracy) is slow. The current alternative to this is to modify the runtime code only in your dev branch to test your code but that comes with potential issues down the line, unwanted commits, extra code changes that shouldn't be required among others.

**Proposal:**
I propose to include this feature flag that we can use for certain constants that usually delay the development cycle. When this the code has been compiled with this flag, the `prod_or_fast` macro developed by parity allows to pass a test value and potentially a value read from the environment at the time of compilation (the latter is the one I used here but I do not see us using it too much)

This way when running the chain locally the `init.sh start-parachain` script builds with that flag, so we can test out altair or centrifuge runtime easily and quickly. 

In addition, I propose to build a docker image as well ready for local testing, without the need to compile again the code. This is particularly useful for other teams that just want to set up a local env quickly.

Two images tags will be pushed:
- `centrifugeio/centrifuge-chain:parachain-$date-$commit`
- `centrifugeio/centrifuge-chain:test-parachain-$date-$commit`
