### PR TITLE
Pallet-anchors: replace Vec storage by BoundedVec

### DIFF
--- a/pallets/anchors/src/tests.rs
+++ b/pallets/anchors/src/tests.rs
@@ -562,7 +562,11 @@ fn anchor_evict_single_anchor_per_day_many_days() {
 				Anchors::get_anchor_id_by_index((day - 1) as u64).unwrap_or_default(),
 				H256([0; 32])
 			);
-			assert!(Anchors::get_evicted_anchor_root_by_day((day - 1) as u32).unwrap() != [0; 32]);
+			assert!(
+				Anchors::get_evicted_anchor_root_by_day((day - 1) as u32)
+					.unwrap()
+					.to_vec() != [0; 32]
+			);
 			assert_eq!(
 				Anchors::get_anchor_evict_date(anchors[day - 2]).unwrap_or_default(),
 				0
@@ -649,7 +653,11 @@ fn anchor_evict_single_anchor_per_day_many_days() {
 		// verify anchor data has been removed until 520th anchor
 		for i in (2 + FIRST_ONES) as usize..(2 + FIRST_ONES + MAX_LOOP_IN_TX) as usize {
 			assert!(Anchors::get_anchor_by_id(anchors[i as usize - 2]).is_none());
-			assert!(Anchors::get_evicted_anchor_root_by_day(i as u32).unwrap() != [0; 32]);
+			assert!(
+				Anchors::get_evicted_anchor_root_by_day(i as u32)
+					.unwrap()
+					.to_vec() != [0; 32]
+			);
 		}
 
 		assert!(


### PR DESCRIPTION
# Description

Replace `Vec` storage with `BoundedVec` in `pallet-anchors` to be prepared for [Weights V2](https://github.com/paritytech/substrate/pull/10918)

Related to: #897

## Changes and Descriptions

Modify `Vec` types found in the `pallet-anchors` storages.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue). In this case, a future issue.

# How Has This Been Tested?

```sh
cargo test -p pallet-anchors
cargo test --workspace --release --features test-benchmarks,try-runtime
cargo run --features runtime-benchmarks benchmark pallet --pallet="pallet-anchors" --chain="altair-dev" --extrinsic="*"
```

# Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `parachain` branch

