### PR TITLE
Update build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Initialize your Wasm Build environment:
 
 Build Wasm and native code:
 
+- Prerequisites : cmake,  libclang-dev
+
 ```bash
 cargo build --release
 ```


### PR DESCRIPTION
Would be nice to have this added to the Readme as the build fails unless `cmake`, `libclang-dev` are installed