### PR TITLE
Change hashing algorithm for PoolMetadata storage

### DIFF
--- a/pallets/pool-registry/src/lib.rs
+++ b/pallets/pool-registry/src/lib.rs
@@ -164,7 +164,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn get_pool_metadata)]
 	pub(crate) type PoolMetadata<T: Config> =
-		StorageMap<_, Blake2_256, T::PoolId, PoolMetadataOf<T>>;
+		StorageMap<_, Blake2_128Concat, T::PoolId, PoolMetadataOf<T>>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn get_pools)]


### PR DESCRIPTION
# Description

Changing the hashing algorithm for `PoolMetadata` in `pallet-pool-registry` from `Blake2_256` to `Blake2_128Concat`.


## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
