### PR TITLE
Use our own primitive types in the service

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -39,7 +39,10 @@ pub mod types {
 	#[cfg(feature = "std")]
 	use serde::{Deserialize, Serialize};
 	use sp_core::{H160, U256};
-	use sp_runtime::traits::{BlakeTwo256, IdentifyAccount, Verify};
+	use sp_runtime::{
+		traits::{BlakeTwo256, IdentifyAccount, Verify},
+		OpaqueExtrinsic,
+	};
 	use sp_std::vec::Vec;
 
 	// Ensure that origin is either Root or fallback to use EnsureOrigin `O`
@@ -88,6 +91,11 @@ pub mod types {
 
 	/// A hash of some data used by the chain.
 	pub type Hash = sp_core::H256;
+
+	/// A generic block for the node to use, as we can not commit to
+	/// a specific Extrinsic format at this point. Runtimes will ensure
+	/// Extrinsic are correctly decoded.
+	pub type Block = sp_runtime::generic::Block<Header, OpaqueExtrinsic>;
 
 	/// Block header type as expected by this runtime.
 	pub type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;

--- a/src/service.rs
+++ b/src/service.rs
@@ -33,7 +33,7 @@ use cumulus_client_service::{
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface};
-use runtime_common::Hash;
+use runtime_common::{Block, Hash};
 use sc_client_api::ExecutorProvider;
 use sc_executor::NativeElseWasmExecutor;
 use sc_network::NetworkService;

--- a/src/service.rs
+++ b/src/service.rs
@@ -33,7 +33,7 @@ use cumulus_client_service::{
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface};
-use node_primitives::{Block, Hash};
+use runtime_common::Hash;
 use sc_client_api::ExecutorProvider;
 use sc_executor::NativeElseWasmExecutor;
 use sc_network::NetworkService;


### PR DESCRIPTION
Just want to be sure, we do not accidentally have changes in the core types of our client. Although, unlikely, wanted to have this in.