### PR TITLE
pallet-epoch implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5944,6 +5944,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-epoch"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "lazy_static",
+ "num-traits",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-fees"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
 	"pallets/interest-accrual",
 	"pallets/keystore",
 	"pallets/investments",
+	"pallets/epoch",
 	"libs/traits",
 	"libs/types",
 	"libs/proofs",

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ On top of the [Substrate FRAME](https://docs.substrate.io/reference/frame-pallet
 
 - [**restricted-tokens**](https://github.com/centrifuge/centrifuge-chain/tree/main/pallets/restricted-tokens) ([docs](https://reference.centrifuge.io/pallet_restricted_tokens/index.html)): Transferring tokens and setting balances. It is wrapping `orml-tokens` with the addition of checking for permissions.
 
+- [**epoch**](https://github.com/centrifuge/centrifuge-chain/tree/main/pallets/epoch) ([docs](https://reference.centrifuge.io/pallet_epoch/index.html)): Utility pallet without extrinsics that handle the concept of epoch and how it changes during the time. Supports different implementations in the same runtime.
+
 ## Developing
 Instructions for building, testing, and developing Centrifuge Chain can be found in [`docs/DEVELOPING.md`](docs/DEVELOPING.md).
 

--- a/pallets/epoch/Cargo.toml
+++ b/pallets/epoch/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "pallet-epoch"
+version = "0.1.0"
+authors = ["Centrifuge <admin@centrifuge.io>"]
+description = "Pallet used to configure events that will be produced perodically"
+edition = "2021"
+homepage = "https://centrifuge.io"
+license = "LGPL-3.0"
+repository = "https://github.com/centrifuge/centrifuge-chain/pallets/epoch"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"]}
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
+num-traits = { version = "0.2", default-features = false }
+
+[dev-dependencies]
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26" }
+lazy_static = "1.4"
+
+[features]
+default = ["std"]
+try-runtime = ["frame-support/try-runtime"]
+std = [
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-runtime/std",
+]

--- a/pallets/epoch/Cargo.toml
+++ b/pallets/epoch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-epoch"
 version = "0.1.0"
 authors = ["Centrifuge <admin@centrifuge.io>"]
-description = "Pallet used to configure events that will be produced perodically"
+description = "Pallet used to configure events that will be produced periodically"
 edition = "2021"
 homepage = "https://centrifuge.io"
 license = "LGPL-3.0"

--- a/pallets/epoch/src/lib.rs
+++ b/pallets/epoch/src/lib.rs
@@ -1,0 +1,123 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+use frame_support::pallet_prelude::*;
+use sp_runtime::traits::{BlockNumberProvider, CheckedAdd, Zero};
+
+pub trait Epoch<BlockNumber, AssociatedType> {
+	fn update_epoch<R>(
+		current_block: BlockNumber,
+		finish: impl FnOnce(&EpochDetails<BlockNumber, AssociatedType>) -> R,
+	) -> Option<R>;
+
+	fn update_next_associated_data<R, E>(
+		mutate: impl FnOnce(&mut AssociatedType) -> Result<R, E>,
+	) -> Result<R, E>;
+}
+
+#[derive(Encode, Decode, TypeInfo, MaxEncodedLen, RuntimeDebug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct EpochDetails<BlockNumber, AssociatedType> {
+	pub number: u64,
+	pub ends_on: BlockNumber,
+	pub associated_data: AssociatedType,
+}
+
+/// Type used to initialize the first epoch with the correct block number
+pub struct FirstEpochDetails<P>(std::marker::PhantomData<P>);
+impl<Provider, BlockNumber, AssociatedType> Get<EpochDetails<BlockNumber, AssociatedType>>
+	for FirstEpochDetails<Provider>
+where
+	BlockNumber: Zero,
+	Provider: BlockNumberProvider<BlockNumber = BlockNumber>,
+	AssociatedType: Default,
+{
+	fn get() -> EpochDetails<BlockNumber, AssociatedType> {
+		EpochDetails {
+			number: Zero::zero(),
+			ends_on: Provider::current_block_number(),
+			associated_data: AssociatedType::default(),
+		}
+	}
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		type AssociatedType: Default + codec::FullCodec + scale_info::TypeInfo + MaxEncodedLen;
+
+		#[pallet::constant]
+		type BlockPerEpoch: Get<Self::BlockNumber>;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	// --------------------------
+	//          Storage
+	// --------------------------
+
+	#[pallet::storage]
+	pub type ActiveEpoch<T: Config> = StorageValue<
+		_,
+		EpochDetails<T::BlockNumber, T::AssociatedType>,
+		ValueQuery,
+		FirstEpochDetails<frame_system::Pallet<T>>,
+	>;
+
+	#[pallet::storage]
+	pub type NextAssociatedData<T: Config> = StorageValue<_, T::AssociatedType, ValueQuery>;
+
+	// --------------------------
+
+	#[pallet::event]
+	//#[pallet::generate_deposit(pub(super) fn deposit_event)] // TODO
+	pub enum Event<T> {}
+
+	#[pallet::error]
+	pub enum Error<T> {}
+
+	impl<T: Config> Epoch<T::BlockNumber, T::AssociatedType> for Pallet<T>
+	where
+		T::BlockNumber: CheckedAdd,
+	{
+		fn update_epoch<R>(
+			current_block: T::BlockNumber,
+			finish: impl FnOnce(&EpochDetails<T::BlockNumber, T::AssociatedType>) -> R,
+		) -> Option<R> {
+			let current_epoch = ActiveEpoch::<T>::get();
+			if current_epoch.ends_on > current_block {
+				return None;
+			}
+
+			ActiveEpoch::<T>::put(EpochDetails {
+				number: current_epoch.number.checked_add(1)?,
+				ends_on: current_epoch
+					.ends_on
+					.checked_add(&T::BlockPerEpoch::get())?,
+				associated_data: NextAssociatedData::<T>::get(),
+			});
+
+			Some(finish(&current_epoch))
+		}
+
+		fn update_next_associated_data<R, E>(
+			mutate: impl FnOnce(&mut T::AssociatedType) -> Result<R, E>,
+		) -> Result<R, E> {
+			NextAssociatedData::<T>::try_mutate(mutate)
+		}
+	}
+}

--- a/pallets/epoch/src/lib.rs
+++ b/pallets/epoch/src/lib.rs
@@ -1,3 +1,8 @@
+//! # Epoch pallet
+//!
+//! Utility pallet without extrinsics that handle the concept of epoch and how it changes during the time.
+//! Supports different implementations in the same runtime.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;
@@ -9,24 +14,33 @@ mod mock;
 mod tests;
 
 use frame_support::pallet_prelude::*;
-use sp_runtime::traits::{BlockNumberProvider, CheckedAdd, Zero};
+use sp_runtime::traits::{BlockNumberProvider, CheckedAdd};
 
+/// Trait to represent the epoch behavior.
 pub trait Epoch<BlockNumber, AssociatedType> {
+	/// Updates the epoch system with a new current block.
+	/// If the given block is higher than the current finalizing block,
+	/// a new epoch is created, and the callback is called with the finalized epoch.
+	/// This method should be be called in an `on_initialized` hook.
 	fn update_epoch<R>(
 		current_block: BlockNumber,
 		finish: impl FnOnce(&EpochDetails<BlockNumber, AssociatedType>) -> R,
 	) -> Option<R>;
 
+	/// Updates the associated epoch data for the incoming epoch.
 	fn update_next_associated_data<R, E>(
 		mutate: impl FnOnce(&mut AssociatedType) -> Result<R, E>,
 	) -> Result<R, E>;
 }
 
+/// Struct that contains the epoch information.
 #[derive(Encode, Decode, TypeInfo, MaxEncodedLen, RuntimeDebug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct EpochDetails<BlockNumber, AssociatedType> {
-	pub number: u64,
+	/// Block when the epoch finalizes.
 	pub ends_on: BlockNumber,
+
+	/// Associated data to the epoch.
 	pub associated_data: AssociatedType,
 }
 
@@ -35,13 +49,11 @@ pub struct FirstEpochDetails<P>(std::marker::PhantomData<P>);
 impl<Provider, BlockNumber, AssociatedType> Get<EpochDetails<BlockNumber, AssociatedType>>
 	for FirstEpochDetails<Provider>
 where
-	BlockNumber: Zero,
 	Provider: BlockNumberProvider<BlockNumber = BlockNumber>,
 	AssociatedType: Default,
 {
 	fn get() -> EpochDetails<BlockNumber, AssociatedType> {
 		EpochDetails {
-			number: Zero::zero(),
 			ends_on: Provider::current_block_number(),
 			associated_data: AssociatedType::default(),
 		}
@@ -53,63 +65,74 @@ pub mod pallet {
 	use super::*;
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
-		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+	pub trait Config<I: 'static = ()>: frame_system::Config {
+		type Event: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::Event>;
 
+		/// Type that represent the user attached data to the epoch.
 		type AssociatedType: Default + codec::FullCodec + scale_info::TypeInfo + MaxEncodedLen;
 
+		/// Epoch interval.
+		/// Each BlockPerEpoch, an epoch finalizes and a new epoch starts.
 		#[pallet::constant]
 		type BlockPerEpoch: Get<Self::BlockNumber>;
 	}
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	pub struct Pallet<T>(_);
+	pub struct Pallet<T, I = ()>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config<I>, I: 'static = ()> {
+		/// Dispatched when a the current epoch finalizes and a new epoch starts.
+		NewEpoch { ends_on: T::BlockNumber },
+	}
+
+	#[pallet::error]
+	pub enum Error<T, I = ()> {}
 
 	// --------------------------
 	//          Storage
 	// --------------------------
 
+	/// Current epoch information
 	#[pallet::storage]
-	pub type ActiveEpoch<T: Config> = StorageValue<
+	pub type ActiveEpoch<T: Config<I>, I: 'static = ()> = StorageValue<
 		_,
 		EpochDetails<T::BlockNumber, T::AssociatedType>,
 		ValueQuery,
 		FirstEpochDetails<frame_system::Pallet<T>>,
 	>;
 
+	/// Stores the associated epoch data for the incoming epoch.
+	/// The current epoch is consider inmutable once it starts.
+	/// This storage allows to modify the the associated data used in the next epoch.
 	#[pallet::storage]
-	pub type NextAssociatedData<T: Config> = StorageValue<_, T::AssociatedType, ValueQuery>;
+	pub type NextAssociatedData<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::AssociatedType, ValueQuery>;
 
 	// --------------------------
 
-	#[pallet::event]
-	//#[pallet::generate_deposit(pub(super) fn deposit_event)] // TODO
-	pub enum Event<T> {}
-
-	#[pallet::error]
-	pub enum Error<T> {}
-
-	impl<T: Config> Epoch<T::BlockNumber, T::AssociatedType> for Pallet<T>
-	where
-		T::BlockNumber: CheckedAdd,
-	{
+	impl<T: Config<I>, I: 'static> Epoch<T::BlockNumber, T::AssociatedType> for Pallet<T, I> {
 		fn update_epoch<R>(
 			current_block: T::BlockNumber,
 			finish: impl FnOnce(&EpochDetails<T::BlockNumber, T::AssociatedType>) -> R,
 		) -> Option<R> {
-			let current_epoch = ActiveEpoch::<T>::get();
+			let current_epoch = ActiveEpoch::<T, I>::get();
 			if current_epoch.ends_on > current_block {
 				return None;
 			}
 
-			ActiveEpoch::<T>::put(EpochDetails {
-				number: current_epoch.number.checked_add(1)?,
-				ends_on: current_epoch
-					.ends_on
-					.checked_add(&T::BlockPerEpoch::get())?,
-				associated_data: NextAssociatedData::<T>::get(),
+			let ends_on = current_epoch
+				.ends_on
+				.checked_add(&T::BlockPerEpoch::get())?;
+
+			ActiveEpoch::<T, I>::put(EpochDetails {
+				ends_on,
+				associated_data: NextAssociatedData::<T, I>::get(),
 			});
+
+			Self::deposit_event(Event::NewEpoch { ends_on });
 
 			Some(finish(&current_epoch))
 		}
@@ -117,7 +140,7 @@ pub mod pallet {
 		fn update_next_associated_data<R, E>(
 			mutate: impl FnOnce(&mut T::AssociatedType) -> Result<R, E>,
 		) -> Result<R, E> {
-			NextAssociatedData::<T>::try_mutate(mutate)
+			NextAssociatedData::<T, I>::try_mutate(mutate)
 		}
 	}
 }

--- a/pallets/epoch/src/mock.rs
+++ b/pallets/epoch/src/mock.rs
@@ -1,0 +1,97 @@
+use frame_support::{
+	traits::{ConstU16, ConstU32, ConstU64, Currency},
+	PalletId,
+};
+use frame_system as system;
+use sp_arithmetic::fixed_point::FixedU64;
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+};
+
+use crate as pallet_rewards;
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+pub const USER_A: u64 = 1;
+pub const USER_B: u64 = 2;
+pub const USER_INITIAL_BALANCE: u64 = 100000;
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Rewards: pallet_rewards::{Pallet, Storage, Event<T>},
+	}
+);
+
+impl system::Config for Test {
+	type AccountData = pallet_balances::AccountData<u64>;
+	type AccountId = u64;
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockHashCount = ConstU64<250>;
+	type BlockLength = ();
+	type BlockNumber = u64;
+	type BlockWeights = ();
+	type Call = Call;
+	type DbWeight = ();
+	type Event = Event;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type Header = Header;
+	type Index = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type MaxConsumers = ConstU32<16>;
+	type OnKilledAccount = ();
+	type OnNewAccount = ();
+	type OnSetCode = ();
+	type Origin = Origin;
+	type PalletInfo = PalletInfo;
+	type SS58Prefix = ConstU16<42>;
+	type SystemWeightInfo = ();
+	type Version = ();
+}
+
+impl pallet_balances::Config for Test {
+	type AccountStore = System;
+	type Balance = u64;
+	type DustRemoval = ();
+	type Event = Event;
+	type ExistentialDeposit = ();
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = ();
+	type WeightInfo = ();
+}
+
+frame_support::parameter_types! {
+	pub const RewardsPalletId: PalletId = PalletId(*b"m/reward");
+}
+
+impl pallet_rewards::Config for Test {
+	type Currency = Balances;
+	type Event = Event;
+	type PalletId = RewardsPalletId;
+	type Rate = FixedU64;
+	type SignedBalance = i128;
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut ext: sp_io::TestExternalities = system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap()
+		.into();
+
+	ext.execute_with(|| {
+		Balances::make_free_balance_be(&USER_A, USER_INITIAL_BALANCE);
+		Balances::make_free_balance_be(&USER_B, USER_INITIAL_BALANCE);
+	});
+
+	ext
+}

--- a/pallets/epoch/src/tests.rs
+++ b/pallets/epoch/src/tests.rs
@@ -1,0 +1,239 @@
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::ArithmeticError;
+
+use super::*;
+use crate::mock::{Rewards as Pallet, *};
+
+const REWARD_1: u64 = 100;
+
+#[test]
+fn reward_to_nothing() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Pallet::distribute_reward(REWARD_1),
+			ArithmeticError::DivisionByZero
+		);
+	});
+}
+
+#[test]
+fn stake() {
+	const USER_A_STAKED_1: u64 = 5000;
+	const USER_A_STAKED_2: u64 = 1000;
+
+	new_test_ext().execute_with(|| {
+		// DISTRIBUTION 0
+		assert_ok!(Pallet::deposit_stake(&USER_A, USER_A_STAKED_1));
+		assert_eq!(
+			Balances::free_balance(&USER_A),
+			USER_INITIAL_BALANCE - USER_A_STAKED_1
+		);
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+
+		// DISTRIBUTION 1
+		assert_ok!(Pallet::deposit_stake(&USER_A, USER_A_STAKED_2));
+		assert_eq!(
+			Balances::free_balance(&USER_A),
+			USER_INITIAL_BALANCE - (USER_A_STAKED_1 + USER_A_STAKED_2)
+		);
+	});
+}
+
+#[test]
+fn stake_insufficient_balance() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Pallet::deposit_stake(&USER_A, USER_INITIAL_BALANCE + 1),
+			pallet_balances::Error::<Test>::InsufficientBalance
+		);
+	});
+}
+
+#[test]
+fn stake_nothing() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Pallet::deposit_stake(&USER_A, 0));
+	});
+}
+
+#[test]
+fn unstake() {
+	const USER_A_STAKED: u64 = 1000;
+	const USER_A_UNSTAKED_1: u64 = 250;
+	const USER_A_UNSTAKED_2: u64 = USER_A_STAKED - USER_A_UNSTAKED_1;
+
+	new_test_ext().execute_with(|| {
+		// DISTRIBUTION 0
+		assert_ok!(Pallet::deposit_stake(&USER_A, USER_A_STAKED));
+		assert_ok!(Pallet::withdraw_stake(&USER_A, USER_A_UNSTAKED_1));
+		let expected_user_balance = USER_INITIAL_BALANCE - USER_A_STAKED + USER_A_UNSTAKED_1;
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_balance);
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+
+		// DISTRIBUTION 1
+		assert_ok!(Pallet::withdraw_stake(&USER_A, USER_A_UNSTAKED_2));
+		assert_eq!(Balances::free_balance(&USER_A), USER_INITIAL_BALANCE);
+	});
+}
+
+#[test]
+fn unstake_insufficient_balance() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(Pallet::withdraw_stake(&USER_A, 1), TokenError::NoFunds);
+
+		assert_ok!(Pallet::deposit_stake(&USER_A, 1000));
+
+		assert_noop!(Pallet::withdraw_stake(&USER_A, 2000), TokenError::NoFunds);
+	});
+}
+
+#[test]
+fn unstake_nothing() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Pallet::withdraw_stake(&USER_A, 0));
+	});
+}
+
+#[test]
+fn claim() {
+	const USER_A_STAKED: u64 = 1000;
+
+	new_test_ext().execute_with(|| {
+		let mut expected_user_balance = USER_INITIAL_BALANCE;
+		// DISTRIBUTION 0
+		assert_ok!(Pallet::deposit_stake(&USER_A, USER_A_STAKED));
+		expected_user_balance -= USER_A_STAKED;
+		assert_ok!(Pallet::claim_reward(&USER_A), 0);
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_balance);
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+
+		// DISTRIBUTION 1
+		assert_eq!(
+			Balances::free_balance(&RewardsPalletId::get().into_account_truncating()),
+			REWARD_1
+		);
+		assert_ok!(Pallet::compute_reward(&USER_A), REWARD_1);
+		assert_ok!(Pallet::claim_reward(&USER_A), REWARD_1);
+		expected_user_balance += REWARD_1;
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_balance);
+		assert_eq!(
+			Balances::free_balance(&RewardsPalletId::get().into_account_truncating()),
+			0
+		);
+
+		assert_ok!(Pallet::compute_reward(&USER_A), 0);
+		assert_ok!(Pallet::claim_reward(&USER_A), 0);
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_balance);
+		assert_eq!(
+			Balances::free_balance(&RewardsPalletId::get().into_account_truncating()),
+			0
+		);
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+
+		// DISTRIBUTION 2
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+		assert_eq!(
+			Balances::free_balance(&RewardsPalletId::get().into_account_truncating()),
+			REWARD_1 * 2
+		);
+
+		// DISTRIBUTION 3
+		assert_ok!(Pallet::claim_reward(&USER_A), REWARD_1 * 2);
+		expected_user_balance += REWARD_1 * 2;
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_balance);
+		assert_ok!(Pallet::withdraw_stake(&USER_A, USER_A_STAKED));
+		expected_user_balance += USER_A_STAKED;
+		// No more stake in the group
+		assert_noop!(
+			Pallet::distribute_reward(REWARD_1),
+			ArithmeticError::DivisionByZero
+		);
+
+		// DISTRIBUTION 4
+		assert_ok!(Pallet::claim_reward(&USER_A), 0);
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_balance);
+	});
+}
+
+#[test]
+fn claim_nothing() {
+	const USER_A_STAKED: u64 = 1000;
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Pallet::claim_reward(&USER_A));
+		assert_eq!(Balances::free_balance(&USER_A), USER_INITIAL_BALANCE);
+
+		assert_ok!(Pallet::deposit_stake(&USER_A, USER_A_STAKED));
+		assert_ok!(Pallet::withdraw_stake(&USER_A, USER_A_STAKED));
+
+		assert_noop!(
+			Pallet::distribute_reward(REWARD_1),
+			ArithmeticError::DivisionByZero
+		);
+
+		// DISTRIBUTION 2
+		assert_ok!(Pallet::claim_reward(&USER_A));
+		assert_eq!(Balances::free_balance(&USER_A), USER_INITIAL_BALANCE);
+	});
+}
+
+#[test]
+fn several_users_interacting() {
+	const USER_A_STAKED: u64 = 1000;
+	const USER_B_STAKED: u64 = 4000;
+
+	new_test_ext().execute_with(|| {
+		let mut expected_user_a_balance = USER_INITIAL_BALANCE;
+		let mut expected_user_b_balance = USER_INITIAL_BALANCE;
+		// DISTRIBUTION 0
+		assert_ok!(Pallet::deposit_stake(&USER_A, USER_A_STAKED));
+		expected_user_a_balance -= USER_A_STAKED;
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_a_balance);
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+
+		// DISTRIBUTION 1
+		assert_ok!(Pallet::deposit_stake(&USER_B, USER_B_STAKED));
+		expected_user_b_balance -= USER_B_STAKED;
+		assert_ok!(Pallet::claim_reward(&USER_A));
+		expected_user_a_balance += REWARD_1;
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_a_balance);
+		assert_eq!(Balances::free_balance(&USER_B), expected_user_b_balance);
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+
+		// DISTRIBUTION 2
+		assert_ok!(Pallet::claim_reward(&USER_A));
+		expected_user_a_balance += REWARD_1 * USER_A_STAKED / (USER_A_STAKED + USER_B_STAKED);
+		assert_ok!(Pallet::claim_reward(&USER_B));
+		expected_user_b_balance += REWARD_1 * USER_B_STAKED / (USER_A_STAKED + USER_B_STAKED);
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_a_balance);
+		assert_eq!(Balances::free_balance(&USER_B), expected_user_b_balance);
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+
+		// DISTRIBUTION 3
+		assert_ok!(Pallet::withdraw_stake(&USER_A, USER_A_STAKED));
+		expected_user_a_balance += USER_A_STAKED;
+		assert_ok!(Pallet::distribute_reward(REWARD_1));
+
+		// DISTRIBUTION 4
+		assert_ok!(Pallet::claim_reward(&USER_A));
+		expected_user_a_balance += REWARD_1 * USER_A_STAKED / (USER_A_STAKED + USER_B_STAKED);
+		assert_ok!(Pallet::claim_reward(&USER_B));
+		expected_user_b_balance +=
+			REWARD_1 * USER_B_STAKED / (USER_A_STAKED + USER_B_STAKED) + REWARD_1;
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_a_balance);
+		assert_eq!(Balances::free_balance(&USER_B), expected_user_b_balance);
+		assert_ok!(Pallet::withdraw_stake(&USER_B, USER_B_STAKED));
+		expected_user_b_balance += USER_B_STAKED;
+		// No more stake in the group
+		assert_noop!(
+			Pallet::distribute_reward(REWARD_1),
+			ArithmeticError::DivisionByZero
+		);
+
+		// DISTRIBUTION 5
+		assert_ok!(Pallet::claim_reward(&USER_A));
+		assert_ok!(Pallet::claim_reward(&USER_B));
+		assert_eq!(Balances::free_balance(&USER_A), expected_user_a_balance);
+		assert_eq!(Balances::free_balance(&USER_B), expected_user_b_balance);
+	});
+}


### PR DESCRIPTION
# Description

Utility pallet without extrinsic that handles the concept of epoch and how it changes over time. Supports different implementations in the same runtime.

**This PR is done for historical reasons**. For the current purpose, this pallet seems overengineering. The logic of this will be moved into `pallet-liquidity-rewards`.