### PR TITLE
Add domain concept to rewards

### DIFF
--- a/pallets/liquidity-rewards/src/lib.rs
+++ b/pallets/liquidity-rewards/src/lib.rs
@@ -152,6 +152,12 @@ pub mod pallet {
 		/// Type used to handle balances.
 		type Balance: Balance + MaxEncodedLen + FixedPointOperand;
 
+		/// Type used to identify domains.
+		type Domain: Get<Self::DomainId>;
+
+		/// Type used to identify domains.
+		type DomainId: TypeInfo + MaxEncodedLen + codec::FullCodec + Copy;
+
 		/// Type used to identify currencies.
 		type CurrencyId: AssetId + MaxEncodedLen + Clone + Ord;
 
@@ -163,9 +169,16 @@ pub mod pallet {
 
 		/// The reward system used.
 		type Rewards: GroupRewards<Balance = Self::Balance, GroupId = Self::GroupId>
-			+ AccountRewards<Self::AccountId, Balance = Self::Balance, CurrencyId = Self::CurrencyId>
-			+ CurrencyGroupChange<GroupId = Self::GroupId, CurrencyId = Self::CurrencyId>
-			+ DistributedRewards<Balance = Self::Balance, GroupId = Self::GroupId>;
+			+ AccountRewards<
+				Self::AccountId,
+				Balance = Self::Balance,
+				CurrencyId = Self::CurrencyId,
+				DomainId = Self::DomainId,
+			> + CurrencyGroupChange<
+				GroupId = Self::GroupId,
+				CurrencyId = Self::CurrencyId,
+				DomainId = Self::DomainId,
+			> + DistributedRewards<Balance = Self::Balance, GroupId = Self::GroupId>;
 
 		/// Max groups used by this pallet.
 		/// If this limit is reached, the exceeded groups are either not computed and not stored.
@@ -276,7 +289,7 @@ pub mod pallet {
 						}
 
 						for (&currency_id, &group_id) in &changes.currencies {
-							T::Rewards::attach_currency(currency_id, group_id)?;
+							T::Rewards::attach_currency(T::Domain::get(), currency_id, group_id)?;
 							currency_changes += 1;
 						}
 
@@ -320,7 +333,7 @@ pub mod pallet {
 			AllowedCurrencies::<T>::try_get(currency_id)
 				.map_err(|_| Error::<T>::CurrencyNotAllowed)?;
 
-			T::Rewards::deposit_stake(currency_id, &account_id, amount)
+			T::Rewards::deposit_stake(T::Domain::get(), currency_id, &account_id, amount)
 		}
 
 		/// Withdraw a stake amount associated to a currency for the origin's account.
@@ -338,7 +351,7 @@ pub mod pallet {
 			AllowedCurrencies::<T>::try_get(currency_id)
 				.map_err(|_| Error::<T>::CurrencyNotAllowed)?;
 
-			T::Rewards::withdraw_stake(currency_id, &account_id, amount)
+			T::Rewards::withdraw_stake(T::Domain::get(), currency_id, &account_id, amount)
 		}
 
 		/// Claims the reward the associated to a currency.
@@ -351,7 +364,7 @@ pub mod pallet {
 			AllowedCurrencies::<T>::try_get(currency_id)
 				.map_err(|_| Error::<T>::CurrencyNotAllowed)?;
 
-			T::Rewards::claim_reward(currency_id, &account_id).map(|_| ())
+			T::Rewards::claim_reward(T::Domain::get(), currency_id, &account_id).map(|_| ())
 		}
 
 		/// Admin method to set the reward amount used for the next epochs.

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1361,6 +1361,12 @@ impl pallet_keystore::pallet::Config for Runtime {
 	type WeightInfo = weights::pallet_keystore::SubstrateWeight<Runtime>;
 }
 
+#[derive(Clone, Copy, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub enum RewardDomain {
+	Liquidity,
+	Block,
+}
+
 frame_support::parameter_types! {
 	pub const RewardsPalletId: PalletId = PalletId(*b"d/reward");
 	pub const RewardCurrency: CurrencyId = CurrencyId::Native;
@@ -1373,6 +1379,7 @@ impl pallet_rewards::Config for Runtime {
 	type Balance = Balance;
 	type Currency = Tokens;
 	type CurrencyId = CurrencyId;
+	type DomainId = RewardDomain;
 	type Event = Event;
 	type GroupId = u32;
 	type MaxCurrencyMovements = MaxCurrencyMovements;
@@ -1388,12 +1395,16 @@ frame_support::parameter_types! {
 
 	#[derive(scale_info::TypeInfo, Debug, PartialEq, Clone)]
 	pub const MaxChangesPerEpoch: u32 = 50;
+
+	pub const LiquidityDomain: RewardDomain = RewardDomain::Liquidity;
 }
 
 impl pallet_liquidity_rewards::Config for Runtime {
 	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
+	type Domain = LiquidityDomain;
+	type DomainId = RewardDomain;
 	type Event = Event;
 	type GroupId = u32;
 	type MaxChangesPerEpoch = MaxChangesPerEpoch;


### PR DESCRIPTION
# Description

Support different rewards for the same currency, adding a domain concept that splits the reward system.

## Changes and Descriptions

- Currency-related methods of the `rewards` trait now add a `domain_id` parameter.
- `pallet-rewards` and `pallet-liquidity-rewards` are now configured with a `DomainId` type.
 
## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I rebased on the latest `main` branch
