### PR TITLE
Bump srtool build to Rust 1.62

### DIFF
--- a/.github/workflows/build-matrix.json
+++ b/.github/workflows/build-matrix.json
@@ -11,7 +11,7 @@
     "target": "build-runtime",
     "package": "altair-runtime",
     "run_on_event": "push",
-    "rust_toolchain": "1.60.0"
+    "rust_toolchain": "1.62.0"
   },
 
   {
@@ -19,6 +19,6 @@
     "target": "build-runtime",
     "package": "centrifuge-runtime",
     "run_on_event": "push",
-    "rust_toolchain": "1.60.0"
+    "rust_toolchain": "1.62.0"
   }
 ]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,7 +3,7 @@
 set -eux
 
 RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-nightly-2022-05-09}"
-SRTOOL_VERSION="${SRTOOL_VERSION:-1.60.0}"
+SRTOOL_VERSION="${SRTOOL_VERSION:-1.62.0}"
 PACKAGE="${PACKAGE:-centrifuge-runtime}" # Need to replicate job for all runtimes
 
 # Enable warnings about unused extern crates


### PR DESCRIPTION
At this point one of Parity's libraries requires 1.62, so we can't stay on 1.60 any longer.