### PR TITLE
Pallet-loans: replace Vec storage by BoundedVec

### DIFF
--- a/pallets/loans/src/functions.rs
+++ b/pallets/loans/src/functions.rs
@@ -631,21 +631,13 @@ impl<T: Config> Pallet<T> {
 			Error::<T>::InvalidWriteOffGroup
 		);
 
-		// ensure we have not exceeded the max number of write off groups
-		let number_of_write_off_groups = PoolWriteOffGroups::<T>::get(pool_id).len();
-		ensure!(
-			number_of_write_off_groups < T::MaxWriteOffGroups::get() as usize,
-			Error::<T>::TooManyWriteOffGroups
-		);
-
 		// append new group
-		let index = PoolWriteOffGroups::<T>::mutate(pool_id, |write_off_groups| -> u32 {
-			write_off_groups.push(group);
-			// return the index of the latest write off group
-			(write_off_groups.len() - 1) as u32
-		});
-
-		Ok(index)
+		PoolWriteOffGroups::<T>::mutate(pool_id, |write_off_groups| {
+			write_off_groups
+				.try_push(group)
+				.map(|_| (write_off_groups.len() - 1) as u32)
+				.map_err(|_| Error::<T>::TooManyWriteOffGroups.into())
+		})
 	}
 
 	/// writes off a given unhealthy loan

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -47,7 +47,7 @@ use sp_runtime::{
 	traits::{AccountIdConversion, AtLeast32BitUnsigned, BlockNumberProvider},
 	DispatchError, FixedPointNumber, FixedPointOperand,
 };
-use sp_std::{vec, vec::Vec};
+use sp_std::vec;
 use types::*;
 
 #[cfg(test)]
@@ -228,8 +228,13 @@ pub mod pallet {
 	/// Stores the pool associated with the its write off groups
 	#[pallet::storage]
 	#[pallet::getter(fn pool_writeoff_groups)]
-	pub(crate) type PoolWriteOffGroups<T: Config> =
-		StorageMap<_, Blake2_128Concat, PoolIdOf<T>, Vec<WriteOffGroup<T::Rate>>, ValueQuery>;
+	pub(crate) type PoolWriteOffGroups<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		PoolIdOf<T>,
+		BoundedVec<WriteOffGroup<T::Rate>, T::MaxWriteOffGroups>,
+		ValueQuery,
+	>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]


### PR DESCRIPTION
# Description

Replace `Vec` storage with `BoundedVec` in `pallet-loans` to be prepared for [Weights V2](https://github.com/paritytech/substrate/pull/10918)

Related to: #897

## Changes and Descriptions

Modify `Vec` types found in the `pallet-loans` storages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue). In this case, a future issue.

# How Has This Been Tested?

```sh
cargo test -p pallet-loans
cargo test --workspace --release --features test-benchmarks,try-runtime
```

# Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `parachain` branch
