### PR TITLE
Adding pallet-collator-selection to std for centrifuge runtime

### DIFF
--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -160,6 +160,7 @@ std = [
     "pallet-bridge/std",
     "pallet-claims/std",
     "pallet-collator-allowlist/std",
+    "pallet-collator-selection/std",
     "pallet-collective/std",
     "pallet-crowdloan-claim/std",
     "pallet-crowdloan-reward/std",


### PR DESCRIPTION
# Description

The pipeline broke for the latest Polkadot upgrade (https://github.com/centrifuge/centrifuge-chain/actions/runs/3323478337/jobs/5493874232#step:7:1567). I added `pallet-collator-selection` to `std` for the `centrifuge` runtime, and this should fix the problem.


## Changes and Descriptions

### Example pools-pallet

EXAMPLE change in the pools pallet EXAMPLE

### Example integration-tests 

EXAMPLE Updated the tests to fit the new pools pallet EXAMPLE

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally, all tests run through.


# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
