### PR TITLE
Adding templates for PRs and Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,14 +1,8 @@
 ### Which part of the code is the issue addressing?
 
-* [ ] Archicture 
-* [ ] Adressing a bug
+* [ ] Addressing a bug
 * [ ] Refactoring
-* [ ] pallet_xyz
-* [ ] pallet_xyz
-* [ ] Suggesting a new pallet
-* [ ] Runtime
-* [ ] Cross-Chain
-* [ ] Protocol
+* [ ] Feature
 
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,29 @@
+### Which part of the code is the issue addressing?
+
+* [ ] Archicture 
+* [ ] Adressing a bug
+* [ ] Refactoring
+* [ ] pallet_xyz
+* [ ] pallet_xyz
+* [ ] Suggesting a new pallet
+* [ ] Runtime
+* [ ] Cross-Chain
+* [ ] Protocol
+
+
+### Description
+
+[Description of the issue or feature]
+
+
+### Research/based on
+
+[Which codebases, pallets or designs did you base your design on]
+
+### How will this affect the code base
+
+[Does it improve readability, performance? Will it introduce new complexity?]
+
+### What are forseen obstacles or hurdles to overcome?
+
+[Are migrations needed, structural changes around testing etc?]

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,32 @@
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+# Checklist:
+
+- [ ] I have added Rust doc comments to structs, enums, traits and functions
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have performed a self-review of my code
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I rebased on the latest `parachain` branch

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -4,6 +4,16 @@ Please include a summary of the changes and the related issue. Please also inclu
 
 Fixes # (issue)
 
+## Changes and Descriptions
+
+### Example pools-pallet
+
+EXAMPLE change in the pools pallet EXAMPLE
+
+### Example integration-tests 
+
+EXAMPLE Updated the tests to fit the new pools pallet EXAMPLE
+
 ## Type of change
 
 Please delete options that are not relevant.


### PR DESCRIPTION
A first suggestion for using templates when opening new PRs or Issues. This is an attempt to remind developers to think about edge cases, thinking problems through, gathering feedback etc.

This shouldn't prevent PRs from being opened (quality gate), it is just so newcomers have an easier time contributing by having some guidelines, and to unify PR descriptions and issue descriptions.

Very happy to get feedback for adding/removing/rewording sections. That's just a first attempt!