### PR TITLE
Add `taplo` to lint Cargo.toml files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           default: true
+      - name: Install taplo
+        uses: actions-rs/install@v0.1
+        with:
+          crate: taplo-cli
+          version: 0.7.2
+          use-tool-cache: true
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c
       - name: Run tests
         run: ./ci/script.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,43 +27,43 @@ path = "src/main.rs"
 
 [workspace]
 members = [
-	"libs/primitives",
-	"libs/proofs",
-	"libs/traits",
-	"libs/types",
-	"pallets/anchors",
-	"pallets/bridge",
-	"pallets/claims",
-	"pallets/collator-allowlist",
-	"pallets/crowdloan-claim",
-	"pallets/crowdloan-reward",
-	"pallets/fees",
-	"pallets/interest-accrual",
-	"pallets/investments",
-	"pallets/keystore",
-	"pallets/loans",
-	"pallets/migration",
-	"pallets/nft",
-	"pallets/nft-sales",
-	"pallets/permissions",
-	"pallets/rewards",
-	"pallets/liquidity-rewards",
-	"libs/traits",
-	"libs/test-utils",
-	"libs/types",
-	"libs/proofs",
-	"libs/primitives",
-	"pallets/pools",
-	"pallets/restricted-tokens",
-	"runtime/altair",
-	"runtime/centrifuge",
-	"runtime/common",
-	"runtime/integration-tests",
+  "libs/primitives",
+  "libs/proofs",
+  "libs/traits",
+  "libs/types",
+  "pallets/anchors",
+  "pallets/bridge",
+  "pallets/claims",
+  "pallets/collator-allowlist",
+  "pallets/crowdloan-claim",
+  "pallets/crowdloan-reward",
+  "pallets/fees",
+  "pallets/interest-accrual",
+  "pallets/investments",
+  "pallets/keystore",
+  "pallets/loans",
+  "pallets/migration",
+  "pallets/nft",
+  "pallets/nft-sales",
+  "pallets/permissions",
+  "pallets/rewards",
+  "pallets/liquidity-rewards",
+  "libs/traits",
+  "libs/test-utils",
+  "libs/types",
+  "libs/proofs",
+  "libs/primitives",
+  "pallets/pools",
+  "pallets/restricted-tokens",
+  "runtime/altair",
+  "runtime/centrifuge",
+  "runtime/common",
+  "runtime/integration-tests",
 ]
 
 [dependencies]
 # third-party dependencies
-clap = { version = "3.1", features = [ "derive" ] }
+clap = { version = "3.1", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false }
 futures = { version = "0.3.21", features = ["compat"] }
 hex-literal = "0.2.1"
@@ -84,14 +84,14 @@ sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polk
 sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-sp-timestamp = { default-features = false,  git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+sp-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # client dependencies
 grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
@@ -125,8 +125,7 @@ substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate
 # Cli specific
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 node-inspect = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", optional = true , branch = "polkadot-v0.9.29" }
-
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.29" }
 
 # Local dependencies
 cfg-types = { path = "./libs/types" }
@@ -137,25 +136,25 @@ pallet-pools = { path = "./pallets/pools" }
 # frame dependencies
 pallet-im-online = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-substrate-frame-rpc-system  = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 
 # Cumulus dependencies
-cumulus-client-cli = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
-cumulus-client-consensus-aura = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
-cumulus-client-consensus-common = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
-cumulus-client-consensus-relay-chain = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
-cumulus-client-network = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
-cumulus-client-service = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
-cumulus-primitives-parachain-inherent = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
+cumulus-client-cli = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
+cumulus-client-consensus-aura = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
+cumulus-client-consensus-common = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
+cumulus-client-consensus-relay-chain = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
+cumulus-client-network = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
+cumulus-client-service = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
 cumulus-relay-chain-inprocess-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
 cumulus-relay-chain-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
 
 # Polkadot dependencies
-polkadot-cli = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
-polkadot-parachain = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
-polkadot-primitives = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
-polkadot-service = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
+polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 
 # node-specific dependencies
 altair-runtime = { path = "runtime/altair" }
@@ -172,45 +171,45 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", optional
 runtime-integration-tests = { path = "runtime/integration-tests", optional = true }
 
 [build-dependencies]
+substrate-build-script-utils = { optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 vergen = "3.0.4"
-substrate-build-script-utils  = { optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
-sc-service-test = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-tempfile = "3.1.0"
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+sc-service-test = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+tempfile = "3.1.0"
 
 [features]
-default = [ "std", "cli" ]
+default = ["std", "cli"]
 std = [
-	"sc-service/rocksdb",
-	"substrate-build-script-utils",
-	"sp-consensus-babe/std",
+  "sc-service/rocksdb",
+  "substrate-build-script-utils",
+  "sp-consensus-babe/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
-	"altair-runtime/runtime-benchmarks",
-	"centrifuge-runtime/runtime-benchmarks",
-	"development-runtime/runtime-benchmarks",
-	"runtime-common/runtime-benchmarks",
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+  "altair-runtime/runtime-benchmarks",
+  "centrifuge-runtime/runtime-benchmarks",
+  "development-runtime/runtime-benchmarks",
+  "runtime-common/runtime-benchmarks",
 ]
 test-benchmarks = [
-	"runtime-benchmarks",
-	"runtime-integration-tests/runtime-benchmarks",
+  "runtime-benchmarks",
+  "runtime-integration-tests/runtime-benchmarks",
 ]
 cli = [
-	'try-runtime-cli',
+  'try-runtime-cli',
 ]
 try-runtime = [
-	"centrifuge-runtime/try-runtime",
-	"altair-runtime/try-runtime",
-	"try-runtime-cli"
+  "centrifuge-runtime/try-runtime",
+  "altair-runtime/try-runtime",
+  "try-runtime-cli",
 ]
 
 fast-runtime = [
-	"altair-runtime/fast-runtime",
-	"centrifuge-runtime/fast-runtime"
+  "altair-runtime/fast-runtime",
+  "centrifuge-runtime/fast-runtime",
 ]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -41,6 +41,7 @@ case $TARGET in
 
   lint)
     cargo fmt -- --check
+    taplo fmt --check
     ;;
 
   clippy)

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -83,7 +83,12 @@ You can play with it from the parachain client, make transfers, inspect events, 
 
 ## Linting
 
-Lint the project with `cargo +nightly fmt`. This excludes certain paths (defined in `rustfmt.toml`) that we want to stay as close as possible to `paritytech/substrate` to simplify upgrading to new releases.
+### Source code
+Lint the source code with `cargo +nightly fmt`. This excludes certain paths (defined in `rustfmt.toml`) that we want to stay as close as possible to `paritytech/substrate` to simplify upgrading to new releases.
+
+### Cargo.toml files
+1. Install [taplo](https://github.com/tamasfe/taplo) with `cargo install taplo-cli`.
+2. Lint the `Cargo.toml` files with `taplo fmt`.
 
 ## Verifying Runtime
 1. Check out the commit at which the runtime was built.

--- a/libs/primitives/Cargo.toml
+++ b/libs/primitives/Cargo.toml
@@ -11,35 +11,32 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.119" }
 
 # substrate primitives dependencies
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # substrate frame dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = []
 std = [
-    'codec/std',
-    'sp-std/std',
-    'scale-info/std',
-    'sp-core/std',
-    'frame-support/std',
-    'sp-runtime/std',
-    'frame-system/std',
-    'pallet-collective/std',
-    'sp-consensus-aura/std'
+  'codec/std',
+  'sp-std/std',
+  'scale-info/std',
+  'sp-core/std',
+  'frame-support/std',
+  'sp-runtime/std',
+  'frame-system/std',
+  'pallet-collective/std',
+  'sp-consensus-aura/std',
 ]
-
-

--- a/libs/proofs/Cargo.toml
+++ b/libs/proofs/Cargo.toml
@@ -11,9 +11,9 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
@@ -21,8 +21,6 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ['std']
 std = [
-    'codec/std',
-    "sp-std/std"
+  'codec/std',
+  "sp-std/std",
 ]
-
-

--- a/libs/test-utils/Cargo.toml
+++ b/libs/test-utils/Cargo.toml
@@ -11,43 +11,43 @@ repository = 'https://github.com/centrifuge/centrifuge-chain'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-cfg-traits = { path = '../traits', default-features = false }
 cfg-primitives = { path = '../primitives', default-features = false }
+cfg-traits = { path = '../traits', default-features = false }
 cfg-types = { path = '../types', default-features = false }
 
-serde = { version = "1.0.119" , default-features = false }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119", default-features = false }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Optional dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 std = [
-    'cfg-traits/std',
-    'cfg-types/std',
-    'cfg-primitives/std',
-    'serde/std',
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-runtime/std',
-    'sp-std/std'
+  'cfg-traits/std',
+  'cfg-types/std',
+  'cfg-primitives/std',
+  'serde/std',
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-runtime/std',
+  'sp-std/std',
 ]
 runtime-benchmarks = [
-    "frame-benchmarking/runtime-benchmarks",
-    "frame-support/runtime-benchmarks",
-    "frame-system/runtime-benchmarks",
-    "sp-runtime/runtime-benchmarks",
-    "cfg-primitives/runtime-benchmarks",
-    "cfg-traits/runtime-benchmarks",
-    "cfg-types/runtime-benchmarks"
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+  "sp-runtime/runtime-benchmarks",
+  "cfg-primitives/runtime-benchmarks",
+  "cfg-traits/runtime-benchmarks",
+  "cfg-types/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime", "frame-system/try-runtime"]

--- a/libs/traits/Cargo.toml
+++ b/libs/traits/Cargo.toml
@@ -11,37 +11,37 @@ version = '0.1.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-impl-trait-for-tuples = "0.2.1"
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-orml-asset-registry = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 cfg-primitives = { path = '../primitives', default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+impl-trait-for-tuples = "0.2.1"
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Testing libraries that must be exported
-mockall = { version = "0.11", optional = true }
 lazy_static = { version = "1.4", optional = true }
+mockall = { version = "0.11", optional = true }
 
 [dev-dependencies]
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
 cfg-types = { path = '../types', default-features = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = []
 std = [
-    "serde/std",
-    "codec/std",
-    "frame-support/std",
-    "sp-runtime/std",
-    "sp-arithmetic/std",
-    "sp-std/std",
-    "cfg-primitives/std",
-    "orml-asset-registry/std",
-    "mockall",
-    "lazy_static",
+  "serde/std",
+  "codec/std",
+  "frame-support/std",
+  "sp-runtime/std",
+  "sp-arithmetic/std",
+  "sp-std/std",
+  "cfg-primitives/std",
+  "orml-asset-registry/std",
+  "mockall",
+  "lazy_static",
 ]

--- a/libs/types/Cargo.toml
+++ b/libs/types/Cargo.toml
@@ -11,44 +11,42 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 bitflags = { version = "1.3", default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.119" }
 
 # substrate dependencies
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-orml-asset-registry = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
 
 # local dependencies
-cfg-traits = { path = '../traits', default-features = false }
 cfg-primitives = { path = '../primitives', default-features = false }
+cfg-traits = { path = '../traits', default-features = false }
 
 [dev-dependencies]
-frame-support = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = [
-    'frame-support/runtime-benchmarks',
-    'frame-system/runtime-benchmarks'
+  'frame-support/runtime-benchmarks',
+  'frame-system/runtime-benchmarks',
 ]
 std = [
-    'codec/std',
-    'sp-std/std',
-    'frame-support/std',
-    'cfg-traits/std',
-    'sp-runtime/std',
-    'cfg-primitives/std',
-    'frame-system/std',
-    'sp-runtime/std',
+  'codec/std',
+  'sp-std/std',
+  'frame-support/std',
+  'cfg-traits/std',
+  'sp-runtime/std',
+  'cfg-primitives/std',
+  'frame-system/std',
+  'sp-runtime/std',
 ]
-
-

--- a/pallets/anchors/Cargo.toml
+++ b/pallets/anchors/Cargo.toml
@@ -11,44 +11,44 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
 cfg-traits = { path = "../../libs/traits", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # optional dependencies for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = [
-    "frame-benchmarking/runtime-benchmarks",
-    "pallet-timestamp/runtime-benchmarks",
+  "frame-benchmarking/runtime-benchmarks",
+  "pallet-timestamp/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]
 std = [
-    'codec/std',
-    'sp-core/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-runtime/std',
-    'sp-std/std',
-    "sp-arithmetic/std",
-    'pallet-timestamp/std',
-    'cfg-traits/std',
+  'codec/std',
+  'sp-core/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  "sp-arithmetic/std",
+  'pallet-timestamp/std',
+  'cfg-traits/std',
 ]

--- a/pallets/bridge-mapping/Cargo.toml
+++ b/pallets/bridge-mapping/Cargo.toml
@@ -11,23 +11,23 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
+cfg-primitives = { path = "../../libs/primitives" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-cfg-primitives = { path = "../../libs/primitives" }
 
 [features]
 default = ['std']
 std = [
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-runtime/std',
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-runtime/std',
 ]

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -13,40 +13,40 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
-chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = false, branch = "polkadot-v0.9.29" }
 cfg-traits = { path = "../../libs/traits", default-features = false }
+chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = false, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-pallet-fees = { path = "../fees"}
-runtime-common = { path = "../../runtime/common" }
 cfg-primitives = { path = "../../libs/primitives" }
 cfg-types = { path = "../../libs/types" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+pallet-fees = { path = "../fees" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+runtime-common = { path = "../../runtime/common" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = ["chainbridge/runtime-benchmarks", "frame-support/runtime-benchmarks"]
 std = [
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-core/std',
-    'sp-runtime/std',
-    'sp-std/std',
-    'chainbridge/std',
-    'cfg-traits/std',
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-core/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'chainbridge/std',
+  'cfg-traits/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/claims/Cargo.toml
+++ b/pallets/claims/Cargo.toml
@@ -12,27 +12,26 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
+cfg-primitives = { path = '../../libs/primitives', default_features = false }
+cfg-types = { path = '../../libs/types', default_features = false }
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-cfg-types = { path= '../../libs/types', default_features = false }
-cfg-primitives = { path= '../../libs/primitives', default_features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-node-primitives = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+node-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # optional dependencies for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
-node-primitives = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = true  , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-
+node-primitives = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']

--- a/pallets/collator-allowlist/Cargo.toml
+++ b/pallets/collator-allowlist/Cargo.toml
@@ -11,30 +11,30 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # optional dependencies for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = ["frame-benchmarking"]
 std = [
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-std/std',
-    'sp-runtime/std'
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-std/std',
+  'sp-runtime/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/crowdloan-claim/Cargo.toml
+++ b/pallets/crowdloan-claim/Cargo.toml
@@ -14,32 +14,32 @@ targets = ['x86_64-unknown-linux-gnu']
 [dependencies]
 # General dependencies
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false }
-serde = { version = "1.0.119" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
 # Substrate dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # optional dependencies for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 # Local dependencies
-cfg-traits = { path= '../../libs/traits', default_features = false }
+cfg-traits = { path = '../../libs/traits', default_features = false }
 cfg-types = { path = "../../libs/types", default-features = false }
-proofs = { path= '../../libs/proofs', default_features = false }
+proofs = { path = '../../libs/proofs', default_features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-sp-trie = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
+hex = { version = "0.4.3", default_features = true }
+pallet-crowdloan-reward = { path = '../crowdloan-reward', default_features = true }
 pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
-pallet-crowdloan-reward = { path='../crowdloan-reward', default_features = true }
-hex = { version="0.4.3", default_features = true }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-trie = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']

--- a/pallets/crowdloan-reward/Cargo.toml
+++ b/pallets/crowdloan-reward/Cargo.toml
@@ -14,30 +14,28 @@ targets = ['x86_64-unknown-linux-gnu']
 [dependencies]
 # General dependencies
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false }
-serde = { version = "1.0.119" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
 # Substrae dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Local dependencies
-cfg-traits = { path= '../../libs/traits', default_features = false }
-
+cfg-traits = { path = '../../libs/traits', default_features = false }
 
 [dev-dependencies]
-cfg-types = { path= '../../libs/types', default_features = true }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+cfg-types = { path = '../../libs/types', default_features = true }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 serde = { version = "1.0.119" }
-
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
@@ -50,6 +48,6 @@ std = [
   'frame-system/std',
   'pallet-balances/std',
   'pallet-vesting/std',
-  'cfg-traits/std'
+  'cfg-traits/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/fees/Cargo.toml
+++ b/pallets/fees/Cargo.toml
@@ -11,39 +11,39 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 
 cfg-traits = { path = "../../libs/traits", default-features = false }
 
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # optional dependencies for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
-pallet-treasury = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = ["frame-benchmarking"]
 std = [
-    'codec/std',
-    'scale-info/std',
-    'sp-runtime/std',
-    'sp-std/std',
-    'cfg-traits/std',
-    'frame-support/std',
-    'frame-system/std',
-    'pallet-authorship/std',
-    'pallet-treasury/std',
+  'codec/std',
+  'scale-info/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'cfg-traits/std',
+  'frame-support/std',
+  'frame-system/std',
+  'pallet-authorship/std',
+  'pallet-treasury/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/interest-accrual/Cargo.toml
+++ b/pallets/interest-accrual/Cargo.toml
@@ -11,23 +11,23 @@ version = '0.1.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
+cfg-primitives = { path = "../../libs/primitives", default-features = false }
 cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-types = { path = "../../libs/types", default-features = false }
-cfg-primitives = { path = "../../libs/primitives", default-features = false }
 
 [dev-dependencies]
 bitflags = "1.3"
@@ -35,21 +35,21 @@ bitflags = "1.3"
 [features]
 default = ['std']
 runtime-benchmarks = [
-    "frame-benchmarking",
+  "frame-benchmarking",
 ]
 std = [
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'frame-benchmarking/std',
-    'sp-core/std',
-    'sp-io/std',
-    'sp-runtime/std',
-    'sp-arithmetic/std',
-    'sp-std/std',
-    'pallet-timestamp/std',
-    'cfg-traits/std',
-    'cfg-types/std',
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'frame-benchmarking/std',
+  'sp-core/std',
+  'sp-io/std',
+  'sp-runtime/std',
+  'sp-arithmetic/std',
+  'sp-std/std',
+  'pallet-timestamp/std',
+  'cfg-traits/std',
+  'cfg-types/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/investments/Cargo.toml
+++ b/pallets/investments/Cargo.toml
@@ -12,55 +12,54 @@ version = '1.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+cfg-primitives = { path = "../../libs/primitives", default-features = false }
 cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-types = { path = "../../libs/types", default-features = false }
-cfg-primitives = { path = "../../libs/primitives", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Benchmarking dependencies - optional
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
-runtime-common = { path = "../../runtime/common", default-features = true }
-pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = true}
-cfg-test-utils = { path = "../../libs/test-utils",default-features = true }
+cfg-test-utils = { path = "../../libs/test-utils", default-features = true }
 cfg-types = { path = "../../libs/types", default-features = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true , branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = true }
 rand = "0.8.5"
-
+runtime-common = { path = "../../runtime/common", default-features = true }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = [
-    'frame-benchmarking/runtime-benchmarks',
-    'frame-system/runtime-benchmarks',
-    'frame-support/runtime-benchmarks',
-    'sp-runtime/runtime-benchmarks',
-    'cfg-types/runtime-benchmarks',
-    'cfg-traits/runtime-benchmarks',
-    'cfg-primitives/runtime-benchmarks'
+  'frame-benchmarking/runtime-benchmarks',
+  'frame-system/runtime-benchmarks',
+  'frame-support/runtime-benchmarks',
+  'sp-runtime/runtime-benchmarks',
+  'cfg-types/runtime-benchmarks',
+  'cfg-traits/runtime-benchmarks',
+  'cfg-primitives/runtime-benchmarks',
 ]
 std = [
-    'cfg-primitives/std',
-    'cfg-traits/std',
-    'cfg-types/std',
-    'codec/std',
-    'frame-support/std',
-    'frame-system/std',
-    'scale-info/std',
-    'sp-runtime/std',
-    'sp-std/std',
+  'cfg-primitives/std',
+  'cfg-traits/std',
+  'cfg-types/std',
+  'codec/std',
+  'frame-support/std',
+  'frame-system/std',
+  'scale-info/std',
+  'sp-runtime/std',
+  'sp-std/std',
 ]
 try-runtime = ['frame-support/try-runtime']

--- a/pallets/keystore/Cargo.toml
+++ b/pallets/keystore/Cargo.toml
@@ -11,30 +11,30 @@ version = '1.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = ['frame-benchmarking']
 std = [
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-runtime/std',
-    'sp-std/std',
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-runtime/std',
+  'sp-std/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/liquidity-rewards/Cargo.toml
+++ b/pallets/liquidity-rewards/Cargo.toml
@@ -12,17 +12,17 @@ repository = "https://github.com/centrifuge/centrifuge-chain/pallets/liquidity-r
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"]}
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+cfg-traits = { path = "../../libs/traits", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+num-traits = { version = "0.2", default-features = false }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-num-traits = { version = "0.2", default-features = false }
-cfg-traits = { path = "../../libs/traits", default-features = false }
 
 # optional dependencies for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
@@ -33,10 +33,10 @@ default = ["std"]
 try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = ["frame-benchmarking"]
 std = [
-    "codec/std",
-    "frame-support/std",
-    "frame-system/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "cfg-traits/std",
+  "codec/std",
+  "frame-support/std",
+  "frame-system/std",
+  "sp-runtime/std",
+  "sp-std/std",
+  "cfg-traits/std",
 ]

--- a/pallets/loans/Cargo.toml
+++ b/pallets/loans/Cargo.toml
@@ -11,82 +11,81 @@ version = '1.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # our pallets
-cfg-traits = { path = "../../libs/traits", default-features = false}
-cfg-types = { path = "../../libs/types", default-features = false }
 cfg-primitives = { path = "../../libs/primitives", default-features = false }
-pallet-permissions = { path = "../../pallets/permissions", default-features = false}
-pallet-interest-accrual = { path = "../../pallets/interest-accrual", default-features = false}
+cfg-traits = { path = "../../libs/traits", default-features = false }
+cfg-types = { path = "../../libs/types", default-features = false }
+pallet-interest-accrual = { path = "../../pallets/interest-accrual", default-features = false }
+pallet-permissions = { path = "../../pallets/permissions", default-features = false }
 
 # optional dependencies for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.29" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.29" }
-pallet-pools = { path = "../pools", optional = true, default-features = false}
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false, optional = true, branch = "polkadot-v0.9.29" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
-orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 cfg-test-utils = { path = "../../libs/test-utils", default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+pallet-pools = { path = "../pools", optional = true, default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", default-features =  true, branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = true, branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = true, branch = "polkadot-v0.9.29" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = true, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
-orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
 
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = true, branch = "release-v0.9.29" }
 
-pallet-pools = { path = "../pools", default-features = true }
 cfg-test-utils = { path = "../../libs/test-utils", default-features = true }
-
+pallet-pools = { path = "../pools", default-features = true }
 
 [features]
 default = ['std']
 runtime-benchmarks = [
-    "frame-benchmarking",
-    "frame-system/runtime-benchmarks",
-    "frame-support/runtime-benchmarks",
-    "pallet-balances/runtime-benchmarks",
-    "pallet-uniques/runtime-benchmarks",
-    "orml-tokens/runtime-benchmarks",
-    "orml-traits",
-    "pallet-timestamp/runtime-benchmarks",
-    "pallet-pools/runtime-benchmarks",
-    "orml-asset-registry/runtime-benchmarks",
-    "cfg-test-utils/runtime-benchmarks"
+  "frame-benchmarking",
+  "frame-system/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "pallet-balances/runtime-benchmarks",
+  "pallet-uniques/runtime-benchmarks",
+  "orml-tokens/runtime-benchmarks",
+  "orml-traits",
+  "pallet-timestamp/runtime-benchmarks",
+  "pallet-pools/runtime-benchmarks",
+  "orml-asset-registry/runtime-benchmarks",
+  "cfg-test-utils/runtime-benchmarks",
 ]
 std = [
-    'serde/std',
-    'scale-info/std',
-    'pallet-permissions/std',
-    'codec/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-core/std',
-    'sp-runtime/std',
-    'sp-std/std',
-    'sp-arithmetic/std',
-    'parachain-info/std',
-    'pallet-interest-accrual/std',
-    'cfg-traits/std',
-    'cfg-types/std',
-    'cfg-primitives/std'
+  'serde/std',
+  'scale-info/std',
+  'pallet-permissions/std',
+  'codec/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-core/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'sp-arithmetic/std',
+  'parachain-info/std',
+  'pallet-interest-accrual/std',
+  'cfg-traits/std',
+  'cfg-types/std',
+  'cfg-primitives/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/migration/Cargo.toml
+++ b/pallets/migration/Cargo.toml
@@ -11,21 +11,21 @@ version = '0.1.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 log = { version = "0.4.14", default-features = false }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-version = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
 hex = "0.4.3"
@@ -35,11 +35,11 @@ rand = "0.8.5"
 default = ['std']
 runtime-benchmarks = ["frame-benchmarking"]
 std = [
-    'codec/std',
-    'frame-support/std',
-    'frame-system/std',
-    'pallet-vesting/std',
-    'pallet-balances/std',
-    'pallet-proxy/std'
+  'codec/std',
+  'frame-support/std',
+  'frame-system/std',
+  'pallet-vesting/std',
+  'pallet-balances/std',
+  'pallet-proxy/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/nft-sales/Cargo.toml
+++ b/pallets/nft-sales/Cargo.toml
@@ -11,28 +11,28 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Optional dependencies for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.29" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.29" }
+cfg-primitives = { path = "../../libs/primitives", default-features = false, optional = true }
+cfg-types = { path = "../../libs/types", default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
-cfg-types = { path = "../../libs/types", default-features = false, optional = true }
-cfg-primitives = { path = "../../libs/primitives", default-features = false, optional = true }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 
 [dev-dependencies]
 # Substrate crates & pallets
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = true, branch = "polkadot-v0.9.29" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = true, branch = "polkadot-v0.9.29" }
 
 # Orml crates
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
@@ -40,29 +40,29 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 
 # Local crates
 cfg-primitives = { path = "../../libs/primitives", default-features = true }
-cfg-types = { path = "../../libs/types", default-features = true}
+cfg-types = { path = "../../libs/types", default-features = true }
 
 [features]
 default = ['std']
 runtime-benchmarks = [
-    "frame-benchmarking",
-    "pallet-balances",
-    "pallet-uniques",
-    "cfg-types",
-    "cfg-primitives",
-    "orml-tokens",
-    "orml-traits",
+  "frame-benchmarking",
+  "pallet-balances",
+  "pallet-uniques",
+  "cfg-types",
+  "cfg-primitives",
+  "orml-tokens",
+  "orml-traits",
 ]
 std = [
-    'codec/std',
-    'cfg-types/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-std/std',
-    'sp-runtime/std',
-    'orml-tokens/std',
-    'orml-traits/std',
-    'pallet-balances/std',
-    'cfg-primitives/std',
+  'codec/std',
+  'cfg-types/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-std/std',
+  'sp-runtime/std',
+  'orml-tokens/std',
+  'orml-traits/std',
+  'pallet-balances/std',
+  'cfg-primitives/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/nft/Cargo.toml
+++ b/pallets/nft/Cargo.toml
@@ -14,24 +14,24 @@ targets = ['x86_64-unknown-linux-gnu']
 [dependencies]
 # Substrate dependencies
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Centrifuge Chain dependencies
+cfg-primitives = { path = '../../libs/primitives', default-features = false }
+cfg-traits = { path = "../../libs/traits", default-features = false }
+cfg-types = { path = "../../libs/types", default-features = false }
 chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = false, branch = "polkadot-v0.9.29" }
 pallet-anchors = { path = "../anchors", default-features = false }
 proofs = { path = "../../libs/proofs", default-features = false }
 unique-assets = { git = "https://github.com/centrifuge/unique-assets", default-features = false, branch = "polkadot-v0.9.29" }
-cfg-traits = { path = "../../libs/traits", default-features = false }
-cfg-primitives = { path = '../../libs/primitives', default-features = false }
-cfg-types = { path = "../../libs/types", default-features = false }
 
 [dev-dependencies]
 # Testing and mocking dependencies
@@ -48,20 +48,20 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = t
 default = ['std']
 runtime-benchmarks = ["chainbridge/runtime-benchmarks", "frame-benchmarking"]
 std = [
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'pallet-balances/std',
-    'proofs/std',
-    'sp-core/std',
-    'sp-runtime/std',
-    'sp-std/std',
-    'sp-io/std',
-    'chainbridge/std',
-    'pallet-anchors/std',
-    'proofs/std',
-    'cfg-traits/std',
-    'cfg-primitives/std'
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'pallet-balances/std',
+  'proofs/std',
+  'sp-core/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'sp-io/std',
+  'chainbridge/std',
+  'pallet-anchors/std',
+  'proofs/std',
+  'cfg-traits/std',
+  'cfg-primitives/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/permissions/Cargo.toml
+++ b/pallets/permissions/Cargo.toml
@@ -12,17 +12,16 @@ version = '0.1.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
 cfg-traits = { path = "../../libs/traits", default-features = false }
-
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # benchmarking
 cfg-types = { path = "../../libs/types", default-features = false, optional = true }
@@ -33,19 +32,18 @@ bitflags = "1.3"
 [features]
 default = ['std']
 runtime-benchmarks = [
-    'frame-benchmarking',
-    'cfg-types',
+  'frame-benchmarking',
+  'cfg-types',
 ]
 
 std = [
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'frame-benchmarking/std',
-    'sp-runtime/std',
-    'sp-std/std',
-    'cfg-traits/std'
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'frame-benchmarking/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'cfg-traits/std',
 ]
 try-runtime = ['frame-support/try-runtime']
-

--- a/pallets/pools/Cargo.toml
+++ b/pallets/pools/Cargo.toml
@@ -12,80 +12,80 @@ version = '3.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-rev_slice = { version = "0.1.5", default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 lazy_static = { version = "1.4.0", optional = true, default-features = false }
+rev_slice = { version = "0.1.5", default-features = false }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+cfg-primitives = { path = "../../libs/primitives", default-features = false }
 cfg-traits = { path = "../../libs/traits", default-features = false }
-cfg-primitives = { path = "../../libs/primitives", default-features = false}
 cfg-types = { path = "../../libs/types", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
-pallet-permissions = { path = "../../pallets/permissions", default-features = false}
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-orml-asset-registry = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-permissions = { path = "../../pallets/permissions", default-features = false }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
 
 # Benchmarking dependencies - optional
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-pallet-investments = { path = "../../pallets/investments", default-features = false, optional = true}
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+pallet-investments = { path = "../../pallets/investments", default-features = false, optional = true }
 
 [dev-dependencies]
-cfg-test-utils = { path = "../../libs/test-utils",default-features = true }
+cfg-test-utils = { path = "../../libs/test-utils", default-features = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+pallet-investments = { path = "../../pallets/investments", default-features = true }
+pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = true }
+parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = true, branch = "polkadot-v0.9.29" }
+rand = "0.8.5"
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
-pallet-investments = { path = "../../pallets/investments", default-features = true}
-pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = true }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
-rand = "0.8.5"
-parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = [
-    'frame-benchmarking/runtime-benchmarks',
-    'frame-support/runtime-benchmarks',
-    'frame-system/runtime-benchmarks',
-    'sp-runtime/runtime-benchmarks',
-    'cfg-traits/runtime-benchmarks',
-    'cfg-primitives/runtime-benchmarks',
-    'cfg-types/runtime-benchmarks',
-    'pallet-timestamp/runtime-benchmarks',
-    'pallet-investments/runtime-benchmarks',
-    'pallet-permissions/runtime-benchmarks',
-    'xcm/runtime-benchmarks',
-    'polkadot-parachain/runtime-benchmarks',
-    'orml-asset-registry/runtime-benchmarks'
+  'frame-benchmarking/runtime-benchmarks',
+  'frame-support/runtime-benchmarks',
+  'frame-system/runtime-benchmarks',
+  'sp-runtime/runtime-benchmarks',
+  'cfg-traits/runtime-benchmarks',
+  'cfg-primitives/runtime-benchmarks',
+  'cfg-types/runtime-benchmarks',
+  'pallet-timestamp/runtime-benchmarks',
+  'pallet-investments/runtime-benchmarks',
+  'pallet-permissions/runtime-benchmarks',
+  'xcm/runtime-benchmarks',
+  'polkadot-parachain/runtime-benchmarks',
+  'orml-asset-registry/runtime-benchmarks',
 ]
 std = [
-    'codec/std',
-    'scale-info/std',
-    'rev_slice/std',
-    'frame-support/std',
-    'frame-system/std',
-    'pallet-timestamp/std',
-    'sp-arithmetic/std',
-    'sp-runtime/std',
-    'sp-std/std',
-    'orml-traits/std',
-    'cfg-traits/std',
-    'cfg-types/std',
-    'cfg-primitives/std',
-    'pallet-permissions/std',
-    'polkadot-parachain/std',
-    'orml-asset-registry/std',
-    'xcm/std',
+  'codec/std',
+  'scale-info/std',
+  'rev_slice/std',
+  'frame-support/std',
+  'frame-system/std',
+  'pallet-timestamp/std',
+  'sp-arithmetic/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'orml-traits/std',
+  'cfg-traits/std',
+  'cfg-types/std',
+  'cfg-primitives/std',
+  'pallet-permissions/std',
+  'polkadot-parachain/std',
+  'orml-asset-registry/std',
+  'xcm/std',
 ]
 try-runtime = ['frame-support/try-runtime', "lazy_static/spin_no_std"]
 test-benchmarks = [
-    'frame-support/try-runtime',
+  'frame-support/try-runtime',
 ]

--- a/pallets/restricted-tokens/Cargo.toml
+++ b/pallets/restricted-tokens/Cargo.toml
@@ -12,52 +12,51 @@ version = '0.1.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-serde = { version = "1.0.119" }
-codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'] , default-features = false }
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , optional = true, branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
 cfg-traits = { path = "../../libs/traits", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 ## Benchmarkind dependencies
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+cfg-primitives = { path = "../../libs/primitives", default-features = false, optional = false }
+cfg-types = { path = "../../libs/types", default-features = false, optional = true }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 pallet-permissions = { path = "../permissions", default-features = false, optional = true }
-cfg-types = { path = "../../libs/types", default-features = false, optional = true }
-cfg-primitives = { path = "../../libs/primitives", default-features = false, optional = false }
 
 [dev-dependencies]
+cfg-types = { path = "../../libs/types", default-features = true }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
-cfg-types = { path = "../../libs/types", default-features = true }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
 
 [features]
 default = ['std']
 runtime-benchmarks = [
-    'frame-benchmarking',
-    'pallet-balances',
-    'sp-runtime',
-    'orml-tokens',
-    'orml-traits',
-    'pallet-permissions',
-    'cfg-types'
+  'frame-benchmarking',
+  'pallet-balances',
+  'sp-runtime',
+  'orml-tokens',
+  'orml-traits',
+  'pallet-permissions',
+  'cfg-types',
 ]
 std = [
-    'codec/std',
-    'scale-info/std',
-    'frame-support/std',
-    'frame-system/std',
-    'sp-runtime/std',
-    'sp-std/std',
-    'cfg-types/std',
-    'cfg-traits/std'
+  'codec/std',
+  'scale-info/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'cfg-types/std',
+  'cfg-traits/std',
 ]
 try-runtime = ['frame-support/try-runtime']
-

--- a/pallets/rewards/Cargo.toml
+++ b/pallets/rewards/Cargo.toml
@@ -12,31 +12,31 @@ repository = "https://github.com/centrifuge/centrifuge-chain/pallets/rewards"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"]}
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+cfg-traits = { path = "../../libs/traits", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+num-traits = { version = "0.2", default-features = false }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-num-traits = { version = "0.2", default-features = false }
-cfg-traits = { path = "../../libs/traits", default-features = false }
 
 [dev-dependencies]
+lazy_static = "1.4"
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
+serde = "1.0"
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
-lazy_static = "1.4"
-serde = "1.0"
 
 [features]
 default = ["std"]
 try-runtime = ["frame-support/try-runtime"]
 std = [
-    "codec/std",
-    "frame-support/std",
-    "frame-system/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "cfg-traits/std",
+  "codec/std",
+  "frame-support/std",
+  "frame-system/std",
+  "sp-runtime/std",
+  "sp-std/std",
+  "cfg-traits/std",
 ]

--- a/runtime/altair/Cargo.toml
+++ b/runtime/altair/Cargo.toml
@@ -11,98 +11,98 @@ repository = "https://github.com/centrifuge/centrifuge-chain"
 [dependencies]
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+hex-literal = { version = "0.3.4", optional = true }
 integer-sqrt = { version = "0.1.2" }
+rustc-hex = { version = "2.0", optional = true }
 safe-mix = { version = "1.0", default-features = false }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119", optional = true }
 smallvec = "1.6.1"
 static_assertions = "1.1.0"
-hex-literal = { version = "0.3.4", optional = true }
-rustc-hex = { version = "2.0", optional = true }
-serde = { version = "1.0.119", optional = true }
 
 # parachain
-parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
 cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-collator-selection = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
 
 # polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
 
 # primitives
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate",  default-features = false, branch = "polkadot-v0.9.29" }
-sp-inherents = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-offchain = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-staking = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-session = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-version = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # frame dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-frame-executive = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.29" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-babe = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-collective = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-democracy = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-identity = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-im-online = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-indices = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-membership = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-multisig = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-offences = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-session = { git = "https://github.com/paritytech/substrate",  default-features = false, features = ["historical"] , branch = "polkadot-v0.9.29" }
-pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.29" }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-identity = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-membership = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, features = ["historical"], branch = "polkadot-v0.9.29" }
+pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-staking = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+pallet-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-utility = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-vesting = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # orml pallets
-orml-asset-registry = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
-orml-xcm = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 
@@ -116,12 +116,12 @@ pallet-crowdloan-claim = { path = "../../pallets/crowdloan-claim", default-featu
 pallet-crowdloan-reward = { path = "../../pallets/crowdloan-reward", default-features = false }
 pallet-fees = { path = "../../pallets/fees", default-features = false }
 pallet-interest-accrual = { path = "../../pallets/interest-accrual", default-features = false }
+pallet-investments = { path = "../../pallets/investments", default-features = false }
 pallet-loans = { path = "../../pallets/loans", default-features = false }
 pallet-migration-manager = { path = "../../pallets/migration", default-features = false }
 pallet-nft-sales = { path = "../../pallets/nft-sales", default-features = false }
 pallet-permissions = { path = "../../pallets/permissions", default-features = false }
 pallet-pools = { path = "../../pallets/pools", default-features = false }
-pallet-investments = { path = "../../pallets/investments", default-features = false }
 pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = false }
 runtime-common = { path = "../common", default-features = false }
 
@@ -131,197 +131,196 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 [features]
 default = ["std"]
 std = [
-    "cfg-primitives/std",
-    "codec/std",
-    "cumulus-pallet-aura-ext/std",
-    "cumulus-pallet-parachain-system/std",
-    "cumulus-pallet-xcm/std",
-    "cumulus-pallet-xcmp-queue/std",
-    "cumulus-primitives-timestamp/std",
-    "frame-executive/std",
-    "frame-support/std",
-    "frame-system-rpc-runtime-api/std",
-    "frame-system/std",
-    "frame-try-runtime/std",
-    "orml-asset-registry/std",
-    "orml-tokens/std",
-    "orml-tokens/std",
-    "orml-xcm-support/std",
-    "orml-xcm/std",
-    "orml-xtokens/std",
-    "orml-xtokens/std",
-    "pallet-anchors/std",
-    "pallet-aura/std",
-    "pallet-authority-discovery/std",
-    "pallet-authorship/std",
-    "pallet-babe/std",
-    "pallet-balances/std",
-    "pallet-collator-allowlist/std",
-    "pallet-collator-selection/std",
-    "pallet-collective/std",
-    "pallet-crowdloan-claim/std",
-    "pallet-crowdloan-reward/std",
-    "pallet-democracy/std",
-    "pallet-elections-phragmen/std",
-    "pallet-fees/std",
-    "pallet-grandpa/std",
-    "pallet-identity/std",
-    "pallet-im-online/std",
-    "pallet-indices/std",
-    "pallet-interest-accrual/std",
-    "pallet-investments/std",
-    "pallet-loans/std",
-    "pallet-membership/std",
-    "pallet-migration-manager/std",
-    "pallet-multisig/std",
-    "pallet-nft-sales/std",
-    "pallet-offences/std",
-    "pallet-permissions/std",
-    "pallet-pools/std",
-    "pallet-preimage/std",
-    "pallet-proxy/std",
-    "pallet-randomness-collective-flip/std",
-    "pallet-restricted-tokens/std",
-    "pallet-scheduler/std",
-    "pallet-session/std",
-    "pallet-society/std",
-    "pallet-staking/std",
-    "pallet-timestamp/std",
-    "pallet-transaction-payment-rpc-runtime-api/std",
-    "pallet-transaction-payment/std",
-    "pallet-treasury/std",
-    "pallet-uniques/std",
-    "pallet-utility/std",
-    "pallet-vesting/std",
-    "parachain-info/std",
-    "polkadot-runtime-common/std",
-    "runtime-common/std",
-    "rustc-hex",
-    "safe-mix/std",
-    "serde",
-    "sp-api/std",
-    "sp-arithmetic/std",
-    "sp-authority-discovery/std",
-    "sp-block-builder/std",
-    "sp-consensus-aura/std",
-    "sp-consensus-babe/std",
-    "sp-core/std",
-    "sp-inherents/std",
-    "sp-io/std",
-    "sp-offchain/std",
-    "sp-runtime/std",
-    "sp-session/std",
-    "sp-staking/std",
-    "sp-std/std",
-    "sp-transaction-pool/std",
-    "sp-version/std",
-    "xcm-builder/std",
-    "xcm-executor/std",
-    "xcm/std",
+  "cfg-primitives/std",
+  "codec/std",
+  "cumulus-pallet-aura-ext/std",
+  "cumulus-pallet-parachain-system/std",
+  "cumulus-pallet-xcm/std",
+  "cumulus-pallet-xcmp-queue/std",
+  "cumulus-primitives-timestamp/std",
+  "frame-executive/std",
+  "frame-support/std",
+  "frame-system-rpc-runtime-api/std",
+  "frame-system/std",
+  "frame-try-runtime/std",
+  "orml-asset-registry/std",
+  "orml-tokens/std",
+  "orml-tokens/std",
+  "orml-xcm-support/std",
+  "orml-xcm/std",
+  "orml-xtokens/std",
+  "orml-xtokens/std",
+  "pallet-anchors/std",
+  "pallet-aura/std",
+  "pallet-authority-discovery/std",
+  "pallet-authorship/std",
+  "pallet-babe/std",
+  "pallet-balances/std",
+  "pallet-collator-allowlist/std",
+  "pallet-collator-selection/std",
+  "pallet-collective/std",
+  "pallet-crowdloan-claim/std",
+  "pallet-crowdloan-reward/std",
+  "pallet-democracy/std",
+  "pallet-elections-phragmen/std",
+  "pallet-fees/std",
+  "pallet-grandpa/std",
+  "pallet-identity/std",
+  "pallet-im-online/std",
+  "pallet-indices/std",
+  "pallet-interest-accrual/std",
+  "pallet-investments/std",
+  "pallet-loans/std",
+  "pallet-membership/std",
+  "pallet-migration-manager/std",
+  "pallet-multisig/std",
+  "pallet-nft-sales/std",
+  "pallet-offences/std",
+  "pallet-permissions/std",
+  "pallet-pools/std",
+  "pallet-preimage/std",
+  "pallet-proxy/std",
+  "pallet-randomness-collective-flip/std",
+  "pallet-restricted-tokens/std",
+  "pallet-scheduler/std",
+  "pallet-session/std",
+  "pallet-society/std",
+  "pallet-staking/std",
+  "pallet-timestamp/std",
+  "pallet-transaction-payment-rpc-runtime-api/std",
+  "pallet-transaction-payment/std",
+  "pallet-treasury/std",
+  "pallet-uniques/std",
+  "pallet-utility/std",
+  "pallet-vesting/std",
+  "parachain-info/std",
+  "polkadot-runtime-common/std",
+  "runtime-common/std",
+  "rustc-hex",
+  "safe-mix/std",
+  "serde",
+  "sp-api/std",
+  "sp-arithmetic/std",
+  "sp-authority-discovery/std",
+  "sp-block-builder/std",
+  "sp-consensus-aura/std",
+  "sp-consensus-babe/std",
+  "sp-core/std",
+  "sp-inherents/std",
+  "sp-io/std",
+  "sp-offchain/std",
+  "sp-runtime/std",
+  "sp-session/std",
+  "sp-staking/std",
+  "sp-std/std",
+  "sp-transaction-pool/std",
+  "sp-version/std",
+  "xcm-builder/std",
+  "xcm-executor/std",
+  "xcm/std",
 ]
 runtime-benchmarks = [
-    "cfg-types/runtime-benchmarks",
-    "frame-benchmarking/runtime-benchmarks",
-    "frame-support/runtime-benchmarks",
-    "frame-system-benchmarking",
-    "frame-system/runtime-benchmarks",
-    "hex-literal",
-    "pallet-anchors/runtime-benchmarks",
-    "pallet-balances/runtime-benchmarks",
-    "pallet-collator-allowlist/runtime-benchmarks",
-    "pallet-collator-selection/runtime-benchmarks",
-    "pallet-collective/runtime-benchmarks",
-    "pallet-crowdloan-claim/runtime-benchmarks",
-    "pallet-crowdloan-reward/runtime-benchmarks",
-    "pallet-democracy/runtime-benchmarks",
-    "pallet-elections-phragmen/runtime-benchmarks",
-    "pallet-fees/runtime-benchmarks",
-    "pallet-identity/runtime-benchmarks",
-    "pallet-interest-accrual/runtime-benchmarks",
-    "pallet-investments/runtime-benchmarks",
-    "pallet-loans/runtime-benchmarks",
-    "pallet-migration-manager/runtime-benchmarks",
-    "pallet-multisig/runtime-benchmarks",
-    "pallet-nft-sales/runtime-benchmarks",
-    "pallet-permissions/runtime-benchmarks",
-    "pallet-pools/runtime-benchmarks",
-    "pallet-preimage/runtime-benchmarks",
-    "pallet-proxy/runtime-benchmarks",
-    "pallet-restricted-tokens/runtime-benchmarks",
-    "pallet-scheduler/runtime-benchmarks",
-    "pallet-session-benchmarking",
-    "pallet-society/runtime-benchmarks",
-    "pallet-timestamp/runtime-benchmarks",
-    "pallet-treasury/runtime-benchmarks",
-    "pallet-uniques/runtime-benchmarks",
-    "pallet-utility/runtime-benchmarks",
-    "pallet-vesting/runtime-benchmarks",
-    "pallet-xcm/runtime-benchmarks",
-    "runtime-common/runtime-benchmarks",
-    "xcm-builder/runtime-benchmarks",
+  "cfg-types/runtime-benchmarks",
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system-benchmarking",
+  "frame-system/runtime-benchmarks",
+  "hex-literal",
+  "pallet-anchors/runtime-benchmarks",
+  "pallet-balances/runtime-benchmarks",
+  "pallet-collator-allowlist/runtime-benchmarks",
+  "pallet-collator-selection/runtime-benchmarks",
+  "pallet-collective/runtime-benchmarks",
+  "pallet-crowdloan-claim/runtime-benchmarks",
+  "pallet-crowdloan-reward/runtime-benchmarks",
+  "pallet-democracy/runtime-benchmarks",
+  "pallet-elections-phragmen/runtime-benchmarks",
+  "pallet-fees/runtime-benchmarks",
+  "pallet-identity/runtime-benchmarks",
+  "pallet-interest-accrual/runtime-benchmarks",
+  "pallet-investments/runtime-benchmarks",
+  "pallet-loans/runtime-benchmarks",
+  "pallet-migration-manager/runtime-benchmarks",
+  "pallet-multisig/runtime-benchmarks",
+  "pallet-nft-sales/runtime-benchmarks",
+  "pallet-permissions/runtime-benchmarks",
+  "pallet-pools/runtime-benchmarks",
+  "pallet-preimage/runtime-benchmarks",
+  "pallet-proxy/runtime-benchmarks",
+  "pallet-restricted-tokens/runtime-benchmarks",
+  "pallet-scheduler/runtime-benchmarks",
+  "pallet-session-benchmarking",
+  "pallet-society/runtime-benchmarks",
+  "pallet-timestamp/runtime-benchmarks",
+  "pallet-treasury/runtime-benchmarks",
+  "pallet-uniques/runtime-benchmarks",
+  "pallet-utility/runtime-benchmarks",
+  "pallet-vesting/runtime-benchmarks",
+  "pallet-xcm/runtime-benchmarks",
+  "runtime-common/runtime-benchmarks",
+  "xcm-builder/runtime-benchmarks",
 ]
 
 try-runtime = [
-    "cumulus-pallet-aura-ext/try-runtime",
-    "cumulus-pallet-dmp-queue/try-runtime",
-    "cumulus-pallet-parachain-system/try-runtime",
-    "cumulus-pallet-xcm/try-runtime",
-    "cumulus-pallet-xcmp-queue/try-runtime",
-    "frame-executive/try-runtime",
-    "frame-support/try-runtime",
-    "frame-system/try-runtime",
-    "frame-try-runtime",
-    "orml-asset-registry/try-runtime",
-    "orml-tokens/try-runtime",
-    "orml-xcm/try-runtime",
-    "orml-xtokens/try-runtime",
-    "pallet-anchors/try-runtime",
-    "pallet-aura/try-runtime",
-    "pallet-authorship/try-runtime",
-    "pallet-balances/try-runtime",
-    "pallet-collator-allowlist/try-runtime",
-    "pallet-collator-selection/try-runtime",
-    "pallet-collective/try-runtime",
-    "pallet-crowdloan-claim/try-runtime",
-    "pallet-crowdloan-reward/try-runtime",
-    "pallet-democracy/try-runtime",
-    "pallet-elections-phragmen/try-runtime",
-    "pallet-fees/try-runtime",
-    "pallet-identity/try-runtime",
-    "pallet-interest-accrual/try-runtime",
-    "pallet-investments/try-runtime",
-    "pallet-loans/try-runtime",
-    "pallet-migration-manager/try-runtime",
-    "pallet-multisig/try-runtime",
-    "pallet-nft-sales/try-runtime",
-    "pallet-permissions/try-runtime",
-    "pallet-pools/try-runtime",
-    "pallet-preimage/try-runtime",
-    "pallet-proxy/try-runtime",
-    "pallet-randomness-collective-flip/try-runtime",
-    "pallet-restricted-tokens/try-runtime",
-    "pallet-restricted-tokens/try-runtime",
-    "pallet-scheduler/try-runtime",
-    "pallet-session-benchmarking",
-    "pallet-session/try-runtime",
-    "pallet-society/try-runtime",
-    "pallet-timestamp/try-runtime",
-    "pallet-transaction-payment/try-runtime",
-    "pallet-treasury/try-runtime",
-    "pallet-uniques/try-runtime",
-    "pallet-utility/try-runtime",
-    "pallet-vesting/try-runtime",
-    "pallet-xcm/try-runtime",
-    "parachain-info/try-runtime",
-    "runtime-common/try-runtime",
+  "cumulus-pallet-aura-ext/try-runtime",
+  "cumulus-pallet-dmp-queue/try-runtime",
+  "cumulus-pallet-parachain-system/try-runtime",
+  "cumulus-pallet-xcm/try-runtime",
+  "cumulus-pallet-xcmp-queue/try-runtime",
+  "frame-executive/try-runtime",
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
+  "frame-try-runtime",
+  "orml-asset-registry/try-runtime",
+  "orml-tokens/try-runtime",
+  "orml-xcm/try-runtime",
+  "orml-xtokens/try-runtime",
+  "pallet-anchors/try-runtime",
+  "pallet-aura/try-runtime",
+  "pallet-authorship/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-collator-allowlist/try-runtime",
+  "pallet-collator-selection/try-runtime",
+  "pallet-collective/try-runtime",
+  "pallet-crowdloan-claim/try-runtime",
+  "pallet-crowdloan-reward/try-runtime",
+  "pallet-democracy/try-runtime",
+  "pallet-elections-phragmen/try-runtime",
+  "pallet-fees/try-runtime",
+  "pallet-identity/try-runtime",
+  "pallet-interest-accrual/try-runtime",
+  "pallet-investments/try-runtime",
+  "pallet-loans/try-runtime",
+  "pallet-migration-manager/try-runtime",
+  "pallet-multisig/try-runtime",
+  "pallet-nft-sales/try-runtime",
+  "pallet-permissions/try-runtime",
+  "pallet-pools/try-runtime",
+  "pallet-preimage/try-runtime",
+  "pallet-proxy/try-runtime",
+  "pallet-randomness-collective-flip/try-runtime",
+  "pallet-restricted-tokens/try-runtime",
+  "pallet-restricted-tokens/try-runtime",
+  "pallet-scheduler/try-runtime",
+  "pallet-session-benchmarking",
+  "pallet-session/try-runtime",
+  "pallet-society/try-runtime",
+  "pallet-timestamp/try-runtime",
+  "pallet-transaction-payment/try-runtime",
+  "pallet-treasury/try-runtime",
+  "pallet-uniques/try-runtime",
+  "pallet-utility/try-runtime",
+  "pallet-vesting/try-runtime",
+  "pallet-xcm/try-runtime",
+  "parachain-info/try-runtime",
+  "runtime-common/try-runtime",
 ]
-
 
 # A feature that should be enabled when the runtime should be build for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [
-    "sp-api/disable-logging",
+  "sp-api/disable-logging",
 ]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -11,93 +11,93 @@ repository = "https://github.com/centrifuge/centrifuge-chain"
 [dependencies]
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+hex-literal = { version = "0.3.4", optional = true }
 integer-sqrt = { version = "0.1.2" }
+rustc-hex = { version = "2.0", optional = true }
 safe-mix = { version = "1.0", default-features = false }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119", optional = true }
 smallvec = "1.6.1"
 static_assertions = "1.1.0"
-hex-literal = { version = "0.3.4", optional = true }
-rustc-hex = { version = "2.0", optional = true }
-serde = { version = "1.0.119", optional = true }
 
 # parachain
-cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
 cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-collator-selection = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
 parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
 
 # polkadot dependencies
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
 
 # primitives
-sp-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate",  default-features = false, branch = "polkadot-v0.9.29" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-inherents = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-offchain = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-session = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-staking = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-version = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # frame dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-frame-executive = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.29" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
 pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-babe = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-collective = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-democracy = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-identity = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-im-online = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-indices = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-membership = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-multisig = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-offences = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-session = { git = "https://github.com/paritytech/substrate",  default-features = false, features = ["historical"] , branch = "polkadot-v0.9.29" }
-pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true, branch = "polkadot-v0.9.29" }
-pallet-staking = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-identity = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-membership = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, features = ["historical"], branch = "polkadot-v0.9.29" }
+pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+pallet-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-utility = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-vesting = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Orml pallets
-orml-asset-registry = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
@@ -129,195 +129,195 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 [features]
 default = ["std"]
 std = [
-    "cfg-primitives/std",
-    "cfg-traits/std",
-    "cfg-types/std",
-    "chainbridge/std",
-    "codec/std",
-    "cumulus-pallet-aura-ext/std",
-    "cumulus-pallet-dmp-queue/std",
-    "cumulus-pallet-parachain-system/std",
-    "cumulus-pallet-xcm/std",
-    "cumulus-pallet-xcmp-queue/std",
-    "cumulus-primitives-timestamp/std",
-    "frame-executive/std",
-    "frame-support/std",
-    "frame-system-rpc-runtime-api/std",
-    "frame-system/std",
-    "frame-try-runtime/std",
-    "orml-asset-registry/std",
-    "orml-tokens/std",
-    "orml-traits/std",
-    "orml-xcm-support/std",
-    "orml-xcm/std",
-    "orml-xtokens/std",
-    "pallet-anchors/std",
-    "pallet-aura/std",
-    "pallet-authority-discovery/std",
-    "pallet-authorship/std",
-    "pallet-babe/std",
-    "pallet-balances/std",
-    "pallet-bridge/std",
-    "pallet-claims/std",
-    "pallet-collator-allowlist/std",
-    "pallet-collator-selection/std",
-    "pallet-collective/std",
-    "pallet-crowdloan-claim/std",
-    "pallet-crowdloan-reward/std",
-    "pallet-democracy/std",
-    "pallet-elections-phragmen/std",
-    "pallet-fees/std",
-    "pallet-fees/std",
-    "pallet-grandpa/std",
-    "pallet-identity/std",
-    "pallet-im-online/std",
-    "pallet-indices/std",
-    "pallet-membership/std",
-    "pallet-migration-manager/std",
-    "pallet-multisig/std",
-    "pallet-nft/std",
-    "pallet-offences/std",
-    "pallet-preimage/std",
-    "pallet-proxy/std",
-    "pallet-randomness-collective-flip/std",
-    "pallet-restricted-tokens/std",
-    "pallet-scheduler/std",
-    "pallet-session/std",
-    "pallet-staking/std",
-    "pallet-timestamp/std",
-    "pallet-transaction-payment-rpc-runtime-api/std",
-    "pallet-transaction-payment/std",
-    "pallet-treasury/std",
-    "pallet-utility/std",
-    "pallet-vesting/std",
-    "pallet-xcm/std",
-    "parachain-info/std",
-    "polkadot-parachain/std",
-    "polkadot-runtime-common/std",
-    "runtime-common/std",
-    "rustc-hex",
-    "safe-mix/std",
-    "serde",
-    "sp-api/std",
-    "sp-arithmetic/std",
-    "sp-authority-discovery/std",
-    "sp-block-builder/std",
-    "sp-consensus-aura/std",
-    "sp-consensus-babe/std",
-    "sp-core/std",
-    "sp-inherents/std",
-    "sp-io/std",
-    "sp-offchain/std",
-    "sp-runtime/std",
-    "sp-session/std",
-    "sp-staking/std",
-    "sp-std/std",
-    "sp-transaction-pool/std",
-    "sp-version/std",
-    "xcm-builder/std",
-    "xcm-executor/std",
-    "xcm/std",
+  "cfg-primitives/std",
+  "cfg-traits/std",
+  "cfg-types/std",
+  "chainbridge/std",
+  "codec/std",
+  "cumulus-pallet-aura-ext/std",
+  "cumulus-pallet-dmp-queue/std",
+  "cumulus-pallet-parachain-system/std",
+  "cumulus-pallet-xcm/std",
+  "cumulus-pallet-xcmp-queue/std",
+  "cumulus-primitives-timestamp/std",
+  "frame-executive/std",
+  "frame-support/std",
+  "frame-system-rpc-runtime-api/std",
+  "frame-system/std",
+  "frame-try-runtime/std",
+  "orml-asset-registry/std",
+  "orml-tokens/std",
+  "orml-traits/std",
+  "orml-xcm-support/std",
+  "orml-xcm/std",
+  "orml-xtokens/std",
+  "pallet-anchors/std",
+  "pallet-aura/std",
+  "pallet-authority-discovery/std",
+  "pallet-authorship/std",
+  "pallet-babe/std",
+  "pallet-balances/std",
+  "pallet-bridge/std",
+  "pallet-claims/std",
+  "pallet-collator-allowlist/std",
+  "pallet-collator-selection/std",
+  "pallet-collective/std",
+  "pallet-crowdloan-claim/std",
+  "pallet-crowdloan-reward/std",
+  "pallet-democracy/std",
+  "pallet-elections-phragmen/std",
+  "pallet-fees/std",
+  "pallet-fees/std",
+  "pallet-grandpa/std",
+  "pallet-identity/std",
+  "pallet-im-online/std",
+  "pallet-indices/std",
+  "pallet-membership/std",
+  "pallet-migration-manager/std",
+  "pallet-multisig/std",
+  "pallet-nft/std",
+  "pallet-offences/std",
+  "pallet-preimage/std",
+  "pallet-proxy/std",
+  "pallet-randomness-collective-flip/std",
+  "pallet-restricted-tokens/std",
+  "pallet-scheduler/std",
+  "pallet-session/std",
+  "pallet-staking/std",
+  "pallet-timestamp/std",
+  "pallet-transaction-payment-rpc-runtime-api/std",
+  "pallet-transaction-payment/std",
+  "pallet-treasury/std",
+  "pallet-utility/std",
+  "pallet-vesting/std",
+  "pallet-xcm/std",
+  "parachain-info/std",
+  "polkadot-parachain/std",
+  "polkadot-runtime-common/std",
+  "runtime-common/std",
+  "rustc-hex",
+  "safe-mix/std",
+  "serde",
+  "sp-api/std",
+  "sp-arithmetic/std",
+  "sp-authority-discovery/std",
+  "sp-block-builder/std",
+  "sp-consensus-aura/std",
+  "sp-consensus-babe/std",
+  "sp-core/std",
+  "sp-inherents/std",
+  "sp-io/std",
+  "sp-offchain/std",
+  "sp-runtime/std",
+  "sp-session/std",
+  "sp-staking/std",
+  "sp-std/std",
+  "sp-transaction-pool/std",
+  "sp-version/std",
+  "xcm-builder/std",
+  "xcm-executor/std",
+  "xcm/std",
 ]
 
 runtime-benchmarks = [
-    "hex-literal",
-    "frame-benchmarking",
-    "frame-system-benchmarking",
-    "cfg-types/runtime-benchmarks",
-    "chainbridge/runtime-benchmarks",
-    "frame-benchmarking/runtime-benchmarks",
-    "frame-support/runtime-benchmarks",
-    "frame-system/runtime-benchmarks",
-    "pallet-anchors/runtime-benchmarks",
-    "pallet-balances/runtime-benchmarks",
-    "pallet-collator-allowlist/runtime-benchmarks",
-    "pallet-collator-selection/runtime-benchmarks",
-    "pallet-collective/runtime-benchmarks",
-    "pallet-crowdloan-claim/runtime-benchmarks",
-    "pallet-crowdloan-reward/runtime-benchmarks",
-    "pallet-democracy/runtime-benchmarks",
-    "pallet-elections-phragmen/runtime-benchmarks",
-    "pallet-fees/runtime-benchmarks",
-    "pallet-identity/runtime-benchmarks",
-    "pallet-migration-manager/runtime-benchmarks",
-    "pallet-multisig/runtime-benchmarks",
-    "pallet-preimage/runtime-benchmarks",
-    "pallet-proxy/runtime-benchmarks",
-    "pallet-restricted-tokens/runtime-benchmarks",
-    "pallet-scheduler/runtime-benchmarks",
-    "pallet-session-benchmarking",
-    "pallet-session-benchmarking",
-    "pallet-timestamp/runtime-benchmarks",
-    "pallet-treasury/runtime-benchmarks",
-    "pallet-utility/runtime-benchmarks",
-    "pallet-vesting/runtime-benchmarks",
-    "pallet-xcm/runtime-benchmarks",
-    "runtime-common/runtime-benchmarks",
-    "xcm-builder/runtime-benchmarks",
+  "hex-literal",
+  "frame-benchmarking",
+  "frame-system-benchmarking",
+  "cfg-types/runtime-benchmarks",
+  "chainbridge/runtime-benchmarks",
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+  "pallet-anchors/runtime-benchmarks",
+  "pallet-balances/runtime-benchmarks",
+  "pallet-collator-allowlist/runtime-benchmarks",
+  "pallet-collator-selection/runtime-benchmarks",
+  "pallet-collective/runtime-benchmarks",
+  "pallet-crowdloan-claim/runtime-benchmarks",
+  "pallet-crowdloan-reward/runtime-benchmarks",
+  "pallet-democracy/runtime-benchmarks",
+  "pallet-elections-phragmen/runtime-benchmarks",
+  "pallet-fees/runtime-benchmarks",
+  "pallet-identity/runtime-benchmarks",
+  "pallet-migration-manager/runtime-benchmarks",
+  "pallet-multisig/runtime-benchmarks",
+  "pallet-preimage/runtime-benchmarks",
+  "pallet-proxy/runtime-benchmarks",
+  "pallet-restricted-tokens/runtime-benchmarks",
+  "pallet-scheduler/runtime-benchmarks",
+  "pallet-session-benchmarking",
+  "pallet-session-benchmarking",
+  "pallet-timestamp/runtime-benchmarks",
+  "pallet-treasury/runtime-benchmarks",
+  "pallet-utility/runtime-benchmarks",
+  "pallet-vesting/runtime-benchmarks",
+  "pallet-xcm/runtime-benchmarks",
+  "runtime-common/runtime-benchmarks",
+  "xcm-builder/runtime-benchmarks",
 ]
 
 try-runtime = [
-    "cumulus-pallet-aura-ext/try-runtime",
-    "cumulus-pallet-dmp-queue/try-runtime",
-    "cumulus-pallet-parachain-system/try-runtime",
-    "cumulus-pallet-xcm/try-runtime",
-    "cumulus-pallet-xcmp-queue/try-runtime",
-    "frame-executive/try-runtime",
-    "frame-support/try-runtime",
-    "frame-system/try-runtime",
-    "frame-try-runtime",
-    "chainbridge/try-runtime",
-    "orml-asset-registry/try-runtime",
-    "orml-tokens/try-runtime",
-    "orml-xcm/try-runtime",
-    "orml-xtokens/try-runtime",
-    "pallet-anchors/try-runtime",
-    "pallet-aura/try-runtime",
-    "pallet-authority-discovery/try-runtime",
-    "pallet-authorship/try-runtime",
-    "pallet-babe/try-runtime",
-    "pallet-balances/try-runtime",
-    "pallet-bridge/try-runtime",
-    "pallet-claims/try-runtime",
-    "pallet-collator-allowlist/try-runtime",
-    "pallet-collator-selection/try-runtime",
-    "pallet-collective/try-runtime",
-    "pallet-crowdloan-claim/try-runtime",
-    "pallet-crowdloan-reward/try-runtime",
-    "pallet-democracy/try-runtime",
-    "pallet-elections-phragmen/try-runtime",
-    "pallet-fees/try-runtime",
-    "pallet-grandpa/try-runtime",
-    "pallet-identity/try-runtime",
-    "pallet-im-online/try-runtime",
-    "pallet-indices/try-runtime",
-    "pallet-membership/try-runtime",
-    "pallet-migration-manager/try-runtime",
-    "pallet-multisig/try-runtime",
-    "pallet-nft/try-runtime",
-    "pallet-offences/try-runtime",
-    "pallet-preimage/try-runtime",
-    "pallet-proxy/try-runtime",
-    "pallet-randomness-collective-flip/try-runtime",
-    "pallet-restricted-tokens/try-runtime",
-    "pallet-scheduler/try-runtime",
-    "pallet-session/try-runtime",
-    "pallet-staking/try-runtime",
-    "pallet-timestamp/try-runtime",
-    "pallet-transaction-payment/try-runtime",
-    "pallet-treasury/try-runtime",
-    "pallet-utility/try-runtime",
-    "pallet-vesting/try-runtime",
-    "pallet-xcm/try-runtime",
-    "parachain-info/try-runtime",
-    "runtime-common/try-runtime",
+  "cumulus-pallet-aura-ext/try-runtime",
+  "cumulus-pallet-dmp-queue/try-runtime",
+  "cumulus-pallet-parachain-system/try-runtime",
+  "cumulus-pallet-xcm/try-runtime",
+  "cumulus-pallet-xcmp-queue/try-runtime",
+  "frame-executive/try-runtime",
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
+  "frame-try-runtime",
+  "chainbridge/try-runtime",
+  "orml-asset-registry/try-runtime",
+  "orml-tokens/try-runtime",
+  "orml-xcm/try-runtime",
+  "orml-xtokens/try-runtime",
+  "pallet-anchors/try-runtime",
+  "pallet-aura/try-runtime",
+  "pallet-authority-discovery/try-runtime",
+  "pallet-authorship/try-runtime",
+  "pallet-babe/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-bridge/try-runtime",
+  "pallet-claims/try-runtime",
+  "pallet-collator-allowlist/try-runtime",
+  "pallet-collator-selection/try-runtime",
+  "pallet-collective/try-runtime",
+  "pallet-crowdloan-claim/try-runtime",
+  "pallet-crowdloan-reward/try-runtime",
+  "pallet-democracy/try-runtime",
+  "pallet-elections-phragmen/try-runtime",
+  "pallet-fees/try-runtime",
+  "pallet-grandpa/try-runtime",
+  "pallet-identity/try-runtime",
+  "pallet-im-online/try-runtime",
+  "pallet-indices/try-runtime",
+  "pallet-membership/try-runtime",
+  "pallet-migration-manager/try-runtime",
+  "pallet-multisig/try-runtime",
+  "pallet-nft/try-runtime",
+  "pallet-offences/try-runtime",
+  "pallet-preimage/try-runtime",
+  "pallet-proxy/try-runtime",
+  "pallet-randomness-collective-flip/try-runtime",
+  "pallet-restricted-tokens/try-runtime",
+  "pallet-scheduler/try-runtime",
+  "pallet-session/try-runtime",
+  "pallet-staking/try-runtime",
+  "pallet-timestamp/try-runtime",
+  "pallet-transaction-payment/try-runtime",
+  "pallet-treasury/try-runtime",
+  "pallet-utility/try-runtime",
+  "pallet-vesting/try-runtime",
+  "pallet-xcm/try-runtime",
+  "parachain-info/try-runtime",
+  "runtime-common/try-runtime",
 ]
 
 # A feature that should be enabled when the runtime should be build for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [
-    "sp-api/disable-logging",
+  "sp-api/disable-logging",
 ]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -16,33 +16,33 @@ smallvec = "1.6.1"
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-node-primitives = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-collective = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+node-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-sp-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Polkadot dependencies
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
 
 # ORML dependencies
-orml-traits = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 
 # Local Dependencies
-cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-primitives = { path = "../../libs/primitives", default-features = false }
-pallet-anchors = { path = "../../pallets/anchors", default-features = false }
-pallet-pools = { path = "../../pallets/pools", default-features = false }
+cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-types = { path = "../../libs/types", default-features = false }
+pallet-anchors = { path = "../../pallets/anchors", default-features = false }
 pallet-permissions = { path = "../../pallets/permissions", default-features = false }
+pallet-pools = { path = "../../pallets/pools", default-features = false }
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
@@ -50,39 +50,38 @@ sp-io = { git = "https://github.com/paritytech/substrate", default-features = fa
 [features]
 default = ["std"]
 std = [
-    "serde/std",
-    "codec/std",
-    "serde/std",
-    "frame-support/std",
-    "frame-system/std",
-    "node-primitives/std",
-    "pallet-authorship/std",
-    "pallet-balances/std",
-    "pallet-collective/std",
-    "pallet-treasury/std",
-    "pallet-permissions/std",
-    "serde",
-    "sp-core/std",
-    "sp-api/std",
-    "sp-std/std",
-    "sp-arithmetic/std",
-    "sp-core/std",
-    "sp-consensus-aura/std",
-    "sp-runtime/std",
-    "cfg-types/std",
-    "pallet-anchors/std",
-    "cfg-traits/std",
-    "frame-support/std",
-    "frame-system/std",
-    "cfg-primitives/std",
+  "serde/std",
+  "codec/std",
+  "serde/std",
+  "frame-support/std",
+  "frame-system/std",
+  "node-primitives/std",
+  "pallet-authorship/std",
+  "pallet-balances/std",
+  "pallet-collective/std",
+  "pallet-treasury/std",
+  "pallet-permissions/std",
+  "serde",
+  "sp-core/std",
+  "sp-api/std",
+  "sp-std/std",
+  "sp-arithmetic/std",
+  "sp-core/std",
+  "sp-consensus-aura/std",
+  "sp-runtime/std",
+  "cfg-types/std",
+  "pallet-anchors/std",
+  "cfg-traits/std",
+  "frame-support/std",
+  "frame-system/std",
+  "cfg-primitives/std",
 ]
 runtime-benchmarks = [
-    "frame-support/runtime-benchmarks",
-    "frame-system/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
 ]
 
 on-chain-release-build = [
-    "sp-api/disable-logging",
+  "sp-api/disable-logging",
 ]
 try-runtime = ["frame-support/try-runtime"]
-

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -11,128 +11,128 @@ repository = "https://github.com/centrifuge/centrifuge-chain"
 [dependencies]
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+hex-literal = { version = "0.3.4", optional = true }
 integer-sqrt = { version = "0.1.2" }
+rustc-hex = { version = "2.0", optional = true }
 safe-mix = { version = "1.0", default-features = false }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.119", optional = true }
 smallvec = "1.6.1"
 static_assertions = "1.1.0"
-hex-literal = { version = "0.3.4", optional = true }
-rustc-hex = { version = "2.0", optional = true }
-serde = { version = "1.0.119", optional = true }
 
 # parachain
-parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
 cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-collator-selection = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
+parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.29" }
 
 # polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.29" }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.29" }
 
 # primitives
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate",  default-features = false, branch = "polkadot-v0.9.29" }
-sp-inherents = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-offchain = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-core = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-runtime = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-staking = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-session = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-version = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # frame dependencies
-frame-executive = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-support = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-system = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.29" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.29" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-babe = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-balances = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-collective = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-democracy = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-im-online = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-indices = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-membership = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-multisig = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-offences = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-session = { git = "https://github.com/paritytech/substrate",  default-features = false, features = ["historical"] , branch = "polkadot-v0.9.29" }
-pallet-staking = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-utility = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-identity = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-vesting = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.29" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-identity = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-membership = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, features = ["historical"], branch = "polkadot-v0.9.29" }
 pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.29" }
+pallet-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 
 # orml pallets
-orml-asset-registry = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
-orml-tokens = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
-orml-traits = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
-orml-xcm = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
-orml-xcm-support = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
-orml-xtokens = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
 
-runtime-common = { path = "../common", default-features = false }
-cfg-types = { path = "../../libs/types", default-features = false }
-cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-primitives = { path = "../../libs/primitives", default-features = false }
+cfg-traits = { path = "../../libs/traits", default-features = false }
+cfg-types = { path = "../../libs/types", default-features = false }
+runtime-common = { path = "../common", default-features = false }
 
 # bridge pallets
 chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = false, branch = "polkadot-v0.9.29" }
 
 # our custom pallets
 pallet-anchors = { path = "../../pallets/anchors", default-features = false }
-pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = false }
-pallet-fees = { path = "../../pallets/fees", default-features = false }
-pallet-collator-allowlist = { path = "../../pallets/collator-allowlist", default-features = false }
+pallet-bridge = { path = "../../pallets/bridge", default-features = false }
 pallet-claims = { path = "../../pallets/claims", default-features = false }
-pallet-pools = { path = "../../pallets/pools", default-features = false }
-pallet-migration-manager = { path = "../../pallets/migration", default-features = false }
+pallet-collator-allowlist = { path = "../../pallets/collator-allowlist", default-features = false }
 pallet-crowdloan-claim = { path = "../../pallets/crowdloan-claim", default-features = false }
 pallet-crowdloan-reward = { path = "../../pallets/crowdloan-reward", default-features = false }
-pallet-loans = { path = "../../pallets/loans", default-features = false }
-pallet-permissions = { path = "../../pallets/permissions", default-features = false }
-pallet-nft-sales = { path = "../../pallets/nft-sales", default-features = false }
-pallet-bridge = { path = "../../pallets/bridge", default-features = false }
-pallet-nft = { path = "../../pallets/nft", default-features = false }
+pallet-fees = { path = "../../pallets/fees", default-features = false }
 pallet-interest-accrual = { path = "../../pallets/interest-accrual", default-features = false }
-pallet-keystore = { path = "../../pallets/keystore", default-features = false }
 pallet-investments = { path = "../../pallets/investments", default-features = false }
-pallet-rewards = { path = "../../pallets/rewards", default-features = false }
+pallet-keystore = { path = "../../pallets/keystore", default-features = false }
 pallet-liquidity-rewards = { path = "../../pallets/liquidity-rewards", default-features = false }
+pallet-loans = { path = "../../pallets/loans", default-features = false }
+pallet-migration-manager = { path = "../../pallets/migration", default-features = false }
+pallet-nft = { path = "../../pallets/nft", default-features = false }
+pallet-nft-sales = { path = "../../pallets/nft-sales", default-features = false }
+pallet-permissions = { path = "../../pallets/permissions", default-features = false }
+pallet-pools = { path = "../../pallets/pools", default-features = false }
+pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = false }
+pallet-rewards = { path = "../../pallets/rewards", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
@@ -140,189 +140,189 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 [features]
 default = ["std"]
 std = [
-    "cfg-primitives/std",
-    "cfg-types/std",
-    "chainbridge/std",
-    "chainbridge/std",
-    "codec/std",
-    "cumulus-pallet-aura-ext/std",
-    "cumulus-pallet-parachain-system/std",
-    "cumulus-pallet-xcm/std",
-    "cumulus-pallet-xcmp-queue/std",
-    "cumulus-primitives-timestamp/std",
-    "frame-executive/std",
-    "frame-support/std",
-    "frame-system-rpc-runtime-api/std",
-    "frame-system/std",
-    "orml-asset-registry/std",
-    "orml-tokens/std",
-    "orml-xtokens/std",
-    "pallet-anchors/std",
-    "pallet-aura/std",
-    "pallet-authority-discovery/std",
-    "pallet-authorship/std",
-    "pallet-babe/std",
-    "pallet-balances/std",
-    "pallet-bridge/std",
-    "pallet-claims/std",
-    "pallet-collator-allowlist/std",
-    "pallet-collator-selection/std",
-    "pallet-collective/std",
-    "pallet-crowdloan-claim/std",
-    "pallet-crowdloan-reward/std",
-    "pallet-democracy/std",
-    "pallet-elections-phragmen/std",
-    "pallet-fees/std",
-    "pallet-grandpa/std",
-    "pallet-identity/std",
-    "pallet-im-online/std",
-    "pallet-indices/std",
-    "pallet-interest-accrual/std",
-    "pallet-investments/std",
-    "pallet-keystore/std",
-    "pallet-liquidity-rewards/std",
-    "pallet-loans/std",
-    "pallet-membership/std",
-    "pallet-migration-manager/std",
-    "pallet-multisig/std",
-    "pallet-nft-sales/std",
-    "pallet-nft/std",
-    "pallet-offences/std",
-    "pallet-permissions/std",
-    "pallet-preimage/std",
-    "pallet-proxy/std",
-    "pallet-randomness-collective-flip/std",
-    "pallet-restricted-tokens/std",
-    "pallet-rewards/std",
-    "pallet-scheduler/std",
-    "pallet-session/std",
-    "pallet-society/std",
-    "pallet-society/std",
-    "pallet-staking/std",
-    "pallet-sudo/std",
-    "pallet-timestamp/std",
-    "pallet-transaction-payment-rpc-runtime-api/std",
-    "pallet-transaction-payment/std",
-    "pallet-treasury/std",
-    "pallet-uniques/std",
-    "pallet-utility/std",
-    "pallet-vesting/std",
-    "parachain-info/std",
-    "polkadot-runtime-common/std",
-    "runtime-common/std",
-    "rustc-hex",
-    "safe-mix/std",
-    "serde",
-    "sp-api/std",
-    "sp-arithmetic/std",
-    "sp-authority-discovery/std",
-    "sp-block-builder/std",
-    "sp-consensus-aura/std",
-    "sp-consensus-babe/std",
-    "sp-core/std",
-    "sp-inherents/std",
-    "sp-io/std",
-    "sp-offchain/std",
-    "sp-runtime/std",
-    "sp-session/std",
-    "sp-staking/std",
-    "sp-std/std",
-    "sp-transaction-pool/std",
-    "sp-version/std",
-    "xcm-builder/std",
-    "xcm-executor/std",
-    "xcm/std",
+  "cfg-primitives/std",
+  "cfg-types/std",
+  "chainbridge/std",
+  "chainbridge/std",
+  "codec/std",
+  "cumulus-pallet-aura-ext/std",
+  "cumulus-pallet-parachain-system/std",
+  "cumulus-pallet-xcm/std",
+  "cumulus-pallet-xcmp-queue/std",
+  "cumulus-primitives-timestamp/std",
+  "frame-executive/std",
+  "frame-support/std",
+  "frame-system-rpc-runtime-api/std",
+  "frame-system/std",
+  "orml-asset-registry/std",
+  "orml-tokens/std",
+  "orml-xtokens/std",
+  "pallet-anchors/std",
+  "pallet-aura/std",
+  "pallet-authority-discovery/std",
+  "pallet-authorship/std",
+  "pallet-babe/std",
+  "pallet-balances/std",
+  "pallet-bridge/std",
+  "pallet-claims/std",
+  "pallet-collator-allowlist/std",
+  "pallet-collator-selection/std",
+  "pallet-collective/std",
+  "pallet-crowdloan-claim/std",
+  "pallet-crowdloan-reward/std",
+  "pallet-democracy/std",
+  "pallet-elections-phragmen/std",
+  "pallet-fees/std",
+  "pallet-grandpa/std",
+  "pallet-identity/std",
+  "pallet-im-online/std",
+  "pallet-indices/std",
+  "pallet-interest-accrual/std",
+  "pallet-investments/std",
+  "pallet-keystore/std",
+  "pallet-liquidity-rewards/std",
+  "pallet-loans/std",
+  "pallet-membership/std",
+  "pallet-migration-manager/std",
+  "pallet-multisig/std",
+  "pallet-nft-sales/std",
+  "pallet-nft/std",
+  "pallet-offences/std",
+  "pallet-permissions/std",
+  "pallet-preimage/std",
+  "pallet-proxy/std",
+  "pallet-randomness-collective-flip/std",
+  "pallet-restricted-tokens/std",
+  "pallet-rewards/std",
+  "pallet-scheduler/std",
+  "pallet-session/std",
+  "pallet-society/std",
+  "pallet-society/std",
+  "pallet-staking/std",
+  "pallet-sudo/std",
+  "pallet-timestamp/std",
+  "pallet-transaction-payment-rpc-runtime-api/std",
+  "pallet-transaction-payment/std",
+  "pallet-treasury/std",
+  "pallet-uniques/std",
+  "pallet-utility/std",
+  "pallet-vesting/std",
+  "parachain-info/std",
+  "polkadot-runtime-common/std",
+  "runtime-common/std",
+  "rustc-hex",
+  "safe-mix/std",
+  "serde",
+  "sp-api/std",
+  "sp-arithmetic/std",
+  "sp-authority-discovery/std",
+  "sp-block-builder/std",
+  "sp-consensus-aura/std",
+  "sp-consensus-babe/std",
+  "sp-core/std",
+  "sp-inherents/std",
+  "sp-io/std",
+  "sp-offchain/std",
+  "sp-runtime/std",
+  "sp-session/std",
+  "sp-staking/std",
+  "sp-std/std",
+  "sp-transaction-pool/std",
+  "sp-version/std",
+  "xcm-builder/std",
+  "xcm-executor/std",
+  "xcm/std",
 ]
 
 runtime-benchmarks = [
-    "cfg-types/runtime-benchmarks",
-    "chainbridge/runtime-benchmarks",
-    "frame-benchmarking/runtime-benchmarks",
-    "frame-support/runtime-benchmarks",
-    "frame-system-benchmarking",
-    "frame-system/runtime-benchmarks",
-    "hex-literal",
-    "pallet-anchors/runtime-benchmarks",
-    "pallet-balances/runtime-benchmarks",
-    "pallet-collator-allowlist/runtime-benchmarks",
-    "pallet-collator-selection/runtime-benchmarks",
-    "pallet-collective/runtime-benchmarks",
-    "pallet-crowdloan-claim/runtime-benchmarks",
-    "pallet-crowdloan-reward/runtime-benchmarks",
-    "pallet-fees/runtime-benchmarks",
-    "pallet-interest-accrual/runtime-benchmarks",
-    "pallet-investments/runtime-benchmarks",
-    "pallet-keystore/runtime-benchmarks",
-    "pallet-liquidity-rewards/runtime-benchmarks",
-    "pallet-loans/runtime-benchmarks",
-    "pallet-migration-manager/runtime-benchmarks",
-    "pallet-nft-sales/runtime-benchmarks",
-    "pallet-permissions/runtime-benchmarks",
-    "pallet-pools/runtime-benchmarks",
-    "pallet-restricted-tokens/runtime-benchmarks",
-    "pallet-society/runtime-benchmarks",
-    "pallet-uniques/runtime-benchmarks",
-    "pallet-xcm/runtime-benchmarks",
-    "runtime-common/runtime-benchmarks",
-    "xcm-builder/runtime-benchmarks",
+  "cfg-types/runtime-benchmarks",
+  "chainbridge/runtime-benchmarks",
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system-benchmarking",
+  "frame-system/runtime-benchmarks",
+  "hex-literal",
+  "pallet-anchors/runtime-benchmarks",
+  "pallet-balances/runtime-benchmarks",
+  "pallet-collator-allowlist/runtime-benchmarks",
+  "pallet-collator-selection/runtime-benchmarks",
+  "pallet-collective/runtime-benchmarks",
+  "pallet-crowdloan-claim/runtime-benchmarks",
+  "pallet-crowdloan-reward/runtime-benchmarks",
+  "pallet-fees/runtime-benchmarks",
+  "pallet-interest-accrual/runtime-benchmarks",
+  "pallet-investments/runtime-benchmarks",
+  "pallet-keystore/runtime-benchmarks",
+  "pallet-liquidity-rewards/runtime-benchmarks",
+  "pallet-loans/runtime-benchmarks",
+  "pallet-migration-manager/runtime-benchmarks",
+  "pallet-nft-sales/runtime-benchmarks",
+  "pallet-permissions/runtime-benchmarks",
+  "pallet-pools/runtime-benchmarks",
+  "pallet-restricted-tokens/runtime-benchmarks",
+  "pallet-society/runtime-benchmarks",
+  "pallet-uniques/runtime-benchmarks",
+  "pallet-xcm/runtime-benchmarks",
+  "runtime-common/runtime-benchmarks",
+  "xcm-builder/runtime-benchmarks",
 ]
 
 try-runtime = [
-    "cumulus-pallet-aura-ext/try-runtime",
-    "cumulus-pallet-dmp-queue/try-runtime",
-    "cumulus-pallet-parachain-system/try-runtime",
-    "cumulus-pallet-xcm/try-runtime",
-    "cumulus-pallet-xcmp-queue/try-runtime",
-    "frame-executive/try-runtime",
-    "frame-support/try-runtime",
-    "frame-system/try-runtime",
-    "orml-asset-registry/try-runtime",
-    "orml-tokens/try-runtime",
-    "orml-xcm/try-runtime",
-    "orml-xtokens/try-runtime",
-    "pallet-anchors/try-runtime",
-    "pallet-aura/try-runtime",
-    "pallet-authorship/try-runtime",
-    "pallet-balances/try-runtime",
-    "pallet-collator-allowlist/try-runtime",
-    "pallet-collator-selection/try-runtime",
-    "pallet-collective/try-runtime",
-    "pallet-crowdloan-claim/try-runtime",
-    "pallet-crowdloan-reward/try-runtime",
-    "pallet-democracy/try-runtime",
-    "pallet-elections-phragmen/try-runtime",
-    "pallet-fees/try-runtime",
-    "pallet-identity/try-runtime",
-    "pallet-interest-accrual/try-runtime",
-    "pallet-investments/try-runtime",
-    "pallet-liquidity-rewards/try-runtime",
-    "pallet-loans/try-runtime",
-    "pallet-migration-manager/try-runtime",
-    "pallet-multisig/try-runtime",
-    "pallet-nft-sales/try-runtime",
-    "pallet-permissions/try-runtime",
-    "pallet-pools/try-runtime",
-    "pallet-preimage/try-runtime",
-    "pallet-proxy/try-runtime",
-    "pallet-randomness-collective-flip/try-runtime",
-    "pallet-restricted-tokens/try-runtime",
-    "pallet-scheduler/try-runtime",
-    "pallet-session/try-runtime",
-    "pallet-society/try-runtime",
-    "pallet-timestamp/try-runtime",
-    "pallet-transaction-payment/try-runtime",
-    "pallet-treasury/try-runtime",
-    "pallet-uniques/try-runtime",
-    "pallet-utility/try-runtime",
-    "pallet-vesting/try-runtime",
-    "pallet-xcm/try-runtime",
-    "parachain-info/try-runtime",
-    "runtime-common/try-runtime",
+  "cumulus-pallet-aura-ext/try-runtime",
+  "cumulus-pallet-dmp-queue/try-runtime",
+  "cumulus-pallet-parachain-system/try-runtime",
+  "cumulus-pallet-xcm/try-runtime",
+  "cumulus-pallet-xcmp-queue/try-runtime",
+  "frame-executive/try-runtime",
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
+  "orml-asset-registry/try-runtime",
+  "orml-tokens/try-runtime",
+  "orml-xcm/try-runtime",
+  "orml-xtokens/try-runtime",
+  "pallet-anchors/try-runtime",
+  "pallet-aura/try-runtime",
+  "pallet-authorship/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-collator-allowlist/try-runtime",
+  "pallet-collator-selection/try-runtime",
+  "pallet-collective/try-runtime",
+  "pallet-crowdloan-claim/try-runtime",
+  "pallet-crowdloan-reward/try-runtime",
+  "pallet-democracy/try-runtime",
+  "pallet-elections-phragmen/try-runtime",
+  "pallet-fees/try-runtime",
+  "pallet-identity/try-runtime",
+  "pallet-interest-accrual/try-runtime",
+  "pallet-investments/try-runtime",
+  "pallet-liquidity-rewards/try-runtime",
+  "pallet-loans/try-runtime",
+  "pallet-migration-manager/try-runtime",
+  "pallet-multisig/try-runtime",
+  "pallet-nft-sales/try-runtime",
+  "pallet-permissions/try-runtime",
+  "pallet-pools/try-runtime",
+  "pallet-preimage/try-runtime",
+  "pallet-proxy/try-runtime",
+  "pallet-randomness-collective-flip/try-runtime",
+  "pallet-restricted-tokens/try-runtime",
+  "pallet-scheduler/try-runtime",
+  "pallet-session/try-runtime",
+  "pallet-society/try-runtime",
+  "pallet-timestamp/try-runtime",
+  "pallet-transaction-payment/try-runtime",
+  "pallet-treasury/try-runtime",
+  "pallet-uniques/try-runtime",
+  "pallet-utility/try-runtime",
+  "pallet-vesting/try-runtime",
+  "pallet-xcm/try-runtime",
+  "parachain-info/try-runtime",
+  "runtime-common/try-runtime",
 ]
 
 # A feature that should be enabled when the runtime should be build for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [
-    "sp-api/disable-logging",
+  "sp-api/disable-logging",
 ]

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -7,16 +7,15 @@ license = "LGPL-3.0"
 homepage = "https://centrifuge.io/"
 repository = "https://github.com/centrifuge/centrifuge-chain"
 
-
 [dependencies]
-fudge = { git = "https://github.com/centrifuge/fudge", branch = "polkadot-v0.9.29" }
-tokio = { version = "1.15", features = ["macros"] }
-tracing = "0.1"
-tracing-subscriber = "0.2"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
+fudge = { git = "https://github.com/centrifuge/fudge", branch = "polkadot-v0.9.29" }
 lazy_static = "1.4.0"
 rand = "0.8.5"
 serde = { version = "1.0.119" }
+tokio = { version = "1.15", features = ["macros"] }
+tracing = "0.1"
+tracing-subscriber = "0.2"
 
 # Substrate
 ## Substrate-Frame
@@ -52,8 +51,8 @@ sc-service = { git = "https://github.com/paritytech/substrate", features = ["roc
 kusama-runtime = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
-polkadot-parachain = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
-polkadot-primitives = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
@@ -66,14 +65,14 @@ cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branc
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
 
 # Orml pallets
-orml-asset-registry = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
-orml-tokens = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
-orml-traits = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
-orml-xcm-support = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
-orml-xtokens = {  git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.29" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29" }
 
 # Misc
- xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", branch = "master" }
+xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", branch = "master" }
 
 # Local
 altair-runtime = { path = "../altair" }
@@ -90,12 +89,12 @@ pallet-loans = { path = "../../pallets/loans" }
 pallet-permissions = { path = "../../pallets/permissions" }
 pallet-pools = { path = "../../pallets/pools" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
-sp-std = { git = "https://github.com/paritytech/substrate",  default-features = true , branch = "polkadot-v0.9.29" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = true , branch = "release-v0.9.29" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.29" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = true, branch = "release-v0.9.29" }
 
 [features]
-default = [ "runtime-development" ]
-runtime-benchmarks = [ "default", "development-runtime/runtime-benchmarks", "frame-benchmarking/runtime-benchmarks"]
+default = ["runtime-development"]
+runtime-benchmarks = ["default", "development-runtime/runtime-benchmarks", "frame-benchmarking/runtime-benchmarks"]
 runtime-development = []
 runtime-altair = []
 runtime-centrifuge = []

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,37 @@
+## https://taplo.tamasfe.dev/configuration/#configuration-file
+
+include = ["**/Cargo.toml"]
+exclude = ["target/**/Cargo.toml"]
+
+[formatting]
+# Align consecutive entries vertically.
+align_entries = false
+# Append trailing commas for multi-line arrays.
+array_trailing_comma = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = false
+# Omit white space padding from single-line arrays
+compact_arrays = true
+# Omit white space padding from the start and end of inline tables.
+compact_inline_tables = false
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 160
+# Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+indent_tables = false
+# The substring that is used for indentation, should be tabs or spaces (but technically can be anything).
+indent_string = '  '
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = false
+# Add trailing newline at the end of the file if not present.
+trailing_newline = true
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Use CRLF for line endings.
+crlf = false
+
+[[rule]]
+keys = ["dependencies", "dev-dependencies", "build-dependencies"]
+formatting = { reorder_keys = true }


### PR DESCRIPTION
Just found https://github.com/tamasfe/taplo, a tool for formatting toml files that a few other projects are using to format their Cargo files. Since I've seen a lot of inconsistent formatting in our Cargo files, let's give it a run.

We add a `taplo.fmt` file that, amogst other things, makes taplo order dependencies alphabetically which is much appreciated.