### PR TITLE
Add `CurrencyPrice` trait and implement for tranche token prices

### DIFF
--- a/libs/common-traits/src/lib.rs
+++ b/libs/common-traits/src/lib.rs
@@ -127,6 +127,30 @@ pub trait PoolReserve<AccountId>: PoolInspect<AccountId> {
 	fn deposit(pool_id: Self::PoolId, from: AccountId, amount: Self::Balance) -> DispatchResult;
 }
 
+/// A trait that can be used to retrieve the current price for a currency
+pub struct CurrencyPair<CurrencyId> {
+	pub base: CurrencyId,
+	pub quote: CurrencyId,
+}
+
+pub struct PriceValue<CurrencyId, Rate, Moment> {
+	pub pair: CurrencyPair<CurrencyId>,
+	pub price: Rate,
+	pub last_updated: Moment,
+}
+
+pub trait CurrencyPrice<CurrencyId> {
+	type Rate;
+	type Moment;
+
+	/// Retrieve the latest price of `base` currency, denominated in the `quote` currency
+	/// If `quote` currency is not passed, then the default `quote` currency is used (when possible)
+	fn get_latest(
+		base: CurrencyId,
+		quote: Option<CurrencyId>,
+	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>>;
+}
+
 /// A trait that can be used to calculate interest accrual for debt
 pub trait InterestAccrual<InterestRate, Balance, Adjustment> {
 	type NormalizedDebt: Member + Parameter + MaxEncodedLen + TypeInfo + Copy + Zero;

--- a/libs/common-traits/src/lib.rs
+++ b/libs/common-traits/src/lib.rs
@@ -109,17 +109,23 @@ pub trait PoolNAV<PoolId, Amount> {
 }
 
 /// A trait that support pool inspection operations such as pool existence checks and pool admin of permission set.
-pub trait PoolInspect<AccountId> {
+pub trait PoolInspect<AccountId, CurrencyId> {
 	type PoolId: Parameter + Member + Debug + Copy + Default + TypeInfo;
 	type TrancheId: Parameter + Member + Debug + Copy + Default + TypeInfo;
+	type Rate;
+	type Moment;
 
 	/// check if the pool exists
 	fn pool_exists(pool_id: Self::PoolId) -> bool;
 	fn tranche_exists(pool_id: Self::PoolId, tranche_id: Self::TrancheId) -> bool;
+	fn get_tranche_token_price(
+		pool_id: Self::PoolId,
+		tranche_id: Self::TrancheId,
+	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>>;
 }
 
 /// A trait that support pool reserve operations such as withdraw and deposit
-pub trait PoolReserve<AccountId>: PoolInspect<AccountId> {
+pub trait PoolReserve<AccountId, CurrencyId>: PoolInspect<AccountId, CurrencyId> {
 	type Balance;
 
 	/// Withdraw `amount` from the reserve to the `to` account.

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -125,7 +125,7 @@ pub mod pallet {
 		type LoansPalletId: Get<PalletId>;
 
 		/// Pool reserve type
-		type Pool: PoolReserve<Self::AccountId, Balance = Self::Balance>;
+		type Pool: PoolReserve<Self::AccountId, Self::CurrencyId, Balance = Self::Balance>;
 
 		type CurrencyId: Parameter + Copy;
 

--- a/pallets/loans/src/test_utils.rs
+++ b/pallets/loans/src/test_utils.rs
@@ -38,7 +38,7 @@ type PermissionsOf<T> = <T as pallet_loans::Config>::Permission;
 
 pub(crate) fn set_role<T: pallet_loans::Config>(
 	scope: PermissionScope<
-		<T::Pool as common_traits::PoolInspect<T::AccountId>>::PoolId,
+		<T::Pool as common_traits::PoolInspect<T::AccountId, T::CurrencyId>>::PoolId,
 		<T as pallet_loans::Config>::CurrencyId,
 	>,
 	who: T::AccountId,

--- a/pallets/loans/src/types.rs
+++ b/pallets/loans/src/types.rs
@@ -210,8 +210,10 @@ pub(crate) type InstanceIdOf<T> =
 	<<T as Config>::NonFungible as Inspect<<T as frame_system::Config>::AccountId>>::ItemId;
 pub(crate) type AssetOf<T> = Asset<<T as Config>::ClassId, <T as Config>::LoanId>;
 
-pub(crate) type PoolIdOf<T> =
-	<<T as Config>::Pool as PoolInspect<<T as frame_system::Config>::AccountId>>::PoolId;
+pub(crate) type PoolIdOf<T> = <<T as Config>::Pool as PoolInspect<
+	<T as frame_system::Config>::AccountId,
+	<T as Config>::CurrencyId,
+>>::PoolId;
 
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
 

--- a/pallets/pools/src/impls.rs
+++ b/pallets/pools/src/impls.rs
@@ -1,0 +1,87 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+use common_traits::{CurrencyPair, PriceValue};
+use common_types::CurrencyId;
+
+use super::*;
+
+impl<T: Config> PoolInspect<T::AccountId, T::CurrencyId> for Pallet<T> {
+	type PoolId = T::PoolId;
+	type TrancheId = T::TrancheId;
+	type Rate = T::BalanceRatio;
+	type Moment = Moment;
+
+	fn pool_exists(pool_id: Self::PoolId) -> bool {
+		Pool::<T>::contains_key(pool_id)
+	}
+
+	fn tranche_exists(pool_id: Self::PoolId, tranche_id: Self::TrancheId) -> bool {
+		Pool::<T>::get(pool_id)
+			.and_then(|pool| pool.tranches.tranche_index(&TrancheLoc::Id(tranche_id)))
+			.is_some()
+	}
+
+	fn get_tranche_token_price(
+		pool_id: Self::PoolId,
+		tranche_id: Self::TrancheId,
+	) -> Option<PriceValue<T::CurrencyId, T::BalanceRatio, Moment>> {
+		let now = Self::now();
+		let mut pool = Pool::<T>::get(pool_id)?;
+
+		// Get cached nav as calculating current nav would be too computationally expensive
+		if let Some((nav, nav_last_updated)) = T::NAV::nav(pool_id) {
+			let total_assets = pool.reserve.total.saturating_add(nav);
+
+			let tranche_index: usize = pool
+				.tranches
+				.tranche_index(&TrancheLoc::Id(tranche_id))?
+				.try_into()
+				.ok()?;
+			let prices = pool
+				.tranches
+				.calculate_prices::<T::BalanceRatio, T::Tokens, _>(total_assets, now)
+				.ok()?;
+
+			let base = pool.tranches.tranche_currency(TrancheLoc::Id(tranche_id))?;
+
+			match prices
+				.get(tranche_index)
+				.map(|rate: &T::BalanceRatio| rate.clone())
+			{
+				Some(price) => Some(PriceValue {
+					pair: CurrencyPair {
+						base,
+						quote: pool.currency,
+					},
+					price,
+					last_updated: nav_last_updated,
+				}),
+				None => None,
+			}
+		} else {
+			None
+		}
+	}
+}
+
+impl<T: Config> PoolReserve<T::AccountId, T::CurrencyId> for Pallet<T> {
+	type Balance = T::Balance;
+
+	fn withdraw(pool_id: Self::PoolId, to: T::AccountId, amount: Self::Balance) -> DispatchResult {
+		Self::do_withdraw(to, pool_id, amount)
+	}
+
+	fn deposit(pool_id: Self::PoolId, from: T::AccountId, amount: Self::Balance) -> DispatchResult {
+		Self::do_deposit(from, pool_id, amount)
+	}
+}

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -38,6 +38,7 @@ use sp_runtime::{
 use sp_std::cmp::Ordering;
 use sp_std::vec::Vec;
 
+pub use impls::*;
 pub use pallet::*;
 pub use solution::*;
 pub use tranche::*;
@@ -45,6 +46,7 @@ pub use weights::*;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+mod impls;
 #[cfg(test)]
 mod mock;
 mod solution;
@@ -2115,32 +2117,5 @@ pub mod pallet {
 			PoolDeposit::<T>::insert(pool, PoolDepositOf::<T> { deposit, depositor });
 			Ok(())
 		}
-	}
-}
-
-impl<T: Config> PoolInspect<T::AccountId> for Pallet<T> {
-	type PoolId = T::PoolId;
-	type TrancheId = T::TrancheId;
-
-	fn pool_exists(pool_id: Self::PoolId) -> bool {
-		Pool::<T>::contains_key(pool_id)
-	}
-
-	fn tranche_exists(pool_id: Self::PoolId, tranche_id: Self::TrancheId) -> bool {
-		Pool::<T>::get(pool_id)
-			.and_then(|pool| pool.tranches.tranche_index(&TrancheLoc::Id(tranche_id)))
-			.is_some()
-	}
-}
-
-impl<T: Config> PoolReserve<T::AccountId> for Pallet<T> {
-	type Balance = T::Balance;
-
-	fn withdraw(pool_id: Self::PoolId, to: T::AccountId, amount: Self::Balance) -> DispatchResult {
-		Self::do_withdraw(to, pool_id, amount)
-	}
-
-	fn deposit(pool_id: Self::PoolId, from: T::AccountId, amount: Self::Balance) -> DispatchResult {
-		Self::do_deposit(from, pool_id, amount)
 	}
 }

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -484,6 +484,16 @@ fn epoch() {
 			}
 		));
 
+		assert_eq!(
+			<Pools as PoolInspect<
+				<Test as frame_system::Config>::AccountId,
+				<Test as Config>::CurrencyId,
+			>>::get_tranche_token_price(0, SeniorTrancheId::get())
+			.unwrap()
+			.price,
+			Rate::one()
+		);
+
 		assert_err!(
 			Pools::close_epoch(pool_owner_origin.clone(), 0),
 			Error::<Test>::MinEpochTimeHasNotPassed
@@ -649,6 +659,15 @@ fn epoch() {
 		assert_eq!(
 			pool.reserve.total + senior_epoch.token_price.saturating_mul_int(250 * CURRENCY),
 			1010 * CURRENCY
+		);
+
+		assert!(
+			<Pools as PoolInspect<
+				<Test as frame_system::Config>::AccountId,
+				<Test as Config>::CurrencyId,
+			>>::get_tranche_token_price(0, SeniorTrancheId::get())
+			.unwrap()
+			.price > Rate::one()
 		);
 	});
 }

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -943,14 +943,19 @@ impl CurrencyPrice<CurrencyId> for CurrencyPriceSource {
 
 	fn get_latest(
 		base: CurrencyId,
-		_quote: Option<CurrencyId>,
+		quote: Option<CurrencyId>,
 	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>> {
 		match base {
 			CurrencyId::Tranche(pool_id, tranche_id) => {
-				<pallet_pools::Pallet<Runtime> as PoolInspect<
-					AccountId,
-					CurrencyId,
-				>>::get_tranche_token_price(pool_id, tranche_id)
+				match <pallet_pools::Pallet<Runtime> as PoolInspect<
+				AccountId,
+				CurrencyId,
+			>>::get_tranche_token_price(pool_id, tranche_id) {
+					// If a specific quote is requested, this needs to match the actual quote.
+					Some(price) if Some(price.pair.quote) != quote => None,
+					Some(price) => Some(price),
+					None => None,
+				}
 			}
 			_ => None,
 		}

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -48,10 +48,8 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use xcm_executor::XcmExecutor;
 
-use common_traits::{
-	CurrencyPair, CurrencyPrice, PoolInspect, PoolUpdateGuard, PreConditions, PriceValue,
-};
-use common_traits::{Permissions as PermissionsT, PoolNAV};
+use common_traits::Permissions as PermissionsT;
+use common_traits::{CurrencyPrice, PoolInspect, PoolUpdateGuard, PreConditions, PriceValue};
 pub use common_types::CurrencyId;
 use common_types::{
 	PermissionRoles, PermissionScope, PermissionedCurrencyRole, PoolId, PoolRole, Role,
@@ -945,7 +943,7 @@ impl CurrencyPrice<CurrencyId> for CurrencyPriceSource {
 
 	fn get_latest(
 		base: CurrencyId,
-		quote: Option<CurrencyId>,
+		_quote: Option<CurrencyId>,
 	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>> {
 		match base {
 			CurrencyId::Tranche(pool_id, tranche_id) => {


### PR DESCRIPTION
Implements a generic trait that return a price for a pair of two `CurrencyId`s. For tranche tokens specifically, we almost always want to get the price denominated in the pool currency, hence to simplify the API and not require clients to know the pool currency id, we make this optional.

This is a requirement for https://github.com/centrifuge/centrifuge-chain/pull/861

In the future, the trait can also be implemented for other currencies, for example referring to an oracle pallet to get stablecoin prices.