### PR TITLE
Testing Benchmark Job - Add status comments

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,18 @@ jobs:
             const [, , runtime] = context.payload.comment.body.split(/\W+/)
             if (!['centrifuge', 'altair'].includes(runtime)) throw new Error('Unsupported Runtime: ${runtime}')
             return `${runtime}`
+      - uses: actions/github-script@v6
+        name: Acknowledge Run Comment
+        id: ack-run-comment
+        with:
+          script: |
+            const comment = await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Running Benchmarks for \`${steps.parse-runtime.outputs.result}\``
+            })
+            return comment.data.id
       - name: Run Benchmark centrifuge
         run: ./ci/script.sh
         env:
@@ -45,3 +57,16 @@ jobs:
         with:
           name: ${{steps.parse-runtime.outputs.result}}-weights
           path: runtime/${{steps.parse-runtime.outputs.result}}/src/weights/
+      - uses: actions/github-script@v6
+        name: Notify Benchmark finished
+        with:
+          script: |
+            await github.rest.issues.updateComment({
+              comment_id: steps.ack-run-comment.outputs.result,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `
+              Uploaded benchmarks for: \`${steps.parse-runtime.outputs.result}\`
+              Find the artifact here: https://github.com/centrifuge/centrifuge-chain/actions/runs/${context.runId}
+              `
+            })

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            console.log("Comment body", context.payload.comment.body)
+            console.log("Comment body:", context.payload.comment.body)
             const [, , runtime] = context.payload.comment.body.split(/\W+/)
             if (!['centrifuge', 'altair'].includes(runtime)) throw new Error('Unsupported Runtime: ${runtime}')
             return `${runtime}`


### PR DESCRIPTION
## Description
Since there is no visible status for the `issue_comment` events, just added a comment at the beginning and at the end of the run for user feedback.

Here is an example of a successful run https://github.com/centrifuge/centrifuge-chain/actions/runs/3597875895 
You can find the zipped artifacts a the bottom of that page. There is no support to link the final artifact anywhere since the artifact_id is not available at the gh action level.