### PR TITLE
cfg-types: Small touch on TokenCurrency + Drop TrancheToken

### DIFF
--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -298,19 +298,6 @@ impl<T> PreConditions<T> for Never {
 	}
 }
 
-/// Trait for converting a pool+tranche ID pair to a CurrencyId
-///
-/// This should be implemented in the runtime to convert from the
-/// PoolId and TrancheId types to a CurrencyId that represents that
-/// tranche.
-///
-/// The pool epoch logic assumes that every tranche has a UNIQUE
-/// currency, but nothing enforces that. Failure to ensure currency
-/// uniqueness will almost certainly cause some wild bugs.
-pub trait TrancheToken<PoolId, TrancheId, CurrencyId> {
-	fn tranche_token(pool: PoolId, tranche: TrancheId) -> CurrencyId;
-}
-
 /// A trait for converting from a PoolId and a TranchId
 /// into a given Self::Currency
 pub trait TrancheCurrency<PoolId, TrancheId> {

--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -80,9 +80,9 @@ pub struct TrancheCurrency {
 	tranche_id: TrancheId,
 }
 
-impl Into<CurrencyId> for TrancheCurrency {
-	fn into(self) -> CurrencyId {
-		CurrencyId::Tranche(self.pool_id, self.tranche_id)
+impl From<TrancheCurrency> for CurrencyId {
+	fn from(x: TrancheCurrency) -> Self {
+		CurrencyId::Tranche(x.pool_id, x.tranche_id)
 	}
 }
 

--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -57,14 +57,6 @@ impl From<u32> for CurrencyId {
 	}
 }
 
-/// A type that can create a TrancheToken from a PoolId and a TrancheId
-pub struct TrancheToken;
-impl cfg_traits::TrancheToken<PoolId, TrancheId, CurrencyId> for TrancheToken {
-	fn tranche_token(pool: PoolId, tranche: TrancheId) -> CurrencyId {
-		CurrencyId::Tranche(pool, tranche)
-	}
-}
-
 /// A Currency that is solely used by tranches.
 ///
 /// We distinguish here between the enum variant CurrencyId::Tranche(PoolId, TranchId)

--- a/pallets/pool-system/src/mock.rs
+++ b/pallets/pool-system/src/mock.rs
@@ -15,11 +15,11 @@ use cfg_traits::{
 	OrderManager, Permissions as PermissionsT, PoolUpdateGuard, PreConditions,
 	TrancheCurrency as TrancheCurrencyT,
 };
+pub use cfg_types::Rate;
 use cfg_types::{
 	CurrencyId, CustomMetadata, PermissionRoles, PermissionScope, PoolRole, Role, TimeProvider,
 	TrancheCurrency, UNION,
 };
-pub use cfg_types::{Rate, TrancheToken};
 use codec::Encode;
 use frame_support::{
 	assert_ok, parameter_types,

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -831,7 +831,7 @@ fn altair_genesis(
 				.map(|k| (k, balance_per_endowed))
 				.collect()
 		}
-		None => (vec![]),
+		None => vec![],
 	};
 
 	altair_runtime::GenesisConfig {


### PR DESCRIPTION
# Description

We do two things here:

1. Implement `From` instead of `Into` for `TrancheCurrency` -> `CurrencyId
By implementing `From`, we get `into()` for free, whereas the opposite is not true. Note that this clippy also complains about this.

2. Drop `TrancheToken` that has been deprecated in favour of `TrancheCurrency`

## Type of change

- [x] Small improvement to existing code with no breaking changes
- [x] Drop unused code
