### PR TITLE
runtime: Set sane BaseCallFilter

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -192,7 +192,6 @@ impl frame_system::Config for Runtime {
 }
 
 /// Base Call Filter
-/// We block any call that could lead for tranche tokens to be transferred through XCM.
 pub struct BaseCallFilter;
 impl Contains<Call> for BaseCallFilter {
 	fn contains(c: &Call) -> bool {

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -153,7 +153,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
-	type BaseCallFilter = Everything;
+	type BaseCallFilter = BaseCallFilter;
 	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
 	type BlockHashCount = BlockHashCount;
 	type BlockLength = RuntimeBlockLength;
@@ -189,6 +189,38 @@ impl frame_system::Config for Runtime {
 	type SystemWeightInfo = weights::frame_system::SubstrateWeight<Runtime>;
 	/// Get the chain's current version.
 	type Version = Version;
+}
+
+/// Base Call Filter
+/// We block any call that could lead for tranche tokens to be transferred through XCM.
+pub struct BaseCallFilter;
+impl Contains<Call> for BaseCallFilter {
+	fn contains(c: &Call) -> bool {
+		match c {
+			Call::PolkadotXcm(method) => match method {
+				// Block these calls when called by a signed extrinsic.
+				// Root will still be able to execute these.
+				pallet_xcm::Call::send { .. }
+				| pallet_xcm::Call::execute { .. }
+				| pallet_xcm::Call::teleport_assets { .. }
+				| pallet_xcm::Call::reserve_transfer_assets { .. }
+				| pallet_xcm::Call::limited_reserve_transfer_assets { .. }
+				| pallet_xcm::Call::limited_teleport_assets { .. } => {
+					return false;
+				}
+				pallet_xcm::Call::__Ignore { .. } => {
+					unimplemented!()
+				}
+				pallet_xcm::Call::force_xcm_version { .. }
+				| pallet_xcm::Call::force_default_xcm_version { .. }
+				| pallet_xcm::Call::force_subscribe_version_notify { .. }
+				| pallet_xcm::Call::force_unsubscribe_version_notify { .. } => {
+					return true;
+				}
+			},
+			_ => true,
+		}
+	}
 }
 
 parameter_types! {

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -230,7 +230,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
-	type BaseCallFilter = Everything;
+	type BaseCallFilter = BaseCallFilter;
 	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
 	type BlockHashCount = BlockHashCount;
 	type BlockLength = RuntimeBlockLength;
@@ -266,6 +266,38 @@ impl frame_system::Config for Runtime {
 	type SystemWeightInfo = weights::frame_system::SubstrateWeight<Runtime>;
 	/// Get the chain's current version.
 	type Version = Version;
+}
+
+/// Base Call Filter
+/// We block any call that could lead for tranche tokens to be transferred through XCM.
+pub struct BaseCallFilter;
+impl Contains<Call> for BaseCallFilter {
+	fn contains(c: &Call) -> bool {
+		match c {
+			Call::PolkadotXcm(method) => match method {
+				// Block these calls when called by a signed extrinsic.
+				// Root will still be able to execute these.
+				pallet_xcm::Call::send { .. }
+				| pallet_xcm::Call::execute { .. }
+				| pallet_xcm::Call::teleport_assets { .. }
+				| pallet_xcm::Call::reserve_transfer_assets { .. }
+				| pallet_xcm::Call::limited_reserve_transfer_assets { .. }
+				| pallet_xcm::Call::limited_teleport_assets { .. } => {
+					return false;
+				}
+				pallet_xcm::Call::__Ignore { .. } => {
+					unimplemented!()
+				}
+				pallet_xcm::Call::force_xcm_version { .. }
+				| pallet_xcm::Call::force_default_xcm_version { .. }
+				| pallet_xcm::Call::force_subscribe_version_notify { .. }
+				| pallet_xcm::Call::force_unsubscribe_version_notify { .. } => {
+					return true;
+				}
+			},
+			_ => true,
+		}
+	}
 }
 
 parameter_types! {

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -269,7 +269,6 @@ impl frame_system::Config for Runtime {
 }
 
 /// Base Call Filter
-/// We block any call that could lead for tranche tokens to be transferred through XCM.
 pub struct BaseCallFilter;
 impl Contains<Call> for BaseCallFilter {
 	fn contains(c: &Call) -> bool {

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -197,7 +197,6 @@ impl frame_system::Config for Runtime {
 }
 
 /// Base Call Filter
-/// We block any call that could lead for tranche tokens to be transferred through XCM.
 pub struct BaseCallFilter;
 impl Contains<Call> for BaseCallFilter {
 	fn contains(c: &Call) -> bool {

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -158,7 +158,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
-	type BaseCallFilter = Everything;
+	type BaseCallFilter = BaseCallFilter;
 	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
 	type BlockHashCount = BlockHashCount;
 	type BlockLength = RuntimeBlockLength;
@@ -194,6 +194,38 @@ impl frame_system::Config for Runtime {
 	type SystemWeightInfo = weights::frame_system::SubstrateWeight<Runtime>;
 	/// Get the chain's current version.
 	type Version = Version;
+}
+
+/// Base Call Filter
+/// We block any call that could lead for tranche tokens to be transferred through XCM.
+pub struct BaseCallFilter;
+impl Contains<Call> for BaseCallFilter {
+	fn contains(c: &Call) -> bool {
+		match c {
+			Call::PolkadotXcm(method) => match method {
+				// Block these calls when called by a signed extrinsic.
+				// Root will still be able to execute these.
+				pallet_xcm::Call::send { .. }
+				| pallet_xcm::Call::execute { .. }
+				| pallet_xcm::Call::teleport_assets { .. }
+				| pallet_xcm::Call::reserve_transfer_assets { .. }
+				| pallet_xcm::Call::limited_reserve_transfer_assets { .. }
+				| pallet_xcm::Call::limited_teleport_assets { .. } => {
+					return false;
+				}
+				pallet_xcm::Call::__Ignore { .. } => {
+					unimplemented!()
+				}
+				pallet_xcm::Call::force_xcm_version { .. }
+				| pallet_xcm::Call::force_default_xcm_version { .. }
+				| pallet_xcm::Call::force_subscribe_version_notify { .. }
+				| pallet_xcm::Call::force_unsubscribe_version_notify { .. } => {
+					return true;
+				}
+			},
+			_ => true,
+		}
+	}
 }
 
 parameter_types! {


### PR DESCRIPTION
Some PolkadotXcm extrinsics allow any user to prepare and send raw XCM messages which is undesired so we block those calls, leaving those only open for Root to execute.
