### PR TITLE
Fixed liquidity-reward benchmarks

### DIFF
--- a/pallets/liquidity-rewards/src/benchmarking.rs
+++ b/pallets/liquidity-rewards/src/benchmarking.rs
@@ -97,7 +97,7 @@ benchmarks! {
 		let mock = init_test_mock_with_expectations();
 
 		Pallet::<T>::set_currency_group(RawOrigin::Root.into(), CURRENCY_ID_A.into(), GROUP_A.into()).unwrap();
-		Pallet::<T>::on_initialize(T::BlockNumber::zero());
+		Pallet::<T>::on_initialize(T::InitialEpochDuration::get());
 
 	}: _(RawOrigin::Signed(caller), CURRENCY_ID_A.into(), T::Balance::zero())
 	verify {
@@ -110,7 +110,7 @@ benchmarks! {
 		let mock = init_test_mock_with_expectations();
 
 		Pallet::<T>::set_currency_group(RawOrigin::Root.into(), CURRENCY_ID_A.into(), GROUP_A.into()).unwrap();
-		Pallet::<T>::on_initialize(T::BlockNumber::zero());
+		Pallet::<T>::on_initialize(T::InitialEpochDuration::get());
 
 	}: _(RawOrigin::Signed(caller), CURRENCY_ID_A.into(), T::Balance::zero())
 	verify {
@@ -123,7 +123,7 @@ benchmarks! {
 		let mock = init_test_mock_with_expectations();
 
 		Pallet::<T>::set_currency_group(RawOrigin::Root.into(), CURRENCY_ID_A.into(), GROUP_A.into()).unwrap();
-		Pallet::<T>::on_initialize(T::BlockNumber::one());
+		Pallet::<T>::on_initialize(T::InitialEpochDuration::get());
 
 	}: _(RawOrigin::Signed(caller), CURRENCY_ID_A.into())
 	verify {


### PR DESCRIPTION
# Description

The addition of an initial epoch duration breaks the `liquidity-rewards` benchmarks for the development runtime. This PR fixes it.

Associated to https://github.com/centrifuge/centrifuge-chain/issues/1128

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```sh
PARA_CHAIN_SPEC=development ./scripts/init.sh benchmark pallet-liquidity-rewards
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
