### PR TITLE
Rewards: Add `pallet-rewards` documentation

### DIFF
--- a/pallets/rewards/README.md
+++ b/pallets/rewards/README.md
@@ -1,0 +1,56 @@
+# Rewards Pallet
+
+The Rewards pallet provides functionality for pull-based reward distributions,
+implementing [these traits](https://reference.centrifuge.io/cfg_traits/rewards/index.html) as interface.
+
+The user can stake an amount to claim a proportional reward.
+The staked amount is reserved/hold from the user account for that currency when it's deposited
+and unreserved/release when it's withdrawed.
+
+The pallet stores three main entities:
+- Groups, where the reward is distributed.
+- Accounts, where the participants deposit and withdraw their stake in order to obtain the reward.
+- Currencies, different stake types used in the same group.
+These currencies can also be moved from one group to another,
+in order to change the reward distribution of the associated accounts.
+
+The exact reward functionality of this pallet is given by the mechanism used when it's configured.
+Current mechanisms:
+- [base](https://solmaz.io/2019/02/24/scalable-reward-changing/) mechanism with support for
+currency movement.
+- [deferred](https://centrifuge.hackmd.io/@Luis/SkB07jq8o) mechanism with support for
+currency movement.
+
+**NOTE**: This pallet does not export any extrinsics, it's supposed to use by other pallets.
+
+## Documentation
+
+- [`pallet-rewards` API documentation](https://reference.centrifuge.io/pallet_rewards/)
+- [Rewards traits API documentation](https://reference.centrifuge.io/cfg_traits/rewards/index.html)
+- [Python example](deferred_python_example.py) for the deferred mechanism.
+- Mechanisms:
+    - [base](https://solmaz.io/2019/02/24/scalable-reward-changing/) mechanism with support for
+    currency movement.
+    - [deferred](https://centrifuge.hackmd.io/@Luis/SkB07jq8o) mechanism with support for
+    currency movement.
+
+## Getting started
+
+Add to your *Substrate* runtime or pallet `Cargo.toml`
+
+```toml
+[dependencies]
+pallet-claims = { git = "https://github.com/centrifuge/centrifuge-chain.git", branch = "release-vX.X.X", default-features = false }
+```
+
+modifying the `X.X.X` to a release that uses the same *Substrate* version as you uses.
+
+You probably will want to use this pallet as a [*loosely coupled pallet*](https://docs.substrate.io/build/pallet-coupling/),
+for that, you need to add the interface traits as a dependency where you use them:
+
+```toml
+[dependencies]
+cfg-traits = { git = "https://github.com/centrifuge/centrifuge-chain.git", branch = "release-vX.X.X", default-features = false }
+```
+
+*Take a look to the runtimes of this repository to see examples of how to configure it*

--- a/pallets/rewards/README.md
+++ b/pallets/rewards/README.md
@@ -14,7 +14,8 @@ The pallet stores three main entities:
 These currencies can also be moved from one group to another,
 in order to change the reward distribution of the associated accounts.
 
-The exact reward functionality of this pallet is given by the mechanism used when it's configured.
+The pallet itself can be understand as a wrapper for pull-based reward distributions,
+the exact reward functionality of this pallet is given by the mechanism used when it's configured.
 Current mechanisms:
 - [base](https://solmaz.io/2019/02/24/scalable-reward-changing/) mechanism with support for
 currency movement.
@@ -43,7 +44,7 @@ Add to your *Substrate* runtime or pallet `Cargo.toml`
 pallet-claims = { git = "https://github.com/centrifuge/centrifuge-chain.git", branch = "release-vX.X.X", default-features = false }
 ```
 
-modifying the `X.X.X` to a release that uses the same *Substrate* version as you uses.
+Modify the `X.X.X` to a release that uses the same *Substrate* version as you uses.
 
 You probably will want to use this pallet as a [*loosely coupled pallet*](https://docs.substrate.io/build/pallet-coupling/),
 for that, you need to add the interface traits as a dependency where you use them:

--- a/pallets/rewards/deferred_python_example.py
+++ b/pallets/rewards/deferred_python_example.py
@@ -1,0 +1,94 @@
+class DeferredPullBasedDistribution:
+    "Constant Time Deferred Reward Distribution with Changing Stake Sizes and Deferred Reward"
+
+    def __init__(self):
+        self.total_stake = 0
+        self.reward_per_token = 0
+        self.last_rate = 0
+        self.lost_reward = 0
+        self.current_distribution_id = 0
+        self.stake = {0x1: 0, 0x2: 0}
+        self.reward_tally = {0x1: 0, 0x2: 0}
+        self.rewarded_stake = {0x1: 0, 0x2: 0}
+        self.distribution_id = {0x1: 0, 0x2: 0}
+
+    def __update_rewarded_stake(self, address):
+        "Ensure the `rewarded_stake` contains the last rewarded stake"
+        if self.distribution_id[address] != self.current_distribution_id:
+            self.distribution_id[address] = self.current_distribution_id
+            self.rewarded_stake[address] = self.stake[address]
+
+    def distribute(self, reward):
+        "Distribute `reward` proportionally to active stakes"
+        if self.total_stake == 0:
+            raise Exception("Cannot distribute to staking pool with 0 stake")
+
+        self.reward_per_token += (reward + self.lost_reward) / self.total_stake
+
+        self.last_rate = reward / self.total_stake
+        self.lost_reward = 0
+        self.current_distribution_id += 1;
+
+    def deposit_stake(self, address, amount):
+        "Increase the stake of `address` by `amount`"
+        self.__update_rewarded_stake(address)
+
+        self.stake[address] += amount
+        self.reward_tally[address] += self.reward_per_token * amount
+        self.total_stake += amount
+
+    def withdraw_stake(self, address, amount):
+        "Decrease the stake of `address` by `amount`"
+        if amount > self.stake[address]:
+            raise Exception("Requested amount greater than staked amount")
+
+        self.__update_rewarded_stake(address)
+
+        unrewarded_stake = max(self.stake[address] - self.rewarded_stake[address], 0)
+        unrewarded_amount = min(amount, unrewarded_stake)
+        rewarded_amount = amount - unrewarded_amount
+        lost_reward = rewarded_amount * self.last_rate
+
+        self.stake[address] -= amount
+        self.reward_tally[address] -= self.reward_per_token * amount - lost_reward
+        self.total_stake -= amount
+
+        self.rewarded_stake[address] -= rewarded_amount
+        self.lost_reward += lost_reward
+
+    def compute_reward(self, address):
+        "Compute reward of `address`. Inmutable"
+        previous_stake = self.rewarded_stake[address]
+        if self.distribution_id[address] != self.current_distribution_id:
+            previous_stake = self.stake[address]
+
+        return (self.stake[address] * self.reward_per_token
+                - self.reward_tally[address]
+                - previous_stake * self.last_rate)
+
+    def withdraw_reward(self, address):
+        "Withdraw rewards of `address`"
+        reward = self.compute_reward(address)
+        self.reward_tally[address] += reward
+        return reward
+
+# Example
+addr1 = 0x1
+addr2 = 0x2
+
+contract = DeferredPullBasedDistribution()
+
+contract.deposit_stake(addr1, 100)
+contract.deposit_stake(addr2, 50)
+
+contract.distribute(10)
+
+contract.withdraw_stake(addr1, 100)
+
+contract.distribute(10)
+
+# Expected to not be rewarded because the participant withdrawed stake before the second distribution
+print(contract.withdraw_reward(addr1))
+
+# Expected to be rewarded with the entire first reward distribution (10)
+print(contract.withdraw_reward(addr2))

--- a/pallets/rewards/src/lib.rs
+++ b/pallets/rewards/src/lib.rs
@@ -15,8 +15,9 @@
 //! # Rewards Pallet
 //!
 //! The Rewards pallet provides functionality for distributing rewards to different accounts with
-//! different currencies. The user can stake an amount to claim a proportional reward.
+//! different currencies.
 //!
+//! The user can stake an amount to claim a proportional reward.
 //! The staked amount is reserved/hold from the user account for that currency when is deposited
 //! and unreserved/release when is withdrawed.
 //!
@@ -48,8 +49,12 @@
 //!
 //! ### Functionality
 //!
-//! The Rewards pallet is based on this [paper](https://solmaz.io/2019/02/24/scalable-reward-changing/)
-//! and extends that functionality to support different groups and currencies.
+//! The exact reward functionality of this pallet is given by the mechanism used when it's
+//! configured. Current mechanisms:
+//! - [base](https://solmaz.io/2019/02/24/scalable-reward-changing/) mechanism with support for
+//! currency movement.
+//! - [deferred](https://centrifuge.hackmd.io/@Luis/SkB07jq8o) mechanism with support for
+//! currency movement.
 //!
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

This pallet is supposed to use by other chains that needs a reward system.
Add a readme with the basic documentation about what this pallet is and how to use it.

Fixes #1093

## Changes and Descriptions

- Added `README.md` to the crate
- Added a python example with the deferred reward implementation used by the [paper](https://centrifuge.hackmd.io/@Luis/SkB07jq8o).

## Type of change

-  Documentation update

# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
