### PR TITLE
patch: fix inconsistent bridge accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
     <br />
     <a href="https://docs.centrifuge.io/build/cent-chain/"><strong>Read the documentation »</strong></a>
   </p>
-</p>
 
 ## About Centrifuge
 Centrifuge is the infrastructure that facilitates the decentralized financing of real-world assets natively on-chain, creating a fully transparent market which allows borrowers and lenders to transact without unnecessary intermediaries. Asset pools are fully collateralized, liquidity providers have legal recourse, and the protocol is asset-class agnostic with pools for assets spanning mortgages, invoices, microlending and consumer finance. Ultimately, the protocol aims to lower the cost of borrowing for businesses around the world, while providing DeFi users with a stable source of collateralized yield that is uncorrelated to the volatile crypto markets. By bringing the entire structured credit market on-chain across securitization, tokenization, privacy, governance, and liquidity integrations, Centrifuge is building a more transparent, affordable, and limitless financial system.

--- a/libs/types/src/ids.rs
+++ b/libs/types/src/ids.rs
@@ -31,7 +31,6 @@ impl<InvestmentId> TypeId for InvestmentAccount<InvestmentId> {
 pub const POOLS_PALLET_ID: PalletId = PalletId(*b"roc/pool");
 pub const LOANS_PALLET_ID: PalletId = PalletId(*b"roc/loan");
 pub const CHAIN_BRIDGE_PALLET_ID: PalletId = PalletId(*b"chnbrdge");
-pub const BRIDGE_PALLET_ID: PalletId = PalletId(*b"c/bridge");
 pub const CLAIMS_PALLET_ID: PalletId = PalletId(*b"p/claims");
 pub const CROWDLOAN_REWARD_PALLET_ID: PalletId = PalletId(*b"cc/rewrd");
 pub const CROWDLOAN_CLAIM_PALLET_ID: PalletId = PalletId(*b"cc/claim");

--- a/libs/types/src/ids.rs
+++ b/libs/types/src/ids.rs
@@ -30,7 +30,7 @@ impl<InvestmentId> TypeId for InvestmentAccount<InvestmentId> {
 // Pallet-Ids that define pallets accounts
 pub const POOLS_PALLET_ID: PalletId = PalletId(*b"roc/pool");
 pub const LOANS_PALLET_ID: PalletId = PalletId(*b"roc/loan");
-pub const CHAIN_BRIDGE_PALLET_ID: PalletId = PalletId(*b"cb/bridg");
+pub const CHAIN_BRIDGE_PALLET_ID: PalletId = PalletId(*b"chnbrdge");
 pub const BRIDGE_PALLET_ID: PalletId = PalletId(*b"c/bridge");
 pub const CLAIMS_PALLET_ID: PalletId = PalletId(*b"p/claims");
 pub const CROWDLOAN_REWARD_PALLET_ID: PalletId = PalletId(*b"cc/rewrd");

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -23,6 +23,9 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 cfg-traits = { path = "../../libs/traits", default-features = false }
 chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = false, branch = "polkadot-v0.9.29" }
 
+cfg-primitives = { path = "../../libs/primitives", default-features = false }
+cfg-types = { path = "../../libs/types", default-features = false }
+
 [dev-dependencies]
 cfg-primitives = { path = "../../libs/primitives" }
 cfg-types = { path = "../../libs/types" }
@@ -48,5 +51,7 @@ std = [
   'sp-std/std',
   'chainbridge/std',
   'cfg-traits/std',
+  'cfg-primitives/std',
+  'cfg-types/std',
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -28,6 +28,8 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+pub mod migration;
+
 // Pallet traits declaration
 pub mod traits;
 

--- a/pallets/bridge/src/migration.rs
+++ b/pallets/bridge/src/migration.rs
@@ -51,7 +51,7 @@ pub mod fix_pallet_account {
 			// more than once.
 			if balance > Zero::zero() {
 				log::info!(
-					"pallet_bridge: will move balance from the wrong account {}",
+					"pallet_bridge: will move balance from the wrong account {:?}",
 					x
 				);
 				let res = T::Currency::transfer(&x, &correct_bridge_account, balance, AllowDeath);

--- a/pallets/bridge/src/migration.rs
+++ b/pallets/bridge/src/migration.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge Chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+use super::*;
+
+pub mod fix_pallet_account {
+	use cfg_primitives::AccountId;
+	use frame_support::{log, weights::Weight};
+	use sp_core::crypto::Ss58Codec;
+	use sp_runtime::traits::AccountIdConversion;
+	use sp_std::{vec, vec::Vec};
+
+	use super::*;
+
+	pub fn migrate<T: Config>() -> Weight
+	where
+		<T as frame_system::Config>::AccountId: From<AccountId>,
+	{
+		log::info!("pallet_bridge: fix pallet account");
+
+		let wrong_accounts: Vec<T::AccountId> = vec![
+			"4dpEcgqFmYGRSkRhTzVZjTG4uKoiB9VBB4Qi33LH73WsWXa4",
+			"4dpEcgqFor2TJw9uWSjx2JpjkNmTic2UjJAK1j9fRtcTUoRu",
+		]
+		.iter()
+		.map(|x| {
+			AccountId::from_string(x)
+				.expect("Account conversion should work")
+				.into()
+		})
+		.collect::<Vec<_>>();
+
+		let correct_bridge_account: T::AccountId =
+			cfg_types::ids::CHAIN_BRIDGE_PALLET_ID.into_account_truncating();
+
+		wrong_accounts.iter().for_each(|x| {
+			let balance = T::Currency::free_balance(&x);
+			// Transfers the balance of the bad account to the correct one
+			T::Currency::transfer(
+				&x,
+				&correct_bridge_account,
+				balance,
+				AllowDeath,
+			)
+				.expect("TODO(nuno)");
+		});
+
+		Weight::from_ref_time(0)
+	}
+}

--- a/pallets/bridge/src/migration.rs
+++ b/pallets/bridge/src/migration.rs
@@ -17,8 +17,7 @@ pub mod fix_pallet_account {
 	#[cfg(feature = "try-runtime")]
 	use frame_support::ensure;
 	use frame_support::{log, weights::Weight};
-	use scale_info::prelude::format;
-	use sp_runtime::traits::{AccountIdConversion, Zero};
+	use sp_runtime::traits::{AccountIdConversion, Get, Zero};
 	use sp_std::vec;
 
 	use super::*; // Not in prelude for try-runtime
@@ -35,6 +34,7 @@ pub mod fix_pallet_account {
 	where
 		<T as frame_system::Config>::AccountId: From<AccountId>,
 	{
+		let mut weight = Weight::from_ref_time(0);
 		log::info!("pallet_bridge: initiating migration to move funds from wrong bridge accounts");
 
 		let correct_bridge_account: T::AccountId =
@@ -64,9 +64,10 @@ pub mod fix_pallet_account {
 					}
 				}
 			}
+			weight += T::DbWeight::get().reads_writes(2, 1);
 		});
 
-		Weight::from_ref_time(0)
+		weight
 	}
 
 	/// Ensure that the wrong accounts' balance is zero after the migration has been executed.

--- a/pallets/bridge/src/migration.rs
+++ b/pallets/bridge/src/migration.rs
@@ -17,6 +17,7 @@ pub mod fix_pallet_account {
 	#[cfg(feature = "try-runtime")]
 	use frame_support::ensure;
 	use frame_support::{log, weights::Weight};
+	use scale_info::prelude::format;
 	use sp_runtime::traits::{AccountIdConversion, Zero};
 	use sp_std::vec;
 
@@ -71,17 +72,17 @@ pub mod fix_pallet_account {
 	/// Ensure that the wrong accounts' balance is zero after the migration has been executed.
 	#[cfg(feature = "try-runtime")]
 	pub fn post_migrate<T: Config>() -> Result<(), &'static str> {
-		vec![
-			WRONG_INBOUND_ID.into_account_truncating(),
-			WRONG_OUTBOUND_ID.into_account_truncating(),
-		]
-		.iter()
-		.for_each(|x| {
-			ensure!(
-				T::Currency::free_balance(&x) == Zero::zero(),
-				format!("Wrong account {:?} still has some balance", x)
-			);
-		});
+		let wrong_account_inbound = WRONG_INBOUND_ID.into_account_truncating();
+		ensure!(
+			T::Currency::free_balance(&wrong_account_inbound) == Zero::zero(),
+			"Inbound account still has balance"
+		);
+
+		let wrong_account_outbound = WRONG_OUTBOUND_ID.into_account_truncating();
+		ensure!(
+			T::Currency::free_balance(&wrong_account_outbound) == Zero::zero(),
+			"Outbound account still has balance"
+		);
 
 		Ok(())
 	}

--- a/pallets/bridge/src/migration.rs
+++ b/pallets/bridge/src/migration.rs
@@ -23,7 +23,7 @@ pub mod fix_pallet_account {
 	use super::*; // Not in prelude for try-runtime
 
 	const WRONG_INBOUND_ID: PalletId = PalletId(*b"cb/bridg");
-	const WRONG_OUTBOUND_ID: PalletId = cfg_types::ids::BRIDGE_PALLET_ID;
+	const WRONG_OUTBOUND_ID: PalletId = PalletId(*b"c/bridge");
 
 	#[cfg(feature = "try-runtime")]
 	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {

--- a/pallets/bridge/src/mock.rs
+++ b/pallets/bridge/src/mock.rs
@@ -181,7 +181,7 @@ impl chainbridge::Config for MockRuntime {
 
 // Parameterize Centrifuge Chain bridge pallet
 parameter_types! {
-	pub const BridgePalletId: PalletId = cfg_types::ids::BRIDGE_PALLET_ID;
+	pub const BridgePalletId: PalletId = cfg_types::ids::CHAIN_BRIDGE_PALLET_ID;
 	pub NativeTokenId: ResourceId = chainbridge::derive_resource_id(1, &blake2_128(b"xCFG"));
 }
 

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -838,14 +838,13 @@ impl pallet_nft::Config for Runtime {
 }
 
 parameter_types! {
-	pub const BridgePalletId: PalletId = cfg_types::ids::BRIDGE_PALLET_ID;
 	pub NativeTokenId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(&cfg_types::ids::CHAIN_BRIDGE_NATIVE_TOKEN_ID));
 	pub const NativeTokenTransferFeeKey: FeeKey = FeeKey::BridgeNativeTransfer;
 }
 
 impl pallet_bridge::Config for Runtime {
 	type BridgeOrigin = chainbridge::EnsureBridge<Runtime>;
-	type BridgePalletId = BridgePalletId;
+	type BridgePalletId = ChainBridgePalletId;
 	type Currency = Balances;
 	type Event = Event;
 	type Fees = Fees;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -23,7 +23,9 @@ use cfg_types::{CustomMetadata, FeeKey};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{EqualPrivilegeOnly, InstanceFilter, LockIdentifier, U128CurrencyToVote},
+	traits::{
+		EqualPrivilegeOnly, InstanceFilter, LockIdentifier, OnRuntimeUpgrade, U128CurrencyToVote,
+	},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
 		ConstantMultiplier, DispatchClass, Weight,
@@ -1043,8 +1045,27 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(),
+	Upgrade,
 >;
+
+pub struct Upgrade;
+impl OnRuntimeUpgrade for Upgrade {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		pallet_bridge::migration::fix_pallet_account::pre_migrate::<Runtime>()
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		let mut weight = Weight::from_ref_time(0);
+		weight += pallet_bridge::migration::fix_pallet_account::migrate::<Runtime>();
+		weight
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		pallet_bridge::migration::fix_pallet_account::post_migrate::<Runtime>()
+	}
+}
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1366,14 +1366,13 @@ impl pallet_connectors::Config for Runtime {
 }
 
 parameter_types! {
-	pub const BridgePalletId: PalletId = cfg_types::ids::BRIDGE_PALLET_ID;
 	pub NativeTokenId: chainbridge::ResourceId = chainbridge::derive_resource_id(1, &sp_io::hashing::blake2_128(b"xRAD"));
 	pub const NativeTokenTransferFeeKey: FeeKey = FeeKey::BridgeNativeTransfer;
 }
 
 impl pallet_bridge::Config for Runtime {
 	type BridgeOrigin = chainbridge::EnsureBridge<Runtime>;
-	type BridgePalletId = BridgePalletId;
+	type BridgePalletId = ChainBridgePalletId;
 	type Currency = Balances;
 	type Event = Event;
 	type Fees = Fees;
@@ -1385,7 +1384,7 @@ impl pallet_bridge::Config for Runtime {
 parameter_types! {
 	pub const ChainId: chainbridge::ChainId = 1;
 	pub const ProposalLifetime: u32 = 500;
-	pub const ChainBridgePalletId: PalletId = PalletId(*b"chnbrdge");
+	pub const ChainBridgePalletId: PalletId = cfg_types::ids::CHAIN_BRIDGE_PALLET_ID;
 	pub const RelayerVoteThreshold: u32 = DEFAULT_RELAYER_VOTE_THRESHOLD;
 }
 


### PR DESCRIPTION
Fixes # (issue)

#1066 

## Changes and Descriptions

Explained in the issue, the only additional info being that we had the runtime upgrade logic to centrifuge to have this pallet_bridge migration executed on the next runtime upgrade.

# How Has This Been Tested?

- [x] With `try-runtime`

``` bash=
cargo build --release --features=try-runtime,runtime-benchmarks

RUST_LOG=runtime=trace,try-runtime::cli=trace,executor=trace ./target/release/centrifuge-chain try-runtime --execution Native --chain centrifuge-local --no-spec-name-check on-runtime-upgrade live --uri wss://fullnode.parachain.centrifuge.io:443
```


# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I rebased on the latest `main` branch
