### PR TITLE
Support for reward domains as currency prefixes

### DIFF
--- a/pallets/liquidity-rewards/src/lib.rs
+++ b/pallets/liquidity-rewards/src/lib.rs
@@ -138,6 +138,8 @@ where
 	}
 }
 
+pub type DomainIdOf<T> = <<T as Config>::Domain as TypedGet>::Type;
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
@@ -152,8 +154,8 @@ pub mod pallet {
 		/// Type used to handle balances.
 		type Balance: Balance + MaxEncodedLen + FixedPointOperand;
 
-		/// Type used to identify domains.
-		type DomainId: TypeInfo + MaxEncodedLen + codec::FullCodec + Copy;
+		/// Domain identification used by this pallet
+		type Domain: TypedGet;
 
 		/// Type used to identify currencies.
 		type CurrencyId: AssetId + MaxEncodedLen + Clone + Ord;
@@ -169,10 +171,10 @@ pub mod pallet {
 			+ AccountRewards<
 				Self::AccountId,
 				Balance = Self::Balance,
-				CurrencyId = (Self::DomainId, Self::CurrencyId),
+				CurrencyId = (DomainIdOf<Self>, Self::CurrencyId),
 			> + CurrencyGroupChange<
 				GroupId = Self::GroupId,
-				CurrencyId = (Self::DomainId, Self::CurrencyId),
+				CurrencyId = (DomainIdOf<Self>, Self::CurrencyId),
 			> + DistributedRewards<Balance = Self::Balance, GroupId = Self::GroupId>;
 
 		/// Max groups used by this pallet.
@@ -185,10 +187,6 @@ pub mod pallet {
 		/// the same id.
 		#[pallet::constant]
 		type MaxChangesPerEpoch: Get<u32> + TypeInfo + sp_std::fmt::Debug + Clone + PartialEq;
-
-		/// Domain identification used by this pallet
-		#[pallet::constant]
-		type Domain: Get<Self::DomainId>;
 
 		/// Information of runtime weights
 		type WeightInfo: WeightInfo;

--- a/pallets/liquidity-rewards/src/mock.rs
+++ b/pallets/liquidity-rewards/src/mock.rs
@@ -8,6 +8,8 @@ use sp_runtime::{
 
 use crate as pallet_liquidity_rewards;
 
+pub const DOMAIN: u8 = 23;
+
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -55,14 +57,17 @@ frame_support::parameter_types! {
 
 	#[derive(scale_info::TypeInfo, Debug, PartialEq, Clone)]
 	pub const MaxChangesPerEpoch: u32 = 50;
+
+	pub const LiquidityDomain: u8 = DOMAIN;
 }
 
-pub type MockRewards = cfg_traits::rewards::mock::MockRewards<u64, u32, u32, u64>;
+pub type MockRewards = cfg_traits::rewards::mock::MockRewards<u64, u32, (u8, u32), u64>;
 
 impl pallet_liquidity_rewards::Config for Test {
 	type AdminOrigin = EnsureRoot<u64>;
 	type Balance = u64;
 	type CurrencyId = u32;
+	type Domain = LiquidityDomain;
 	type Event = Event;
 	type GroupId = u32;
 	type MaxChangesPerEpoch = MaxChangesPerEpoch;

--- a/pallets/liquidity-rewards/src/weights.rs
+++ b/pallets/liquidity-rewards/src/weights.rs
@@ -44,10 +44,10 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn on_initialize(x: u32, y: u32, z: u32) -> Weight {
-		Weight::from_ref_time(21_368_000) // Standard Error: 19_000
-			.saturating_add(Weight::from_ref_time(1_146_000).saturating_mul(x as u64)) // Standard Error: 8_000
-			.saturating_add(Weight::from_ref_time(115_000).saturating_mul(y as u64)) // Standard Error: 8_000
-			.saturating_add(Weight::from_ref_time(8_907_000).saturating_mul(z as u64))
+		Weight::from_ref_time(27_397_000) // Standard Error: 15_000
+			.saturating_add(Weight::from_ref_time(1_011_000).saturating_mul(x as u64)) // Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(50_000).saturating_mul(y as u64)) // Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(8_852_000).saturating_mul(z as u64))
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(x as u64)))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(z as u64)))
@@ -56,20 +56,20 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 
 	fn stake() -> Weight {
-		Weight::from_ref_time(26_000_000)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
+		Weight::from_ref_time(22_000_000)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 
 	fn unstake() -> Weight {
-		Weight::from_ref_time(25_000_000)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
+		Weight::from_ref_time(22_000_000)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 
 	fn claim_reward() -> Weight {
-		Weight::from_ref_time(24_000_000)
-			.saturating_add(T::DbWeight::get().reads(4 as u64))
+		Weight::from_ref_time(21_000_000)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 
@@ -92,19 +92,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 
 	fn set_currency_group() -> Weight {
-		Weight::from_ref_time(7_000_000)
+		Weight::from_ref_time(6_000_000)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
-			.saturating_add(T::DbWeight::get().writes(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn on_initialize(x: u32, y: u32, z: u32) -> Weight {
-		Weight::from_ref_time(21_368_000) // Standard Error: 19_000
-			.saturating_add(Weight::from_ref_time(1_146_000).saturating_mul(x as u64)) // Standard Error: 8_000
-			.saturating_add(Weight::from_ref_time(115_000).saturating_mul(y as u64)) // Standard Error: 8_000
-			.saturating_add(Weight::from_ref_time(8_907_000).saturating_mul(z as u64))
+		Weight::from_ref_time(27_397_000) // Standard Error: 15_000
+			.saturating_add(Weight::from_ref_time(1_011_000).saturating_mul(x as u64)) // Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(50_000).saturating_mul(y as u64)) // Standard Error: 6_000
+			.saturating_add(Weight::from_ref_time(8_852_000).saturating_mul(z as u64))
 			.saturating_add(RocksDbWeight::get().reads(5 as u64))
 			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(x as u64)))
 			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(z as u64)))
@@ -113,20 +113,20 @@ impl WeightInfo for () {
 	}
 
 	fn stake() -> Weight {
-		Weight::from_ref_time(26_000_000)
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
+		Weight::from_ref_time(22_000_000)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 
 	fn unstake() -> Weight {
-		Weight::from_ref_time(25_000_000)
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
+		Weight::from_ref_time(22_000_000)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 
 	fn claim_reward() -> Weight {
-		Weight::from_ref_time(24_000_000)
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
+		Weight::from_ref_time(21_000_000)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 
@@ -149,8 +149,8 @@ impl WeightInfo for () {
 	}
 
 	fn set_currency_group() -> Weight {
-		Weight::from_ref_time(7_000_000)
+		Weight::from_ref_time(6_000_000)
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
-			.saturating_add(RocksDbWeight::get().writes(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 }

--- a/pallets/rewards/src/mock.rs
+++ b/pallets/rewards/src/mock.rs
@@ -22,9 +22,6 @@ pub const USER_B: u64 = 2;
 
 pub const USER_INITIAL_BALANCE: u64 = 100000;
 
-pub const GROUP_A: u32 = 1;
-pub const GROUP_B: u32 = 2;
-
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
@@ -85,6 +82,12 @@ pub enum CurrencyId {
 	C,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, RuntimeDebug)]
+pub enum DomainId {
+	D1,
+	D2,
+}
+
 orml_traits::parameter_type_with_key! {
 	pub ExistentialDeposits: |_currency_id: CurrencyId| -> u64 { 0 };
 }
@@ -117,6 +120,7 @@ impl pallet_rewards::Config for Test {
 	type Balance = u64;
 	type Currency = Tokens;
 	type CurrencyId = CurrencyId;
+	type DomainId = DomainId;
 	type Event = Event;
 	type GroupId = u32;
 	type MaxCurrencyMovements = MaxCurrencyMovements;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1361,6 +1361,12 @@ impl pallet_keystore::pallet::Config for Runtime {
 	type WeightInfo = weights::pallet_keystore::SubstrateWeight<Runtime>;
 }
 
+#[derive(Clone, Copy, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen, RuntimeDebug)]
+pub enum RewardDomain {
+	Liquidity,
+	Block,
+}
+
 frame_support::parameter_types! {
 	pub const RewardsPalletId: PalletId = PalletId(*b"d/reward");
 	pub const RewardCurrency: CurrencyId = CurrencyId::Native;
@@ -1373,6 +1379,7 @@ impl pallet_rewards::Config for Runtime {
 	type Balance = Balance;
 	type Currency = Tokens;
 	type CurrencyId = CurrencyId;
+	type DomainId = RewardDomain;
 	type Event = Event;
 	type GroupId = u32;
 	type MaxCurrencyMovements = MaxCurrencyMovements;
@@ -1388,12 +1395,16 @@ frame_support::parameter_types! {
 
 	#[derive(scale_info::TypeInfo, Debug, PartialEq, Clone)]
 	pub const MaxChangesPerEpoch: u32 = 50;
+
+	pub const LiquidityDomain: RewardDomain = RewardDomain::Liquidity;
 }
 
 impl pallet_liquidity_rewards::Config for Runtime {
 	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
+	type Domain = LiquidityDomain;
+	type DomainId = RewardDomain;
 	type Event = Event;
 	type GroupId = u32;
 	type MaxChangesPerEpoch = MaxChangesPerEpoch;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1404,7 +1404,6 @@ impl pallet_liquidity_rewards::Config for Runtime {
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
 	type Domain = LiquidityDomain;
-	type DomainId = RewardDomain;
 	type Event = Event;
 	type GroupId = u32;
 	type MaxChangesPerEpoch = MaxChangesPerEpoch;


### PR DESCRIPTION
# Description

Support different rewards for the same currency, adding a domain concept that splits the reward 
system.

This PR is a simpler implementation of https://github.com/centrifuge/centrifuge-chain/pull/1057 where de `rewards` traits are no modified.

## Changes and Descriptions

- `pallet-rewards` and `pallet-liquidity-rewards` are now configured with a `DomainId` type.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I rebased on the latest `main` branch
