### PR TITLE
Bugfix set metadata

### DIFF
--- a/pallets/pool-registry/src/lib.rs
+++ b/pallets/pool-registry/src/lib.rs
@@ -163,12 +163,12 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn get_pool_metadata)]
-	pub(super) type PoolMetadata<T: Config> =
+	pub(crate) type PoolMetadata<T: Config> =
 		StorageMap<_, Blake2_256, T::PoolId, PoolMetadataOf<T>>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn get_pools)]
-	pub(super) type Pools<T: Config> = StorageMap<_, Blake2_256, T::PoolId, PoolRegistrationStatus>;
+	pub(crate) type Pools<T: Config> = StorageMap<_, Blake2_256, T::PoolId, PoolRegistrationStatus>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -253,15 +253,17 @@ pub mod pallet {
 				Pools::<T>::insert(pool_id, PoolRegistrationStatus::Registered);
 			}
 
-			let checked_metadata: BoundedVec<u8, T::MaxSizeMetadata> =
-				metadata.try_into().map_err(|_| Error::<T>::BadMetadata)?;
+			if let Some(m) = metadata.clone() {
+				let checked_metadata: BoundedVec<u8, T::MaxSizeMetadata> =
+					m.try_into().map_err(|_| Error::<T>::BadMetadata)?;
 
-			PoolMetadata::<T>::insert(
-				pool_id,
-				PoolMetadataOf::<T> {
-					metadata: checked_metadata.clone(),
-				},
-			);
+				PoolMetadata::<T>::insert(
+					pool_id,
+					PoolMetadataOf::<T> {
+						metadata: checked_metadata.clone(),
+					},
+				);
+			}
 
 			T::ModifyPool::create(
 				admin.clone(),

--- a/pallets/pool-registry/src/lib.rs
+++ b/pallets/pool-registry/src/lib.rs
@@ -253,6 +253,16 @@ pub mod pallet {
 				Pools::<T>::insert(pool_id, PoolRegistrationStatus::Registered);
 			}
 
+			let checked_metadata: BoundedVec<u8, T::MaxSizeMetadata> =
+				metadata.try_into().map_err(|_| Error::<T>::BadMetadata)?;
+
+			PoolMetadata::<T>::insert(
+				pool_id,
+				PoolMetadataOf::<T> {
+					metadata: checked_metadata.clone(),
+				},
+			);
+
 			T::ModifyPool::create(
 				admin.clone(),
 				depositor,

--- a/pallets/pool-registry/src/mock.rs
+++ b/pallets/pool-registry/src/mock.rs
@@ -128,7 +128,7 @@ impl<T: Config + pallet_pool_registry::Config> PoolMutate<T::AccountId, T::PoolI
 		_max_reserve: T::Balance,
 		_metadata: Option<Vec<u8>>,
 	) -> DispatchResult {
-		todo!()
+		Ok(())
 	}
 
 	fn update(

--- a/pallets/pool-registry/src/tests.rs
+++ b/pallets/pool-registry/src/tests.rs
@@ -9,6 +9,7 @@
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
+
 use cfg_types::pools::PoolChanges;
 use frame_support::assert_ok;
 use orml_traits::Change;
@@ -31,6 +32,41 @@ fn update_pool() {
 
 			assert_ok!(PoolRegistry::update(
 				Origin::signed(pool_owner),
+				pool_id,
+				changes,
+			));
+		})
+}
+
+#[test]
+fn register_pool_and_set_metadata() {
+
+	// 			origin: OriginFor<T>,
+	// 			admin: T::AccountId,
+	// 			pool_id: T::PoolId,
+	// 			tranche_inputs: Vec<TrancheInputOf<T>>,
+	// 			currency: T::CurrencyId,
+	// 			max_reserve: T::Balance,
+	// 			metadata: Option<Vec<u8>>,
+
+
+	TestExternalitiesBuilder::default()
+		.build()
+		.execute_with(|| {
+			let pool_owner = 9u64;
+			let pool_id = 0;
+			let changes = PoolChanges {
+				tranches: Change::NoChange,
+				tranche_metadata: Change::NoChange,
+				min_epoch_time: Change::NewValue(10),
+				max_nav_age: Change::NoChange,
+			};
+
+			let tranches_input = Tranches
+
+			assert_ok!(PoolRegistry::register(
+				Origin::signed(pool_owner),
+				pool_owner,
 				pool_id,
 				changes,
 			));


### PR DESCRIPTION
# Description

Setting `metadata` of a pool also when `register`ing a new `pool` (inside `pallet-pool-registry`)

Fixes https://github.com/centrifuge/centrifuge-chain/issues/1096

## Changes and Descriptions

Added the missing setter (and bound check) inside the `register` extrinsic for `pallet-pool-registry`. Added a test as well.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`cargo test --workspace --release --features test-benchmarks,try-runtime,runtime-benchmarks`

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
