### PR TITLE
At at-param to rpc calls

### DIFF
--- a/src/rpc/anchors.rs
+++ b/src/rpc/anchors.rs
@@ -1,6 +1,6 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
-use node_primitives::{BlockNumber, Hash};
+use node_primitives::BlockNumber;
 use pallet_anchors::AnchorData;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -12,10 +12,14 @@ use crate::rpc::invalid_params_error;
 pub use runtime_common::AnchorApi as AnchorRuntimeApi;
 
 #[rpc(client, server)]
-pub trait AnchorApi {
+pub trait AnchorApi<IdHash, BlockHash> {
 	/// Returns an anchor given an anchor id from the runtime storage
 	#[method(name = "anchor_getAnchorById")]
-	fn get_anchor_by_id(&self, id: Hash) -> RpcResult<AnchorData<Hash, BlockNumber>>;
+	fn get_anchor_by_id(
+		&self,
+		id: IdHash,
+		at: Option<BlockId<BlockHash>>,
+	) -> RpcResult<AnchorData<IdHash, BlockNumber>>;
 }
 
 /// A struct that implements the [`AnchorApi`].
@@ -38,12 +42,21 @@ impl<C, Block> AnchorApiServer for Anchors<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
-	C::Api: AnchorRuntimeApi<Block, Hash, BlockNumber>,
+	C::Api: AnchorRuntimeApi<Block, runtime_common::Hash, Block::Hash>,
 {
-	fn get_anchor_by_id(&self, id: Hash) -> RpcResult<AnchorData<Hash, BlockNumber>> {
+	fn get_anchor_by_id(
+		&self,
+		id: runtime_common::Hash,
+		at: Option<BlockId<Block::Hash>>,
+	) -> RpcResult<AnchorData<runtime_common::Hash, BlockNumber>> {
 		let api = self.client.runtime_api();
-		let best = self.client.info().best_hash;
-		let at = BlockId::hash(best);
+		let at = if let Some(block) = at {
+			block
+		} else {
+			let best = self.client.info().best_hash;
+			BlockId::hash(best);
+		};
+
 		api.get_anchor_by_id(&at, id)
 			.ok()
 			.unwrap()


### PR DESCRIPTION
This PR is a minor change. It adds the option to provide an "at" parameter, at which the state the runtime-api should be called. 

I have not tested, but the API should error-out with an "UnknownState", when the block is unknown to the node. Otherwise, we can also query the status before calling the API and return early.

Closes #877

## Tasks
- [x] Test return when calling at non-exisiting block