### PR TITLE
cargo.toml: Fix and standardize [package] entries

### DIFF
--- a/libs/primitives/Cargo.toml
+++ b/libs/primitives/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Primitive types for Centrifuge'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'cfg-primitives'
-repository = "https://github.com/centrifuge/centrifuge-chain/proofs"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '2.0.0'
 
 [package.metadata.docs.rs]

--- a/libs/proofs/Cargo.toml
+++ b/libs/proofs/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Proofs'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'proofs'
-repository = "https://github.com/centrifuge/centrifuge-chain/proofs"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '2.0.0'
 
 [package.metadata.docs.rs]

--- a/libs/types/Cargo.toml
+++ b/libs/types/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Common types for Centrifuge runtime'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'cfg-types'
-repository = "https://github.com/centrifuge/centrifuge-chain/proofs"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '2.0.0'
 
 [package.metadata.docs.rs]

--- a/pallets/anchors/Cargo.toml
+++ b/pallets/anchors/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Centrifuge <admin@centrifuge.io>"]
 description = 'Anchors pallet for runtime'
 edition = '2021'
 license = "LGPL-3.0"
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/anchors"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '2.0.0'
 
 [package.metadata.docs.rs]

--- a/pallets/bridge-mapping/Cargo.toml
+++ b/pallets/bridge-mapping/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Access control list for bridge paths across chains'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'pallet-bridge-mapping'
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/bridge-mapping"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '2.0.0'
 
 [package.metadata.docs.rs]

--- a/pallets/collator-allowlist/Cargo.toml
+++ b/pallets/collator-allowlist/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Collator allowlist pallet'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'pallet-collator-allowlist'
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/collator-allowlist"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '2.0.0'
 
 [package.metadata.docs.rs]

--- a/pallets/connectors/Cargo.toml
+++ b/pallets/connectors/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Centrifuge Connectors Pallet'
 edition = '2018'
 license = "LGPL-3.0"
 name = 'pallet-connectors'
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/connectors"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '0.0.1'
 
 [package.metadata.docs.rs]

--- a/pallets/fees/Cargo.toml
+++ b/pallets/fees/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Fees pallet for runtime'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'pallet-fees'
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/fees"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '2.0.0'
 
 [package.metadata.docs.rs]

--- a/pallets/interest-accrual/Cargo.toml
+++ b/pallets/interest-accrual/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Interest Accrual pallet'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'pallet-interest-accrual'
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/interest-accrual"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '0.1.0'
 
 [package.metadata.docs.rs]

--- a/pallets/keystore/Cargo.toml
+++ b/pallets/keystore/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Centrifuge <admin@centrifuge.io>"]
 description = 'Keystore pallet for runtime'
 edition = '2021'
 license = "LGPL-3.0"
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/keystore"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '1.0.0'
 
 [package.metadata.docs.rs]

--- a/pallets/liquidity-rewards/Cargo.toml
+++ b/pallets/liquidity-rewards/Cargo.toml
@@ -6,7 +6,7 @@ description = "Liquidity Rewards pallet"
 edition = "2021"
 homepage = "https://centrifuge.io"
 license = "LGPL-3.0"
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/liquidity-rewards"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/migration/Cargo.toml
+++ b/pallets/migration/Cargo.toml
@@ -4,7 +4,7 @@ description = 'Migration pallet for the runtime'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'pallet-migration-manager'
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/fees"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '0.1.0'
 
 [package.metadata.docs.rs]

--- a/pallets/nft-sales/Cargo.toml
+++ b/pallets/nft-sales/Cargo.toml
@@ -4,7 +4,7 @@ description = 'NFT Sales pallet'
 edition = '2021'
 license = "LGPL-3.0"
 name = 'pallet-nft-sales'
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/nft-sales"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '2.0.0'
 
 [package.metadata.docs.rs]

--- a/pallets/pool-system/Cargo.toml
+++ b/pallets/pool-system/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
-authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
-description = 'FRAME pallet template for defining custom runtime logic.'
+authors = ["Centrifuge <admin@centrifuge.io>"]
+description = 'Centrifuge Pool System pallet'
 edition = '2021'
-homepage = 'https://substrate.dev'
-license = 'Unlicense'
+license = "LGPL-3.0"
 name = 'pallet-pool-system'
-readme = 'README.md'
-repository = 'https://github.com/substrate-developer-hub/substrate-node-template/'
+repository = "https://github.com/centrifuge/centrifuge-chain"
 version = '3.0.0'
+
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 

--- a/pallets/rewards/Cargo.toml
+++ b/pallets/rewards/Cargo.toml
@@ -6,7 +6,7 @@ description = "Rewards pallet"
 edition = "2021"
 homepage = "https://centrifuge.io"
 license = "LGPL-3.0"
-repository = "https://github.com/centrifuge/centrifuge-chain/pallets/rewards"
+repository = "https://github.com/centrifuge/centrifuge-chain"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
We fix the [package] data for the pool-system pallet and standardize all the 'repository' entries to point to
github.com/centrifuge/centrifuge-chain instead of suffixing the base url with the name of the pallet which currently results in a 404 and adds excessive and unnecessary noise to that entry.
