### PR TITLE
pallet-nft using pallet-fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5761,16 +5761,9 @@ name = "pallet-bridge-mapping"
 version = "2.0.0"
 dependencies = [
  "cfg-primitives",
- "cfg-traits",
- "cfg-types",
- "chainbridge",
  "frame-support",
  "frame-system",
- "pallet-anchors",
- "pallet-authorship",
- "pallet-balances",
  "pallet-nft",
- "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5763,7 +5763,6 @@ dependencies = [
  "cfg-primitives",
  "frame-support",
  "frame-system",
- "pallet-nft",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
             };
 
             # This is a hash of all the Cargo dependencies, for reproducibility.
-            cargoSha256 = "sha256-q3gwCT8dCrkMshGhHnMDPjuYXjbZJbyJwcnCaRElcIU=";
+            cargoSha256 = "sha256-LZFbnX7XvPMa/nNdIZfm/6SdGwCgPMexjVirPuYjeQ4=";
 
             nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
             buildInputs = with pkgs; [ openssl ] ++ (

--- a/libs/primitives/src/lib.rs
+++ b/libs/primitives/src/lib.rs
@@ -218,9 +218,6 @@ pub mod constants {
 	/// Value for a not specified fee key.
 	pub const DEFAULT_FEE_VALUE: Balance = 1 * CFG;
 
-	/// Additional fee charged when validating NFT proofs
-	pub const NFT_PROOF_VALIDATION_FEE: Balance = 10 * CFG;
-
 	/// % of fee addressed to the Treasury. The reminder % will be for the block author.
 	pub const TREASURY_FEE_RATIO: Perbill = Perbill::from_percent(80);
 

--- a/pallets/bridge-mapping/Cargo.toml
+++ b/pallets/bridge-mapping/Cargo.toml
@@ -13,25 +13,15 @@ targets = ['x86_64-unknown-linux-gnu']
 [dependencies]
 codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.26" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.26" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.26" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
 pallet-nft = { path = "../nft", default-features = false }
 
 [dev-dependencies]
-chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = true, branch = "polkadot-v0.9.26" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.26" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.26" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.26" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.26" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.26" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.26" }
-pallet-anchors = { path = "../anchors", default-features = true }
-cfg-types = { path = "../../libs/types", default-features = true}
-cfg-traits = { path = "../../libs/traits", default-features = true }
-cfg-primitives = { path = "../../libs/primitives", default-features = true}
-
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26" }
+cfg-primitives = { path = "../../libs/primitives" }
 
 [features]
 default = ['std']

--- a/pallets/bridge-mapping/Cargo.toml
+++ b/pallets/bridge-mapping/Cargo.toml
@@ -16,7 +16,6 @@ scale-info = { version = "2.0", default-features = false, features = ["derive"] 
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
-pallet-nft = { path = "../nft", default-features = false }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26" }
@@ -31,6 +30,5 @@ std = [
     'frame-support/std',
     'frame-system/std',
     'sp-runtime/std',
-    'pallet-nft/std',
 ]
 

--- a/pallets/bridge-mapping/src/lib.rs
+++ b/pallets/bridge-mapping/src/lib.rs
@@ -36,6 +36,7 @@ mod mock;
 mod tests;
 
 pub mod weights;
+use pallet_nft::ResourceId;
 pub use weights::*;
 
 #[frame_support::pallet]
@@ -95,14 +96,14 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn addr_of)]
 	pub(super) type ResourceToAddress<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::ResourceId, T::Address>;
+		StorageMap<_, Blake2_128Concat, ResourceId, T::Address>;
 
 	/// Maps a chain-specific address to a resource id. A mapping in [ResourceToAddress] will
 	/// always correspond to a mapping here. Resources and addresses are 1 to 1.
 	#[pallet::storage]
 	#[pallet::getter(fn name_of)]
 	pub(super) type AddressToResource<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::Address, T::ResourceId>;
+		StorageMap<_, Blake2_128Concat, T::Address, ResourceId>;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
@@ -111,7 +112,7 @@ pub mod pallet {
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::set())]
 		pub fn set(
 			origin: OriginFor<T>,
-			rid: T::ResourceId,
+			rid: ResourceId,
 			local_addr: T::Address,
 		) -> DispatchResult {
 			Self::ensure_admin_or_root(origin)?;
@@ -122,7 +123,7 @@ pub mod pallet {
 		}
 
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::remove())]
-		pub fn remove(origin: OriginFor<T>, rid: T::ResourceId) -> DispatchResult {
+		pub fn remove(origin: OriginFor<T>, rid: ResourceId) -> DispatchResult {
 			Self::ensure_admin_or_root(origin)?;
 
 			// Call internal
@@ -141,14 +142,14 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Add a new resource mapping in [Names]. Existing entries will be overwritten.
-	pub fn set_resource(rid: T::ResourceId, local_addr: T::Address) {
+	pub fn set_resource(rid: ResourceId, local_addr: T::Address) {
 		// Add the mapping both ways
 		<ResourceToAddress<T>>::insert(rid.clone(), local_addr.clone());
 		<AddressToResource<T>>::insert(local_addr, rid);
 	}
 
 	/// Remove a resource mapping in [Names].
-	pub fn remove_resource(rid: &T::ResourceId) {
+	pub fn remove_resource(rid: &ResourceId) {
 		// If it doesn't exist for some unexpected reason, still allow removal by setting default
 		let address = <ResourceToAddress<T>>::get(rid).unwrap_or_default();
 		// Remove the resource mapping both ways

--- a/pallets/bridge-mapping/src/lib.rs
+++ b/pallets/bridge-mapping/src/lib.rs
@@ -55,7 +55,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config + pallet_nft::Config {
+	pub trait Config: frame_system::Config {
 		/// A local mapping of a resource id.
 		///
 		/// This associated type represents anything that a resource id might map to.

--- a/pallets/bridge-mapping/src/mock.rs
+++ b/pallets/bridge-mapping/src/mock.rs
@@ -30,7 +30,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-use crate::{self as pallet_bridge_mapping, Config as PalletBridgeMappingConfig};
+use crate::{self as pallet_bridge_mapping};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -127,7 +127,6 @@ impl pallet_timestamp::Config for Test {
 
 // Parameterize NFT pallet
 parameter_types! {
-	pub const NftProofValidationFee: u128 = 100;
 	pub MockHashId: ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"hash"));
 }
 
@@ -136,8 +135,7 @@ impl pallet_nft::Config for Test {
 	type ChainId = ChainId;
 	type Event = Event;
 	type HashId = MockHashId;
-	type NftProofValidationFee = NftProofValidationFee;
-	type ResourceId = ResourceId;
+	type NftProofValidationFeeKey = ();
 	type WeightInfo = ();
 }
 
@@ -177,7 +175,7 @@ impl chainbridge::Config for Test {
 }
 
 // Implement Centrifuge Chain bridge mapping pallet configuration trait for the mock runtime
-impl PalletBridgeMappingConfig for Test {
+impl pallet_bridge_mapping::Config for Test {
 	type Address = EthAddress;
 	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type WeightInfo = ();

--- a/pallets/bridge-mapping/src/mock.rs
+++ b/pallets/bridge-mapping/src/mock.rs
@@ -11,20 +11,10 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_primitives::{Balance, EthAddress};
-use cfg_traits::fees::NoFees;
-use chainbridge::{
-	constants::DEFAULT_RELAYER_VOTE_THRESHOLD,
-	types::{ChainId, ResourceId},
-};
-use frame_support::{
-	parameter_types,
-	traits::{Everything, FindAuthor, SortedMembers},
-	ConsensusEngineId, PalletId,
-};
+use cfg_primitives::EthAddress;
+use frame_support::traits::{ConstU32, ConstU64, Everything};
 use frame_system as system;
-use frame_system::EnsureSignedBy;
-use sp_core::{blake2_128, H256};
+use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -35,7 +25,6 @@ use crate::{self as pallet_bridge_mapping};
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
-// For testing the pallet, we construct a mock runtime.
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
@@ -43,25 +32,15 @@ frame_support::construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-		Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Anchors: pallet_anchors::{Pallet, Call, Storage} = 5,
-		ChainBridge: chainbridge::{Pallet, Call, Storage, Event<T>} = 6,
-		Nft: pallet_nft::{Pallet, Call, Storage, Event<T>} = 7,
 		BridgeMapping: pallet_bridge_mapping::{Pallet, Call, Config, Storage} = 8,
 	}
 );
 
-parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-}
-
 impl system::Config for Test {
-	type AccountData = pallet_balances::AccountData<Balance>;
+	type AccountData = ();
 	type AccountId = u64;
 	type BaseCallFilter = Everything;
-	type BlockHashCount = BlockHashCount;
+	type BlockHashCount = ConstU64<250>;
 	type BlockLength = ();
 	type BlockNumber = u64;
 	type BlockWeights = ();
@@ -73,7 +52,7 @@ impl system::Config for Test {
 	type Header = Header;
 	type Index = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = ConstU32<16>;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();
 	type OnSetCode = ();
@@ -84,104 +63,12 @@ impl system::Config for Test {
 	type Version = ();
 }
 
-parameter_types! {
-	pub const ExistentialDeposit: u64 = 1;
-}
-
-impl pallet_balances::Config for Test {
-	type AccountStore = System;
-	type Balance = Balance;
-	type DustRemoval = ();
-	type Event = Event;
-	type ExistentialDeposit = ExistentialDeposit;
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type ReserveIdentifier = ();
-	type WeightInfo = ();
-}
-
-pub struct AuthorGiven;
-
-impl FindAuthor<u64> for AuthorGiven {
-	fn find_author<'a, I>(_digests: I) -> Option<u64>
-	where
-		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
-	{
-		Some(100)
-	}
-}
-
-impl pallet_authorship::Config for Test {
-	type EventHandler = ();
-	type FilterUncle = ();
-	type FindAuthor = AuthorGiven;
-	type UncleGenerations = ();
-}
-
-impl pallet_timestamp::Config for Test {
-	type MinimumPeriod = ();
-	type Moment = u64;
-	type OnTimestampSet = ();
-	type WeightInfo = ();
-}
-
-// Parameterize NFT pallet
-parameter_types! {
-	pub MockHashId: ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"hash"));
-}
-
-// Implement NFT pallet's configuration trait for the mock runtime
-impl pallet_nft::Config for Test {
-	type ChainId = ChainId;
-	type Event = Event;
-	type HashId = MockHashId;
-	type NftProofValidationFeeKey = ();
-	type WeightInfo = ();
-}
-
-impl pallet_anchors::Config for Test {
-	type CommitAnchorFeeKey = ();
-	type Currency = Balances;
-	type Fees = NoFees<Self::AccountId, Balance>;
-	type PreCommitDepositFeeKey = ();
-	type WeightInfo = ();
-}
-
-// Parameterize Centrifuge Chain chainbridge pallet
-parameter_types! {
-	pub const One: u64 = 1;
-	pub const MockChainId: u8 = 5;
-	pub const ChainBridgePalletId: PalletId = cfg_types::ids::CHAIN_BRIDGE_PALLET_ID;
-	pub const ProposalLifetime: u64 = 10;
-	pub const RelayerVoteThreshold: u32 = DEFAULT_RELAYER_VOTE_THRESHOLD;
-}
-
-impl SortedMembers<u64> for One {
-	fn sorted_members() -> Vec<u64> {
-		vec![1]
-	}
-}
-
-// Implement Centrifuge Chain chainbridge pallet configuration trait for the mock runtime
-impl chainbridge::Config for Test {
-	type AdminOrigin = EnsureSignedBy<One, u64>;
-	type ChainId = MockChainId;
-	type Event = Event;
-	type PalletId = ChainBridgePalletId;
-	type Proposal = Call;
-	type ProposalLifetime = ProposalLifetime;
-	type RelayerVoteThreshold = RelayerVoteThreshold;
-	type WeightInfo = ();
-}
-
-// Implement Centrifuge Chain bridge mapping pallet configuration trait for the mock runtime
 impl pallet_bridge_mapping::Config for Test {
 	type Address = EthAddress;
 	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type WeightInfo = ();
 }
 
-// Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	system::GenesisConfig::default()
 		.build_storage::<Test>()

--- a/pallets/bridge-mapping/src/mock.rs
+++ b/pallets/bridge-mapping/src/mock.rs
@@ -66,6 +66,7 @@ impl system::Config for Test {
 impl pallet_bridge_mapping::Config for Test {
 	type Address = EthAddress;
 	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type ResourceId = [u8; 32];
 	type WeightInfo = ();
 }
 

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -15,69 +15,6 @@
 //!
 //! This creates an NFT-like pallet by implementing the `Unique`, `Mintable`,
 //! and `Burnable` traits of the `unique_assets` module.
-//!
-//! - [`Config`]
-//! - [`Call`]
-//! - [`Pallet`]
-//!
-//! ## Overview
-//! Other modules in this runtime can access the interface provided
-//! by this module to define user-facing logic to interact with the
-//! runtime NFTs.
-//!
-//! ## Terminology
-//!
-//! ## Usage
-//!
-//! ## Interface
-//!
-//! ### Supported Origins
-//!
-//! Signed origin is valid.
-//!
-//! ### Types
-//!
-//! `AssetInfo` - The data type that is used to describe this type of asset.
-//! `Event` - Associated type for Event enum.
-//! `WeightInfo` - Weight information for extrinsics in this pallet.
-//!
-//! ### Events
-//!
-//! <code>\`Transferred\`</code> Event triggered when the ownership of the asset has been transferred to the account.
-//!
-//! ### Errors
-//! `AssetExists\` - Thrown when there is an attempt to mint a duplicate asset.
-//! `NonexistentAsset\` - Thrown when there is an attempt to transfer a nonexistent asset.
-//! `NotAssetOwner\` - Thrown when someone who is not the owner of a asset attempts to transfer or burn it.
-//! `DocumentNotAnchored` - A given document id does not match a corresponding document in the anchor storage.
-//!
-//! ### Dispatchable Functions
-//!
-//! Callable functions (or extrinsics), also considered as transactions, materialize the
-//! pallet contract. Here's the callable functions implemented in this module:
-//!
-//! [`transfer`] - Transfer NFT
-//! [`validate_mint`] - Validate NFT proofs
-//!
-//! ### Public Functions
-//!
-//! ## Genesis Configuration
-//! The pallet is parameterized and configured via [parameter_types] macro, at the time the runtime is built
-//! by means of the [`construct_runtime`] macro.
-//!
-//! ## Related Pallets
-//! This pallet is tightly coupled to the following pallets:
-//! - Substrate FRAME's [`balances` pallet](https://github.com/paritytech/substrate/tree/master/frame/balances).
-//! - Centrifuge Chain [`bridge` pallet](https://github.com/centrifuge/centrifuge-chain/tree/master/pallets/bridge).
-//!
-//! ## References
-//! - [Substrate FRAME v2 attribute macros](https://crates.parity.io/frame_support/attr.pallet.html).
-//!
-//! ## Credits
-//! The Centrifugians Tribe <tribe@centrifuge.io>
-//!
-//! ## License
-//! GNU General Public License, Version 3, 29 June 2007 <https://www.gnu.org/licenses/gpl-3.0.html>
 
 // Ensure we're `no_std` when compiling for WebAssembly.
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -103,9 +40,8 @@ mod weights;
 // Export crate types and traits
 use cfg_primitives::types::FixedArray;
 use cfg_traits::fees::{Fee, Fees};
-use chainbridge::types::ResourceId;
+pub use chainbridge::types::ResourceId;
 use codec::FullCodec;
-// Re-export pallet components in crate namespace (for runtime construction)
 pub use pallet::*;
 use proofs::{hashing::bundled_hash_from_proofs, DepositAddress, Proof, Verifier};
 use sp_core::H256;
@@ -130,7 +66,6 @@ pub mod pallet {
 
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use sp_runtime::SaturatedConversion;
 
 	use super::*;
 
@@ -166,29 +101,16 @@ pub mod pallet {
 		/// Chain identifier type
 		type ChainId: Parameter + Member + Debug + Default + FullCodec + Into<u8> + From<u8>;
 
-		/// In order to provide generality, we need some way to associate some action on a source chain
-		/// to some action on a destination chain. This may express tokenX on chain A is equivalent to
-		/// tokenY on chain B, or to simply associate that some action performed on chain A should
-		/// result in some other action occurring on chain B. ResourceId is defined as a 32 byte array
-		/// by ChainSafe.
-		type ResourceId: Member
-			+ Default
-			+ FullCodec
-			+ Into<[u8; 32]>
-			+ From<[u8; 32]>
-			+ MaybeSerializeDeserialize
-			+ TypeInfo;
-
 		/// Resource hash id.
 		///
 		/// This type was initially declared in the bridge pallet but was moved here
 		/// to avoid circular dependencies.
 		#[pallet::constant]
-		type HashId: Get<Self::ResourceId>;
+		type HashId: Get<ResourceId>;
 
 		/// Additional fee charged for validating NFT proof (when minting a NFT).
 		#[pallet::constant]
-		type NftProofValidationFee: Get<u128>;
+		type NftProofValidationFeeKey: Get<<Self::Fees as Fees>::FeeKey>;
 
 		/// Weight information for extrinsics in this pallet
 		type WeightInfo: WeightInfo;
@@ -266,15 +188,12 @@ pub mod pallet {
 
 			// Returns a Ethereum-compatible Keccak hash of deposit_address + hash(keccak(name+value+salt)) of each proof provided.
 			let bundled_hash = Self::get_bundled_hash_from_proofs(proofs, deposit_address);
-			Self::deposit_event(Event::<T>::DepositAsset(bundled_hash));
+			Self::deposit_event(Event::<T>::DepositAsset(bundled_hash)); //
 
 			let metadata = bundled_hash.as_ref().to_vec();
 
 			// Burn additional fees from the calling account
-			T::Fees::fee_to_burn(
-				&who,
-				Fee::Balance(T::NftProofValidationFee::get().saturated_into()),
-			)?;
+			T::Fees::fee_to_burn(&who, Fee::Key(T::NftProofValidationFeeKey::get()))?;
 
 			let resource_id: ResourceId = T::HashId::get().into();
 			<chainbridge::Pallet<T>>::transfer_generic(dest_id.into(), resource_id, metadata)?;

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -40,7 +40,7 @@ mod weights;
 // Export crate types and traits
 use cfg_primitives::types::FixedArray;
 use cfg_traits::fees::{Fee, Fees};
-pub use chainbridge::types::ResourceId;
+use chainbridge::types::ResourceId;
 use codec::FullCodec;
 pub use pallet::*;
 use proofs::{hashing::bundled_hash_from_proofs, DepositAddress, Proof, Verifier};

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -106,7 +106,7 @@ pub mod pallet {
 		/// This type was initially declared in the bridge pallet but was moved here
 		/// to avoid circular dependencies.
 		#[pallet::constant]
-		type HashId: Get<ResourceId>;
+		type ResourceHashId: Get<ResourceId>;
 
 		/// Additional fee charged for validating NFT proof (when minting a NFT).
 		#[pallet::constant]
@@ -188,14 +188,14 @@ pub mod pallet {
 
 			// Returns a Ethereum-compatible Keccak hash of deposit_address + hash(keccak(name+value+salt)) of each proof provided.
 			let bundled_hash = Self::get_bundled_hash_from_proofs(proofs, deposit_address);
-			Self::deposit_event(Event::<T>::DepositAsset(bundled_hash)); //
+			Self::deposit_event(Event::<T>::DepositAsset(bundled_hash));
 
 			let metadata = bundled_hash.as_ref().to_vec();
 
 			// Burn additional fees from the calling account
 			T::Fees::fee_to_burn(&who, Fee::Key(T::NftProofValidationFeeKey::get()))?;
 
-			let resource_id: ResourceId = T::HashId::get().into();
+			let resource_id: ResourceId = T::ResourceHashId::get().into();
 			<chainbridge::Pallet<T>>::transfer_generic(dest_id.into(), resource_id, metadata)?;
 
 			Ok(().into())

--- a/pallets/nft/src/mock.rs
+++ b/pallets/nft/src/mock.rs
@@ -20,7 +20,7 @@
 // Module imports and re-exports
 // ----------------------------------------------------------------------------
 
-use cfg_primitives::{Balance, CFG, NFT_PROOF_VALIDATION_FEE};
+use cfg_primitives::{Balance, CFG};
 use cfg_traits::{fees::test_util::MockFees, impl_mock_fees_state};
 use chainbridge::{
 	constants::DEFAULT_RELAYER_VOTE_THRESHOLD,
@@ -68,6 +68,9 @@ pub(crate) const USER_B: u64 = 0x2;
 
 // Initial balance for user A
 pub(crate) const USER_A_INITIAL_BALANCE: Balance = 100 * CFG;
+
+/// Additional fee charged when validating NFT proofs
+pub(crate) const NFT_PROOF_VALIDATION_FEE: Balance = 10 * CFG;
 
 // ----------------------------------------------------------------------------
 // Mock runtime configuration
@@ -205,7 +208,7 @@ impl_mock_fees_state!(
 	<MockRuntime as frame_system::Config>::AccountId,
 	Balance,
 	(),
-	|_key| 0
+	|_key| NFT_PROOF_VALIDATION_FEE
 );
 
 impl pallet_anchors::Config for MockRuntime {
@@ -218,7 +221,6 @@ impl pallet_anchors::Config for MockRuntime {
 
 // Parameterize NFT pallet
 parameter_types! {
-	pub const NftProofValidationFee: u128 = NFT_PROOF_VALIDATION_FEE;
 	pub MockHashId: ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"hash"));
 }
 
@@ -227,8 +229,7 @@ impl PalletNftConfig for MockRuntime {
 	type ChainId = ChainId;
 	type Event = Event;
 	type HashId = MockHashId;
-	type NftProofValidationFee = NftProofValidationFee;
-	type ResourceId = ResourceId;
+	type NftProofValidationFeeKey = ();
 	type WeightInfo = MockWeightInfo;
 }
 

--- a/pallets/nft/src/mock.rs
+++ b/pallets/nft/src/mock.rs
@@ -221,15 +221,15 @@ impl pallet_anchors::Config for MockRuntime {
 
 // Parameterize NFT pallet
 parameter_types! {
-	pub MockHashId: ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"hash"));
+	pub MockResourceHashId: ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"hash"));
 }
 
 // Implement NFT pallet's configuration trait for the mock runtime
 impl PalletNftConfig for MockRuntime {
 	type ChainId = ChainId;
 	type Event = Event;
-	type HashId = MockHashId;
 	type NftProofValidationFeeKey = ();
+	type ResourceHashId = MockResourceHashId;
 	type WeightInfo = MockWeightInfo;
 }
 

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -17,7 +17,7 @@
 // Module imports and re-exports
 // ----------------------------------------------------------------------------
 
-use cfg_primitives::{MILLISECS_PER_DAY, NFT_PROOF_VALIDATION_FEE};
+use cfg_primitives::MILLISECS_PER_DAY;
 use codec::Encode;
 use frame_support::{assert_err, assert_ok};
 use sp_runtime::traits::{BadOrigin, Hash};

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -866,15 +866,14 @@ impl pallet_collator_allowlist::Config for Runtime {
 
 parameter_types! {
 	pub HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(&cfg_types::ids::CHAIN_BRIDGE_HASH_ID));
-	pub const NftProofValidationFee: u128 = NFT_PROOF_VALIDATION_FEE;
+	pub const NftProofValidationFeeKey: FeeKey = FeeKey::NftProofValidation;
 }
 
 impl pallet_nft::Config for Runtime {
 	type ChainId = chainbridge::ChainId;
 	type Event = Event;
 	type HashId = HashId;
-	type NftProofValidationFee = NftProofValidationFee;
-	type ResourceId = chainbridge::ResourceId;
+	type NftProofValidationFeeKey = NftProofValidationFeeKey;
 	type WeightInfo = ();
 }
 

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -865,15 +865,15 @@ impl pallet_collator_allowlist::Config for Runtime {
 }
 
 parameter_types! {
-	pub HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(&cfg_types::ids::CHAIN_BRIDGE_HASH_ID));
+	pub ResourceHashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(&cfg_types::ids::CHAIN_BRIDGE_HASH_ID));
 	pub const NftProofValidationFeeKey: FeeKey = FeeKey::NftProofValidation;
 }
 
 impl pallet_nft::Config for Runtime {
 	type ChainId = chainbridge::ChainId;
 	type Event = Event;
-	type HashId = HashId;
 	type NftProofValidationFeeKey = NftProofValidationFeeKey;
+	type ResourceHashId = ResourceHashId;
 	type WeightInfo = ();
 }
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1342,15 +1342,14 @@ impl chainbridge::Config for Runtime {
 
 parameter_types! {
 	pub HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(&cfg_types::ids::CHAIN_BRIDGE_HASH_ID));
-	pub const NftProofValidationFee: u128 = NFT_PROOF_VALIDATION_FEE;
+	pub const NftProofValidationFeeKey: FeeKey = FeeKey::NftProofValidation;
 }
 
 impl pallet_nft::Config for Runtime {
 	type ChainId = chainbridge::ChainId;
 	type Event = Event;
 	type HashId = HashId;
-	type NftProofValidationFee = NftProofValidationFee;
-	type ResourceId = chainbridge::ResourceId;
+	type NftProofValidationFeeKey = NftProofValidationFeeKey;
 	type WeightInfo = ();
 }
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1341,15 +1341,15 @@ impl chainbridge::Config for Runtime {
 }
 
 parameter_types! {
-	pub HashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(&cfg_types::ids::CHAIN_BRIDGE_HASH_ID));
+	pub ResourceHashId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(&cfg_types::ids::CHAIN_BRIDGE_HASH_ID));
 	pub const NftProofValidationFeeKey: FeeKey = FeeKey::NftProofValidation;
 }
 
 impl pallet_nft::Config for Runtime {
 	type ChainId = chainbridge::ChainId;
 	type Event = Event;
-	type HashId = HashId;
 	type NftProofValidationFeeKey = NftProofValidationFeeKey;
+	type ResourceHashId = ResourceHashId;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
# Description

Adapt `pallet-nft` in order to use `pallet-fees`.

Fixes #959

## Changes and Descriptions

- `pallet-nft` no longer uses its own mechanism to configure and pay fees.
- `pallet-bridge-mapping` no longer needs `pallet-nft` as dependency.
- `pallet-bridge-mapping` mock simplified.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
```sh
cargo test -p pallet-nft
cargo test -p pallet-bridge-mapping
cargo test --workspace --release --features test-benchmarks,try-runtime
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation:
  - *Should we notify somehow the new way of configuring fees for this pallet?*
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `parachain` branch
