### PR TITLE
Rewards: Generic currency movement counter with support for no counters

### DIFF
--- a/pallets/rewards/src/mock.rs
+++ b/pallets/rewards/src/mock.rs
@@ -11,7 +11,7 @@ use sp_runtime::{
 	FixedI64,
 };
 
-use super::mechanism::{base, deferred};
+use super::mechanism::{base, deferred, MaxCurrencyMovement, NoCurrencyMovement};
 use crate as pallet_rewards;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
@@ -32,6 +32,8 @@ frame_support::construct_runtime!(
 		Tokens: orml_tokens,
 		Rewards1: pallet_rewards::<Instance1>,
 		Rewards2: pallet_rewards::<Instance2>,
+		Rewards3: pallet_rewards::<Instance3>,
+		Rewards4: pallet_rewards::<Instance4>,
 	}
 );
 
@@ -113,9 +115,6 @@ impl orml_tokens::Config for Runtime {
 frame_support::parameter_types! {
 	pub const RewardsPalletId: PalletId = PalletId(*b"m/reward");
 	pub const RewardCurrency: CurrencyId = CurrencyId::Reward;
-
-	#[derive(scale_info::TypeInfo)]
-	pub const MaxCurrencyMovements: u32 = 3;
 }
 
 macro_rules! pallet_rewards_config {
@@ -133,8 +132,10 @@ macro_rules! pallet_rewards_config {
 	};
 }
 
-pallet_rewards_config!(Instance1, base::Mechanism<u64, i128, FixedI64, MaxCurrencyMovements>);
-pallet_rewards_config!(Instance2, deferred::Mechanism<u64, i128, FixedI64, MaxCurrencyMovements>);
+pallet_rewards_config!(Instance1, base::Mechanism<u64, i128, FixedI64, NoCurrencyMovement>);
+pallet_rewards_config!(Instance2, base::Mechanism<u64, i128, FixedI64, MaxCurrencyMovement<u8, 3>>);
+pallet_rewards_config!(Instance3, deferred::Mechanism<u64, i128, FixedI64, NoCurrencyMovement>);
+pallet_rewards_config!(Instance4, deferred::Mechanism<u64, i128, FixedI64, MaxCurrencyMovement<u8, 3>>);
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut storage = frame_system::GenesisConfig::default()

--- a/pallets/rewards/src/tests.rs
+++ b/pallets/rewards/src/tests.rs
@@ -50,17 +50,29 @@ fn empty_distribution<Reward: DistributedRewards<GroupId = u32, Balance = u64>>(
 mod mechanism {
 	use super::*;
 
-	mod base {
+	mod base_no_movement {
 		use super::*;
 
 		common_tests!(Rewards1, Instance1, MechanismKind::Base);
-		currency_movement_tests!(Rewards1, Instance1, MechanismKind::Base);
+	}
+
+	mod base {
+		use super::*;
+
+		common_tests!(Rewards2, Instance2, MechanismKind::Base);
+		currency_movement_tests!(Rewards2, Instance2, MechanismKind::Base);
+	}
+
+	mod deferred_no_movement {
+		use super::*;
+
+		common_tests!(Rewards3, Instance3, MechanismKind::Deferred);
 	}
 
 	mod deferred {
 		use super::*;
 
-		common_tests!(Rewards2, Instance2, MechanismKind::Deferred);
-		currency_movement_tests!(Rewards2, Instance2, MechanismKind::Deferred);
+		common_tests!(Rewards4, Instance4, MechanismKind::Deferred);
+		currency_movement_tests!(Rewards4, Instance4, MechanismKind::Deferred);
 	}
 }

--- a/pallets/rewards/src/tests/common.rs
+++ b/pallets/rewards/src/tests/common.rs
@@ -220,13 +220,15 @@ macro_rules! currency_common_tests {
 					type Mechanism = <Runtime as crate::Config<crate::$instance>>::RewardMechanism;
 					type MaxMovements = <Mechanism as RewardMechanism>::MaxCurrencyMovements;
 
+					let max = <MaxMovements as Get<u32>>::get();
+
 					// Waste all correct movements.
-					for i in 0..<MaxMovements as TypedGet>::get() {
+					for i in 0..max {
 						assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, i + 1));
 					}
 
 					assert_noop!(
-						$pallet::attach_currency(DOM_1_CURRENCY_A, MaxCurrencyMovements::get() + 1),
+						$pallet::attach_currency(DOM_1_CURRENCY_A, max + 1),
 						Error::<Runtime, $instance>::CurrencyMaxMovementsReached
 					);
 				});

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -71,6 +71,7 @@ use pallet_pool_system::EpochSolution;
 use pallet_restricted_tokens::{
 	FungibleInspectPassthrough, FungiblesInspectPassthrough, TransferDetails,
 };
+use pallet_rewards::mechanism::{base, MaxCurrencyMovement};
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo};
@@ -1533,9 +1534,6 @@ pub enum RewardDomain {
 frame_support::parameter_types! {
 	pub const RewardsPalletId: PalletId = PalletId(*b"d/reward");
 	pub const RewardCurrency: CurrencyId = CurrencyId::Native;
-
-	#[derive(scale_info::TypeInfo)]
-	pub const MaxCurrencyMovements: u32 = 50;
 }
 
 impl pallet_rewards::Config<pallet_rewards::Instance1> for Runtime {
@@ -1546,12 +1544,8 @@ impl pallet_rewards::Config<pallet_rewards::Instance1> for Runtime {
 	type GroupId = u32;
 	type PalletId = RewardsPalletId;
 	type RewardCurrency = RewardCurrency;
-	type RewardMechanism = pallet_rewards::mechanism::base::Mechanism<
-		Balance,
-		IBalance,
-		FixedI128,
-		MaxCurrencyMovements,
-	>;
+	type RewardMechanism =
+		base::Mechanism<Balance, IBalance, FixedI128, MaxCurrencyMovement<u8, 50>>;
 }
 
 frame_support::parameter_types! {


### PR DESCRIPTION
# Description

The type used to track the currency movements per account is fixed by the implementation (`u16` wight now). Ideally, we would want to allow the user to choose the type they want:

- If the user doesn't want to move currency, they should be able to use a zero overhead type as `()` to save storage.
- If the user wants to perform more than `u16` movements, they should be able to use `u32` as a counter type, for example.

This PR generalizes the counter type to allow this.

Related to https://github.com/centrifuge/centrifuge-chain/issues/1056

## Changes and Descriptions

- `last_currency_movement` is now generic.
- The type `MaxCurrencyMovements` now implements a new type that allows defining both the max currency movement value and the type used to hold that value: `MaxCurrencyMovement<u8, 50>`

## Type of change

- Refactorization

# How Has This Been Tested?

```sh
cargo test -p pallet-rewards
cargo test -p development-runtime
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
