### PR TITLE
Rewards: Avoid first epoch event with zero duration

### DIFF
--- a/pallets/liquidity-rewards/src/lib.rs
+++ b/pallets/liquidity-rewards/src/lib.rs
@@ -289,15 +289,19 @@ pub mod pallet {
 						epoch_data.reward = changes.reward.unwrap_or(epoch_data.reward);
 						epoch_data.duration = changes.duration.unwrap_or(epoch_data.duration);
 
-						let ends_on = ends_on.ensure_add(epoch_data.duration)?;
+						let last_changes = mem::take(changes);
 
-						EndOfEpoch::<T>::set(EpochTimestamp(ends_on));
+						if epoch_data.duration != T::BlockNumber::zero() {
+							let ends_on = ends_on.ensure_add(epoch_data.duration)?;
 
-						Self::deposit_event(Event::NewEpoch {
-							ends_on: ends_on,
-							reward: epoch_data.reward,
-							last_changes: mem::take(changes),
-						});
+							EndOfEpoch::<T>::set(EpochTimestamp(ends_on));
+
+							Self::deposit_event(Event::NewEpoch {
+								ends_on: ends_on,
+								reward: epoch_data.reward,
+								last_changes,
+							});
+						}
 
 						Ok(())
 					})

--- a/pallets/liquidity-rewards/src/mock.rs
+++ b/pallets/liquidity-rewards/src/mock.rs
@@ -70,6 +70,7 @@ impl pallet_liquidity_rewards::Config for Test {
 	type Domain = LiquidityDomain;
 	type Event = Event;
 	type GroupId = u32;
+	type InitialEpochDuration = ConstU64<0>;
 	type MaxChangesPerEpoch = MaxChangesPerEpoch;
 	type MaxGroups = MaxGroups;
 	type Rewards = MockRewards;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1556,7 +1556,7 @@ frame_support::parameter_types! {
 	#[derive(scale_info::TypeInfo, Debug, PartialEq, Clone)]
 	pub const MaxChangesPerEpoch: u32 = 50;
 
-	pub const InitialEpochDuration: BlockNumber = prod_or_fast!(5 * MINUTES, 1 * MINUTES);
+	pub const InitialEpochDuration: BlockNumber = 1 * MINUTES;
 
 	pub const LiquidityDomain: RewardDomain = RewardDomain::Liquidity;
 }

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -67,7 +67,7 @@ use pallet_restricted_tokens::{
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo};
-use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
+use polkadot_runtime_common::{prod_or_fast, BlockHashCount, SlowAdjustingFeeUpdate};
 use runtime_common::fees::{DealWithFees, WeightToFee};
 pub use runtime_common::*;
 use scale_info::TypeInfo;
@@ -1556,6 +1556,8 @@ frame_support::parameter_types! {
 	#[derive(scale_info::TypeInfo, Debug, PartialEq, Clone)]
 	pub const MaxChangesPerEpoch: u32 = 50;
 
+	pub const InitialEpochDuration: BlockNumber = prod_or_fast!(5 * MINUTES, 1 * MINUTES);
+
 	pub const LiquidityDomain: RewardDomain = RewardDomain::Liquidity;
 }
 
@@ -1566,6 +1568,7 @@ impl pallet_liquidity_rewards::Config for Runtime {
 	type Domain = LiquidityDomain;
 	type Event = Event;
 	type GroupId = u32;
+	type InitialEpochDuration = InitialEpochDuration;
 	type MaxChangesPerEpoch = MaxChangesPerEpoch;
 	type MaxGroups = MaxGroups;
 	type Rewards = Rewards;


### PR DESCRIPTION
# Description

Initially, a not configured epoch has a duration of 0 blocks. Currently, it is generating a NewEpoch event which it should not. This PR allows only to dispatch that event if the epoch has a duration.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```sh
cargo test -p pallet-liquidity-rewards
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `main` branch
