### PR TITLE
Pallet-pools: replace Vec storage by BoundedVec

### DIFF
--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -238,7 +238,7 @@ impl PoolUpdateGuard for UpdateGuard {
 		PoolId,
 	>;
 	type ScheduledUpdateDetails =
-		ScheduledUpdateDetails<Rate, MaxTokenNameLength, MaxTokenSymbolLength>;
+		ScheduledUpdateDetails<Rate, MaxTokenNameLength, MaxTokenSymbolLength, MaxTranches>;
 
 	fn released(
 		_pool: &Self::PoolDetails,
@@ -307,7 +307,9 @@ impl pallet_interest_accrual::Config for MockRuntime {
 }
 
 parameter_types! {
+	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MaxTranches: u8 = 5;
+
 	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MinDelay: Moment = 0;
 

--- a/pallets/pools/src/benchmarking.rs
+++ b/pallets/pools/src/benchmarking.rs
@@ -425,8 +425,12 @@ fn get_pool<T: Config<PoolId = u64>>() -> PoolDetailsOf<T> {
 	Pallet::<T>::pool(T::PoolId::from(POOL)).unwrap()
 }
 
-fn get_scheduled_update<T: Config<PoolId = u64>>(
-) -> ScheduledUpdateDetails<T::InterestRate, T::MaxTokenNameLength, T::MaxTokenSymbolLength> {
+fn get_scheduled_update<T: Config<PoolId = u64>>() -> ScheduledUpdateDetails<
+	T::InterestRate,
+	T::MaxTokenNameLength,
+	T::MaxTokenSymbolLength,
+	T::MaxTranches,
+> {
 	Pallet::<T>::scheduled_update(T::PoolId::from(POOL)).unwrap()
 }
 
@@ -507,14 +511,18 @@ fn create_pool<T: Config<PoolId = u64, Balance = u128, CurrencyId = CurrencyId>>
 }
 
 fn build_update_tranche_metadata<T: Config>(
-) -> Vec<TrancheMetadata<T::MaxTokenNameLength, T::MaxTokenSymbolLength>> {
+) -> BoundedVec<TrancheMetadata<T::MaxTokenNameLength, T::MaxTokenSymbolLength>, T::MaxTranches> {
 	vec![TrancheMetadata {
 		token_name: BoundedVec::default(),
 		token_symbol: BoundedVec::default(),
 	}]
+	.try_into()
+	.expect("T::MaxTranches > 0")
 }
 
-fn build_update_tranches<T: Config>(num_tranches: u32) -> Vec<TrancheUpdate<T::InterestRate>> {
+fn build_update_tranches<T: Config>(
+	num_tranches: u32,
+) -> BoundedVec<TrancheUpdate<T::InterestRate>, T::MaxTranches> {
 	let mut tranches = build_bench_update_tranches::<T>(num_tranches);
 
 	for tranche in &mut tranches {
@@ -537,7 +545,7 @@ fn build_update_tranches<T: Config>(num_tranches: u32) -> Vec<TrancheUpdate<T::I
 
 fn build_bench_update_tranches<T: Config>(
 	num_tranches: u32,
-) -> Vec<TrancheUpdate<T::InterestRate>> {
+) -> BoundedVec<TrancheUpdate<T::InterestRate>, T::MaxTranches> {
 	let senior_interest_rate = T::InterestRate::saturating_from_rational(5, 100)
 		/ T::InterestRate::saturating_from_integer(SECS_PER_YEAR);
 	let mut tranches: Vec<_> = (1..num_tranches)
@@ -559,7 +567,7 @@ fn build_bench_update_tranches<T: Config>(
 		},
 	);
 
-	tranches
+	tranches.try_into().expect("num_tranches <= T::MaxTranches")
 }
 
 fn build_bench_input_tranches<T: Config>(

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -246,6 +246,20 @@ type EpochExecutionInfoOf<T> = EpochExecutionInfo<
 type PoolDepositOf<T> =
 	PoolDepositInfo<<T as frame_system::Config>::AccountId, <T as Config>::Balance>;
 
+type ScheduledUpdateDetailsOf<T> = ScheduledUpdateDetails<
+	<T as Config>::InterestRate,
+	<T as Config>::MaxTokenNameLength,
+	<T as Config>::MaxTokenSymbolLength,
+	<T as Config>::MaxTranches,
+>;
+
+type PoolChangesOf<T> = PoolChanges<
+	<T as Config>::InterestRate,
+	<T as Config>::MaxTokenNameLength,
+	<T as Config>::MaxTokenSymbolLength,
+	<T as Config>::MaxTranches,
+>;
+
 #[frame_support::pallet]
 pub mod pallet {
 	use cfg_traits::PoolUpdateGuard;
@@ -329,12 +343,7 @@ pub mod pallet {
 
 		type UpdateGuard: PoolUpdateGuard<
 			PoolDetails = PoolDetailsOf<Self>,
-			ScheduledUpdateDetails = ScheduledUpdateDetails<
-				Self::InterestRate,
-				Self::MaxTokenNameLength,
-				Self::MaxTokenSymbolLength,
-				Self::MaxTranches,
-			>,
+			ScheduledUpdateDetails = ScheduledUpdateDetailsOf<Self>,
 			Moment = Moment,
 		>;
 
@@ -789,12 +798,7 @@ pub mod pallet {
 		pub fn update(
 			origin: OriginFor<T>,
 			pool_id: T::PoolId,
-			changes: PoolChanges<
-				T::InterestRate,
-				T::MaxTokenNameLength,
-				T::MaxTokenSymbolLength,
-				T::MaxTranches,
-			>,
+			changes: PoolChangesOf<T>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			ensure!(
@@ -1619,12 +1623,7 @@ pub mod pallet {
 
 		pub(crate) fn do_update_pool(
 			pool_id: &T::PoolId,
-			changes: &PoolChanges<
-				T::InterestRate,
-				T::MaxTokenNameLength,
-				T::MaxTokenSymbolLength,
-				T::MaxTranches,
-			>,
+			changes: &PoolChangesOf<T>,
 		) -> DispatchResult {
 			Pool::<T>::try_mutate(pool_id, |pool| -> DispatchResult {
 				let pool = pool.as_mut().ok_or(Error::<T>::NoSuchPool)?;

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -289,6 +289,8 @@ where
 
 parameter_types! {
 	pub const PoolPalletId: frame_support::PalletId = cfg_types::ids::POOLS_PALLET_ID;
+
+	#[derive(scale_info::TypeInfo, Eq, PartialEq, Debug, Clone, Copy )]
 	pub const MaxTranches: u32 = 5;
 
 	pub const MinUpdateDelay: u64 = 0; // no delay
@@ -369,7 +371,7 @@ impl PoolUpdateGuard for UpdateGuard {
 	type PoolDetails =
 		PoolDetails<CurrencyId, u32, Balance, Rate, MaxSizeMetadata, TrancheWeight, TrancheId, u64>;
 	type ScheduledUpdateDetails =
-		ScheduledUpdateDetails<Rate, MaxTokenNameLength, MaxTokenSymbolLength>;
+		ScheduledUpdateDetails<Rate, MaxTokenNameLength, MaxTokenSymbolLength, MaxTranches>;
 
 	fn released(
 		pool: &Self::PoolDetails,

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -810,6 +810,7 @@ impl pallet_collator_selection::Config for Runtime {
 }
 
 parameter_types! {
+	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MaxTranches: u32 = 5;
 
 	// How much time should lapse before a tranche investor can be removed
@@ -1123,7 +1124,7 @@ impl PoolUpdateGuard for UpdateGuard {
 		PoolId,
 	>;
 	type ScheduledUpdateDetails =
-		ScheduledUpdateDetails<Rate, MaxTokenNameLength, MaxTokenSymbolLength>;
+		ScheduledUpdateDetails<Rate, MaxTokenNameLength, MaxTokenSymbolLength, MaxTranches>;
 
 	fn released(
 		pool: &Self::PoolDetails,

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -920,7 +920,7 @@ impl PoolUpdateGuard for UpdateGuard {
 		PoolId,
 	>;
 	type ScheduledUpdateDetails =
-		ScheduledUpdateDetails<Rate, MaxTokenNameLength, MaxTokenSymbolLength>;
+		ScheduledUpdateDetails<Rate, MaxTokenNameLength, MaxTokenSymbolLength, MaxTranches>;
 
 	fn released(
 		pool: &Self::PoolDetails,
@@ -1130,6 +1130,7 @@ impl pallet_loans::Config for Runtime {
 }
 
 parameter_types! {
+	#[derive(Debug, Eq, PartialEq, scale_info::TypeInfo, Clone)]
 	pub const MaxTranches: u32 = 5;
 
 	// How much time should lapse before a tranche investor can be removed


### PR DESCRIPTION
# Description

Replace `Vec` storage with `BoundedVec` in `pallet-pools` to be prepared for [Weights V2](https://github.com/paritytech/substrate/pull/10918)

Related to: #897

## Changes and Descriptions

Modify `Vec` types found in the `pallet-pools` storages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue). In this case, a future issue.

# How Has This Been Tested?

```sh
cargo test -p pallet-pools
cargo test --workspace --release --features test-benchmarks,try-runtime
cargo run --features runtime-benchmarks benchmark pallet --pallet="pallet-pools" --chain="altair-dev" --extrinsic="*"
```

# Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `parachain` branch
