### PR TITLE
Utility: add ensure_op trait methods to simplify overflow errors.

### DIFF
--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -696,7 +696,7 @@ pub mod fees {
 	}
 }
 
-mod ops {
+pub mod ops {
 	pub use sp_runtime::{
 		traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub},
 		ArithmeticError,
@@ -709,7 +709,15 @@ mod ops {
 		/// `ArithmeticError::Overflow` is returned.
 		///
 		/// ```
-		/// u32::max().ensure_add(1)?
+		/// use cfg_traits::ops::EnsureAdd;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic() -> DispatchResult {
+		///     u32::MAX.ensure_add(&1)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic(), Err(DispatchError::Arithmetic(ArithmeticError::Overflow)));
 		/// ```
 		fn ensure_add(&self, v: &Self) -> Result<Self, ArithmeticError> {
 			self.checked_add(v).ok_or(ArithmeticError::Overflow)
@@ -723,7 +731,15 @@ mod ops {
 		/// `ArithmeticError::Underflow` is returned.
 		///
 		/// ```
-		/// 0u32.ensure_sub(1)?
+		/// use cfg_traits::ops::EnsureSub;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic() -> DispatchResult {
+		///     0u32.ensure_sub(&1)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic(), Err(DispatchError::Arithmetic(ArithmeticError::Underflow)));
 		/// ```
 		fn ensure_sub(&self, v: &Self) -> Result<Self, ArithmeticError> {
 			self.checked_sub(v).ok_or(ArithmeticError::Underflow)
@@ -737,7 +753,15 @@ mod ops {
 		/// `ArithmeticError::Overflow` is returned.
 		///
 		/// ```
-		/// u32::max().ensure_mul(2)?
+		/// use cfg_traits::ops::EnsureMul;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic() -> DispatchResult {
+		///     u32::MAX.ensure_mul(&2)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic(), Err(DispatchError::Arithmetic(ArithmeticError::Overflow)));
 		/// ```
 		fn ensure_mul(&self, v: &Self) -> Result<Self, ArithmeticError> {
 			self.checked_mul(v).ok_or(ArithmeticError::Overflow)
@@ -751,7 +775,15 @@ mod ops {
 		/// `ArithmeticError::DivisionByZero` is returned.
 		///
 		/// ```
-		/// u32::max().ensure_div(0)?
+		/// use cfg_traits::ops::EnsureDiv;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic() -> DispatchResult {
+		///     1.ensure_div(&0)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic(), Err(DispatchError::Arithmetic(ArithmeticError::DivisionByZero)));
 		/// ```
 		fn ensure_div(&self, v: &Self) -> Result<Self, ArithmeticError> {
 			self.checked_div(v).ok_or(ArithmeticError::DivisionByZero)

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -698,7 +698,7 @@ pub mod fees {
 
 mod ops {
 	pub use sp_runtime::{
-		traits::{CheckedAdd, CheckedSub},
+		traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub},
 		ArithmeticError,
 	};
 
@@ -730,6 +730,36 @@ mod ops {
 		}
 	}
 
+	/// Performs multiplication that returns `ArithmeticError::Overflow` instead of
+	/// wrapping around on overflow.
+	pub trait EnsureMul: CheckedMul {
+		/// Multiplies two numbers, checking for overflow. If overflow happens,
+		/// `ArithmeticError::Overflow` is returned.
+		///
+		/// ```
+		/// u32::max().ensure_mul(2)?
+		/// ```
+		fn ensure_mul(&self, v: &Self) -> Result<Self, ArithmeticError> {
+			self.checked_mul(v).ok_or(ArithmeticError::Overflow)
+		}
+	}
+
+	/// Performs division that returns `ArithmeticError::DivisionByZero` instead of
+	/// wrapping around on overflow.
+	pub trait EnsureDiv: CheckedDiv {
+		/// Divides two numbers, checking for overflow. If overflow happens,
+		/// `ArithmeticError::DivisionByZero` is returned.
+		///
+		/// ```
+		/// u32::max().ensure_div(0)?
+		/// ```
+		fn ensure_div(&self, v: &Self) -> Result<Self, ArithmeticError> {
+			self.checked_div(v).ok_or(ArithmeticError::DivisionByZero)
+		}
+	}
+
 	impl<T: CheckedAdd> EnsureAdd for T {}
 	impl<T: CheckedSub> EnsureSub for T {}
+	impl<T: CheckedMul> EnsureMul for T {}
+	impl<T: CheckedDiv> EnsureDiv for T {}
 }

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -695,3 +695,41 @@ pub mod fees {
 		}
 	}
 }
+
+mod ops {
+	pub use sp_runtime::{
+		traits::{CheckedAdd, CheckedSub},
+		ArithmeticError,
+	};
+
+	/// Performs addition that returns `ArithmeticError::Overflow` instead of
+	/// wrapping around on overflow.
+	pub trait EnsureAdd: CheckedAdd {
+		/// Adds two numbers, checking for overflow. If overflow happens,
+		/// `ArithmeticError::Overflow` is returned.
+		///
+		/// ```
+		/// u32::max().ensure_add(1)?
+		/// ```
+		fn ensure_add(&self, v: &Self) -> Result<Self, ArithmeticError> {
+			self.checked_add(v).ok_or(ArithmeticError::Overflow)
+		}
+	}
+
+	/// Performs subtraction that returns `ArithmeticError::Underflow` instead of
+	/// wrapping around on underflow.
+	pub trait EnsureSub: CheckedSub {
+		/// Subtracts two numbers, checking for overflow. If overflow happens,
+		/// `ArithmeticError::Underflow` is returned.
+		///
+		/// ```
+		/// 0u32.ensure_sub(1)?
+		/// ```
+		fn ensure_sub(&self, v: &Self) -> Result<Self, ArithmeticError> {
+			self.checked_sub(v).ok_or(ArithmeticError::Underflow)
+		}
+	}
+
+	impl<T: CheckedAdd> EnsureAdd for T {}
+	impl<T: CheckedSub> EnsureSub for T {}
+}


### PR DESCRIPTION
# Description

This PR adds `ensure_add` and `ensure_sub` trait methods to avoid being extremely verbose in math operations overflow checks, making the code more readable.

Before:
```rust
0u32.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
```
After:
```rust
0u32.ensure_sub(1)?;
```

## Changes and Descriptions

Addition of new ops traits into `libs/traits`

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```rust
cargo test -p cfg-traits // Which will run the associated doc examples
```