### PR TITLE
Ensure streamlined hashing

### DIFF
--- a/libs/primitives/src/lib.rs
+++ b/libs/primitives/src/lib.rs
@@ -30,9 +30,8 @@ pub mod types {
 	#[cfg(feature = "std")]
 	use serde::{Deserialize, Serialize};
 	use sp_core::{H160, U256};
-	use sp_runtime::traits;
 	use sp_runtime::{
-		traits::{BlakeTwo256 IdentifyAccount, Verify},
+		traits::{self, BlakeTwo256, IdentifyAccount, Verify},
 		OpaqueExtrinsic,
 	};
 	use sp_std::vec::Vec;

--- a/libs/primitives/src/lib.rs
+++ b/libs/primitives/src/lib.rs
@@ -30,8 +30,9 @@ pub mod types {
 	#[cfg(feature = "std")]
 	use serde::{Deserialize, Serialize};
 	use sp_core::{H160, U256};
+	use sp_runtime::traits;
 	use sp_runtime::{
-		traits::{BlakeTwo256, Hash as HashT, IdentifyAccount, Verify},
+		traits::{BlakeTwo256 IdentifyAccount, Verify},
 		OpaqueExtrinsic,
 	};
 	use sp_std::vec::Vec;
@@ -90,7 +91,7 @@ pub mod types {
 	pub type Index = u32;
 
 	/// A hash of some data used by the chain.
-	pub type Hash = <BlakeTwo256 as HashT>::Output;
+	pub type Hash = <BlakeTwo256 as traits::Hash>::Output;
 
 	/// The hashing algorithm used by the chain
 	///

--- a/libs/primitives/src/lib.rs
+++ b/libs/primitives/src/lib.rs
@@ -31,7 +31,7 @@ pub mod types {
 	use serde::{Deserialize, Serialize};
 	use sp_core::{H160, U256};
 	use sp_runtime::{
-		traits::{BlakeTwo256, IdentifyAccount, Verify},
+		traits::{BlakeTwo256, Hash as HashT, IdentifyAccount, Verify},
 		OpaqueExtrinsic,
 	};
 	use sp_std::vec::Vec;
@@ -90,7 +90,12 @@ pub mod types {
 	pub type Index = u32;
 
 	/// A hash of some data used by the chain.
-	pub type Hash = sp_core::H256;
+	pub type Hash = <BlakeTwo256 as HashT>::Output;
+
+	/// The hashing algorithm used by the chain
+	///
+	/// NOTE: Must never change
+	pub type Hashing = BlakeTwo256;
 
 	/// A generic block for the node to use, as we can not commit to
 	/// a specific Extrinsic format at this point. Runtimes will ensure
@@ -98,7 +103,7 @@ pub mod types {
 	pub type Block = sp_runtime::generic::Block<Header, OpaqueExtrinsic>;
 
 	/// Block header type as expected by this runtime.
-	pub type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
+	pub type Header = sp_runtime::generic::Header<BlockNumber, Hashing>;
 
 	/// Aura consensus authority.
 	pub type AuraId = sp_consensus_aura::sr25519::AuthorityId;

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -171,7 +171,7 @@ impl frame_system::Config for Runtime {
 	/// The type for hashing blocks and tries.
 	type Hash = Hash;
 	/// The hashing algorithm used.
-	type Hashing = BlakeTwo256;
+	type Hashing = Hashing;
 	/// The header type.
 	type Header = Header;
 	/// The index type for storing how many extrinsics an account has signed.

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -170,7 +170,7 @@ impl frame_system::Config for Runtime {
 	/// The type for hashing blocks and tries.
 	type Hash = Hash;
 	/// The hashing algorithm used.
-	type Hashing = BlakeTwo256;
+	type Hashing = Hashing;
 	/// The header type.
 	type Header = Header;
 	/// The index type for storing how many extrinsics an account has signed.

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -178,7 +178,7 @@ impl frame_system::Config for Runtime {
 	/// The type for hashing blocks and tries.
 	type Hash = Hash;
 	/// The hashing algorithm used.
-	type Hashing = BlakeTwo256;
+	type Hashing = Hashing;
 	/// The header type.
 	type Header = Header;
 	/// The index type for storing how many extrinsics an account has signed.


### PR DESCRIPTION
# Description
Syntactical change that ensures primitives is the location where we define our chain hashing and hash tyoe.

Fixes # (issue)

## Changes and Descriptions
* Simple creation of new types
* Usage of new types in runtimes

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
