### PR TITLE
Use Aura timestamp check

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -255,7 +255,7 @@ impl pallet_timestamp::Config for Runtime {
 	type MinimumPeriod = MinimumPeriod;
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = Moment;
-	type OnTimestampSet = ();
+	type OnTimestampSet = Aura;
 	type WeightInfo = weights::pallet_timestamp::SubstrateWeight<Self>;
 }
 

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -342,7 +342,7 @@ impl pallet_timestamp::Config for Runtime {
 	type MinimumPeriod = MinimumPeriod;
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = Moment;
-	type OnTimestampSet = ();
+	type OnTimestampSet = Aura;
 	type WeightInfo = weights::pallet_timestamp::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -260,7 +260,7 @@ impl pallet_timestamp::Config for Runtime {
 	type MinimumPeriod = MinimumPeriod;
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = Moment;
-	type OnTimestampSet = ();
+	type OnTimestampSet = Aura;
 	type WeightInfo = pallet_timestamp::weights::SubstrateWeight<Self>;
 }
 


### PR DESCRIPTION

This change adds an Aura timestamp check to the Timestamp::set pallet implementation.
