### PR TITLE
Enable wasm target in Rust toolchain in Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,6 +56,26 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1659610603,
+        "narHash": "sha256-LYgASYSPYo7O71WfeUOaEUzYfzuXm8c8eavJcel+pfI=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "c6a45e4277fa58abd524681466d3450f896dc094",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1658346836,
@@ -77,6 +97,7 @@
         "fenix": "fenix",
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
+        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,10 @@
       url = github:nix-community/fenix;
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    naersk = {
+      url = github:nmattia/naersk;
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs :
@@ -34,7 +38,7 @@
             file = ./rust-toolchain.toml;
             sha256 = "sha256-CNMj0ouNwwJ4zwgc/gAeTYyDYe0botMoaj/BkeDTy4M=";
           };
-          nightlyRustPlatform = pkgs.makeRustPlatform {
+          naersk' = pkgs.callPackage inputs.naersk {
             cargo = toolchain;
             rustc = toolchain;
           };
@@ -77,7 +81,7 @@
               && builtins.all (name: builtins.baseNameOf path != name) ignoreList;
         in
         rec {
-          defaultPackage = nightlyRustPlatform.buildRustPackage {
+          defaultPackage = naersk'.buildPackage {
             pname = name;
             inherit version;
 
@@ -102,6 +106,10 @@
 
             LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
             PROTOC = "${pkgs.protobuf}/bin/protoc";
+
+            # Either this or `singleStep = true` is needed to build.
+            # See https://github.com/nix-community/naersk/issues/133
+            copySources = ["runtime/development"];
 
             doCheck = false;
           };


### PR DESCRIPTION
This is an attempt at enabling wasm build when building with `nix build`.

It enables wasm target in Rust toolchain using [`fenix.fromTemplateFile`](https://github.com/nix-community/fenix#usage) to create the toolchain from `rust-toolchain.toml` and add supported targets.

This fixes `wasm32-unknown-unknown` target error when building without `SKIP_WASM_BUILD`, but the build fails: with a different error: https://github.com/mpontus/centrifuge-chain/runs/8018805277?check_suite_focus=true

It fails because cargo can't vendor crates from a git source if they reference creates from a parent directory, such 
cargo can't vendor crates from a git source if they reference crates from a parent directory, which appears to be the intended behavior: https://github.com/rust-lang/cargo/issues/8885#issuecomment-735938754
