### PR TITLE
xcm: Support MultiAssets outbound transfers 

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -153,7 +153,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
-	type BaseCallFilter = BaseCallFilter;
+	type BaseCallFilter = Everything;
 	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
 	type BlockHashCount = BlockHashCount;
 	type BlockLength = RuntimeBlockLength;
@@ -1166,55 +1166,6 @@ impl pallet_interest_accrual::Config for Runtime {
 	type InterestRate = Rate;
 	type Time = Timestamp;
 	type Weights = ();
-}
-
-/// Base Call Filter
-/// We block any call that could lead for tranche tokens to be transferred through XCM.
-pub struct BaseCallFilter;
-impl Contains<Call> for BaseCallFilter {
-	fn contains(c: &Call) -> bool {
-		match c {
-			Call::PolkadotXcm(method) => match method {
-				// We disable all PolkadotXcm extrinsics that allow users to build XCM messages
-				// from scratch, which could have them transferring Tranche tokens.
-				// To transfer tokens, use XTokens, for which we have specific filters
-				// blocking tranche transfers.
-				// To send a raw XCM message, use orml_xcm, which ensures the origin of
-				// such call to be root or majority of the collective.
-				pallet_xcm::Call::send { .. }
-				| pallet_xcm::Call::execute { .. }
-				| pallet_xcm::Call::teleport_assets { .. }
-				| pallet_xcm::Call::reserve_transfer_assets { .. }
-				| pallet_xcm::Call::limited_reserve_transfer_assets { .. }
-				| pallet_xcm::Call::limited_teleport_assets { .. } => false,
-				pallet_xcm::Call::force_xcm_version { .. }
-				| pallet_xcm::Call::force_default_xcm_version { .. }
-				| pallet_xcm::Call::force_subscribe_version_notify { .. }
-				| pallet_xcm::Call::force_unsubscribe_version_notify { .. } => true,
-				pallet_xcm::Call::__Ignore { .. } => {
-					unimplemented!()
-				}
-			},
-			Call::XTokens(method) => !matches!(
-				method,
-				orml_xtokens::Call::transfer {
-					currency_id: CurrencyId::Tranche(_, _),
-					..
-				}
-				| orml_xtokens::Call::transfer_with_fee {
-					currency_id: CurrencyId::Tranche(_, _),
-					..
-				}
-				// We preemptively disable this as we haven't encountered a use case for it.
-				// Shall some user or use case require it, we will make it more fine-grained.
-				| orml_xtokens::Call::transfer_multiasset { .. }
-				| orml_xtokens::Call::transfer_multiasset_with_fee { .. }
-				| orml_xtokens::Call::transfer_multiassets { .. }
-				| orml_xtokens::Call::transfer_multicurrencies { .. }
-			),
-			_ => true,
-		}
-	}
 }
 
 // Frame Order in this block dictates the index of each one in the metadata

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -230,7 +230,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
-	type BaseCallFilter = BaseCallFilter;
+	type BaseCallFilter = Everything;
 	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
 	type BlockHashCount = BlockHashCount;
 	type BlockLength = RuntimeBlockLength;
@@ -960,55 +960,6 @@ impl pallet_crowdloan_claim::Config for Runtime {
 	type RelayChainAccountId = AccountId;
 	type RewardMechanism = CrowdloanReward;
 	type WeightInfo = weights::pallet_crowdloan_claim::SubstrateWeight<Self>;
-}
-
-/// Base Call Filter
-/// We block any call that could lead for tranche tokens to be transferred through XCM.
-pub struct BaseCallFilter;
-impl Contains<Call> for BaseCallFilter {
-	fn contains(c: &Call) -> bool {
-		match c {
-			Call::PolkadotXcm(method) => match method {
-				// We disable all PolkadotXcm extrinsics that allow users to build XCM messages
-				// from scratch, which could have them transferring Tranche tokens.
-				// To transfer tokens, use XTokens, for which we have specific filters
-				// blocking tranche transfers.
-				// To send a raw XCM message, use orml_xcm, which ensures the origin of
-				// such call to be root or majority of the collective.
-				pallet_xcm::Call::send { .. }
-				| pallet_xcm::Call::execute { .. }
-				| pallet_xcm::Call::teleport_assets { .. }
-				| pallet_xcm::Call::reserve_transfer_assets { .. }
-				| pallet_xcm::Call::limited_reserve_transfer_assets { .. }
-				| pallet_xcm::Call::limited_teleport_assets { .. } => false,
-				pallet_xcm::Call::force_xcm_version { .. }
-				| pallet_xcm::Call::force_default_xcm_version { .. }
-				| pallet_xcm::Call::force_subscribe_version_notify { .. }
-				| pallet_xcm::Call::force_unsubscribe_version_notify { .. } => true,
-				pallet_xcm::Call::__Ignore { .. } => {
-					unimplemented!()
-				}
-			},
-			Call::XTokens(method) => !matches!(
-				method,
-				orml_xtokens::Call::transfer {
-					currency_id: CurrencyId::Tranche(_, _),
-					..
-				}
-				| orml_xtokens::Call::transfer_with_fee {
-					currency_id: CurrencyId::Tranche(_, _),
-					..
-				}
-				// We preemptively disable this as we haven't encountered a use case for it.
-				// Shall some user or use case require it, we will make it more fine-grained.
-				| orml_xtokens::Call::transfer_multiasset { .. }
-				| orml_xtokens::Call::transfer_multiasset_with_fee { .. }
-				| orml_xtokens::Call::transfer_multiassets { .. }
-				| orml_xtokens::Call::transfer_multicurrencies { .. }
-			),
-			_ => true,
-		}
-	}
 }
 
 // Parameterize collator selection pallet

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -158,7 +158,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
-	type BaseCallFilter = BaseCallFilter;
+	type BaseCallFilter = Everything;
 	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
 	type BlockHashCount = BlockHashCount;
 	type BlockLength = RuntimeBlockLength;
@@ -996,55 +996,6 @@ impl pallet_migration_manager::Config for Runtime {
 	type MigrationMaxProxies = MigrationMaxProxies;
 	type MigrationMaxVestings = MigrationMaxVestings;
 	type WeightInfo = weights::pallet_migration_manager::SubstrateWeight<Self>;
-}
-
-/// Base Call Filter
-/// We block any call that could lead for tranche tokens to be transferred through XCM.
-pub struct BaseCallFilter;
-impl Contains<Call> for BaseCallFilter {
-	fn contains(c: &Call) -> bool {
-		match c {
-			Call::PolkadotXcm(method) => match method {
-				// We disable all PolkadotXcm extrinsics that allow users to build XCM messages
-				// from scratch, which could have them transferring Tranche tokens.
-				// To transfer tokens, use XTokens, for which we have specific filters
-				// blocking tranche transfers.
-				// To send a raw XCM message, use orml_xcm, which ensures the origin of
-				// such call to be root or majority of the collective.
-				pallet_xcm::Call::send { .. }
-				| pallet_xcm::Call::execute { .. }
-				| pallet_xcm::Call::teleport_assets { .. }
-				| pallet_xcm::Call::reserve_transfer_assets { .. }
-				| pallet_xcm::Call::limited_reserve_transfer_assets { .. }
-				| pallet_xcm::Call::limited_teleport_assets { .. } => false,
-				pallet_xcm::Call::force_xcm_version { .. }
-				| pallet_xcm::Call::force_default_xcm_version { .. }
-				| pallet_xcm::Call::force_subscribe_version_notify { .. }
-				| pallet_xcm::Call::force_unsubscribe_version_notify { .. } => true,
-				pallet_xcm::Call::__Ignore { .. } => {
-					unimplemented!()
-				}
-			},
-			Call::XTokens(method) => !matches!(
-				method,
-				orml_xtokens::Call::transfer {
-					currency_id: CurrencyId::Tranche(_, _),
-					..
-				}
-				| orml_xtokens::Call::transfer_with_fee {
-					currency_id: CurrencyId::Tranche(_, _),
-					..
-				}
-				// We preemptively disable this as we haven't encountered a use case for it.
-				// Shall some user or use case require it, we will make it more fine-grained.
-				| orml_xtokens::Call::transfer_multiasset { .. }
-				| orml_xtokens::Call::transfer_multiasset_with_fee { .. }
-				| orml_xtokens::Call::transfer_multiassets { .. }
-				| orml_xtokens::Call::transfer_multicurrencies { .. }
-			),
-			_ => true,
-		}
-	}
 }
 
 // Parameterize crowdloan reward pallet configuration

--- a/runtime/development/src/xcm.rs
+++ b/runtime/development/src/xcm.rs
@@ -45,7 +45,7 @@ use xcm_executor::{traits::JustTry, XcmExecutor};
 
 use super::{
 	AccountId, Balance, Call, Event, Origin, OrmlAssetRegistry, OrmlTokens, ParachainInfo,
-	ParachainSystem, PolkadotXcm, Runtime, Tokens, TreasuryAccount, XcmpQueue,
+	ParachainSystem, PolkadotXcm, PoolPalletIndex, Runtime, Tokens, TreasuryAccount, XcmpQueue,
 };
 
 /// The main XCM config
@@ -246,6 +246,20 @@ impl xcm_executor::traits::Convert<MultiLocation, CurrencyId> for CurrencyIdConv
 					_ => Err(location),
 				},
 
+				_ => OrmlAssetRegistry::location_to_asset_id(location.clone()).ok_or(location),
+			},
+			MultiLocation {
+				parents: 1,
+				interior: X3(Parachain(para_id), PalletInstance(pallet_index), GeneralKey(_)),
+			} => match para_id {
+				// Fail Centrifuge Pools Tranche tokens to avoid them from being transferred
+				// through XCM without permissions.
+				id if id == u32::from(ParachainInfo::get())
+					&& pallet_index == PoolPalletIndex::get() =>
+				{
+					Err(location)
+				}
+				// Still support X3-based Multilocations native to other chains
 				_ => OrmlAssetRegistry::location_to_asset_id(location.clone()).ok_or(location),
 			},
 			_ => OrmlAssetRegistry::location_to_asset_id(location.clone()).ok_or(location),

--- a/runtime/integration-tests/src/xcm/kusama/restricted_calls.rs
+++ b/runtime/integration-tests/src/xcm/kusama/restricted_calls.rs
@@ -29,9 +29,11 @@ use orml_traits::{asset_registry::AssetMetadata, FixedConversionRateProvider, Mu
 use runtime_common::xcm_fees::{default_per_second, ksm_per_second};
 use sp_runtime::{DispatchError, DispatchError::BadOrigin};
 use xcm::{
-	latest::{Junction, Junction::*, Junctions::*, MultiLocation, NetworkId},
-	v1::MultiAsset,
-	v2::{AssetId, Fungibility, Instruction::WithdrawAsset, Xcm},
+	latest::{
+		AssetId, Fungibility, Junction, Junction::*, Junctions::*, MultiAsset, MultiLocation,
+		NetworkId,
+	},
+	v2::{Instruction::WithdrawAsset, Xcm},
 	VersionedMultiLocation,
 };
 use xcm_emulator::TestExt;
@@ -41,75 +43,128 @@ use crate::xcm::kusama::{
 	test_net::{Altair, KusamaNet, Sibling, TestNet},
 };
 
-/// Verify that calls that must be blocked by the BaseCallFilter are indeed blocked.
+/// Verify that calls that would allow for Tranche token to be transferred through XCM
+/// fail because the underlying CurrencyIdConvert doesn't handle Tranche tokens.
 pub mod blocked {
+	use sp_runtime::{traits::ConstU32, WeakBoundedVec};
+	use xcm::{latest::MultiAssets, VersionedMultiAsset, VersionedMultiAssets};
+
 	use super::*;
 
 	#[test]
 	fn xtokens_transfer() {
 		// For now, Tranche tokens are not supported in the XCM config so
 		// we just safe-guard that trying to transfer a tranche token fails.
-		// Once Tranche tokens are supported, we need to tighten this test.
-		Altair::execute_with(|| {
-			assert!(XTokens::transfer(
-				Origin::signed(ALICE.into()),
-				CurrencyId::Tranche(401, [0; 16]),
-				42,
-				Box::new(
-					MultiLocation::new(
-						1,
-						X2(
-							Parachain(PARA_ID_SIBLING),
-							Junction::AccountId32 {
-								network: NetworkId::Any,
-								id: BOB.into(),
-							}
-						)
-					)
-					.into()
-				),
-				8_000_000_000_000,
-			)
-			.is_err());
-		});
-	}
-
-	#[test]
-	fn polkadot_xcm_send() {
 		Altair::execute_with(|| {
 			assert_noop!(
-				Call::dispatch(
-					Call::PolkadotXcm(pallet_xcm::Call::send {
-						dest: Box::new(
-							MultiLocation::new(1, X1(Parachain(PARA_ID_SIBLING))).into()
-						),
-						message: Box::new(xcm::VersionedXcm::V2(Xcm::<Call>(vec![]).into())),
-					}),
-					Origin::signed(ALICE.into())
+				XTokens::transfer(
+					Origin::signed(ALICE.into()),
+					CurrencyId::Tranche(401, [0; 16]),
+					42,
+					Box::new(
+						MultiLocation::new(
+							1,
+							X2(
+								Parachain(PARA_ID_SIBLING),
+								Junction::AccountId32 {
+									network: NetworkId::Any,
+									id: BOB.into(),
+								}
+							)
+						)
+						.into()
+					),
+					8_000_000_000_000,
 				),
-				frame_system::Error::<altair_runtime::Runtime>::CallFiltered
+				orml_xtokens::Error::<altair_runtime::Runtime>::NotCrossChainTransferableCurrency
 			);
 		});
 	}
-}
 
-/// Verify calls that must remain allowed. Sanity check to avoid us
-/// from silently block calls we didn't mean to block.
-pub mod allowed {
-	use super::*;
+	// Verify that trying to transfer Tranche tokens using their MultiLocation representation
+	// also fails.
+	#[test]
+	fn xtokens_transfer_multiasset() {
+		use codec::Encode;
+
+		let tranche_currency = CurrencyId::Tranche(401, [0; 16]);
+		let tranche_id =
+			WeakBoundedVec::<u8, ConstU32<32>>::force_from(tranche_currency.encode(), None);
+		let tranche_location = MultiLocation {
+			parents: 1,
+			interior: X3(Parachain(123), PalletInstance(42), GeneralKey(tranche_id)),
+		};
+		let tranche_multi_asset = VersionedMultiAsset::from(MultiAsset::from((
+			AssetId::Concrete(tranche_location),
+			Fungibility::Fungible(42),
+		)));
+
+		Altair::execute_with(|| {
+			assert_noop!(
+				XTokens::transfer_multiasset(
+					Origin::signed(ALICE.into()),
+					Box::new(tranche_multi_asset),
+					Box::new(
+						MultiLocation::new(
+							1,
+							X2(
+								Parachain(PARA_ID_SIBLING),
+								Junction::AccountId32 {
+									network: NetworkId::Any,
+									id: BOB.into(),
+								}
+							)
+						)
+						.into()
+					),
+					8_000_000_000_000,
+				),
+				orml_xtokens::Error::<altair_runtime::Runtime>::XcmExecutionFailed
+			);
+		});
+	}
 
 	#[test]
-	fn polkadot_xcm_force_xcm_version() {
+	fn xtokens_transfer_multiassets() {
+		use codec::Encode;
+
+		let tranche_currency = CurrencyId::Tranche(401, [0; 16]);
+		let tranche_id =
+			WeakBoundedVec::<u8, ConstU32<32>>::force_from(tranche_currency.encode(), None);
+		let tranche_location = MultiLocation {
+			parents: 1,
+			interior: X3(Parachain(123), PalletInstance(42), GeneralKey(tranche_id)),
+		};
+		let tranche_multi_asset = MultiAsset::from((
+			AssetId::Concrete(tranche_location),
+			Fungibility::Fungible(42),
+		));
+
 		Altair::execute_with(|| {
-			assert_ok!(Call::dispatch(
-				Call::PolkadotXcm(pallet_xcm::Call::force_xcm_version {
-					location: Box::new(
-						MultiLocation::new(1, X1(Parachain(PARA_ID_SIBLING))).into()
+			assert_noop!(
+				XTokens::transfer_multiassets(
+					Origin::signed(ALICE.into()),
+					Box::new(VersionedMultiAssets::from(MultiAssets::from(vec![
+						tranche_multi_asset
+					]))),
+					0,
+					Box::new(
+						MultiLocation::new(
+							1,
+							X2(
+								Parachain(PARA_ID_SIBLING),
+								Junction::AccountId32 {
+									network: NetworkId::Any,
+									id: BOB.into(),
+								}
+							)
+						)
+						.into()
 					),
-					xcm_version: 2,
-				}),
-				Origin::root(),
-			));
+					8_000_000_000_000,
+				),
+				orml_xtokens::Error::<altair_runtime::Runtime>::XcmExecutionFailed
+			);
 		});
 	}
 }

--- a/runtime/integration-tests/src/xcm/polkadot/tests/currency_id_convert.rs
+++ b/runtime/integration-tests/src/xcm/polkadot/tests/currency_id_convert.rs
@@ -27,13 +27,17 @@ use centrifuge_runtime::{
 };
 use cfg_primitives::{constants::currency_decimals, parachains, Balance};
 use cfg_types::{CurrencyId, CustomMetadata, XcmMetadata};
+use codec::Encode;
 use frame_support::{assert_noop, assert_ok};
 use orml_traits::{asset_registry::AssetMetadata, FixedConversionRateProvider, MultiCurrency};
 use runtime_common::{
 	xcm::general_key,
 	xcm_fees::{default_per_second, ksm_per_second},
 };
-use sp_runtime::traits::Convert as C2;
+use sp_runtime::{
+	traits::{ConstU32, Convert as C2},
+	WeakBoundedVec,
+};
 use xcm::{
 	latest::{Junction, Junction::*, Junctions::*, MultiLocation, NetworkId},
 	VersionedMultiLocation,
@@ -78,6 +82,39 @@ fn convert_cfg() {
 		assert_eq!(
 			<CurrencyIdConvert as C2<_, _>>::convert(CurrencyId::Native),
 			Some(cfg_location_canonical)
+		)
+	});
+}
+
+/// Verify that Tranche tokens are not handled by the CurrencyIdConvert
+/// since we don't allow Tranche tokens to be transferable through XCM.
+#[test]
+fn convert_tranche() {
+	// We don't yet know the pools pallet index on the Centrifuge runtime
+	const MOCK_POOLS_PALLET_INDEX: u8 = 42;
+	let tranche_currency = CurrencyId::Tranche(401, [0; 16]);
+	let tranche_id =
+		WeakBoundedVec::<u8, ConstU32<32>>::force_from(tranche_currency.encode(), None);
+	let tranche_multilocation = MultiLocation {
+		parents: 1,
+		interior: X3(
+			Parachain(parachains::polkadot::centrifuge::ID),
+			PalletInstance(MOCK_POOLS_PALLET_INDEX),
+			GeneralKey(tranche_id),
+		),
+	};
+
+	Centrifuge::execute_with(|| {
+		assert_eq!(
+			<CurrencyIdConvert as C1<_, _>>::convert(tranche_multilocation.clone()),
+			Err(tranche_multilocation),
+		);
+	});
+
+	Centrifuge::execute_with(|| {
+		assert_eq!(
+			<CurrencyIdConvert as C2<_, _>>::convert(tranche_currency),
+			None
 		)
 	});
 }


### PR DESCRIPTION
# Description

With the current `BaseCallFilter` set in all our runtimes, it is _not_ possible to build custom XCM message using `pallet_xcm` or `orml_xtokens` to transfer multiassets all together. We introduced this call filter to block all backdoors that would allow users to transfer Tranche tokens through XCM without the right permission checks. At the time we had no use case needing those calls in the first place, we just blocked them all. 

However, we now have an upcoming use case where to transfer xcUSDC tokens from Centrifuge to Moonbeam we will need either `transfer_multiassets` or `transfer_multiasset_with_fee`.

## Changes and Descriptions

We now have more clarity surrounding how Tranche tokens will be transferred with permissions through Connectors, which won't make use of the common XCM fungibles config. Thus we can simply rely on the fact that `CurrencyIdConvert` doesn't handle Tranche tokens and therefore those extrinsics that do allow to specify Tranche tokens either directly `CurrencyId::Tranche` or as a MultiLocation will fail to execute.

That means that drop the BaseCallFilter and add tests verifying that `CurrencyIdConvert` doesn't handle Tranche tokens and that said extrinsics fail to execute when involving Tranche tokens.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] integration-tests for `restricted_calls` for Altair and Centrifuge
- [x] integration tests covering CurrencyIdConvert handling of Tranche tokens for Altair and Centrifuge

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I rebased on the latest `main` branch
