### PR TITLE
pools: Add PalletIndex type

### DIFF
--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -26,7 +26,7 @@ use cfg_types::{
 };
 use frame_support::{
 	parameter_types,
-	traits::{AsEnsureOriginWithArg, Everything, GenesisBuild, SortedMembers},
+	traits::{AsEnsureOriginWithArg, Everything, GenesisBuild, PalletInfoAccess, SortedMembers},
 	PalletId,
 };
 use frame_system::{EnsureSigned, EnsureSignedBy};
@@ -152,6 +152,9 @@ impl orml_tokens::Config for MockRuntime {
 parameter_types! {
 	pub const PoolPalletId: frame_support::PalletId = cfg_types::ids::POOLS_PALLET_ID;
 
+	/// The index with which this pallet is instantiated in this runtime.
+	pub PoolPalletIndex: u8 = <Pools as PalletInfoAccess>::index() as u8;
+
 	pub const ChallengeTime: u64 = 0; // disable challenge period
 	pub const MinUpdateDelay: u64 = 0; // no delay
 	pub const RequireRedeemFulfillmentsBeforeUpdates: bool = false;
@@ -209,6 +212,7 @@ impl pallet_pools::Config for MockRuntime {
 	type MinUpdateDelay = MinUpdateDelay;
 	type NAV = Loans;
 	type PalletId = PoolPalletId;
+	type PalletIndex = PoolPalletIndex;
 	type ParachainId = ParachainId;
 	type Permission = Permissions;
 	type PoolCreateOrigin = EnsureSigned<u64>;
@@ -317,7 +321,7 @@ parameter_types! {
 }
 impl pallet_permissions::Config for MockRuntime {
 	type AdminOrigin = EnsureSignedBy<One, u64>;
-	type Editors = frame_support::traits::Everything;
+	type Editors = Everything;
 	type Event = Event;
 	type MaxRolesPerScope = MaxRoles;
 	type Role = Role;

--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -311,6 +311,11 @@ pub mod pallet {
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 
+		/// The immutable index of this pallet when instantiated within the
+		/// context of a runtime where it is used.
+		#[pallet::constant]
+		type PalletIndex: Get<u8>;
+
 		type PoolId: Member
 			+ Parameter
 			+ Default
@@ -730,6 +735,7 @@ pub mod pallet {
 				let metadata = tranche.create_asset_metadata(
 					decimals,
 					parachain_id,
+					T::PalletIndex::get(),
 					token_name.to_vec(),
 					token_symbol.to_vec(),
 				);

--- a/pallets/pools/src/mock.rs
+++ b/pallets/pools/src/mock.rs
@@ -10,7 +10,7 @@ use codec::Encode;
 use frame_support::{
 	parameter_types,
 	sp_std::marker::PhantomData,
-	traits::{Contains, GenesisBuild, Hooks, SortedMembers},
+	traits::{Contains, GenesisBuild, Hooks, PalletInfoAccess, SortedMembers},
 	Blake2_128, StorageHasher,
 };
 use frame_system as system;
@@ -290,6 +290,9 @@ where
 parameter_types! {
 	pub const PoolPalletId: frame_support::PalletId = cfg_types::ids::POOLS_PALLET_ID;
 
+	/// The index with which this pallet is instantiated in this runtime.
+	pub PoolPalletIndex: u8 = <Pools as PalletInfoAccess>::index() as u8;
+
 	#[derive(scale_info::TypeInfo, Eq, PartialEq, Debug, Clone, Copy )]
 	pub const MaxTranches: u32 = 5;
 
@@ -340,6 +343,7 @@ impl Config for Test {
 	type MinUpdateDelay = MinUpdateDelay;
 	type NAV = FakeNav;
 	type PalletId = PoolPalletId;
+	type PalletIndex = PoolPalletIndex;
 	type ParachainId = ParachainInfo;
 	type Permission = Permissions;
 	type PoolCreateOrigin = EnsureSigned<u64>;

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -22,7 +22,7 @@ use sp_runtime::{
 };
 use xcm::{
 	latest::MultiLocation,
-	prelude::{GeneralKey, Parachain, X2},
+	prelude::{GeneralKey, PalletInstance, Parachain, X3},
 	VersionedMultiLocation,
 };
 
@@ -2990,7 +2990,11 @@ fn create_tranche_token_metadata() {
 				existential_deposit: 0,
 				location: Some(VersionedMultiLocation::V1(MultiLocation {
 					parents: 1,
-					interior: X2(Parachain(MockParachainId::get()), GeneralKey(tranche_id)),
+					interior: X3(
+						Parachain(MockParachainId::get()),
+						PalletInstance(PoolPalletIndex::get()),
+						GeneralKey(tranche_id)
+					),
 				})),
 				additional: CustomMetadata {
 					mintable: false,

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -22,7 +22,7 @@ use sp_arithmetic::traits::{checked_pow, BaseArithmetic, Unsigned};
 use sp_runtime::WeakBoundedVec;
 use xcm::{
 	latest::MultiLocation,
-	prelude::{GeneralKey, Parachain, X2},
+	prelude::{GeneralKey, PalletInstance, Parachain, X3},
 	VersionedMultiLocation,
 };
 
@@ -265,6 +265,7 @@ where
 		&self,
 		decimals: u32,
 		parachain_id: ParachainId,
+		pallet_index: u8,
 		token_name: Vec<u8>,
 		token_symbol: Vec<u8>,
 	) -> AssetMetadata<Balance, CustomMetadata>
@@ -283,7 +284,11 @@ where
 			existential_deposit: Zero::zero(),
 			location: Some(VersionedMultiLocation::V1(MultiLocation {
 				parents: 1,
-				interior: X2(Parachain(parachain_id.into()), GeneralKey(tranche_id)),
+				interior: X3(
+					Parachain(parachain_id.into()),
+					PalletInstance(pallet_index),
+					GeneralKey(tranche_id),
+				),
 			})),
 			additional: CustomMetadata {
 				mintable: false,

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -32,7 +32,7 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
 		AsEnsureOriginWithArg, Contains, EqualPrivilegeOnly, InstanceFilter, LockIdentifier,
-		U128CurrencyToVote, UnixTime,
+		PalletInfoAccess, U128CurrencyToVote, UnixTime,
 	},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
@@ -1007,6 +1007,9 @@ impl pallet_loans::Config for Runtime {
 parameter_types! {
 	pub const PoolPalletId: frame_support::PalletId = cfg_types::ids::POOLS_PALLET_ID;
 
+	/// The index with which this pallet is instantiated in this runtime.
+	pub PoolPalletIndex: u8 = <Pools as PalletInfoAccess>::index() as u8;
+
 	pub const MinUpdateDelay: u64 = if cfg!(feature = "runtime-benchmarks") {
 		0
 	} else {
@@ -1082,6 +1085,7 @@ impl pallet_pools::Config for Runtime {
 	type MinUpdateDelay = MinUpdateDelay;
 	type NAV = Loans;
 	type PalletId = PoolPalletId;
+	type PalletIndex = PoolPalletIndex;
 	type ParachainId = ParachainInfo;
 	type Permission = Permissions;
 	type PoolCreateOrigin = PoolCreateOrigin;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -38,7 +38,7 @@ use frame_support::{
 	sp_std::marker::PhantomData,
 	traits::{
 		AsEnsureOriginWithArg, Contains, EitherOfDiverse, EqualPrivilegeOnly, InstanceFilter,
-		LockIdentifier, U128CurrencyToVote, UnixTime,
+		LockIdentifier, PalletInfoAccess, U128CurrencyToVote, UnixTime,
 	},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
@@ -825,6 +825,9 @@ impl pallet_claims::Config for Runtime {
 parameter_types! {
 	pub const PoolPalletId: frame_support::PalletId = cfg_types::ids::POOLS_PALLET_ID;
 
+	/// The index with which this pallet is instantiated in this runtime.
+	pub PoolPalletIndex: u8 = <Pools as PalletInfoAccess>::index() as u8;
+
 	pub const MinUpdateDelay: u64 = 0; // no delay
 	pub const ChallengeTime: BlockNumber = if cfg!(feature = "runtime-benchmarks") {
 		// Disable challenge time in benchmarks
@@ -878,6 +881,7 @@ impl pallet_pools::Config for Runtime {
 	type MinUpdateDelay = MinUpdateDelay;
 	type NAV = Loans;
 	type PalletId = PoolPalletId;
+	type PalletIndex = PoolPalletIndex;
 	type ParachainId = ParachainInfo;
 	type Permission = Permissions;
 	type PoolCreateOrigin = EnsureSigned<AccountId>;


### PR DESCRIPTION
# Description

Currently, all of our native assets are described in `MultiLocation` as `X2(Parachain(_), GeneralKey(y))`. This works well for all assets with a static general key since we can _match_ on those static, const values. However, with Tranche tokens, as their general key is only obtained at runtime, we don't have a way of matching a MultiLocation representing a tranche apart from an exclusion-based approach.

Since we don't have tranche assets being used in production yet, hereby I suggest that we change the MultiLocation we use for tranche assets to be `X3(Parachain(x), PalletInstance(<pools_pallet_index>), GeneralKey(y))`, making it super easy to match on tranche tokens.

This comes particularly helpful in order to easily block transfers made through PolkadotXcm or XTokens that involve tranche tokens, which are disallowed to avoid transfers to non-whitelisted destination addresses. We now block all the extrinsics of those two pallets that allow for an arbitrary number of assets to be transferred, which we need to have enabled for USDC transfers where GLRM also needs to be sent alongside to cover for fee costs.

## Changes and Descriptions

1. We change the multilocation to which tranche tokens are represented as
2. We pass a `PalletIndex` type param to the pools pallet

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

^ I mean, in theory it's a breaking change but in practise I don't believe it's breaking anything.

# How Has This Been Tested?

We have adapted the affected tests and mocks in the pools pallet to cover this change.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
