### PR TITLE
Fix: Remove allowance of multi-residual tranches in low level api

### DIFF
--- a/pallets/pools/src/lib.rs
+++ b/pallets/pools/src/lib.rs
@@ -1970,56 +1970,30 @@ pub mod pallet {
 				Error::<T>::TooManyTranches
 			);
 
-			// At least one tranche must exist, and the first (most junior) tranche must have an
-			// interest rate of 0, indicating that it receives all remaining equity
-			ensure!(
-				match new_tranches.first() {
-					None => false,
-					Some(tranche_input) => {
-						tranche_input.tranche_type == TrancheType::Residual
-					}
-				},
-				Error::<T>::InvalidJuniorTranche
-			);
-
-			// All but the most junior tranche should have min risk buffers and interest rates
-			let (_residual_tranche, non_residual_tranche) = new_tranches
-				.split_first()
+			let mut tranche_iter = new_tranches.iter();
+			let mut prev_tranche = tranche_iter
+				.next()
 				.ok_or(Error::<T>::InvalidJuniorTranche)?;
-
-			// Currently we only allow a single junior tranche per pool
-			// This is subject to change in the future
-			ensure!(
-				match non_residual_tranche.iter().next() {
-					None => true,
-					Some(next_tranche) => {
-						next_tranche.tranche_type != TrancheType::Residual
-					}
-				},
-				Error::<T>::InvalidTrancheStructure
-			);
-
-			let mut prev_tranche_type = &TrancheType::Residual;
-			let mut prev_seniority = &None;
 			let max_seniority = new_tranches
 				.len()
 				.try_into()
 				.expect("MaxTranches is u32. qed.");
 
-			for tranche_input in new_tranches.iter() {
+			for tranche_input in tranche_iter {
 				ensure!(
-					prev_tranche_type.valid_next_tranche(&tranche_input.tranche_type),
+					prev_tranche
+						.tranche_type
+						.valid_next_tranche(&tranche_input.tranche_type),
 					Error::<T>::InvalidTrancheStructure
 				);
 
 				ensure!(
-					prev_seniority <= &tranche_input.seniority
+					prev_tranche.seniority <= tranche_input.seniority
 						&& tranche_input.seniority <= Some(max_seniority),
 					Error::<T>::InvalidTrancheSeniority
 				);
 
-				prev_tranche_type = &tranche_input.tranche_type;
-				prev_seniority = &tranche_input.seniority;
+				prev_tranche = tranche_input;
 			}
 
 			// In case we are not setting up a new pool (i.e. a tranche setup already exists) we check

--- a/pallets/pools/src/tests.rs
+++ b/pallets/pools/src/tests.rs
@@ -1945,7 +1945,7 @@ fn valid_tranche_structure_is_enforced() {
 				10_000 * CURRENCY,
 				None
 			),
-			Error::<Test>::InvalidJuniorTranche
+			Error::<Test>::InvalidTrancheStructure
 		);
 
 		assert_noop!(

--- a/pallets/pools/src/tranche.rs
+++ b/pallets/pools/src/tranche.rs
@@ -105,7 +105,7 @@ where
 {
 	/// Compares tranches with the following schema:
 	///
-	/// * (Residual, Residual) => true
+	/// * (Residual, Residual) => false
 	/// * (Residual, NonResidual) => true,
 	/// * (NonResidual, Residual) => false,
 	/// * (NonResidual, NonResidual) =>
@@ -114,7 +114,7 @@ where
 	///
 	pub fn valid_next_tranche(&self, next: &TrancheType<Rate>) -> bool {
 		match (self, next) {
-			(TrancheType::Residual, TrancheType::Residual) => true,
+			(TrancheType::Residual, TrancheType::Residual) => false,
 			(TrancheType::Residual, TrancheType::NonResidual { .. }) => true,
 			(TrancheType::NonResidual { .. }, TrancheType::Residual) => false,
 			(


### PR DESCRIPTION
# Description
Previsouly, the high-levl logic of creating a pool took care of ensuring that only a single residual tranche is used. The lower level logic on the `TrancheType` itself already allowed for this. This is misleading and lead to an error in some changes made on a feature branch. Hence, this cleans this up!

## Changes and Descriptions
* Remove high level check for one residual tranche only
* Clean up tranche check logic
* Forbid residual after residual tranche in low level logic

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?
Normal unit tests of pools cover this

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
