### PR TITLE
Rewards: Fix for deferred mechanism

### DIFF
--- a/pallets/rewards/deferred_python_example.py
+++ b/pallets/rewards/deferred_python_example.py
@@ -23,9 +23,8 @@ class DeferredPullBasedDistribution:
         if self.total_stake == 0:
             raise Exception("Cannot distribute to staking pool with 0 stake")
 
-        self.reward_per_token += (reward + self.lost_reward) / self.total_stake
-
-        self.last_rate = reward / self.total_stake
+        self.last_rate = (reward + self.lost_reward) / self.total_stake
+        self.reward_per_token += self.last_rate
         self.lost_reward = 0
         self.current_distribution_id += 1;
 

--- a/pallets/rewards/src/mechanism/deferred.rs
+++ b/pallets/rewards/src/mechanism/deferred.rs
@@ -157,14 +157,16 @@ where
 		amount: Self::Balance,
 		distribution_id: Self::DistributionId,
 	) -> Result<(), ArithmeticError> {
+		let reward = amount.ensure_add(group.lost_reward)?;
+
 		base::Mechanism::<Balance, IBalance, Rate, MaxCurrencyMovements>::reward_group(
 			&mut group.base,
-			amount + group.lost_reward,
+			reward,
 			(),
 		)?;
 
 		group.lost_reward = Balance::zero();
-		group.last_rate = Rate::ensure_from_rational(amount, group.base.total_stake)?;
+		group.last_rate = Rate::ensure_from_rational(reward, group.base.total_stake)?;
 		group.distribution_id = distribution_id;
 
 		Ok(())


### PR DESCRIPTION
# Description

- Minor fix for the deferred mechanism to avoid sum overflow.
- The lost reward distribution is now added for the next epoch. This change is forced because adding the lost reward in the same epoch does not distribute the reward well for all participants.

*NOTE: This mechanism will be substituted for another mechanism that distributes the reward correctly even in cases when the reward is "lost" because of withdraws. The intention of this PR is to leave the mechanism finished without errors in the git history.*