### PR TITLE
Update pool events

### DIFF
--- a/pallets/pool-registry/src/lib.rs
+++ b/pallets/pool-registry/src/lib.rs
@@ -192,6 +192,8 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// Invalid metadata passed
 		BadMetadata,
+		/// A Pool with the given ID was already registered in the past
+		PoolAlreadyRegistered,
 		/// Pre-requirements for a TrancheUpdate are not met
 		/// for example: Tranche changed but not its metadata or vice versa
 		InvalidTrancheUpdate,
@@ -245,7 +247,11 @@ pub mod pallet {
 			// admin as our depositor.
 			let depositor = ensure_signed(origin).unwrap_or(admin.clone());
 
-			Pools::<T>::set(pool_id, Some(PoolRegistrationStatus::Registered));
+			if Pools::<T>::contains_key(pool_id) {
+				return Err(Error::<T>::PoolAlreadyRegistered.into());
+			} else {
+				Pools::<T>::insert(pool_id, PoolRegistrationStatus::Registered);
+			}
 
 			T::ModifyPool::create(
 				admin.clone(),

--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -165,7 +165,7 @@ impl<T: Config> PoolMutate<T::AccountId, T::PoolId> for Pallet<T> {
 
 			tranches_essence_for_event.push(TrancheEssence {
 				currency: tranche.currency,
-				ty: tranche.tranche_type,
+				tranche_type: tranche.tranche_type,
 				metadata: TrancheMetadata {
 					token_name: tranche_input.metadata.token_name.clone(),
 					token_symbol: tranche_input.metadata.token_symbol.clone(),

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -661,8 +661,6 @@ pub mod pallet {
 				T::MaxTokenNameLength,
 				T::MaxTokenSymbolLength,
 			>,
-			admin:
-
 		},
 		PoolUpdated {
 			id: T::PoolId,

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -369,7 +369,7 @@ where
 	/// Currency that the tranche is denominated in
 	pub currency: TrancheCurrency,
 	/// Type of the tranche (Residual or NonResidual)
-	pub ty: TrancheType<Rate>,
+	pub tranche_type: TrancheType<Rate>,
 	/// Metadata of a Tranche
 	pub metadata: TrancheMetadata<MaxTokenNameLength, MaxTokenSymbolLength>,
 }

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -653,6 +653,8 @@ pub mod pallet {
 		},
 		/// An Pool was created.
 		PoolCreated {
+			admin: T::AccountId,
+			depositor: T::AccountId,
 			pool_id: T::PoolId,
 			essence: PoolEssence<
 				T::CurrencyId,

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -651,6 +651,7 @@ pub mod pallet {
 			pool_id: T::PoolId,
 			epoch_id: T::EpochId,
 		},
+		/// An Pool was created.
 		PoolCreated {
 			pool_id: T::PoolId,
 			essence: PoolEssence<
@@ -662,6 +663,7 @@ pub mod pallet {
 				T::MaxTokenSymbolLength,
 			>,
 		},
+		/// An Pool was updated.
 		PoolUpdated {
 			id: T::PoolId,
 			old: PoolEssence<

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -635,11 +635,6 @@ pub mod pallet {
 		Rebalanced { pool_id: T::PoolId },
 		/// The max reserve was updated.
 		MaxReserveSet { pool_id: T::PoolId },
-		/// Pool metadata was set.
-		MetadataSet {
-			pool_id: T::PoolId,
-			metadata: BoundedVec<u8, T::MaxSizeMetadata>,
-		},
 		/// An epoch was closed.
 		EpochClosed {
 			pool_id: T::PoolId,
@@ -655,6 +650,19 @@ pub mod pallet {
 		EpochExecuted {
 			pool_id: T::PoolId,
 			epoch_id: T::EpochId,
+		},
+		PoolCreated {
+			pool: T::PoolId,
+			essence: PoolEssence<
+				T::CurrencyId,
+				T::Balance,
+				T::TrancheCurrency,
+				T::Rate,
+				T::MaxTokenNameLength,
+				T::MaxTokenSymbolLength,
+			>,
+			admin:
+
 		},
 		PoolUpdated {
 			id: T::PoolId,

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -292,7 +292,7 @@ impl<CurrencyId, TrancheCurrency, EpochId, Balance, Rate, MetaSize, Weight, Tran
 
 			tranches.push(TrancheEssence {
 				currency: tranche.currency.into(),
-				ty: tranche.tranche_type.into(),
+				tranche_type: tranche.tranche_type.into(),
 				metadata: TrancheMetadata {
 					token_name: BoundedVec::try_from(metadata.clone().unwrap().name)
 						.unwrap_or(BoundedVec::default()),

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -652,7 +652,7 @@ pub mod pallet {
 			epoch_id: T::EpochId,
 		},
 		PoolCreated {
-			pool: T::PoolId,
+			pool_id: T::PoolId,
 			essence: PoolEssence<
 				T::CurrencyId,
 				T::Balance,

--- a/runtime/integration-tests/src/pools/pool_starts.rs
+++ b/runtime/integration-tests/src/pools/pool_starts.rs
@@ -66,7 +66,7 @@ async fn create_init_and_price() {
 		Event,
 		EventRange::All,
 		Event::System(frame_system::Event::ExtrinsicFailed{..}) if [count 0],
-		Event::PoolRegistry(pallet_pool_registry::Event::Created { pool_id, .. }) if [pool_id == 0],
+		Event::PoolRegistry(pallet_pool_registry::Event::Registered { pool_id, .. }) if [pool_id == 0],
 		Event::Loans(pallet_loans::Event::PoolInitialised{pool_id}) if [pool_id == 0],
 		Event::Loans(pallet_loans::Event::Created{pool_id, loan_id, collateral})
 			if [pool_id == 0 && loan_id == ItemId(1) && collateral == Asset(4294967296, ItemId(1))],

--- a/runtime/integration-tests/src/pools/utils/pools.rs
+++ b/runtime/integration-tests/src/pools/utils/pools.rs
@@ -353,7 +353,7 @@ pub fn create_pool_call(
 	max_reserve: Balance,
 	tranche_inputs: Vec<TrancheInput<Rate, MaxTokenNameLength, MaxTokenSymbolLength>>,
 ) -> Call {
-	Call::PoolRegistry(PoolRegistryCall::create {
+	Call::PoolRegistry(PoolRegistryCall::register {
 		admin,
 		pool_id,
 		tranche_inputs,


### PR DESCRIPTION
# Description

I adjusted the events for both `pool-registry` and `pool-system`, and renamed the `create` extrinsic in `pool-registry` to `register`.

### `pallet-pool-registry`

* Added an enum `PoolRegistrationStatus` 
* Added a storage item `Pools`, which maps over `PoolId` and `PoolRegistrationStatus`
* Renamed the `create` extrinsic to `register`
* On each call to `register`, saving the `PoolId` of the new pool with the status `Registered`
* Emit `Registered` event with `PoolId` when pool is registered

### `pallet-pool-system`

* Remove not needed `MetadataSet` event
* Added `PoolCreated` event
* Emit `PoolCreated` event after a new pool is inserted in the `create()` function

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] integration tests

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
