### PR TITLE
ci: Add SRTOOL_VERSION to differentiate from RUSTC

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,7 +3,8 @@
 set -eux
 
 RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-nightly-2022-05-09}"
-PACKAGE="${PACKAGE:-centrifuge-runtime}" #Need to replicate job for all runtimes
+SRTOOL_VERSION="${SRTOOL_VERSION:-1.60.0}"
+PACKAGE="${PACKAGE:-centrifuge-runtime}" # Need to replicate job for all runtimes
 
 # Enable warnings about unused extern crates
 export RUSTFLAGS=" -W unused-extern-crates"
@@ -21,7 +22,7 @@ case $TARGET in
 
   build-runtime)
     export RUSTC_VERSION=$RUST_TOOLCHAIN
-    docker run --rm -e PACKAGE=$PACKAGE -v $PWD:/build -v /tmp/cargo:/cargo-home paritytech/srtool:$RUSTC_VERSION build
+    docker run --rm -e PACKAGE=$PACKAGE -v $PWD:/build -v /tmp/cargo:/cargo-home paritytech/srtool:$SRTOOL_VERSION build
     ;;
 
   tests)


### PR DESCRIPTION
While this script does work on the CI, locally it will most likely fail because `RUST_TOOLCHAIN` won't hold a valid `srtool` version, leading to this error when following the Readme `Verify runtime` section:

```
λ TARGET=build-runtime RUST_TOOLCHAIN=nightly ./ci/script.sh
+ RUST_TOOLCHAIN=nightly
+ PACKAGE=altair-runtime
+ export 'RUSTFLAGS= -W unused-extern-crates'
+ RUSTFLAGS=' -W unused-extern-crates'
+ ./scripts/init.sh install-toolchain
+ RUST_TOOLCHAIN=nightly
+ echo 'Using rust toolchain: nightly'
Using rust toolchain: nightly
+ echo '*** Initializing WASM build environment'
*** Initializing WASM build environment
+ rustup update nightly
info: syncing channel updates for 'nightly-aarch64-apple-darwin'

  nightly-aarch64-apple-darwin unchanged - rustc 1.64.0-nightly (27eb6d701 2022-07-04)

info: checking for self-updates
+ rustup toolchain install nightly
info: syncing channel updates for 'nightly-aarch64-apple-darwin'

  nightly-aarch64-apple-darwin unchanged - rustc 1.64.0-nightly (27eb6d701 2022-07-04)

info: checking for self-updates
+ rustup default nightly
info: using existing install for 'nightly-aarch64-apple-darwin'
info: default toolchain set to 'nightly-aarch64-apple-darwin'

  nightly-aarch64-apple-darwin unchanged - rustc 1.64.0-nightly (27eb6d701 2022-07-04)

+ rustup component add rustfmt
info: component 'rustfmt' for target 'aarch64-apple-darwin' is up to date
+ rustup target add wasm32-unknown-unknown --toolchain nightly
info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
+ rustc --version
rustc 1.64.0-nightly (27eb6d701 2022-07-04)
+ rustup --version
rustup 1.24.3 (ce5817a94 2021-05-31)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.64.0-nightly (27eb6d701 2022-07-04)`
+ cargo --version
cargo 1.64.0-nightly (dbff32b27 2022-06-24)
+ case $TARGET in
+ export RUSTC_VERSION=nightly
+ RUSTC_VERSION=nightly
+ docker run --rm -e PACKAGE=altair-runtime -v /Users/n/centrifuge/centrifuge-chain:/build -v /tmp/cargo:/cargo-home paritytech/srtool:nightly build
Unable to find image 'paritytech/srtool:nightly' locally
docker: Error response from daemon: manifest for paritytech/srtool:nightly not found: manifest unknown: manifest unknown.
See 'docker run --help'.
```

The [srtool docker images](https://hub.docker.com/r/paritytech/srtool/tags) are versioned differently than the Rust toolchain so we should target each component's version separately.

