### PR TITLE
rpc: Ressurections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.7",
  "once_cell",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ dependencies = [
  "safe-mix",
  "scale-info",
  "serde",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
@@ -196,7 +196,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -312,14 +312,14 @@ dependencies = [
  "concurrent-queue",
  "futures-lite",
  "libc",
- "log 0.4.17",
+ "log",
  "once_cell",
  "parking",
  "polling",
  "slab",
  "socket2",
  "waker-fn",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -345,7 +345,7 @@ dependencies = [
  "libc",
  "once_cell",
  "signal-hook",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -360,14 +360,14 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-process",
- "crossbeam-utils 0.8.9",
+ "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
  "futures-lite",
  "gloo-timers",
  "kv-log-macro",
- "log 0.4.17",
+ "log",
  "memchr",
  "once_cell",
  "pin-project-lite 0.2.9",
@@ -414,7 +414,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -435,16 +435,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
+ "winapi",
 ]
 
 [[package]]
@@ -488,25 +479,6 @@ checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -530,7 +502,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "hex",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-chain-spec",
@@ -563,7 +535,7 @@ dependencies = [
  "beefy-primitives",
  "futures 0.3.21",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-rpc",
@@ -843,7 +815,7 @@ dependencies = [
  "bp-runtime",
  "frame-support",
  "parity-scale-codec",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-api",
  "sp-runtime",
  "sp-std",
@@ -973,16 +945,6 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
-name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
@@ -1067,12 +1029,8 @@ dependencies = [
  "frame-system",
  "futures 0.3.21",
  "hex-literal 0.2.2",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
- "jsonrpc-pubsub",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "node-inspect",
  "node-primitives",
  "pallet-anchors",
@@ -1141,7 +1099,7 @@ dependencies = [
  "tempfile",
  "tracing-core",
  "try-runtime-cli",
- "url 2.2.2",
+ "url",
  "vergen",
 ]
 
@@ -1215,7 +1173,7 @@ dependencies = [
  "safe-mix",
  "scale-info",
  "serde",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
@@ -1320,7 +1278,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1402,15 +1360,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1562,9 +1511,9 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "gimli",
- "log 0.4.17",
+ "log",
  "regalloc",
- "smallvec 1.8.0",
+ "smallvec",
  "target-lexicon",
 ]
 
@@ -1599,8 +1548,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
- "log 0.4.17",
- "smallvec 1.8.0",
+ "log",
+ "smallvec",
  "target-lexicon",
 ]
 
@@ -1625,8 +1574,8 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "itertools",
- "log 0.4.17",
- "smallvec 1.8.0",
+ "log",
+ "smallvec",
  "wasmparser",
  "wasmtime-types",
 ]
@@ -1647,7 +1596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.9",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1658,7 +1607,7 @@ checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.9",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1667,9 +1616,9 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.9",
+ "crossbeam-utils",
  "memoffset",
  "once_cell",
  "scopeguard",
@@ -1682,18 +1631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.9",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.1.0",
- "cfg-if 0.1.10",
- "lazy_static",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1792,7 +1730,7 @@ dependencies = [
  "clap",
  "sc-cli",
  "sc-service",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -1998,7 +1936,7 @@ dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
@@ -2020,7 +1958,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "polkadot-parachain",
@@ -2043,7 +1981,7 @@ name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.24#95ca5a085727c1494ddeeae4a2b2e69c4ee1933b"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -2074,7 +2012,7 @@ dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
@@ -2417,7 +2355,7 @@ dependencies = [
  "safe-mix",
  "scale-info",
  "serde",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
@@ -2497,7 +2435,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2508,7 +2446,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2670,7 +2608,7 @@ checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.17",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -2689,7 +2627,7 @@ checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2781,7 +2719,7 @@ checksum = "f5aa1e3ae159e592ad222dc90c5acbad632b527779ba88486abe92782ab268bd"
 dependencies = [
  "expander 0.0.4",
  "indexmap",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -2814,7 +2752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
  "env_logger",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -2826,7 +2764,7 @@ dependencies = [
  "either",
  "futures 0.3.21",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.11.2",
@@ -2869,21 +2807,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "fork-tree"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
@@ -2898,7 +2821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2909,7 +2832,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "linregress",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
@@ -2942,7 +2865,7 @@ dependencies = [
  "kvdb",
  "lazy_static",
  "linked-hash-map",
- "log 0.4.17",
+ "log",
  "memory-db",
  "parity-scale-codec",
  "rand 0.8.5",
@@ -2978,7 +2901,7 @@ name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -3038,13 +2961,13 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
- "log 0.4.17",
+ "log",
  "once_cell",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-arithmetic",
  "sp-core",
  "sp-core-hashing-proc-macro",
@@ -3076,7 +2999,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -3098,7 +3021,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "frame-support",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -3159,7 +3082,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "libloading 0.5.2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3169,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3177,28 +3100,6 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
@@ -3351,7 +3252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -3414,7 +3315,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log 0.4.17",
+ "log",
  "regex",
 ]
 
@@ -3447,7 +3348,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -3466,7 +3367,7 @@ version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66d0c1b6e3abfd1e72818798925e16e02ed77e1b47f6c25a95a23b377ee4299"
 dependencies = [
- "log 0.4.17",
+ "log",
  "pest",
  "pest_derive",
  "serde",
@@ -3607,7 +3508,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3616,7 +3517,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "itoa 1.0.2",
 ]
@@ -3627,7 +3528,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "http",
  "pin-project-lite 0.2.9",
 ]
@@ -3652,30 +3553,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
-dependencies = [
- "base64 0.9.3",
- "httparse",
- "language-tags",
- "log 0.3.9",
- "mime",
- "num_cpus",
- "time",
- "traitobject",
- "typeable",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "hyper"
 version = "0.14.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3700,23 +3582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
- "hyper 0.14.19",
- "log 0.4.17",
+ "hyper",
+ "log",
  "rustls",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
-]
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -3737,7 +3608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc0fa01ffc752e9dbc72818cdb072cd028b86be5e09dd04c5a643704fe101a9"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3752,7 +3623,7 @@ dependencies = [
  "futures 0.3.21",
  "if-addrs",
  "ipnet",
- "log 0.4.17",
+ "log",
  "rtnetlink",
  "system-configuration",
  "windows",
@@ -3793,7 +3664,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown 0.12.1",
  "serde",
 ]
@@ -3829,15 +3700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ip_network"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,7 +3713,7 @@ checksum = "723519edce41262b05d4143ceb95050e4c614f483e78e9fd9e39a8275a84ad98"
 dependencies = [
  "socket2",
  "widestring",
- "winapi 0.3.9",
+ "winapi",
  "winreg",
 ]
 
@@ -3898,77 +3760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonrpc-client-transports"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
-dependencies = [
- "derive_more",
- "futures 0.3.21",
- "hyper 0.14.19",
- "jsonrpc-core",
- "jsonrpc-pubsub",
- "log 0.4.17",
- "serde",
- "serde_json",
- "tokio",
- "url 1.7.2",
- "websocket",
-]
-
-[[package]]
-name = "jsonrpc-core"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
-dependencies = [
- "futures 0.3.21",
- "futures-executor",
- "futures-util",
- "log 0.4.17",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "jsonrpc-core-client"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
-dependencies = [
- "futures 0.3.21",
- "jsonrpc-client-transports",
-]
-
-[[package]]
-name = "jsonrpc-derive"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
-dependencies = [
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jsonrpc-pubsub"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
-dependencies = [
- "futures 0.3.21",
- "jsonrpc-core",
- "lazy_static",
- "log 0.4.17",
- "parking_lot 0.11.2",
- "rand 0.7.3",
- "serde",
 ]
 
 [[package]]
@@ -4021,7 +3812,7 @@ dependencies = [
  "futures-channel",
  "futures-timer",
  "futures-util",
- "hyper 0.14.19",
+ "hyper",
  "jsonrpsee-types",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -4043,14 +3834,14 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "globset",
- "hyper 0.14.19",
+ "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "lazy_static",
  "serde_json",
  "tokio",
  "tracing",
- "unicase 2.6.0",
+ "unicase",
 ]
 
 [[package]]
@@ -4059,7 +3850,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b8d7f449cab3b747f12c3efc27f5cad537f3b597c6a3838b0fac628f4bf730a"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -4126,16 +3917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "kusama-runtime"
 version = "0.9.24"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#22836e55d41eef24ed5917fd654ee82a683a7cfe"
@@ -4149,7 +3930,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "kusama-runtime-constants",
- "log 0.4.17",
+ "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -4195,7 +3976,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_derive",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
@@ -4228,7 +4009,7 @@ dependencies = [
  "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-runtime",
 ]
 
@@ -4238,7 +4019,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -4248,7 +4029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a301d8ecb7989d4a6e2c57a49baca77d353bdbf879909debe3f375fe25d61f86"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.8.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -4270,21 +4051,15 @@ checksum = "ca7fbdfd71cd663dceb0faf3367a99f8cf724514933e9867cec4995b6027cbc1"
 dependencies = [
  "fs-swap",
  "kvdb",
- "log 0.4.17",
+ "log",
  "num_cpus",
  "owning_ref",
  "parity-util-mem",
  "parking_lot 0.12.1",
  "regex",
  "rocksdb",
- "smallvec 1.8.0",
+ "smallvec",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -4311,7 +4086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4321,7 +4096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4336,7 +4111,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41726ee8f662563fafba2d2d484b14037cc8ecb8c953fbfc8439d4ce3a0a9029"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.21",
  "futures-timer",
  "getrandom 0.2.7",
@@ -4371,7 +4146,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project 1.0.10",
  "rand 0.7.3",
- "smallvec 1.8.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -4387,7 +4162,7 @@ dependencies = [
  "libp2p-core 0.33.0",
  "libp2p-request-response",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "rand 0.8.5",
@@ -4408,7 +4183,7 @@ dependencies = [
  "futures-timer",
  "instant",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "multiaddr",
  "multihash",
  "multistream-select",
@@ -4420,7 +4195,7 @@ dependencies = [
  "ring",
  "rw-stream-sink 0.2.1",
  "sha2 0.10.2",
- "smallvec 1.8.0",
+ "smallvec",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -4443,7 +4218,7 @@ dependencies = [
  "instant",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "multiaddr",
  "multihash",
  "multistream-select",
@@ -4455,7 +4230,7 @@ dependencies = [
  "ring",
  "rw-stream-sink 0.3.0",
  "sha2 0.10.2",
- "smallvec 1.8.0",
+ "smallvec",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -4482,9 +4257,9 @@ dependencies = [
  "async-std-resolver",
  "futures 0.3.21",
  "libp2p-core 0.33.0",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
- "smallvec 1.8.0",
+ "smallvec",
  "trust-dns-resolver",
 ]
 
@@ -4499,11 +4274,11 @@ dependencies = [
  "futures 0.3.21",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "rand 0.7.3",
- "smallvec 1.8.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -4513,23 +4288,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e064ba4d7832e01c738626c6b274ae100baba05f5ffcc7b265c2a3ed398108"
 dependencies = [
  "asynchronous-codec",
- "base64 0.13.0",
+ "base64",
  "byteorder",
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures 0.3.21",
  "hex_fmt",
  "instant",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "prometheus-client",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "rand 0.7.3",
  "regex",
  "sha2 0.10.2",
- "smallvec 1.8.0",
+ "smallvec",
  "unsigned-varint",
  "wasm-timer",
 ]
@@ -4545,12 +4320,12 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "lru 0.7.7",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "prost-codec",
- "smallvec 1.8.0",
+ "smallvec",
  "thiserror",
  "void",
 ]
@@ -4563,7 +4338,7 @@ checksum = "5f6b5d4de90fcd35feb65ea6223fd78f3b747a64ca4b65e0813fbe66a27d56aa"
 dependencies = [
  "arrayvec 0.7.2",
  "asynchronous-codec",
- "bytes 1.1.0",
+ "bytes",
  "either",
  "fnv",
  "futures 0.3.21",
@@ -4571,12 +4346,12 @@ dependencies = [
  "instant",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "rand 0.7.3",
  "sha2 0.10.2",
- "smallvec 1.8.0",
+ "smallvec",
  "thiserror",
  "uint",
  "unsigned-varint",
@@ -4597,9 +4372,9 @@ dependencies = [
  "lazy_static",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
- "smallvec 1.8.0",
+ "smallvec",
  "socket2",
  "void",
 ]
@@ -4627,14 +4402,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ff9c893f2367631a711301d703c47432af898c9bb8253bea0e2c051a13f7640"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.21",
  "libp2p-core 0.33.0",
- "log 0.4.17",
+ "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
  "rand 0.7.3",
- "smallvec 1.8.0",
+ "smallvec",
  "unsigned-varint",
 ]
 
@@ -4644,12 +4419,12 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2cee1dad1c83325bbd182a8e94555778699cec8a9da00086efb7522c4c15ad"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "curve25519-dalek 3.2.0",
  "futures 0.3.21",
  "lazy_static",
  "libp2p-core 0.33.0",
- "log 0.4.17",
+ "log",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "rand 0.8.5",
@@ -4671,7 +4446,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "rand 0.7.3",
  "void",
 ]
@@ -4683,10 +4458,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db007e737adc5d28b2e03223b0210164928ad742591127130796a72aa8eaf54f"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.21",
  "libp2p-core 0.33.0",
- "log 0.4.17",
+ "log",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "unsigned-varint",
@@ -4700,7 +4475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1a458bbda880107b5b36fcb9b5a1ef0c329685da0e203ed692a8ebe64cc92c"
 dependencies = [
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "pin-project 1.0.10",
  "rand 0.7.3",
  "salsa20",
@@ -4714,20 +4489,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624ead3406f64437a0d4567c31bd128a9a0b8226d5f16c074038f5d0fc32f650"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.1.0",
+ "bytes",
  "either",
  "futures 0.3.21",
  "futures-timer",
  "instant",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "pin-project 1.0.10",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "prost-codec",
  "rand 0.8.5",
- "smallvec 1.8.0",
+ "smallvec",
  "static_assertions",
  "thiserror",
  "void",
@@ -4746,7 +4521,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "rand 0.8.5",
@@ -4763,14 +4538,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b02e0acb725e5a757d77c96b95298fd73a7394fe82ba7b8bbeea510719cbe441"
 dependencies = [
  "async-trait",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.21",
  "instant",
  "libp2p-core 0.33.0",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "rand 0.7.3",
- "smallvec 1.8.0",
+ "smallvec",
  "unsigned-varint",
 ]
 
@@ -4786,10 +4561,10 @@ dependencies = [
  "futures-timer",
  "instant",
  "libp2p-core 0.33.0",
- "log 0.4.17",
+ "log",
  "pin-project 1.0.10",
  "rand 0.7.3",
- "smallvec 1.8.0",
+ "smallvec",
  "thiserror",
  "void",
 ]
@@ -4817,7 +4592,7 @@ dependencies = [
  "ipnet",
  "libc",
  "libp2p-core 0.33.0",
- "log 0.4.17",
+ "log",
  "socket2",
 ]
 
@@ -4830,7 +4605,7 @@ dependencies = [
  "async-std",
  "futures 0.3.21",
  "libp2p-core 0.32.1",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -4857,12 +4632,12 @@ dependencies = [
  "futures 0.3.21",
  "futures-rustls",
  "libp2p-core 0.33.0",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "quicksink",
  "rw-stream-sink 0.3.0",
  "soketto",
- "url 2.2.2",
+ "url",
  "webpki-roots",
 ]
 
@@ -4901,7 +4676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
 dependencies = [
  "arrayref",
- "base64 0.13.0",
+ "base64",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -4986,30 +4761,12 @@ checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.17",
 ]
 
 [[package]]
@@ -5115,12 +4872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5159,7 +4910,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -5224,15 +4975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5249,45 +4991,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log 0.4.17",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
- "log 0.4.17",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
 ]
 
 [[package]]
@@ -5307,11 +5018,11 @@ dependencies = [
  "byteorder",
  "data-encoding",
  "multihash",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
  "static_assertions",
  "unsigned-varint",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -5348,7 +5059,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -5368,11 +5079,11 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363a84be6453a70e63513660f4894ef815daf88e3356bffcda9ca27d810ce83b"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "pin-project 1.0.10",
- "smallvec 1.8.0",
+ "smallvec",
  "unsigned-varint",
 ]
 
@@ -5421,35 +5132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 
 [[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log 0.4.17",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "netlink-packet-core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5493,9 +5175,9 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8785b8141e8432aa45fceb922a7e876d7da3fad37fa7e7ec702ace3aa0826b"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "netlink-packet-core",
  "netlink-sys",
  "tokio",
@@ -5508,10 +5190,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4c9f9547a08241bee7b6558b9b98e1f290d187de8b7cfca2bbb4937bcaa8f8"
 dependencies = [
  "async-io",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.21",
  "libc",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -5585,7 +5267,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -5615,7 +5297,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -5625,7 +5307,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -5637,7 +5319,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -5648,7 +5330,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "libm",
 ]
 
@@ -5701,49 +5383,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
-dependencies = [
- "autocfg 1.1.0",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "orchestra"
@@ -5768,7 +5411,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#2283
 dependencies = [
  "expander 0.0.6",
  "petgraph",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -5991,7 +5634,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
@@ -6015,7 +5658,7 @@ dependencies = [
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -6030,7 +5673,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -6063,7 +5706,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "log 0.4.17",
+ "log",
  "pallet-beefy",
  "pallet-mmr",
  "pallet-session",
@@ -6083,7 +5726,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
@@ -6128,7 +5771,7 @@ dependencies = [
  "bp-runtime",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6147,7 +5790,7 @@ dependencies = [
  "finality-grandpa",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
@@ -6190,7 +5833,7 @@ dependencies = [
  "bp-runtime",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
@@ -6207,7 +5850,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
@@ -6259,7 +5902,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -6279,7 +5922,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6299,7 +5942,7 @@ dependencies = [
  "getrandom 0.2.7",
  "hex",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "pallet-balances",
  "pallet-crowdloan-reward",
  "pallet-vesting",
@@ -6325,7 +5968,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-balances",
  "pallet-indices",
  "pallet-vesting",
@@ -6363,7 +6006,7 @@ dependencies = [
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "rand 0.7.3",
  "scale-info",
@@ -6385,7 +6028,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6435,7 +6078,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -6473,7 +6116,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
@@ -6536,7 +6179,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6553,7 +6196,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "log 0.4.17",
+ "log",
  "pallet-balances",
  "pallet-proxy",
  "pallet-vesting",
@@ -6682,7 +6325,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6698,7 +6341,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
@@ -6843,7 +6486,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
@@ -6859,7 +6502,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -6911,7 +6554,7 @@ dependencies = [
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -6930,7 +6573,7 @@ name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -6941,7 +6584,7 @@ name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "sp-arithmetic",
 ]
 
@@ -6967,7 +6610,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
@@ -6984,7 +6627,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
@@ -7062,7 +6705,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -7093,7 +6736,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -7107,7 +6750,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#2283
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -7142,7 +6785,7 @@ dependencies = [
  "fs2",
  "hex",
  "libc",
- "log 0.4.17",
+ "log",
  "lz4",
  "memmap2 0.2.3",
  "parking_lot 0.11.2",
@@ -7170,7 +6813,7 @@ version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -7194,8 +6837,8 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.12.1",
  "primitive-types",
- "smallvec 1.8.0",
- "winapi 0.3.9",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -7232,23 +6875,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.2",
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.7",
+ "lock_api",
  "parking_lot_core 0.8.5",
 ]
 
@@ -7258,23 +6890,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.7",
+ "lock_api",
  "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "rustc_version 0.2.3",
- "smallvec 0.6.14",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -7286,9 +6903,9 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.13",
- "smallvec 1.8.0",
- "winapi 0.3.9",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -7299,8 +6916,8 @@ checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.13",
- "smallvec 1.8.0",
+ "redox_syscall",
+ "smallvec",
  "windows-sys",
 ]
 
@@ -7333,12 +6950,6 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -7550,7 +7161,7 @@ dependencies = [
  "clap",
  "frame-benchmarking-cli",
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "polkadot-client",
  "polkadot-node-core-pvf",
  "polkadot-node-metrics",
@@ -7705,7 +7316,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#2283
 dependencies = [
  "always-assert",
  "async-trait",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.21",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -7995,7 +7606,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#2283
 dependencies = [
  "async-std",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "mick-jaeger",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8014,7 +7625,7 @@ dependencies = [
  "bs58",
  "futures 0.3.21",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "polkadot-primitives",
  "prioritized-metered-channel",
@@ -8092,7 +7703,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-statement-table",
  "sc-network",
- "smallvec 1.8.0",
+ "smallvec",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -8176,7 +7787,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#2283
 dependencies = [
  "env_logger",
  "kusama-runtime",
- "log 0.4.17",
+ "log",
  "polkadot-erasure-coding",
  "polkadot-node-core-pvf",
  "polkadot-node-primitives",
@@ -8259,7 +7870,7 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "log 0.4.17",
+ "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -8302,7 +7913,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_derive",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-api",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -8338,7 +7949,7 @@ dependencies = [
  "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "pallet-bags-list",
  "pallet-balances",
@@ -8379,7 +7990,7 @@ dependencies = [
  "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-runtime",
 ]
 
@@ -8405,7 +8016,7 @@ dependencies = [
  "derive_more",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -8574,9 +8185,9 @@ checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "log 0.4.17",
+ "log",
  "wepoll-ffi",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -8638,15 +8249,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
@@ -8665,7 +8267,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -8676,7 +8278,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -8747,7 +8349,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost-derive 0.9.0",
 ]
 
@@ -8757,7 +8359,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost-derive 0.10.1",
 ]
 
@@ -8767,11 +8369,11 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "heck 0.3.3",
  "itertools",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "multimap",
  "petgraph",
  "prost 0.9.0",
@@ -8787,13 +8389,13 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "cfg-if 1.0.0",
  "cmake",
  "heck 0.4.0",
  "itertools",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "multimap",
  "petgraph",
  "prost 0.10.4",
@@ -8810,7 +8412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00af1e92c33b4813cc79fda3f2dbf56af5169709be0202df730e9ebc3e4cd007"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.1.0",
+ "bytes",
  "prost 0.10.4",
  "thiserror",
  "unsigned-varint",
@@ -8848,7 +8450,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost 0.9.0",
 ]
 
@@ -8858,7 +8460,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost 0.10.4",
 ]
 
@@ -8905,25 +8507,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg 0.1.2",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -8932,7 +8515,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
  "rand_pcg 0.2.1",
 ]
 
@@ -8945,16 +8528,6 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -8976,21 +8549,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -9022,64 +8580,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -9101,15 +8606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9121,7 +8617,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -9135,24 +8631,9 @@ checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.9",
+ "crossbeam-utils",
  "num_cpus",
 ]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -9170,7 +8651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.7",
- "redox_syscall 0.2.13",
+ "redox_syscall",
  "thiserror",
 ]
 
@@ -9213,9 +8694,9 @@ version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
- "log 0.4.17",
+ "log",
  "rustc-hash",
- "smallvec 1.8.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -9253,7 +8734,7 @@ dependencies = [
  "bitflags",
  "libc",
  "mach",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -9263,7 +8744,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "env_logger",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "serde",
  "serde_json",
@@ -9279,7 +8760,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -9327,7 +8808,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -9356,7 +8837,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
- "log 0.4.17",
+ "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -9392,7 +8873,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_derive",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-api",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -9422,7 +8903,7 @@ dependencies = [
  "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-runtime",
 ]
 
@@ -9433,7 +8914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -9444,7 +8925,7 @@ checksum = "6f54290e54521dac3de4149d83ddf9f62a359b3cc93bcb494a794a41e6f4744b"
 dependencies = [
  "async-global-executor",
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "netlink-packet-route",
  "netlink-proto",
  "nix",
@@ -9470,7 +8951,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-api",
  "sp-arithmetic",
  "sp-consensus-aura",
@@ -9586,7 +9067,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -9595,7 +9076,7 @@ version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
- "log 0.4.17",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -9619,7 +9100,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -9666,12 +9147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "salsa20"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9694,7 +9169,7 @@ name = "sc-allocator"
 version = "4.1.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "sp-core",
  "sp-wasm-interface",
  "thiserror",
@@ -9710,7 +9185,7 @@ dependencies = [
  "futures-timer",
  "ip_network",
  "libp2p",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "prost 0.10.4",
  "prost-build 0.9.0",
@@ -9734,7 +9209,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-block-builder",
  "sc-client-api",
@@ -9788,7 +9263,7 @@ name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -9805,7 +9280,7 @@ dependencies = [
  "futures 0.3.21",
  "hex",
  "libp2p",
- "log 0.4.17",
+ "log",
  "names",
  "parity-scale-codec",
  "rand 0.7.3",
@@ -9841,7 +9316,7 @@ dependencies = [
  "fnv",
  "futures 0.3.21",
  "hash-db",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-executor",
@@ -9871,7 +9346,7 @@ dependencies = [
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "linked-hash-map",
- "log 0.4.17",
+ "log",
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9895,7 +9370,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "libp2p",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "sc-client-api",
  "sc-utils",
@@ -9917,7 +9392,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "async-trait",
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-block-builder",
  "sc-client-api",
@@ -9947,7 +9422,7 @@ dependencies = [
  "async-trait",
  "fork-tree",
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "merlin 2.0.1",
  "num-bigint",
  "num-rational 0.2.4",
@@ -10025,7 +9500,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.21",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
@@ -10102,7 +9577,7 @@ name = "sc-executor-wasmi"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor-common",
@@ -10119,7 +9594,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
  "sc-allocator",
@@ -10143,7 +9618,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "hex",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -10178,7 +9653,7 @@ dependencies = [
  "finality-grandpa",
  "futures 0.3.21",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-finality-grandpa",
@@ -10199,7 +9674,7 @@ dependencies = [
  "ansi_term",
  "futures 0.3.21",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-util-mem",
  "sc-client-api",
  "sc-network",
@@ -10231,7 +9706,7 @@ dependencies = [
  "async-trait",
  "asynchronous-codec",
  "bitflags",
- "bytes 1.1.0",
+ "bytes",
  "cid",
  "either",
  "fnv",
@@ -10243,7 +9718,7 @@ dependencies = [
  "libp2p",
  "linked-hash-map",
  "linked_hash_set",
- "log 0.4.17",
+ "log",
  "lru 0.7.7",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10261,7 +9736,7 @@ dependencies = [
  "sc-utils",
  "serde",
  "serde_json",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10285,7 +9760,7 @@ dependencies = [
  "parity-scale-codec",
  "prost-build 0.9.0",
  "sc-peerset",
- "smallvec 1.8.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -10297,7 +9772,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "libp2p",
- "log 0.4.17",
+ "log",
  "lru 0.7.7",
  "sc-network",
  "sp-runtime",
@@ -10312,7 +9787,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "futures 0.3.21",
  "libp2p",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "prost 0.10.4",
  "prost-build 0.9.0",
@@ -10335,7 +9810,7 @@ dependencies = [
  "fork-tree",
  "futures 0.3.21",
  "libp2p",
- "log 0.4.17",
+ "log",
  "lru 0.7.7",
  "parity-scale-codec",
  "prost 0.10.4",
@@ -10344,7 +9819,7 @@ dependencies = [
  "sc-consensus",
  "sc-network-common",
  "sc-peerset",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10359,12 +9834,12 @@ name = "sc-offchain"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures 0.3.21",
  "futures-timer",
  "hex",
- "hyper 0.14.19",
+ "hyper",
  "hyper-rustls",
  "num_cpus",
  "once_cell",
@@ -10389,7 +9864,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "futures 0.3.21",
  "libp2p",
- "log 0.4.17",
+ "log",
  "sc-utils",
  "serde_json",
  "wasm-timer",
@@ -10400,7 +9875,7 @@ name = "sc-proposer-metrics"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10412,7 +9887,7 @@ dependencies = [
  "futures 0.3.21",
  "hash-db",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-block-builder",
@@ -10441,7 +9916,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "futures 0.3.21",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-chain-spec",
@@ -10464,7 +9939,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "futures 0.3.21",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "serde_json",
  "substrate-prometheus-endpoint",
  "tokio",
@@ -10482,7 +9957,7 @@ dependencies = [
  "futures-timer",
  "hash-db",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.12.1",
@@ -10544,7 +10019,7 @@ dependencies = [
  "futures 0.3.21",
  "hex",
  "hex-literal 0.3.4",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-block-builder",
@@ -10577,7 +10052,7 @@ name = "sc-state-db"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parity-util-mem-derive",
@@ -10612,7 +10087,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "futures 0.3.21",
  "libc",
- "log 0.4.17",
+ "log",
  "rand 0.7.3",
  "rand_pcg 0.2.1",
  "regex",
@@ -10632,7 +10107,7 @@ dependencies = [
  "chrono",
  "futures 0.3.21",
  "libp2p",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "pin-project 1.0.10",
  "rand 0.7.3",
@@ -10652,7 +10127,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log",
  "once_cell",
  "parking_lot 0.12.1",
  "regex",
@@ -10678,7 +10153,7 @@ name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -10692,7 +10167,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "linked-hash-map",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.12.1",
@@ -10717,7 +10192,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "serde",
  "sp-blockchain",
  "sp-runtime",
@@ -10732,7 +10207,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "prometheus",
 ]
@@ -10757,7 +10232,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e334bb10a245e28e5fd755cabcafd96cfcd167c99ae63a46924ca8d8703a3c"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -10984,21 +10459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
-
-[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11136,16 +10596,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
 dependencies = [
- "version_check 0.9.4",
-]
-
-[[package]]
-name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
+ "version_check",
 ]
 
 [[package]]
@@ -11184,7 +10635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -11193,12 +10644,12 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
+ "base64",
+ "bytes",
  "flate2",
  "futures 0.3.21",
  "httparse",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
  "sha-1 0.9.8",
 ]
@@ -11209,7 +10660,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "hash-db",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-api-proc-macro",
  "sp-core",
@@ -11226,7 +10677,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "blake2",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -11303,7 +10754,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "lru 0.7.7",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -11323,7 +10774,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.21",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-core",
  "sp-inherents",
@@ -11420,7 +10871,7 @@ dependencies = [
  "impl-serde",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "merlin 2.0.1",
  "num-traits",
  "parity-scale-codec",
@@ -11509,7 +10960,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "finality-grandpa",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -11543,7 +10994,7 @@ dependencies = [
  "futures 0.3.21",
  "hash-db",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "secp256k1",
@@ -11602,7 +11053,7 @@ name = "sp-mmr-primitives"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -11664,7 +11115,7 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "paste",
@@ -11701,7 +11152,7 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "Inflector",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -11712,7 +11163,7 @@ name = "sp-sandbox"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-core",
  "sp-io",
@@ -11761,12 +11212,12 @@ version = "0.12.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "hash-db",
- "log 0.4.17",
+ "log",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.7.3",
- "smallvec 1.8.0",
+ "smallvec",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
@@ -11800,7 +11251,7 @@ name = "sp-tasks"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "sp-core",
  "sp-externalities",
  "sp-io",
@@ -11815,7 +11266,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "async-trait",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-api",
  "sp-inherents",
@@ -11851,7 +11302,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "async-trait",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -11911,7 +11362,7 @@ version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-std",
  "wasmi",
@@ -12068,7 +11519,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.21",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
@@ -12087,8 +11538,8 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "futures-util",
- "hyper 0.14.19",
- "log 0.4.17",
+ "hyper",
+ "log",
  "prometheus",
  "thiserror",
  "tokio",
@@ -12100,7 +11551,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
@@ -12151,7 +11602,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
- "log 0.4.17",
+ "log",
  "memory-db",
  "pallet-babe",
  "pallet-timestamp",
@@ -12302,9 +11753,9 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "libc",
- "redox_syscall 0.2.13",
+ "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -12374,7 +11825,7 @@ checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "log 0.4.17",
+ "log",
  "ordered-float",
  "threadpool",
 ]
@@ -12398,7 +11849,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -12441,10 +11892,10 @@ version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "libc",
  "memchr",
- "mio 0.8.4",
+ "mio",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
@@ -12452,39 +11903,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "tokio-io",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log 0.4.17",
+ "winapi",
 ]
 
 [[package]]
@@ -12499,25 +11918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
- "lazy_static",
- "log 0.4.17",
- "mio 0.6.23",
- "num_cpus",
- "parking_lot 0.9.0",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12529,47 +11929,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-dependencies = [
- "fnv",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "mio 0.6.23",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
-dependencies = [
- "futures 0.1.31",
- "native-tls",
- "tokio-io",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -12653,7 +12018,7 @@ version = "0.9.24"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#22836e55d41eef24ed5917fd654ee82a683a7cfe"
 dependencies = [
  "expander 0.0.6",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -12667,7 +12032,7 @@ checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "ahash",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "lru 0.7.7",
  "tracing-core",
 ]
@@ -12697,19 +12062,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.8.0",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
 ]
-
-[[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trie-db"
@@ -12719,9 +12078,9 @@ checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
 dependencies = [
  "hash-db",
  "hashbrown 0.12.1",
- "log 0.4.17",
+ "log",
  "rustc-hex",
- "smallvec 1.8.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -12746,15 +12105,15 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 0.2.3",
+ "idna",
  "ipnet",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
- "smallvec 1.8.0",
+ "smallvec",
  "thiserror",
  "tinyvec",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -12767,11 +12126,11 @@ dependencies = [
  "futures-util",
  "ipconfig",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "lru-cache",
  "parking_lot 0.12.1",
  "resolv-conf",
- "smallvec 1.8.0",
+ "smallvec",
  "thiserror",
  "trust-dns-proto",
 ]
@@ -12789,7 +12148,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#81
 dependencies = [
  "clap",
  "jsonrpsee",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "remote-externalities",
  "sc-chain-spec",
@@ -12826,12 +12185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
-
-[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12857,20 +12210,11 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -12937,7 +12281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.1.0",
+ "bytes",
  "futures-io",
  "futures-util",
 ]
@@ -12950,25 +12294,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -12984,7 +12317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -13003,12 +12336,6 @@ dependencies = [
  "chrono",
  "rustc_version 0.4.0",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -13035,7 +12362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -13045,7 +12372,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.17",
+ "log",
  "try-lock",
 ]
 
@@ -13085,7 +12412,7 @@ checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "proc-macro2",
  "quote",
  "syn",
@@ -13139,7 +12466,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c32691b6c7e6c14e7f8fd55361a9088b507aa49620fcd06c09b3a1082186b9"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-wasm 0.32.0",
  "rustc-demangle",
 ]
@@ -13212,7 +12539,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log",
  "object 0.27.1",
  "once_cell",
  "paste",
@@ -13227,7 +12554,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -13237,16 +12564,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c6ab24291fa7cb3a181f5669f6c72599b7ef781669759b45c7828c5999d0c0"
 dependencies = [
  "anyhow",
- "base64 0.13.0",
+ "base64",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
- "log 0.4.17",
+ "log",
  "rustix",
  "serde",
  "sha2 0.9.9",
  "toml",
- "winapi 0.3.9",
+ "winapi",
  "zstd",
 ]
 
@@ -13263,7 +12590,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-wasm",
  "gimli",
- "log 0.4.17",
+ "log",
  "more-asserts",
  "object 0.27.1",
  "target-lexicon",
@@ -13282,7 +12609,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "indexmap",
- "log 0.4.17",
+ "log",
  "more-asserts",
  "object 0.27.1",
  "serde",
@@ -13304,7 +12631,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli",
- "log 0.4.17",
+ "log",
  "object 0.27.1",
  "region",
  "rustc-demangle",
@@ -13315,7 +12642,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit-debug",
  "wasmtime-runtime",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -13341,7 +12668,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "indexmap",
  "libc",
- "log 0.4.17",
+ "log",
  "mach",
  "memfd",
  "memoffset",
@@ -13352,7 +12679,7 @@ dependencies = [
  "thiserror",
  "wasmtime-environ",
  "wasmtime-jit-debug",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -13397,47 +12724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "websocket"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413b37840b9e27b340ce91b319ede10731de8c72f5bc4cb0206ec1ca4ce581d0"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "hyper 0.10.16",
- "native-tls",
- "rand 0.6.5",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-tls",
- "unicase 1.4.2",
- "url 1.7.2",
- "websocket-base",
-]
-
-[[package]]
-name = "websocket-base"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3810f0d00c4dccb54c30a4eee815e703232819dec7b007db115791c42aa374"
-dependencies = [
- "base64 0.10.1",
- "bitflags",
- "byteorder",
- "bytes 0.4.12",
- "futures 0.1.31",
- "native-tls",
- "rand 0.6.5",
- "sha1",
- "tokio-codec",
- "tokio-io",
- "tokio-tcp",
- "tokio-tls",
-]
-
-[[package]]
 name = "wepoll-ffi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13465,12 +12751,6 @@ checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -13478,12 +12758,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -13497,7 +12771,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -13598,17 +12872,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]
@@ -13638,7 +12902,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#2283
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "xcm-procedural",
@@ -13651,7 +12915,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#2283
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polkadot-parachain",
@@ -13695,7 +12959,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24#2283
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-arithmetic",
  "sp-core",
@@ -13723,7 +12987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0608f53c1dc0bad505d03a34bbd49fbf2ad7b51eb036123e896365532745a1"
 dependencies = [
  "futures 0.3.21",
- "log 0.4.17",
+ "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,8 @@ dependencies = [
  "node-primitives",
  "pallet-anchors",
  "pallet-im-online",
+ "pallet-loans",
+ "pallet-pools",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ dependencies = [
  "sp-runtime",
  "sp-runtime-interface",
  "sp-session",
+ "sp-std",
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,15 +53,11 @@ members = [
 
 [dependencies]
 # third-party dependencies
-jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 serde = { version = "1.0.106", features = ["derive"] }
 futures = { version = "0.3.21", features = ["compat"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 hex-literal = "0.2.1"
-jsonrpc-core = "18.0.0"
-jsonrpc-core-client = { version = "18.0.0", features = ["http", "ws"] }
-jsonrpc-derive = "18.0.0"
-jsonrpc-pubsub = "18.0.0"
 log = "0.4.8"
 serde_json = "1.0"
 clap = { version = "3.1", features = [ "derive" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ sp-runtime-interface = { git = "https://github.com/paritytech/substrate", defaul
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
 sp-keystore = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
 
 # client dependencies
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,8 +121,13 @@ frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", bran
 try-runtime-cli = { git = "https://github.com/paritytech/substrate", optional = true , branch = "polkadot-v0.9.24" }
 node-inspect = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
 
+
+# Local dependencies
+pallet-anchors = { path = "./pallets/anchors" }
+pallet-loans = { path = "./pallets/loans" }
+pallet-pools = { path = "./pallets/pools" }
+
 # frame dependencies
-pallet-anchors = { path = "./pallets/anchors", default-features = false }
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
 substrate-frame-rpc-system  = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
 pallet-im-online = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }

--- a/pallets/anchors/src/lib.rs
+++ b/pallets/anchors/src/lib.rs
@@ -26,8 +26,8 @@ use sp_arithmetic::traits::{CheckedAdd, CheckedMul};
 use sp_runtime::{traits::Hash, ArithmeticError};
 use sp_std::{convert::TryInto, vec::Vec};
 
-pub use weights::*;
 pub use pallet::*;
+pub use weights::*;
 pub mod weights;
 
 #[cfg(feature = "std")]
@@ -71,7 +71,7 @@ pub struct PreCommitData<Hash, AccountId, BlockNumber> {
 
 /// The data structure for storing committed anchors.
 #[derive(Encode, Decode, Default, Clone, PartialEq, RuntimeDebug, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct AnchorData<Hash, BlockNumber> {
 	id: Hash,
 	pub doc_root: Hash,

--- a/pallets/anchors/src/lib.rs
+++ b/pallets/anchors/src/lib.rs
@@ -19,15 +19,16 @@ use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchError, DispatchResult},
 	storage::child,
-	StateVersion,
+	RuntimeDebug, StateVersion,
 };
-pub use pallet::*;
-pub mod weights;
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::{CheckedAdd, CheckedMul};
 use sp_runtime::{traits::Hash, ArithmeticError};
 use sp_std::{convert::TryInto, vec::Vec};
+
 pub use weights::*;
+pub use pallet::*;
+pub mod weights;
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -69,7 +70,7 @@ pub struct PreCommitData<Hash, AccountId, BlockNumber> {
 }
 
 /// The data structure for storing committed anchors.
-#[derive(Encode, Decode, Default, Clone, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, Default, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 pub struct AnchorData<Hash, BlockNumber> {
 	id: Hash,

--- a/pallets/loans/src/functions.rs
+++ b/pallets/loans/src/functions.rs
@@ -431,9 +431,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// updates nav for the given pool and returns the latest NAV at this instant and number of loans accrued.
-	pub(crate) fn update_nav_of_pool(
-		pool_id: PoolIdOf<T>,
-	) -> Result<(T::Amount, Moment), DispatchError> {
+	pub fn update_nav_of_pool(pool_id: PoolIdOf<T>) -> Result<(T::Amount, Moment), DispatchError> {
 		let now = Self::now();
 		let write_off_groups = PoolWriteOffGroups::<T>::get(pool_id);
 		let mut updated_loans = 0;

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -173,7 +173,7 @@ pub mod pallet {
 	/// Stores the loan info for given pool and loan id
 	#[pallet::storage]
 	#[pallet::getter(fn get_loan)]
-	pub(crate) type Loan<T: Config> = StorageDoubleMap<
+	pub type Loan<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		PoolIdOf<T>,
@@ -186,7 +186,7 @@ pub mod pallet {
 	/// Stores the pool nav against poolId
 	#[pallet::storage]
 	#[pallet::getter(fn nav)]
-	pub(crate) type PoolNAV<T: Config> =
+	pub type PoolNAV<T: Config> =
 		StorageMap<_, Blake2_128Concat, PoolIdOf<T>, NAVDetails<T::Amount>, OptionQuery>;
 
 	/// Stores the pool associated with the its write off groups

--- a/pallets/loans/src/types.rs
+++ b/pallets/loans/src/types.rs
@@ -14,6 +14,7 @@
 //! Module provides base types and their functions
 use super::*;
 use common_traits::PoolInspect;
+use frame_support::RuntimeDebug;
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::Zero;
 
@@ -35,7 +36,7 @@ pub(crate) struct ClosedLoan<T: pallet::Config> {
 }
 
 /// The data structure for storing pool nav details
-#[derive(Encode, Decode, Copy, Clone, PartialEq, Default, TypeInfo)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, Default, RuntimeDebug, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 pub struct NAVDetails<Amount> {
 	// this is the latest nav for the given pool.
@@ -45,15 +46,15 @@ pub struct NAVDetails<Amount> {
 	// So NAV could be
 	//	approximate when current time != last_updated
 	//	exact when current time == last_updated
-	pub(crate) latest: Amount,
+	pub latest: Amount,
 
 	// this is the last time when the nav was calculated for the entire pool
-	pub(crate) last_updated: Moment,
+	pub last_updated: Moment,
 }
 
 /// The data structure for storing a specific write off group
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Default, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, RuntimeDebug, Debug))]
 pub struct WriteOffGroup<Rate> {
 	/// percentage of outstanding debt we are going to write off on a loan
 	pub(crate) percentage: Rate,
@@ -89,7 +90,7 @@ pub enum NAVUpdateType {
 
 /// The data structure for storing loan info
 #[derive(Encode, Decode, Copy, Clone, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, RuntimeDebug, Debug))]
 pub struct LoanDetails<Rate, Amount, Asset> {
 	pub(crate) collateral: Asset,
 	pub(crate) loan_type: LoanType<Rate, Amount>,
@@ -193,7 +194,7 @@ where
 	}
 
 	/// returns the max_borrow_amount amount for the loan based on the loan type
-	pub(crate) fn max_borrow_amount(&self, now: Moment) -> Amount {
+	pub fn max_borrow_amount(&self, now: Moment) -> Amount {
 		match self.loan_type {
 			LoanType::BulletLoan(bl) => bl.max_borrow_amount(self.total_borrowed),
 			LoanType::CreditLine(cl) => {

--- a/pallets/loans/src/types.rs
+++ b/pallets/loans/src/types.rs
@@ -37,7 +37,7 @@ pub(crate) struct ClosedLoan<T: pallet::Config> {
 
 /// The data structure for storing pool nav details
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Default, RuntimeDebug, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct NAVDetails<Amount> {
 	// this is the latest nav for the given pool.
 	// this will be updated on these scenarios
@@ -53,8 +53,8 @@ pub struct NAVDetails<Amount> {
 }
 
 /// The data structure for storing a specific write off group
-#[derive(Encode, Decode, Copy, Clone, PartialEq, Default, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, RuntimeDebug, Debug))]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, Default, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct WriteOffGroup<Rate> {
 	/// percentage of outstanding debt we are going to write off on a loan
 	pub(crate) percentage: Rate,
@@ -89,8 +89,8 @@ pub enum NAVUpdateType {
 }
 
 /// The data structure for storing loan info
-#[derive(Encode, Decode, Copy, Clone, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, RuntimeDebug, Debug))]
+#[derive(Encode, Decode, Copy, Clone, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct LoanDetails<Rate, Amount, Asset> {
 	pub(crate) collateral: Asset,
 	pub(crate) loan_type: LoanType<Rate, Amount>,

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -12,21 +12,6 @@
 // GNU General Public License for more details.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use pallet::*;
-pub use solution::*;
-pub use tranche::*;
-pub use weights::*;
-
-#[cfg(feature = "runtime-benchmarks")]
-mod benchmarking;
-#[cfg(test)]
-mod mock;
-mod solution;
-#[cfg(test)]
-mod tests;
-mod tranche;
-pub mod weights;
-
 use codec::HasCompact;
 use common_traits::{
 	Permissions, PoolInspect, PoolNAV, PoolReserve, PoolUpdateGuard, TrancheToken,
@@ -41,6 +26,8 @@ use frame_support::{dispatch::DispatchResult, pallet_prelude::*, traits::UnixTim
 use frame_system::pallet_prelude::*;
 use orml_traits::Change;
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 use sp_arithmetic::traits::BaseArithmetic;
 use sp_runtime::{
 	traits::{
@@ -50,6 +37,21 @@ use sp_runtime::{
 };
 use sp_std::cmp::Ordering;
 use sp_std::vec::Vec;
+
+pub use pallet::*;
+pub use solution::*;
+pub use tranche::*;
+pub use weights::*;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+#[cfg(test)]
+mod mock;
+mod solution;
+#[cfg(test)]
+mod tests;
+mod tranche;
+pub mod weights;
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct PoolDetails<CurrencyId, EpochId, Balance, Rate, MetaSize, Weight, TrancheId, PoolId>
@@ -1375,7 +1377,7 @@ pub mod pallet {
 		///
 		/// This function checks the state a pool would be in when applying a solution
 		/// to an epoch. Depending on the state, the correct scoring function is chosen.
-		pub(crate) fn score_solution(
+		pub fn score_solution(
 			pool_id: &PoolDetailsOf<T>,
 			epoch: &EpochExecutionInfoOf<T>,
 			solution: &[TrancheSolution],

--- a/pallets/pools/src/solution.rs
+++ b/pallets/pools/src/solution.rs
@@ -84,6 +84,7 @@ impl PoolState {
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum UnhealthyState {
 	MaxReserveViolated,
 	MinRiskBufferViolated,
@@ -91,6 +92,7 @@ pub enum UnhealthyState {
 
 /// The solutions struct for epoch solution
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum EpochSolution<Balance> {
 	Healthy(HealthySolution<Balance>),
 	Unhealthy(UnhealthySolution<Balance>),
@@ -300,6 +302,7 @@ where
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct HealthySolution<Balance> {
 	pub solution: Vec<TrancheSolution>,
 	pub score: Balance,
@@ -315,6 +318,7 @@ where
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct UnhealthySolution<Balance> {
 	pub state: Vec<UnhealthyState>,
 	pub solution: Vec<TrancheSolution>,
@@ -383,7 +387,8 @@ where
 }
 
 // The solution struct for a specific tranche
-#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, Default, TypeInfo, Copy)]
+#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, Default, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct TrancheSolution {
 	pub invest_fulfillment: Perquintill,
 	pub redeem_fulfillment: Perquintill,

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -58,6 +58,7 @@ pub type Seniority = u32;
 pub type TrancheInput<Rate> = (TrancheType<Rate>, Option<Seniority>);
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum TrancheLoc<TrancheId> {
 	Index(TrancheIndex),
 	Id(TrancheId),
@@ -108,7 +109,7 @@ where
 pub struct Tranche<Balance, Rate, Weight, Currency> {
 	pub(super) tranche_type: TrancheType<Rate>,
 	pub(super) seniority: Seniority,
-	pub(super) currency: Currency,
+	pub currency: Currency,
 
 	pub(super) outstanding_invest_orders: Balance,
 	pub(super) outstanding_redeem_orders: Balance,
@@ -341,6 +342,10 @@ where
 			ids,
 			salt,
 		})
+	}
+
+	pub fn tranche_currency(&self, id: TrancheLoc<TrancheId>) -> Option<CurrencyId> {
+		self.get_tranche(id).map(|tranche| tranche.currency)
 	}
 
 	pub fn tranche_id(&self, id: TrancheLoc<TrancheId>) -> Option<TrancheId> {

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1151,7 +1151,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl runtime_common::AnchorApi<Block> for Runtime {
+	impl runtime_common::apis::AnchorApi<Block, Hash, BlockNumber> for Runtime {
 		fn get_anchor_by_id(id: Hash) -> Option<AnchorData<Hash, BlockNumber>> {
 			Anchor::get_anchor_by_id(id)
 		}

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -964,7 +964,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl runtime_common::AnchorApi<Block> for Runtime {
+	impl runtime_common::apis::AnchorApi<Block, Hash, BlockNumber> for Runtime {
 		fn get_anchor_by_id(id: Hash) -> Option<AnchorData<Hash, BlockNumber>> {
 			Anchor::get_anchor_by_id(id)
 		}

--- a/runtime/common/src/apis/anchors.rs
+++ b/runtime/common/src/apis/anchors.rs
@@ -1,0 +1,26 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+use codec::Codec;
+use pallet_anchors::AnchorData;
+use sp_api::decl_runtime_apis;
+
+decl_runtime_apis! {
+	/// Runtime Api for the pallet-anchors, to be implemented
+	/// by and for a specific runtime that uses that pallet.
+	pub trait AnchorApi<Hash, BlockNumber>
+	where
+		Hash: Codec,
+		BlockNumber: Codec
+	{
+		fn get_anchor_by_id(id: Hash) -> Option<AnchorData<Hash, BlockNumber>>;
+	}
+}

--- a/runtime/common/src/apis/mod.rs
+++ b/runtime/common/src/apis/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Runtime apis useful in the Centrifuge ecosystem
+pub use anchors::*;
+pub use pools::*;
+
+mod anchors;
+mod pools;

--- a/runtime/common/src/apis/pools.rs
+++ b/runtime/common/src/apis/pools.rs
@@ -14,7 +14,6 @@ use pallet_pools::{EpochSolution, TrancheIndex, TrancheLoc, TrancheSolution};
 use sp_api::decl_runtime_apis;
 use sp_std::vec::Vec;
 
-//TODO(nuno): convert to latest quo
 decl_runtime_apis! {
 	/// Runtime for pallet-pools.
 	///

--- a/runtime/common/src/apis/pools.rs
+++ b/runtime/common/src/apis/pools.rs
@@ -1,0 +1,45 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+use codec::Codec;
+use pallet_pools::{EpochSolution, TrancheIndex, TrancheLoc, TrancheSolution};
+use sp_api::decl_runtime_apis;
+use sp_std::vec::Vec;
+
+//TODO(nuno): convert to latest quo
+decl_runtime_apis! {
+	/// Runtime for pallet-pools.
+	///
+	/// Note: That the runtime api is pallet specific, while the rpcs method
+	///       are more focused on domain-specifc logic
+	pub trait PoolsApi<PoolId, TrancheId, Balance, Currency, BalanceRatio>
+	where
+		PoolId: Codec,
+		TrancheId: Codec,
+		Balance: Codec,
+		Currency: Codec,
+		BalanceRatio: Codec,
+	{
+		fn currency(pool_id: PoolId) -> Option<Currency>;
+
+		fn inspect_epoch_solution(pool_id: PoolId, solution: Vec<TrancheSolution>) -> Option<EpochSolution<Balance>>;
+
+		fn tranche_token_price(pool_id: PoolId, tranche: TrancheLoc<TrancheId>) -> Option<BalanceRatio>;
+
+		fn tranche_token_prices(pool_id: PoolId) -> Option<Vec<BalanceRatio>>;
+
+		fn tranche_ids(pool_id: PoolId) -> Option<Vec<TrancheId>>;
+
+		fn tranche_id(pool_id: PoolId, tranche_index: TrancheIndex) -> Option<TrancheId>;
+
+		fn tranche_currency(pool_id: PoolId, tranche_loc: TrancheLoc<TrancheId>) -> Option<Currency>;
+	}
+}

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -14,28 +14,16 @@
 //! # Common types and primitives used for Centrifuge chain runtime.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+pub use common_types::CurrencyId;
+
 pub use apis::*;
 pub use constants::*;
 pub use impls::*;
 pub use types::*;
 
+pub mod apis;
 mod fixed_point;
 mod impls;
-
-pub use common_types::CurrencyId;
-
-pub mod apis {
-	use node_primitives::{BlockNumber, Hash};
-	use pallet_anchors::AnchorData;
-	use sp_api::decl_runtime_apis;
-
-	decl_runtime_apis! {
-		/// The API to query anchoring info.
-		pub trait AnchorApi {
-			fn get_anchor_by_id(id: Hash) -> Option<AnchorData<Hash, BlockNumber>>;
-		}
-	}
-}
 
 /// Common types for all runtimes
 pub mod types {

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -10,7 +10,7 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
 		AsEnsureOriginWithArg, Contains, EnsureOneOf, EqualPrivilegeOnly, Everything,
-		InstanceFilter, LockIdentifier, U128CurrencyToVote,
+		InstanceFilter, LockIdentifier, U128CurrencyToVote, UnixTime,
 	},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
@@ -57,7 +57,9 @@ use common_types::{
 	TimeProvider, UNION,
 };
 use pallet_anchors::AnchorData;
-use pallet_pools::{PoolDetails, ScheduledUpdateDetails};
+use pallet_pools::{
+	EpochSolution, PoolDetails, ScheduledUpdateDetails, TrancheIndex, TrancheLoc, TrancheSolution,
+};
 use pallet_restricted_tokens::{
 	FungibleInspectPassthrough, FungiblesInspectPassthrough, TransferDetails,
 };
@@ -1511,9 +1513,73 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl runtime_common::AnchorApi<Block> for Runtime {
+	/* Runtime Apis impls */
+
+	// AnchorApi
+	impl runtime_common::apis::AnchorApi<Block, Hash, BlockNumber> for Runtime {
 		fn get_anchor_by_id(id: Hash) -> Option<AnchorData<Hash, BlockNumber>> {
 			Anchor::get_anchor_by_id(id)
+		}
+	}
+
+	// PoolsApi
+	impl runtime_common::apis::PoolsApi<Block, PoolId, TrancheId, Balance, CurrencyId, Rate> for Runtime {
+		fn currency(pool_id: PoolId) -> Option<CurrencyId>{
+			pallet_pools::Pool::<Runtime>::get(pool_id).map(|details| details.currency)
+		}
+
+		fn inspect_epoch_solution(pool_id: PoolId, solution: Vec<TrancheSolution>) -> Option<EpochSolution<Balance>>{
+			let pool = pallet_pools::Pool::<Runtime>::get(pool_id)?;
+			let epoch_execution_info = pallet_pools::EpochExecution::<Runtime>::get(pool_id)?;
+			pallet_pools::Pallet::<Runtime>::score_solution(
+				&pool,
+				&epoch_execution_info,
+				&solution
+			).ok()
+		}
+
+		fn tranche_token_price(pool_id: PoolId, tranche: TrancheLoc<TrancheId>) -> Option<Rate>{
+			let now = <pallet_timestamp::Pallet::<Runtime> as UnixTime>::now().as_secs();
+			let mut pool = pallet_pools::Pool::<Runtime>::get(pool_id)?;
+			let nav: Balance = pallet_loans::Pallet::<Runtime>::update_nav_of_pool(pool_id)
+				.ok()
+				.map(|(latest, _)| latest.into())?;
+			let total_assets = pool.reserve.total.saturating_add(nav);
+			let index: usize = pool.tranches.tranche_index(&tranche)?.try_into().ok()?;
+			let prices = pool
+				.tranches
+				.calculate_prices::<_, OrmlTokens, _>(total_assets, now)
+				.ok()?;
+			prices.get(index).map(|rate: &Rate| rate.clone())
+		}
+
+		fn tranche_token_prices(pool_id: PoolId) -> Option<Vec<Rate>>{
+			let now = <pallet_timestamp::Pallet::<Runtime> as UnixTime>::now().as_secs();
+			let mut pool = pallet_pools::Pool::<Runtime>::get(pool_id)?;
+			let nav: Balance = pallet_loans::Pallet::<Runtime>::update_nav_of_pool(pool_id)
+				.ok()
+				.map(|(latest, _)| latest.into())?;
+			let total_assets = pool.reserve.total.saturating_add(nav);
+			pool
+				.tranches
+				.calculate_prices::<Rate, OrmlTokens, AccountId>(total_assets, now)
+				.ok()
+		}
+
+		fn tranche_ids(pool_id: PoolId) -> Option<Vec<TrancheId>>{
+			let pool = pallet_pools::Pool::<Runtime>::get(pool_id)?;
+			Some(pool.tranches.ids_residual_top())
+		}
+
+		fn tranche_id(pool_id: PoolId, tranche_index: TrancheIndex) -> Option<TrancheId>{
+			let pool = pallet_pools::Pool::<Runtime>::get(pool_id)?;
+			let index: usize = tranche_index.try_into().ok()?;
+			pool.tranches.ids_residual_top().get(index).map(|id| id.clone())
+		}
+
+		fn tranche_currency(pool_id: PoolId, tranche_loc: TrancheLoc<TrancheId>) -> Option<CurrencyId>{
+			let pool = pallet_pools::Pool::<Runtime>::get(pool_id)?;
+			pool.tranches.tranche_currency(tranche_loc)
 		}
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
 //! Centrifuge Chain Node CLI library.
 #![warn(missing_docs)]
 
-mod api;
 mod chain_spec;
+mod cli;
+mod command;
 mod rpc;
 #[macro_use]
 mod service;
-mod cli;
-mod command;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/src/rpc/anchors.rs
+++ b/src/rpc/anchors.rs
@@ -20,12 +20,12 @@ pub trait AnchorApi {
 }
 
 /// A struct that implements the [`AnchorApi`].
-pub struct AnchorRpc<C, P> {
+pub struct Anchors<C, P> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<P>,
 }
 
-impl<C, P> AnchorRpc<C, P> {
+impl<C, P> Anchors<C, P> {
 	/// Create new `Anchor` with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self {
@@ -36,11 +36,11 @@ impl<C, P> AnchorRpc<C, P> {
 }
 
 #[async_trait]
-impl<C, Block> AnchorApiServer for AnchorRpc<C, Block>
+impl<C, Block> AnchorApiServer for Anchors<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
-	C::Api: AnchorRuntimeApi<Block>,
+	C::Api: AnchorRuntimeApi<Block, Hash, BlockNumber>,
 {
 	async fn get_anchor_by_id(&self, id: Hash) -> RpcResult<AnchorData<Hash, BlockNumber>> {
 		let api = self.client.runtime_api();

--- a/src/rpc/anchors.rs
+++ b/src/rpc/anchors.rs
@@ -1,7 +1,4 @@
-use jsonrpsee::{
-	core::RpcResult,
-	proc_macros::rpc,
-};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 use node_primitives::{BlockNumber, Hash};
 use pallet_anchors::AnchorData;
@@ -50,9 +47,6 @@ where
 		api.get_anchor_by_id(&at, id)
 			.ok()
 			.unwrap()
-			.ok_or(invalid_params_error(
-				"Unable to find anchor",
-				format!("Hash {:?}", id),
-			))
+			.ok_or(invalid_params_error("Unable to find anchor"))
 	}
 }

--- a/src/rpc/anchors.rs
+++ b/src/rpc/anchors.rs
@@ -1,22 +1,24 @@
 use jsonrpsee::{
-	core::{async_trait, Error as JsonRpseeError, RpcResult},
+	core::RpcResult,
 	proc_macros::rpc,
-	types::error::{CallError, ErrorCode, ErrorObject},
 };
 
 use node_primitives::{BlockNumber, Hash};
 use pallet_anchors::AnchorData;
-pub use runtime_common::AnchorApi as AnchorRuntimeApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
+use crate::rpc::invalid_params_error;
+
+pub use runtime_common::AnchorApi as AnchorRuntimeApi;
+
 #[rpc(client, server)]
 pub trait AnchorApi {
 	/// Returns an anchor given an anchor id from the runtime storage
 	#[method(name = "anchor_getAnchorById")]
-	async fn get_anchor_by_id(&self, id: Hash) -> RpcResult<AnchorData<Hash, BlockNumber>>;
+	fn get_anchor_by_id(&self, id: Hash) -> RpcResult<AnchorData<Hash, BlockNumber>>;
 }
 
 /// A struct that implements the [`AnchorApi`].
@@ -35,24 +37,22 @@ impl<C, P> Anchors<C, P> {
 	}
 }
 
-#[async_trait]
 impl<C, Block> AnchorApiServer for Anchors<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	C::Api: AnchorRuntimeApi<Block, Hash, BlockNumber>,
 {
-	async fn get_anchor_by_id(&self, id: Hash) -> RpcResult<AnchorData<Hash, BlockNumber>> {
+	fn get_anchor_by_id(&self, id: Hash) -> RpcResult<AnchorData<Hash, BlockNumber>> {
 		let api = self.client.runtime_api();
 		let best = self.client.info().best_hash;
 		let at = BlockId::hash(best);
 		api.get_anchor_by_id(&at, id)
 			.ok()
 			.unwrap()
-			.ok_or(JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
-				ErrorCode::InternalError.code(),
+			.ok_or(invalid_params_error(
 				"Unable to find anchor",
-				Some(format!("{:?}", id)),
-			))))
+				format!("Hash {:?}", id),
+			))
 	}
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -10,7 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-//! Centrifuge specific rpc endpoints (common endpoints across all environments)
+//! Centrifuge specific rpcs endpoints (common endpoints across all environments)
 
 use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 use runtime_common::{AccountId, Balance, Index};
@@ -21,6 +21,9 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use std::sync::Arc;
 use substrate_frame_rpc_system::{System, SystemApiServer};
+
+pub mod anchors;
+// pub mod pools; TODO(NUNO)
 
 /// A type representing all RPC extensions.
 pub type RpcExtension = jsonrpsee::RpcModule<()>;
@@ -47,4 +50,20 @@ where
 	module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 
 	Ok(module)
+}
+
+//TODO(nuno): make sure we need this with jsonrpsee
+
+/// Error type of our RPC methods
+pub enum Error {
+	/// The call to runtime failed.
+	RuntimeError,
+}
+
+impl From<Error> for i64 {
+	fn from(e: Error) -> i64 {
+		match e {
+			Error::RuntimeError => 1,
+		}
+	}
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -12,6 +12,7 @@
 
 //! Centrifuge specific rpcs endpoints (common endpoints across all environments)
 
+use std::fmt::Debug;
 use jsonrpsee::{
 	core::Error as JsonRpseeError,
 	types::error::{CallError, ErrorCode, ErrorObject},
@@ -63,11 +64,11 @@ pub enum CustomServerError {
 	RuntimeError = 1,
 }
 
-pub fn runtime_error(message: &'static str, data: String) -> JsonRpseeError {
+pub fn runtime_error<InnerError: Debug>(message: &'static str, inner_error: InnerError) -> JsonRpseeError {
 	JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
 		ErrorCode::ServerError(CustomServerError::RuntimeError as i32).code(),
 		message,
-		Some(data),
+		Some(format!("{:?}", inner_error)),
 	)))
 }
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -12,7 +12,6 @@
 
 //! Centrifuge specific rpcs endpoints (common endpoints across all environments)
 
-use std::fmt::Debug;
 use jsonrpsee::{
 	core::Error as JsonRpseeError,
 	types::error::{CallError, ErrorCode, ErrorObject},
@@ -24,6 +23,7 @@ use sc_service::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use std::fmt::Debug;
 use std::sync::Arc;
 use substrate_frame_rpc_system::{System, SystemApiServer};
 
@@ -64,7 +64,10 @@ pub enum CustomServerError {
 	RuntimeError = 1,
 }
 
-pub fn runtime_error<InnerError: Debug>(message: &'static str, inner_error: InnerError) -> JsonRpseeError {
+pub fn runtime_error<InnerError: Debug>(
+	message: &'static str,
+	inner_error: InnerError,
+) -> JsonRpseeError {
 	JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
 		ErrorCode::ServerError(CustomServerError::RuntimeError as i32).code(),
 		message,
@@ -72,10 +75,10 @@ pub fn runtime_error<InnerError: Debug>(message: &'static str, inner_error: Inne
 	)))
 }
 
-pub fn invalid_params_error(msg: &'static str, params: String) -> JsonRpseeError {
+pub fn invalid_params_error(msg: &'static str) -> JsonRpseeError {
 	JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
 		ErrorCode::InvalidParams.code(),
 		msg,
-		Some(params),
+		Option::<()>::None,
 	)))
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -10,7 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-//! Centrifuge specific rpcs endpoints (common endpoints across all environments)
+//! Centrifuge RPC endpoints (common endpoints across all environments)
 
 use jsonrpsee::{
 	core::Error as JsonRpseeError,

--- a/src/rpc/pools.rs
+++ b/src/rpc/pools.rs
@@ -72,10 +72,7 @@ where
 
 		api.currency(&at, pool_id)
 			.map_err(|e| runtime_error("Unable to query pool currency", e))?
-			.ok_or(invalid_params_error(
-				"Pool not found",
-				format!("PoolId: {:?}", pool_id),
-			))
+			.ok_or(invalid_params_error("Pool not found"))
 	}
 
 	fn inspect_epoch_solution(
@@ -88,16 +85,8 @@ where
 		let at = BlockId::hash(best);
 
 		api.inspect_epoch_solution(&at, pool_id, solution.clone())
-			.map_err(|e| {
-				runtime_error(
-					"Unable to query inspection for epoch solution",
-					e,
-				)
-			})?
-			.ok_or(invalid_params_error(
-				"Pool not found or invalid solution",
-				format!("PoolId: {:?}, Solution: {:?}", pool_id, solution),
-			))
+			.map_err(|e| runtime_error("Unable to query inspection for epoch solution", e))?
+			.ok_or(invalid_params_error("Pool not found or invalid solution"))
 	}
 
 	fn tranche_token_price(
@@ -111,10 +100,7 @@ where
 
 		api.tranche_token_price(&at, pool_id, TrancheLoc::Id(tranche_id.clone()))
 			.map_err(|e| runtime_error("Unable to query tranche token price", e))?
-			.ok_or(invalid_params_error(
-				"Pool or tranche not found",
-				format!("PoolId: {:?}, TrancheId: {:?}", pool_id, tranche_id),
-			))
+			.ok_or(invalid_params_error("Pool or tranche not found"))
 	}
 
 	fn tranche_token_prices(&self, pool_id: PoolId) -> RpcResult<Vec<BalanceRatio>> {
@@ -123,13 +109,8 @@ where
 		let at = BlockId::hash(best);
 
 		api.tranche_token_prices(&at, pool_id)
-			.map_err(|e| {
-				runtime_error("Unable to query tranche token prices.", e)
-			})?
-			.ok_or(invalid_params_error(
-				"Pool not found.",
-				format!("PoolId: {:?}", pool_id),
-			))
+			.map_err(|e| runtime_error("Unable to query tranche token prices.", e))?
+			.ok_or(invalid_params_error("Pool not found."))
 	}
 
 	fn tranche_ids(&self, pool_id: PoolId) -> RpcResult<Vec<TrancheId>> {
@@ -139,10 +120,7 @@ where
 
 		api.tranche_ids(&at, pool_id)
 			.map_err(|e| runtime_error("Unable to query tranche ids.", e))?
-			.ok_or(invalid_params_error(
-				"Pool not found",
-				format!("PoolId: {:?}", pool_id),
-			))
+			.ok_or(invalid_params_error("Pool not found"))
 	}
 
 	fn tranche_id(&self, pool_id: PoolId, tranche_index: TrancheIndex) -> RpcResult<TrancheId> {
@@ -152,10 +130,7 @@ where
 
 		api.tranche_id(&at, pool_id, tranche_index)
 			.map_err(|e| runtime_error("Unable to query tranche ids.", e))?
-			.ok_or(invalid_params_error(
-				"Pool or tranche not found.",
-				format!("PoolId: {:?}, TrancheIndex: {:?}", pool_id, tranche_index),
-			))
+			.ok_or(invalid_params_error("Pool or tranche not found."))
 	}
 
 	fn tranche_currency(&self, pool_id: PoolId, tranche_id: TrancheId) -> RpcResult<Currency> {
@@ -165,9 +140,6 @@ where
 
 		api.tranche_currency(&at, pool_id, TrancheLoc::Id(tranche_id.clone()))
 			.map_err(|e| runtime_error("Unable to query tranche currency.", e))?
-			.ok_or(invalid_params_error(
-				"Pool or tranche not found.",
-				format!("PoolId: {:?}, TrancheId: {:?}", pool_id, tranche_id),
-			))
+			.ok_or(invalid_params_error("Pool or tranche not found."))
 	}
 }

--- a/src/rpc/pools.rs
+++ b/src/rpc/pools.rs
@@ -71,7 +71,7 @@ where
 		let at = BlockId::hash(best);
 
 		api.currency(&at, pool_id)
-			.map_err(|e| runtime_error("Unable to query pool currency", format!("{:?}", e)))?
+			.map_err(|e| runtime_error("Unable to query pool currency", e))?
 			.ok_or(invalid_params_error(
 				"Pool not found",
 				format!("PoolId: {:?}", pool_id),
@@ -91,7 +91,7 @@ where
 			.map_err(|e| {
 				runtime_error(
 					"Unable to query inspection for epoch solution",
-					format!("{:?}", e),
+					e,
 				)
 			})?
 			.ok_or(invalid_params_error(
@@ -110,7 +110,7 @@ where
 		let at = BlockId::hash(best);
 
 		api.tranche_token_price(&at, pool_id, TrancheLoc::Id(tranche_id.clone()))
-			.map_err(|e| runtime_error("Unable to query tranche token price", format!("{:?}", e)))?
+			.map_err(|e| runtime_error("Unable to query tranche token price", e))?
 			.ok_or(invalid_params_error(
 				"Pool or tranche not found",
 				format!("PoolId: {:?}, TrancheId: {:?}", pool_id, tranche_id),
@@ -124,7 +124,7 @@ where
 
 		api.tranche_token_prices(&at, pool_id)
 			.map_err(|e| {
-				runtime_error("Unable to query tranche token prices.", format!("{:?}", e))
+				runtime_error("Unable to query tranche token prices.", e)
 			})?
 			.ok_or(invalid_params_error(
 				"Pool not found.",
@@ -138,7 +138,7 @@ where
 		let at = BlockId::hash(best);
 
 		api.tranche_ids(&at, pool_id)
-			.map_err(|e| runtime_error("Unable to query tranche ids.", format!("{:?}", e)))?
+			.map_err(|e| runtime_error("Unable to query tranche ids.", e))?
 			.ok_or(invalid_params_error(
 				"Pool not found",
 				format!("PoolId: {:?}", pool_id),
@@ -151,7 +151,7 @@ where
 		let at = BlockId::hash(best);
 
 		api.tranche_id(&at, pool_id, tranche_index)
-			.map_err(|e| runtime_error("Unable to query tranche ids.", format!("{:?}", e)))?
+			.map_err(|e| runtime_error("Unable to query tranche ids.", e))?
 			.ok_or(invalid_params_error(
 				"Pool or tranche not found.",
 				format!("PoolId: {:?}, TrancheIndex: {:?}", pool_id, tranche_index),
@@ -164,7 +164,7 @@ where
 		let at = BlockId::hash(best);
 
 		api.tranche_currency(&at, pool_id, TrancheLoc::Id(tranche_id.clone()))
-			.map_err(|e| runtime_error("Unable to query tranche currency.", format!("{:?}", e)))?
+			.map_err(|e| runtime_error("Unable to query tranche currency.", e))?
 			.ok_or(invalid_params_error(
 				"Pool or tranche not found.",
 				format!("PoolId: {:?}, TrancheId: {:?}", pool_id, tranche_id),

--- a/src/rpc/pools.rs
+++ b/src/rpc/pools.rs
@@ -1,0 +1,197 @@
+use codec::Codec;
+use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
+use jsonrpc_derive::rpc;
+use pallet_pools::{EpochSolution, TrancheIndex, TrancheLoc, TrancheSolution};
+use runtime_common::apis::PoolsApi as PoolsRuntimeApi;
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[rpc]
+pub trait PoolsApi<PoolId, TrancheId, Balance, Currency, BalanceRatio> {
+	#[rpc(name = "pools_currency")]
+	fn currency(&self, poold_id: PoolId) -> Result<Currency>;
+
+	#[rpc(name = "pools_inspectEpochSolution")]
+	fn inspect_epoch_solution(
+		&self,
+		pool_id: PoolId,
+		solution: Vec<TrancheSolution>,
+	) -> Result<EpochSolution<Balance>>;
+
+	#[rpc(name = "pools_trancheTokenPrice")]
+	fn tranche_token_price(&self, pool_id: PoolId, tranche: TrancheId) -> Result<BalanceRatio>;
+
+	#[rpc(name = "pools_trancheTokenPrices")]
+	fn tranche_token_prices(&self, pool_id: PoolId) -> Result<Vec<BalanceRatio>>;
+
+	#[rpc(name = "pools_trancheIds")]
+	fn tranche_ids(&self, pool_id: PoolId) -> Result<Vec<TrancheId>>;
+
+	#[rpc(name = "pools_trancheId")]
+	fn tranche_id(&self, pool_id: PoolId, tranche_index: TrancheIndex) -> Result<TrancheId>;
+
+	#[rpc(name = "pools_trancheCurrency")]
+	fn tranche_currency(&self, pool_id: PoolId, tranche_id: TrancheId) -> Result<Currency>;
+}
+
+pub struct Pools<C, P> {
+	client: Arc<C>,
+	_marker: std::marker::PhantomData<P>,
+}
+
+impl<C, P> Pools<C, P> {
+	pub fn new(client: Arc<C>) -> Self {
+		Pools {
+			client,
+			_marker: Default::default(),
+		}
+	}
+}
+
+impl<C, Block, PoolId, TrancheId, Balance, Currency, BalanceRatio>
+PoolsApiServer<PoolId, TrancheId, Balance, Currency, BalanceRatio> for Pools<C, Block>
+	where
+		Block: BlockT,
+		C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+		C::Api: PoolsRuntimeApi<Block, PoolId, TrancheId, Balance, Currency, BalanceRatio>,
+		Balance: Codec + Copy,
+		PoolId: Codec + Copy + Debug,
+		TrancheId: Codec + Clone + Debug,
+		Currency: Codec,
+		BalanceRatio: Codec,
+{
+	fn currency(&self, pool_id: PoolId) -> Result<Currency> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+
+		api.currency(&at, pool_id)
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(crate::rpc::Error::RuntimeError.into()),
+				message: "Unable to query currency of pool.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})?
+			.ok_or(RpcError {
+				code: ErrorCode::InvalidParams,
+				message: "Pool not found.".into(),
+				data: Some(format!("PoolId: {:?}", pool_id).into()),
+			})
+	}
+
+	fn inspect_epoch_solution(
+		&self,
+		pool_id: PoolId,
+		solution: Vec<TrancheSolution>,
+	) -> Result<EpochSolution<Balance>> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+
+		api.inspect_epoch_solution(&at, pool_id, solution.clone())
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(crate::rpc::Error::RuntimeError.into()),
+				message: "Unable to query inspection for epoch solution.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})?
+			.ok_or(RpcError {
+				code: ErrorCode::InvalidParams,
+				message: "Pool not found or invalid solution.".into(),
+				data: Some(format!("PoolId: {:?}, Solution: {:?}", pool_id, solution).into()),
+			})
+	}
+
+	fn tranche_token_price(&self, pool_id: PoolId, tranche_id: TrancheId) -> Result<BalanceRatio> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+
+		api.tranche_token_price(&at, pool_id, TrancheLoc::Id(tranche_id.clone()))
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(crate::rpc::Error::RuntimeError.into()),
+				message: "Unable to query tranche token price.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})?
+			.ok_or(RpcError {
+				code: ErrorCode::InvalidParams,
+				message: "Pool or tranche not found.".into(),
+				data: Some(format!("PoolId: {:?}, TrancheId: {:?}", pool_id, tranche_id).into()),
+			})
+	}
+
+	fn tranche_token_prices(&self, pool_id: PoolId) -> Result<Vec<BalanceRatio>> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+
+		api.tranche_token_prices(&at, pool_id)
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(crate::rpc::Error::RuntimeError.into()),
+				message: "Unable to query tranche token prices.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})?
+			.ok_or(RpcError {
+				code: ErrorCode::InvalidParams,
+				message: "Pool not found.".into(),
+				data: Some(format!("PoolId: {:?}", pool_id).into()),
+			})
+	}
+
+	fn tranche_ids(&self, pool_id: PoolId) -> Result<Vec<TrancheId>> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+
+		api.tranche_ids(&at, pool_id)
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(crate::rpc::Error::RuntimeError.into()),
+				message: "Unable to query tranche ids.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})?
+			.ok_or(RpcError {
+				code: ErrorCode::InvalidParams,
+				message: "Pool not found.".into(),
+				data: Some(format!("PoolId: {:?}", pool_id).into()),
+			})
+	}
+
+	fn tranche_id(&self, pool_id: PoolId, tranche_index: TrancheIndex) -> Result<TrancheId> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+
+		api.tranche_id(&at, pool_id, tranche_index)
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(crate::rpc::Error::RuntimeError.into()),
+				message: "Unable to query tranche ids.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})?
+			.ok_or(RpcError {
+				code: ErrorCode::InvalidParams,
+				message: "Pool or tranche not found.".into(),
+				data: Some(
+					format!("PoolId: {:?}, TrancheIndex: {:?}", pool_id, tranche_index).into(),
+				),
+			})
+	}
+
+	fn tranche_currency(&self, pool_id: PoolId, tranche_id: TrancheId) -> Result<Currency> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+
+		api.tranche_currency(&at, pool_id, TrancheLoc::Id(tranche_id.clone()))
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(crate::rpc::Error::RuntimeError.into()),
+				message: "Unable to query tranche currency.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})?
+			.ok_or(RpcError {
+				code: ErrorCode::InvalidParams,
+				message: "Pool or tranche not found.".into(),
+				data: Some(format!("PoolId: {:?}, TrancheId: {:?}", pool_id, tranche_id).into()),
+			})
+	}
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -816,9 +816,6 @@ pub async fn start_development_node(
 				.merge(Anchors::new(client.clone()).into_rpc())
 				.map_err(|e| sc_service::Error::Application(e.into()))?;
 			module
-				.merge(Anchors::new(client.clone()).into_rpc())
-				.map_err(|e| sc_service::Error::Application(e.into()))?;
-			module
 				.merge(Pools::new(client.clone()).into_rpc())
 				.map_err(|e| sc_service::Error::Application(e.into()))?;
 			Ok(module)

--- a/src/service.rs
+++ b/src/service.rs
@@ -15,8 +15,12 @@
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	api::{AnchorApiServer, AnchorRpc},
 	cli::RpcConfig,
+	rpc::{
+		self,
+		anchors::{AnchorApiServer, Anchors},
+		// pools::{Pools, PoolsApiServer},
+	},
 };
 
 use cumulus_client_cli::CollatorOptions;
@@ -259,7 +263,7 @@ where
 				>,
 			>,
 			DenyUnsafe,
-		) -> Result<crate::rpc::RpcExtension, sc_service::Error>
+		) -> Result<rpc::RpcExtension, sc_service::Error>
 		+ Send
 		+ Sync
 		+ 'static,
@@ -491,9 +495,9 @@ pub async fn start_altair_node(
 		id,
 		rpc_config,
 		|client, pool, deny_unsafe| {
-			let mut module = crate::rpc::create_full(client.clone(), pool, deny_unsafe)?;
+			let mut module = rpc::create_full(client.clone(), pool, deny_unsafe)?;
 			module
-				.merge(AnchorRpc::new(client.clone()).into_rpc())
+				.merge(Anchors::new(client.clone()).into_rpc())
 				.map_err(|e| sc_service::Error::Application(e.into()))?;
 			Ok(module)
 		},
@@ -649,9 +653,9 @@ pub async fn start_centrifuge_node(
 		id,
 		rpc_config,
 		|client, pool, deny_unsafe| {
-			let mut module = crate::rpc::create_full(client.clone(), pool, deny_unsafe)?;
+			let mut module = rpc::create_full(client.clone(), pool, deny_unsafe)?;
 			module
-				.merge(AnchorRpc::new(client.clone()).into_rpc())
+				.merge(Anchors::new(client.clone()).into_rpc())
 				.map_err(|e| sc_service::Error::Application(e.into()))?;
 			Ok(module)
 		},
@@ -801,28 +805,23 @@ pub async fn start_development_node(
 		>,
 	>,
 )> {
-	// let rpc_builder = {
-	// 	let client = client.clone();
-	// 	move |_, _| {
-	// 		let deps = crate::rpc::FullDeps {
-	// 			client: client.clone(),
-	// 			command_sink: rpc_sink.clone(),
-	// 			_marker: Default::default(),
-	// 		};
-	// 		crate::rpc::create_full(deps).map_err(Into::into)
-	// 	}
-	// };
-
 	start_node_impl::<development_runtime::RuntimeApi, DevelopmentRuntimeExecutor, _, _, _>(
 		parachain_config,
 		polkadot_config,
 		id,
 		rpc_config,
 		|client, pool, deny_unsafe| {
-			let mut module = crate::rpc::create_full(client.clone(), pool, deny_unsafe)?;
+			let mut module = rpc::create_full(client.clone(), pool, deny_unsafe)?;
 			module
-				.merge(AnchorRpc::new(client.clone()).into_rpc())
+				.merge(Anchors::new(client.clone()).into_rpc())
 				.map_err(|e| sc_service::Error::Application(e.into()))?;
+			module
+				.merge(Anchors::new(client.clone()).into_rpc())
+				.map_err(|e| sc_service::Error::Application(e.into()))?;
+			//TODO(nuno):
+			// module
+			// 	.merge(Pool::new(client.clone()).into_rpc())
+			// 	.map_err(|e| sc_service::Error::Application(e.into()))?;
 			Ok(module)
 		},
 		build_development_import_queue,

--- a/src/service.rs
+++ b/src/service.rs
@@ -19,7 +19,7 @@ use crate::{
 	rpc::{
 		self,
 		anchors::{AnchorApiServer, Anchors},
-		// pools::{Pools, PoolsApiServer},
+		pools::{Pools, PoolsApiServer},
 	},
 };
 
@@ -818,10 +818,9 @@ pub async fn start_development_node(
 			module
 				.merge(Anchors::new(client.clone()).into_rpc())
 				.map_err(|e| sc_service::Error::Application(e.into()))?;
-			//TODO(nuno):
-			// module
-			// 	.merge(Pool::new(client.clone()).into_rpc())
-			// 	.map_err(|e| sc_service::Error::Application(e.into()))?;
+			module
+				.merge(Pools::new(client.clone()).into_rpc())
+				.map_err(|e| sc_service::Error::Application(e.into()))?;
 			Ok(module)
 		},
 		build_development_import_queue,


### PR DESCRIPTION
We resurrect [#747](https://github.com/centrifuge/centrifuge-chain/pull/796) which was git-reverted in #833 due to lots of conflicts and the need to quickly deliver on that upgrade.

### Changes

- resurrect the new RPC methods that had been added, as well as follow the restructure that it had introduced.
- migrate rpc::pools to be built with `jsonrpsee`
- abstract and clean error building boiler plate code

Note: In e1282d8348b261088786909ad89bd505dffac28d I drop the params being passed to every `invalid_params_error`.  That data is just printing the params passed by the user/client, so there is really no value nor need to bloat the code with all this redundant code as far as I see. Let me know if you feel differently about it.