### PR TITLE
feat: Add cfg-utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-utils"
+version = "2.0.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec 3.2.1",
+ "scale-info",
+ "sp-std",
+]
+
+[[package]]
 name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "libs/test-utils",
   "libs/traits",
   "libs/types",
+  "libs/utils",
   "pallets/anchors",
   "pallets/bridge",
   "pallets/connectors",

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
             };
 
             # This is a hash of all the Cargo dependencies, for reproducibility.
-            cargoSha256 = "sha256-ASxX71cTWacrROpszIqLdZbSZ7MY1KWNsp/ctFe0aoU=";
+            cargoSha256 = "sha256-jLfRNjUB+GRScaMSIo34LcxIE8t38umgtpXhM0HaYwg=";
 
             nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
             buildInputs = with pkgs; [ openssl ] ++ (

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+authors = ["Centrifuge <admin@centrifuge.io>"]
+description = 'Utility functions for Centrifuge'
+edition = '2021'
+license = "LGPL-3.0"
+name = 'cfg-utils'
+repository = "https://github.com/centrifuge/centrifuge-chain"
+version = '2.0.0'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dependencies]
+codec = { package = 'parity-scale-codec', version = '3.0.0', features = ['derive'], default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+
+[features]
+default = ['std']
+std = [
+  'frame-support/std',
+  'sp-std/std',
+]

--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -1,0 +1,86 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Ensure we're `no_std` when compiling for WebAssembly.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_std::{cmp::min, vec::Vec};
+
+/// Build a fixed-size array using as many elements from `src` as possible without
+/// overflowing and ensuring that the array is 0 padded in the case where
+/// `src.len()` is smaller than S.
+pub fn vec_to_fixed_array<const S: usize>(src: Vec<u8>) -> [u8; S] {
+	let mut dest = [0; S];
+	let len = min(src.len(), S);
+	dest[..len].copy_from_slice(&src.as_slice()[..len]);
+
+	dest
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	mod vec_to_fixed_array {
+		use super::*;
+
+		// Verify that `vec_to_fixed_array` converts a source Vec that's shorter than
+		// the desired output fixed-array by copying all elements of source and filling
+		// the remaining bytes to 0.
+		#[test]
+		fn short_source() {
+			let src = "TrNcH".as_bytes().to_vec();
+			let symbol: [u8; 32] = vec_to_fixed_array(src.clone());
+
+			assert!(symbol.starts_with("TrNcH".as_bytes()));
+			assert_eq!(
+				symbol,
+				[
+					84, 114, 78, 99, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0, 0, 0
+				]
+			);
+		}
+
+		// Verify that `vec_to_fixed_array` converts a source Vec that's exactly as big
+		// the desired output fixed-array by copying all elements of source to said array.
+		#[test]
+		fn max_source() {
+			let src: Vec<u8> = (0..32).collect();
+			let symbol: [u8; 32] = vec_to_fixed_array(src.clone());
+
+			assert_eq!(
+				symbol,
+				[
+					0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+					22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+				]
+			);
+		}
+
+		// Verify that `vec_to_fixed_array` converts a source Vec that's longer than the
+		// desired output fixed-array by copying all elements of source until said array is full.
+		#[test]
+		fn exceeding_source() {
+			let src: Vec<u8> = (0..64).collect();
+			let symbol: [u8; 32] = vec_to_fixed_array(src.clone());
+
+			assert_eq!(
+				symbol,
+				[
+					0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+					22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+				]
+			);
+		}
+	}
+}


### PR DESCRIPTION
We add this crate to place general utils that can be used across other pallets, runtimes, tests, etc.

To bootstrap it, we added and test a `vec_to_fixed_array` function that is used in https://github.com/centrifuge/centrifuge-chain/pull/1083