### PR TITLE
[WIP] pallet-anchors: add precommit deposit

### DIFF
--- a/pallets/anchors/src/lib.rs
+++ b/pallets/anchors/src/lib.rs
@@ -19,8 +19,10 @@ use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchError, DispatchResult},
 	storage::child,
+	traits::Currency,
 	RuntimeDebug, StateVersion,
 };
+
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::{CheckedAdd, CheckedMul};
 use sp_runtime::{traits::Hash, ArithmeticError};
@@ -40,6 +42,9 @@ mod mock;
 mod tests;
 
 mod common;
+
+type BalanceOf<T> =
+	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
 /// Expiration duration in blocks of a pre-commit
 /// This is the maximum expected time for document consensus to take place between a pre-commit of an anchor and a
@@ -83,6 +88,7 @@ pub mod pallet {
 	// Import various types used to declare pallet in scope.
 	use super::*;
 	use frame_support::pallet_prelude::*;
+	use frame_support::traits::ReservableCurrency;
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::traits::Hash;
 	use sp_std::vec::Vec;
@@ -100,6 +106,12 @@ pub mod pallet {
 	{
 		/// Type representing the weight of this pallet
 		type WeightInfo: WeightInfo;
+
+		/// Currency as viewed from this pallet
+		type Currency: ReservableCurrency<Self::AccountId>;
+
+		#[pallet::constant]
+		type PrecommitDepositAmount: Get<BalanceOf<Self>>;
 	}
 
 	/// PreCommits store the map of anchor Id to the pre-commit, which is a lock on an anchor id to be committed later
@@ -223,6 +235,8 @@ pub mod pallet {
 				Error::<T>::PreCommitAlreadyExists
 			);
 
+			<T as pallet::Config>::Currency::reserve(&who, T::PrecommitDepositAmount::get())?;
+
 			let expiration_block = <frame_system::Pallet<T>>::block_number()
 				.checked_add(&T::BlockNumber::from(PRE_COMMIT_EXPIRATION_DURATION_BLOCKS))
 				.ok_or(ArithmeticError::Overflow)?;
@@ -236,6 +250,7 @@ pub mod pallet {
 			);
 
 			Self::put_pre_commit_into_eviction_bucket(anchor_id, expiration_block)?;
+
 			Ok(())
 		}
 
@@ -338,7 +353,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			evict_bucket: T::BlockNumber,
 		) -> DispatchResult {
-			ensure_signed(origin)?;
+			let who = ensure_signed(origin)?;
 			ensure!(
 				<frame_system::Pallet<T>>::block_number() >= evict_bucket,
 				Error::<T>::EvictionNotPossible
@@ -355,6 +370,8 @@ pub mod pallet {
 					.map(|pre_commit_id| <PreCommits<T>>::remove(pre_commit_id));
 
 				<PreCommitEvictionBuckets<T>>::remove((evict_bucket, idx));
+
+				<T as pallet::Config>::Currency::unreserve(&who, T::PrecommitDepositAmount::get());
 
 				// decreases the evict bucket item count or remove index completely if empty
 				if idx == 0 {

--- a/pallets/anchors/src/lib.rs
+++ b/pallets/anchors/src/lib.rs
@@ -516,15 +516,15 @@ impl<T: Config> Pallet<T> {
 			.take(MAX_LOOP_IN_TX as usize)
 			// get eviction date of the anchor given by index
 			.filter_map(|idx| {
-				let anchor_index = <AnchorIndexes<T>>::get(idx)?;
-				let eviction_date = <AnchorEvictDates<T>>::get(anchor_index).unwrap_or_default();
-				Some((idx, anchor_index, eviction_date))
+				let anchor_id = <AnchorIndexes<T>>::get(idx)?;
+				let eviction_date = <AnchorEvictDates<T>>::get(anchor_id).unwrap_or_default();
+				Some((idx, anchor_id, eviction_date))
 			})
 			// filter out evictable anchors, anchor_evict_date can be 0 when evicting before any anchors are created
 			.filter(|(_, _, anchor_evict_date)| anchor_evict_date <= &yesterday)
 			// remove indexes
-			.map(|(idx, anchor_index, _)| {
-				<AnchorEvictDates<T>>::remove(anchor_index);
+			.map(|(idx, anchor_id, _)| {
+				<AnchorEvictDates<T>>::remove(anchor_id);
 				<AnchorIndexes<T>>::remove(idx);
 				<LatestEvictedAnchorIndex<T>>::put(idx);
 			})


### PR DESCRIPTION
This is a WIP PR, I have some pending questions:

- [ ] 1. Should we do the same (adding a deposit) for `commit()` and `evict_anchors()` (which removes part of the data that `commit` adds)?
- [ ] 2. Should `commit()` be called even if a `recommit` has not been made before? Currently exists this possibility.
- [ ] 3. Should we configure the deposit amount as a constant or should it be set by a pallet call (similar to the keystore pallet with its `set_deposit`)? I understand that the purpose of how keystore works is to update the amount without needing to update the runtime. Do we want the same?
- [ ] 4. `precommit` error handling: See [issue](https://github.com/centrifuge/centrifuge-chain-internal/issues/22)

Notes: 
- I have not added a refund in the `commit()` call for the `precommit` resources because a `commit` does not remove the `recommit` data; only the `evit_pre_commits()` call does.


Closes https://github.com/centrifuge/centrifuge-chain/issues/865