### PR TITLE
Ensure Ops extended

### DIFF
--- a/libs/traits/src/ops.rs
+++ b/libs/traits/src/ops.rs
@@ -86,7 +86,7 @@ pub mod ensure {
 		/// Subtracts two numbers, checking for overflow.
 		/// If overflow happens, `ArithmeticError` is returned.
 		///
-		/// Similar to [`CheckedAdd::checked_sub()`] but returning an `ArithmeticError` error
+		/// Similar to [`CheckedSub::checked_sub()`] but returning an `ArithmeticError` error
 		///
 		/// ```
 		/// use cfg_traits::ops::ensure::EnsureSub;
@@ -115,7 +115,7 @@ pub mod ensure {
 		/// Multiplies two numbers, checking for overflow. If overflow happens,
 		/// `ArithmeticError` is returned.
 		///
-		/// Similar to [`CheckedAdd::checked_mul()`] but returning an `ArithmeticError` error
+		/// Similar to [`CheckedMul::checked_mul()`] but returning an `ArithmeticError` error
 		///
 		/// ```
 		/// use cfg_traits::ops::ensure::EnsureMul;
@@ -145,7 +145,7 @@ pub mod ensure {
 		/// Divides two numbers, checking for overflow.
 		/// If overflow happens, `ArithmeticError` is returned.
 		///
-		/// Similar to [`CheckedAdd::checked_div()`] but returning an `ArithmeticError` error
+		/// Similar to [`CheckedDiv::checked_div()`] but returning an `ArithmeticError` error
 		///
 		/// ```
 		/// use cfg_traits::ops::ensure::EnsureDiv;
@@ -331,7 +331,7 @@ pub mod ensure {
 				.ok_or_else(|| error::division(n, d))
 		}
 
-		/// Checked multiplication for integer type `N`. Equal to `self * n`.
+		/// Ensure multiplication for integer type `N`. Equal to `self * n`.
 		///
 		/// Returns `ArithmeticError` if the result does not fit in `N`.
 		///
@@ -358,7 +358,7 @@ pub mod ensure {
 				.ok_or_else(|| error::multiplication(self, n))
 		}
 
-		/// Checked division for integer type `N`. Equal to `self / d`.
+		/// Ensure division for integer type `N`. Equal to `self / d`.
 		///
 		/// Returns `ArithmeticError` if the result does not fit in `N` or `d == 0`.
 		///

--- a/libs/traits/src/ops.rs
+++ b/libs/traits/src/ops.rs
@@ -1,20 +1,17 @@
-use sp_runtime::{
-	traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero},
-	ArithmeticError, FixedPointNumber, FixedPointOperand,
-};
+use sp_runtime::traits::Zero;
 
-// Numerical Sign
+/// Numerical Sign
 #[derive(Clone, Copy, PartialEq)]
 pub enum NumSign {
-	// A negative value
+	/// A negative value
 	Negative,
 
-	// A positive/zero value
+	/// A positive/zero value
 	Positive,
 }
 
-/// Request the signum of a value.
-pub trait Signum: PartialOrd + Zero {
+/// Request the signum of a number.
+pub trait Signum: PartialOrd + Zero + Copy {
 	/// Get the signum.
 	fn signum(&self) -> NumSign {
 		if *self < Self::zero() {
@@ -25,380 +22,392 @@ pub trait Signum: PartialOrd + Zero {
 	}
 }
 
-impl<T: PartialOrd + Zero> Signum for T {}
+impl<T: PartialOrd + Zero + Copy> Signum for T {}
 
-fn addition_error<L: Signum>(l: &L) -> ArithmeticError {
-	match l.signum() {
-		NumSign::Negative => ArithmeticError::Underflow,
-		NumSign::Positive => ArithmeticError::Overflow,
-	}
-}
+/// Arithmetic operations with safe error handling
+/// The `EnsureOps` family functions follows the same behavior as `CheckedOps` but
+/// returning an [`ArithmeticError`] instead of `None`
+///
+/// [`ArithmeticError`]: sp_runtime::ArithmeticError
+pub mod ensure {
+	use sp_runtime::{
+		traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub},
+		ArithmeticError, FixedPointNumber, FixedPointOperand,
+	};
 
-fn subtraction_error<L: Signum>(l: &L) -> ArithmeticError {
-	match l.signum() {
-		NumSign::Negative => ArithmeticError::Overflow,
-		NumSign::Positive => ArithmeticError::Underflow,
-	}
-}
+	use super::{NumSign, Signum};
 
-fn multiplication_error<R: Signum, L: Signum>(r: &R, l: &L) -> ArithmeticError {
-	match r.signum() != l.signum() {
-		true => ArithmeticError::Underflow,
-		false => ArithmeticError::Overflow,
-	}
-}
-
-fn division_error<N: Signum, D: Signum>(n: &N, d: &D) -> ArithmeticError {
-	if d.is_zero() {
-		ArithmeticError::DivisionByZero
-	} else {
-		match n.signum() != d.signum() {
-			true => ArithmeticError::Underflow,
-			false => ArithmeticError::Overflow,
+	/// Performs addition that returns `ArithmeticError` instead of wrapping around on overflow.
+	pub trait EnsureAdd: CheckedAdd + Signum {
+		/// Adds two numbers, checking for overflow.
+		/// If overflow happens, `ArithmeticError` is returned.
+		///
+		/// Similar to [`CheckedAdd::checked_add()`] but returning an `ArithmeticError` error
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureAdd;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     u32::MAX.ensure_add(1)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_underflow() -> DispatchResult {
+		///     i32::MIN.ensure_add(-1)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
+		/// ```
+		fn ensure_add(self, v: Self) -> Result<Self, ArithmeticError> {
+			self.checked_add(&v).ok_or_else(|| error::addition(&v))
 		}
 	}
-}
 
-/// Performs addition that returns `ArithmeticError` instead of wrapping around on overflow.
-pub trait EnsureAdd: CheckedAdd + Signum {
-	/// Adds two numbers, checking for overflow.
-	/// If overflow happens, `ArithmeticError` is returned.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureAdd;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     u32::MAX.ensure_add(1)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_underflow() -> DispatchResult {
-	///     i32::MIN.ensure_add(-1)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-	/// ```
-	fn ensure_add(&self, v: Self) -> Result<Self, ArithmeticError> {
-		self.checked_add(&v).ok_or_else(|| addition_error(&v))
-	}
-}
-
-/// Performs subtraction that returns `ArithmeticError` instead of wrapping around on underflow.
-pub trait EnsureSub: CheckedSub + Signum {
-	/// Subtracts two numbers, checking for overflow.
-	/// If overflow happens, `ArithmeticError` is returned.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureSub;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-	///
-	/// fn extrinsic_underflow() -> DispatchResult {
-	///     0u32.ensure_sub(1)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     i32::MAX.ensure_sub(-1)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// ```
-	fn ensure_sub(&self, v: Self) -> Result<Self, ArithmeticError> {
-		self.checked_sub(&v).ok_or_else(|| subtraction_error(&v))
-	}
-}
-
-/// Performs multiplication that returns `ArithmeticError` instead of wrapping around on overflow.
-pub trait EnsureMul: CheckedMul + Signum {
-	/// Multiplies two numbers, checking for overflow. If overflow happens,
-	/// `ArithmeticError` is returned.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureMul;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     u32::MAX.ensure_mul(2)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_underflow() -> DispatchResult {
-	///     i32::MAX.ensure_mul(-2)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-	/// ```
-	fn ensure_mul(&self, v: Self) -> Result<Self, ArithmeticError> {
-		self.checked_mul(&v)
-			.ok_or_else(|| multiplication_error(self, &v))
-	}
-}
-
-/// Performs division that returns `ArithmeticError` instead of wrapping around on overflow.
-pub trait EnsureDiv: CheckedDiv + Signum {
-	/// Divides two numbers, checking for overflow.
-	/// If overflow happens, `ArithmeticError` is returned.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureDiv;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-	///
-	/// fn extrinsic_zero() -> DispatchResult {
-	///     1.ensure_div(0)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     FixedI64::from(i64::MIN).ensure_div(FixedI64::from(-1))?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// ```
-	fn ensure_div(&self, v: Self) -> Result<Self, ArithmeticError> {
-		self.checked_div(&v).ok_or_else(|| division_error(self, &v))
-	}
-}
-
-impl<T: CheckedAdd + Signum> EnsureAdd for T {}
-impl<T: CheckedSub + Signum> EnsureSub for T {}
-impl<T: CheckedMul + Signum> EnsureMul for T {}
-impl<T: CheckedDiv + Signum> EnsureDiv for T {}
-
-/// Performs self addition that returns `ArithmeticError` instead of wrapping around on overflow.
-pub trait EnsureAddAssign: EnsureAdd {
-	/// Adds two numbers overwriting the left hand one, checking for overflow.
-	/// If overflow happens, `ArithmeticError` is returned.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureAddAssign;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     let mut max = u32::MAX;
-	///     max.ensure_add_assign(1)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_underflow() -> DispatchResult {
-	///     let mut max = i32::MIN;
-	///     max.ensure_add_assign(-1)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-	/// ```
-	fn ensure_add_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
-		*self = self.ensure_add(v)?;
-		Ok(())
-	}
-}
-
-/// Performs self subtraction that returns `ArithmeticError` instead of wrapping around on underflow.
-pub trait EnsureSubAssign: EnsureSub {
-	/// Subtracts two numbers overwriting the left hand one, checking for overflow.
-	/// If overflow happens, `ArithmeticError` is returned.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureSubAssign;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-	///
-	/// fn extrinsic_underflow() -> DispatchResult {
-	///     let mut zero: u32 = 0;
-	///     zero.ensure_sub_assign(1)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     let mut zero = i32::MAX;
-	///     zero.ensure_sub_assign(-1)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// ```
-	fn ensure_sub_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
-		*self = self.ensure_sub(v)?;
-		Ok(())
-	}
-}
-
-/// Performs self multiplication that returns `ArithmeticError` instead of wrapping around on overflow.
-pub trait EnsureMulAssign: EnsureMul {
-	/// Multiplies two numbers overwriting the left hand one, checking for overflow.
-	/// If overflow happens, `ArithmeticError` is returned.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureMulAssign;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     let mut max = u32::MAX;
-	///     max.ensure_mul_assign(2)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_underflow() -> DispatchResult {
-	///     let mut max = i32::MAX;
-	///     max.ensure_mul_assign(-2)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-	/// ```
-	fn ensure_mul_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
-		*self = self.ensure_mul(v)?;
-		Ok(())
-	}
-}
-
-/// Performs self division that returns `ArithmeticError` instead of wrapping around on overflow.
-pub trait EnsureDivAssign: EnsureDiv {
-	/// Divides two numbers overwriting the left hand one, checking for overflow.
-	/// If overflow happens, `ArithmeticError` is returned.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureDivAssign;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-	///
-	/// fn extrinsic_zero() -> DispatchResult {
-	///     let mut one = 1;
-	///     one.ensure_div_assign(0)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     let mut min = FixedI64::from(i64::MIN);
-	///     min.ensure_div_assign(FixedI64::from(-1))?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// ```
-	fn ensure_div_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
-		*self = self.ensure_div(v)?;
-		Ok(())
-	}
-}
-
-impl<T: EnsureAdd> EnsureAddAssign for T {}
-impl<T: EnsureSub> EnsureSubAssign for T {}
-impl<T: EnsureMul> EnsureMulAssign for T {}
-impl<T: EnsureDiv> EnsureDivAssign for T {}
-
-/// Extends `FixedPointNumber with` the Ensure family functions.
-pub trait EnsureFixedPointNumber: FixedPointNumber {
-	/// Creates `self` from a rational number. Equal to `n / d`.
-	///
-	/// Returns `ArithmeticError` if `d == 0` or `n / d` exceeds accuracy.
-	/// ```
-	/// use cfg_traits::ops::EnsureFixedPointNumber;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-	///
-	/// fn extrinsic_zero() -> DispatchResult {
-	///     FixedI64::ensure_from_rational(1, 0)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_underflow() -> DispatchResult {
-	///     FixedI64::ensure_from_rational(i64::MAX, -1)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
-	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-	/// ```
-	fn ensure_from_rational<N: FixedPointOperand, D: FixedPointOperand>(
-		n: N,
-		d: D,
-	) -> Result<Self, ArithmeticError> {
-		<Self as FixedPointNumber>::checked_from_rational(n, d)
-			.ok_or_else(|| division_error(&n, &d))
+	/// Performs subtraction that returns `ArithmeticError` instead of wrapping around on underflow.
+	pub trait EnsureSub: CheckedSub + Signum {
+		/// Subtracts two numbers, checking for overflow.
+		/// If overflow happens, `ArithmeticError` is returned.
+		///
+		/// Similar to [`CheckedAdd::checked_sub()`] but returning an `ArithmeticError` error
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureSub;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic_underflow() -> DispatchResult {
+		///     0u32.ensure_sub(1)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     i32::MAX.ensure_sub(-1)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// ```
+		fn ensure_sub(self, v: Self) -> Result<Self, ArithmeticError> {
+			self.checked_sub(&v).ok_or_else(|| error::subtraction(&v))
+		}
 	}
 
-	/// Checked multiplication for integer type `N`. Equal to `self * n`.
-	///
-	/// Returns `ArithmeticError` if the result does not fit in `N`.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureFixedPointNumber;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     FixedI64::from(i64::MAX).ensure_mul_int(2)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_underflow() -> DispatchResult {
-	///     FixedI64::from(i64::MAX).ensure_mul_int(-2)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-	/// ```
-	fn ensure_mul_int<N: FixedPointOperand>(self, n: N) -> Result<N, ArithmeticError> {
-		self.checked_mul_int(n)
-			.ok_or_else(|| multiplication_error(&self, &n))
+	/// Performs multiplication that returns `ArithmeticError` instead of wrapping around on overflow.
+	pub trait EnsureMul: CheckedMul + Signum {
+		/// Multiplies two numbers, checking for overflow. If overflow happens,
+		/// `ArithmeticError` is returned.
+		///
+		/// Similar to [`CheckedAdd::checked_mul()`] but returning an `ArithmeticError` error
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureMul;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     u32::MAX.ensure_mul(2)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_underflow() -> DispatchResult {
+		///     i32::MAX.ensure_mul(-2)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
+		/// ```
+		fn ensure_mul(self, v: Self) -> Result<Self, ArithmeticError> {
+			self.checked_mul(&v)
+				.ok_or_else(|| error::multiplication(&self, &v))
+		}
 	}
 
-	/// Checked division for integer type `N`. Equal to `self / d`.
-	///
-	/// Returns `ArithmeticError` if the result does not fit in `N` or `d == 0`.
-	///
-	/// ```
-	/// use cfg_traits::ops::EnsureFixedPointNumber;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-	///
-	/// fn extrinsic_zero() -> DispatchResult {
-	///     FixedI64::from(1).ensure_div_int(0)?;
-	///     Ok(())
-	/// }
-	///
-	/// fn extrinsic_overflow() -> DispatchResult {
-	///     FixedI64::from(i64::MIN).ensure_div_int(-1)?;
-	///     Ok(())
-	/// }
-	///
-	/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
-	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// ```
-	fn ensure_div_int<D: FixedPointOperand>(self, d: D) -> Result<D, ArithmeticError> {
-		self.checked_div_int(d)
-			.ok_or_else(|| division_error(&self, &d))
+	/// Performs division that returns `ArithmeticError` instead of wrapping around on overflow.
+	pub trait EnsureDiv: CheckedDiv + Signum {
+		/// Divides two numbers, checking for overflow.
+		/// If overflow happens, `ArithmeticError` is returned.
+		///
+		/// Similar to [`CheckedAdd::checked_div()`] but returning an `ArithmeticError` error
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureDiv;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
+		///
+		/// fn extrinsic_zero() -> DispatchResult {
+		///     1.ensure_div(0)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     FixedI64::from(i64::MIN).ensure_div(FixedI64::from(-1))?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// ```
+		fn ensure_div(self, v: Self) -> Result<Self, ArithmeticError> {
+			self.checked_div(&v)
+				.ok_or_else(|| error::division(&self, &v))
+		}
 	}
-}
 
-impl<T: FixedPointNumber> EnsureFixedPointNumber for T {}
+	impl<T: CheckedAdd + Signum> EnsureAdd for T {}
+	impl<T: CheckedSub + Signum> EnsureSub for T {}
+	impl<T: CheckedMul + Signum> EnsureMul for T {}
+	impl<T: CheckedDiv + Signum> EnsureDiv for T {}
 
-#[cfg(test)]
-mod test {
-	use super::*;
+	/// Performs self addition that returns `ArithmeticError` instead of wrapping around on overflow.
+	pub trait EnsureAddAssign: EnsureAdd {
+		/// Adds two numbers overwriting the left hand one, checking for overflow.
+		/// If overflow happens, `ArithmeticError` is returned.
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureAddAssign;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     let mut max = u32::MAX;
+		///     max.ensure_add_assign(1)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_underflow() -> DispatchResult {
+		///     let mut max = i32::MIN;
+		///     max.ensure_add_assign(-1)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
+		/// ```
+		fn ensure_add_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
+			*self = self.ensure_add(v)?;
+			Ok(())
+		}
+	}
 
-	#[test]
-	fn per_thing_support() {
-		// Ensure per thing support is implemented automatically.
-		use sp_runtime::Perbill;
+	/// Performs self subtraction that returns `ArithmeticError` instead of wrapping around on underflow.
+	pub trait EnsureSubAssign: EnsureSub {
+		/// Subtracts two numbers overwriting the left hand one, checking for overflow.
+		/// If overflow happens, `ArithmeticError` is returned.
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureSubAssign;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic_underflow() -> DispatchResult {
+		///     let mut zero: u32 = 0;
+		///     zero.ensure_sub_assign(1)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     let mut zero = i32::MAX;
+		///     zero.ensure_sub_assign(-1)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// ```
+		fn ensure_sub_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
+			*self = self.ensure_sub(v)?;
+			Ok(())
+		}
+	}
 
-		assert_eq!(
-			Perbill::from_percent(3).ensure_sub(Perbill::from_percent(1)),
-			Ok(Perbill::from_percent(2))
-		);
-		assert_eq!(
-			Perbill::from_percent(0).ensure_sub(Perbill::from_percent(1)),
-			Err(ArithmeticError::Underflow.into())
-		);
+	/// Performs self multiplication that returns `ArithmeticError` instead of wrapping around on overflow.
+	pub trait EnsureMulAssign: EnsureMul {
+		/// Multiplies two numbers overwriting the left hand one, checking for overflow.
+		/// If overflow happens, `ArithmeticError` is returned.
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureMulAssign;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     let mut max = u32::MAX;
+		///     max.ensure_mul_assign(2)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_underflow() -> DispatchResult {
+		///     let mut max = i32::MAX;
+		///     max.ensure_mul_assign(-2)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
+		/// ```
+		fn ensure_mul_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
+			*self = self.ensure_mul(v)?;
+			Ok(())
+		}
+	}
+
+	/// Performs self division that returns `ArithmeticError` instead of wrapping around on overflow.
+	pub trait EnsureDivAssign: EnsureDiv {
+		/// Divides two numbers overwriting the left hand one, checking for overflow.
+		/// If overflow happens, `ArithmeticError` is returned.
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureDivAssign;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
+		///
+		/// fn extrinsic_zero() -> DispatchResult {
+		///     let mut one = 1;
+		///     one.ensure_div_assign(0)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     let mut min = FixedI64::from(i64::MIN);
+		///     min.ensure_div_assign(FixedI64::from(-1))?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// ```
+		fn ensure_div_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
+			*self = self.ensure_div(v)?;
+			Ok(())
+		}
+	}
+
+	impl<T: EnsureAdd> EnsureAddAssign for T {}
+	impl<T: EnsureSub> EnsureSubAssign for T {}
+	impl<T: EnsureMul> EnsureMulAssign for T {}
+	impl<T: EnsureDiv> EnsureDivAssign for T {}
+
+	/// Extends `FixedPointNumber with` the Ensure family functions.
+	pub trait EnsureFixedPointNumber: FixedPointNumber {
+		/// Creates `self` from a rational number. Equal to `n / d`.
+		///
+		/// Returns `ArithmeticError` if `d == 0` or `n / d` exceeds accuracy.
+		///
+		/// Similar to [`FixedPointNumber::checked_from_rational()`] but returning an ArithmeticError error
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureFixedPointNumber;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
+		///
+		/// fn extrinsic_zero() -> DispatchResult {
+		///     FixedI64::ensure_from_rational(1, 0)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_underflow() -> DispatchResult {
+		///     FixedI64::ensure_from_rational(i64::MAX, -1)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
+		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
+		/// ```
+		fn ensure_from_rational<N: FixedPointOperand, D: FixedPointOperand>(
+			n: N,
+			d: D,
+		) -> Result<Self, ArithmeticError> {
+			<Self as FixedPointNumber>::checked_from_rational(n, d)
+				.ok_or_else(|| error::division(&n, &d))
+		}
+
+		/// Checked multiplication for integer type `N`. Equal to `self * n`.
+		///
+		/// Returns `ArithmeticError` if the result does not fit in `N`.
+		///
+		/// Similar to [`FixedPointNumber::checked_mul_int()`] but returning an ArithmeticError error
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureFixedPointNumber;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     FixedI64::from(i64::MAX).ensure_mul_int(2)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_underflow() -> DispatchResult {
+		///     FixedI64::from(i64::MAX).ensure_mul_int(-2)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
+		/// ```
+		fn ensure_mul_int<N: FixedPointOperand>(self, n: N) -> Result<N, ArithmeticError> {
+			self.checked_mul_int(n)
+				.ok_or_else(|| error::multiplication(&self, &n))
+		}
+
+		/// Checked division for integer type `N`. Equal to `self / d`.
+		///
+		/// Returns `ArithmeticError` if the result does not fit in `N` or `d == 0`.
+		///
+		/// Similar to [`FixedPointNumber::checked_div_int()`] but returning an ArithmeticError error
+		///
+		/// ```
+		/// use cfg_traits::ops::ensure::EnsureFixedPointNumber;
+		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
+		///
+		/// fn extrinsic_zero() -> DispatchResult {
+		///     FixedI64::from(1).ensure_div_int(0)?;
+		///     Ok(())
+		/// }
+		///
+		/// fn extrinsic_overflow() -> DispatchResult {
+		///     FixedI64::from(i64::MIN).ensure_div_int(-1)?;
+		///     Ok(())
+		/// }
+		///
+		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
+		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
+		/// ```
+		fn ensure_div_int<D: FixedPointOperand>(self, d: D) -> Result<D, ArithmeticError> {
+			self.checked_div_int(d)
+				.ok_or_else(|| error::division(&self, &d))
+		}
+	}
+
+	impl<T: FixedPointNumber> EnsureFixedPointNumber for T {}
+
+	mod error {
+		use super::{ArithmeticError, NumSign, Signum};
+
+		pub fn addition<R: Signum>(r: &R) -> ArithmeticError {
+			match r.signum() {
+				NumSign::Negative => ArithmeticError::Underflow,
+				NumSign::Positive => ArithmeticError::Overflow,
+			}
+		}
+
+		pub fn subtraction<R: Signum>(r: &R) -> ArithmeticError {
+			match r.signum() {
+				NumSign::Negative => ArithmeticError::Overflow,
+				NumSign::Positive => ArithmeticError::Underflow,
+			}
+		}
+
+		pub fn multiplication<L: Signum, R: Signum>(l: &L, r: &R) -> ArithmeticError {
+			match l.signum() != r.signum() {
+				true => ArithmeticError::Underflow,
+				false => ArithmeticError::Overflow,
+			}
+		}
+
+		pub fn division<N: Signum, D: Signum>(n: &N, d: &D) -> ArithmeticError {
+			if d.is_zero() {
+				ArithmeticError::DivisionByZero
+			} else {
+				match n.signum() != d.signum() {
+					true => ArithmeticError::Underflow,
+					false => ArithmeticError::Overflow,
+				}
+			}
+		}
 	}
 }

--- a/libs/traits/src/ops.rs
+++ b/libs/traits/src/ops.rs
@@ -475,10 +475,7 @@ pub mod ensure {
 			if d.is_zero() {
 				ArithmeticError::DivisionByZero
 			} else {
-				match n.signum() != d.signum() {
-					true => ArithmeticError::Underflow,
-					false => ArithmeticError::Overflow,
-				}
+				multiplication(n, d)
 			}
 		}
 	}

--- a/libs/traits/src/ops.rs
+++ b/libs/traits/src/ops.rs
@@ -69,20 +69,20 @@ pub trait EnsureAdd: CheckedAdd + Signum {
 	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
 	///
 	/// fn extrinsic_overflow() -> DispatchResult {
-	///     u32::MAX.ensure_add(&1)?;
+	///     u32::MAX.ensure_add(1)?;
 	///     Ok(())
 	/// }
 	///
 	/// fn extrinsic_underflow() -> DispatchResult {
-	///     i32::MIN.ensure_add(&-1)?;
+	///     i32::MIN.ensure_add(-1)?;
 	///     Ok(())
 	/// }
 	///
 	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
 	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
 	/// ```
-	fn ensure_add(&self, v: &Self) -> Result<Self, ArithmeticError> {
-		self.checked_add(v).ok_or_else(|| addition_error(v))
+	fn ensure_add(&self, v: Self) -> Result<Self, ArithmeticError> {
+		self.checked_add(&v).ok_or_else(|| addition_error(&v))
 	}
 }
 
@@ -96,20 +96,20 @@ pub trait EnsureSub: CheckedSub + Signum {
 	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
 	///
 	/// fn extrinsic_underflow() -> DispatchResult {
-	///     0u32.ensure_sub(&1)?;
+	///     0u32.ensure_sub(1)?;
 	///     Ok(())
 	/// }
 	///
 	/// fn extrinsic_overflow() -> DispatchResult {
-	///     i32::MAX.ensure_sub(&-1)?;
+	///     i32::MAX.ensure_sub(-1)?;
 	///     Ok(())
 	/// }
 	///
 	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
 	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
 	/// ```
-	fn ensure_sub(&self, v: &Self) -> Result<Self, ArithmeticError> {
-		self.checked_sub(v).ok_or_else(|| subtraction_error(v))
+	fn ensure_sub(&self, v: Self) -> Result<Self, ArithmeticError> {
+		self.checked_sub(&v).ok_or_else(|| subtraction_error(&v))
 	}
 }
 
@@ -123,21 +123,21 @@ pub trait EnsureMul: CheckedMul + Signum {
 	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
 	///
 	/// fn extrinsic_overflow() -> DispatchResult {
-	///     u32::MAX.ensure_mul(&2)?;
+	///     u32::MAX.ensure_mul(2)?;
 	///     Ok(())
 	/// }
 	///
 	/// fn extrinsic_underflow() -> DispatchResult {
-	///     i32::MAX.ensure_mul(&-2)?;
+	///     i32::MAX.ensure_mul(-2)?;
 	///     Ok(())
 	/// }
 	///
 	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
 	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
 	/// ```
-	fn ensure_mul(&self, v: &Self) -> Result<Self, ArithmeticError> {
-		self.checked_mul(v)
-			.ok_or_else(|| multiplication_error(self, v))
+	fn ensure_mul(&self, v: Self) -> Result<Self, ArithmeticError> {
+		self.checked_mul(&v)
+			.ok_or_else(|| multiplication_error(self, &v))
 	}
 }
 
@@ -151,26 +151,20 @@ pub trait EnsureDiv: CheckedDiv + Signum {
 	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
 	///
 	/// fn extrinsic_zero() -> DispatchResult {
-	///     1.ensure_div(&0)?;
+	///     1.ensure_div(0)?;
 	///     Ok(())
 	/// }
 	///
 	/// fn extrinsic_overflow() -> DispatchResult {
-	///     FixedI64::from(i64::MIN).ensure_div(&FixedI64::from(-1))?;
-	///     Ok(())
-	/// }
-	///
-	/// fn c() -> DispatchResult {
-	///     FixedI64::from(i64::MIN).ensure_div(&FixedI64::from(1))?;
+	///     FixedI64::from(i64::MIN).ensure_div(FixedI64::from(-1))?;
 	///     Ok(())
 	/// }
 	///
 	/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
 	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-	/// assert_eq!(c(), Ok(()));
 	/// ```
-	fn ensure_div(&self, v: &Self) -> Result<Self, ArithmeticError> {
-		self.checked_div(v).ok_or_else(|| division_error(self, v))
+	fn ensure_div(&self, v: Self) -> Result<Self, ArithmeticError> {
+		self.checked_div(&v).ok_or_else(|| division_error(self, &v))
 	}
 }
 
@@ -190,20 +184,20 @@ pub trait EnsureAddAssign: EnsureAdd {
 	///
 	/// fn extrinsic_overflow() -> DispatchResult {
 	///     let mut max = u32::MAX;
-	///     max.ensure_add_assign(&1)?;
+	///     max.ensure_add_assign(1)?;
 	///     Ok(())
 	/// }
 	///
 	/// fn extrinsic_underflow() -> DispatchResult {
 	///     let mut max = i32::MIN;
-	///     max.ensure_add_assign(&-1)?;
+	///     max.ensure_add_assign(-1)?;
 	///     Ok(())
 	/// }
 	///
 	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
 	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
 	/// ```
-	fn ensure_add_assign(&mut self, v: &Self) -> Result<(), ArithmeticError> {
+	fn ensure_add_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
 		*self = self.ensure_add(v)?;
 		Ok(())
 	}
@@ -220,20 +214,20 @@ pub trait EnsureSubAssign: EnsureSub {
 	///
 	/// fn extrinsic_underflow() -> DispatchResult {
 	///     let mut zero: u32 = 0;
-	///     zero.ensure_sub_assign(&1)?;
+	///     zero.ensure_sub_assign(1)?;
 	///     Ok(())
 	/// }
 	///
 	/// fn extrinsic_overflow() -> DispatchResult {
 	///     let mut zero = i32::MAX;
-	///     zero.ensure_sub_assign(&-1)?;
+	///     zero.ensure_sub_assign(-1)?;
 	///     Ok(())
 	/// }
 	///
 	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
 	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
 	/// ```
-	fn ensure_sub_assign(&mut self, v: &Self) -> Result<(), ArithmeticError> {
+	fn ensure_sub_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
 		*self = self.ensure_sub(v)?;
 		Ok(())
 	}
@@ -250,20 +244,20 @@ pub trait EnsureMulAssign: EnsureMul {
 	///
 	/// fn extrinsic_overflow() -> DispatchResult {
 	///     let mut max = u32::MAX;
-	///     max.ensure_mul_assign(&2)?;
+	///     max.ensure_mul_assign(2)?;
 	///     Ok(())
 	/// }
 	///
 	/// fn extrinsic_underflow() -> DispatchResult {
 	///     let mut max = i32::MAX;
-	///     max.ensure_mul_assign(&-2)?;
+	///     max.ensure_mul_assign(-2)?;
 	///     Ok(())
 	/// }
 	///
 	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
 	/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
 	/// ```
-	fn ensure_mul_assign(&mut self, v: &Self) -> Result<(), ArithmeticError> {
+	fn ensure_mul_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
 		*self = self.ensure_mul(v)?;
 		Ok(())
 	}
@@ -276,17 +270,24 @@ pub trait EnsureDivAssign: EnsureDiv {
 	///
 	/// ```
 	/// use cfg_traits::ops::EnsureDivAssign;
-	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
+	/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
 	///
-	/// fn extrinsic() -> DispatchResult {
+	/// fn extrinsic_zero() -> DispatchResult {
 	///     let mut one = 1;
-	///     one.ensure_div_assign(&0)?;
+	///     one.ensure_div_assign(0)?;
 	///     Ok(())
 	/// }
 	///
-	/// assert_eq!(extrinsic(), Err(ArithmeticError::DivisionByZero.into()));
+	/// fn extrinsic_overflow() -> DispatchResult {
+	///     let mut min = FixedI64::from(i64::MIN);
+	///     min.ensure_div_assign(FixedI64::from(-1))?;
+	///     Ok(())
+	/// }
+	///
+	/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
+	/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
 	/// ```
-	fn ensure_div_assign(&mut self, v: &Self) -> Result<(), ArithmeticError> {
+	fn ensure_div_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
 		*self = self.ensure_div(v)?;
 		Ok(())
 	}
@@ -384,33 +385,19 @@ impl<T: FixedPointNumber> EnsureFixedPointNumber for T {}
 
 #[cfg(test)]
 mod test {
-	use sp_runtime::{FixedU128, Perbill};
-
 	use super::*;
-
-	// Ensure the following substrate types are implemented automatically for the EnsureOps
-	// family traits
-
-	#[test]
-	fn fixed_point_support() {
-		assert_eq!(
-			FixedU128::from(3).ensure_sub(&FixedU128::from(1)),
-			Ok(FixedU128::from(2))
-		);
-		assert_eq!(
-			FixedU128::from(0).ensure_sub(&FixedU128::from(1)),
-			Err(ArithmeticError::Underflow.into())
-		);
-	}
 
 	#[test]
 	fn per_thing_support() {
+		// Ensure per thing support is implemented automatically.
+		use sp_runtime::Perbill;
+
 		assert_eq!(
-			Perbill::from_percent(3).ensure_sub(&Perbill::from_percent(1)),
+			Perbill::from_percent(3).ensure_sub(Perbill::from_percent(1)),
 			Ok(Perbill::from_percent(2))
 		);
 		assert_eq!(
-			Perbill::from_percent(0).ensure_sub(&Perbill::from_percent(1)),
+			Perbill::from_percent(0).ensure_sub(Perbill::from_percent(1)),
 			Err(ArithmeticError::Underflow.into())
 		);
 	}


### PR DESCRIPTION
# Description

Improve the `cfg_traits::ops::ensure` module with more functionality.

Follows this work #1034

## Changes and Descriptions

More support for the `ops::ensure` module:

- Added `EnsureFixedPointNumber` trait that adds `ensure_from_rational()`, `ensure_mul_int()` and `ensure_div_int()` for any `FixedPointNumber`.
- Added `EnsureInto` and `EnsureFrom` traits to check the overflow when numbers are converted.
- More accurate division error.
- Improve documentation.

## Type of change

- New feature (non-breaking change which adds *internal* functionality)

# How Has This Been Tested?

```sh
cargo test -p cfg-traits (run test in the examples)
cargo doc -p cfg-traits (check documentation links)
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `main` branch
