### PR TITLE
Remove accrual migration from Altair

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1315,26 +1315,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	upgrade::Upgrade,
 >;
-
-/// Runtime upgrade logic
-mod upgrade {
-	use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
-
-	use super::*;
-
-	pub struct Upgrade;
-	impl OnRuntimeUpgrade for Upgrade {
-		fn on_runtime_upgrade() -> Weight {
-			let mut weight = 0;
-			weight += InterestAccrual::upgrade_to_v1();
-			weight += Loans::reference_active_rates();
-			weight += InterestAccrual::remove_unused_rates();
-			weight
-		}
-	}
-}
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {


### PR DESCRIPTION
# Description

This removes the migration from Altair, but leaves the code in the interest-accrual pallet. We _shouldn't_ ever need it again, but I don't want to rewrite the whole migration boilerplate for the next migration, so I'm leaving the dead code in place for now.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `main` branch
