### PR TITLE
relay-cli: Handle None case for shared base path

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -536,9 +536,12 @@ impl CliConfiguration<Self> for RelayChainCli {
 	}
 
 	fn base_path(&self) -> Result<Option<BasePath>> {
-		self.shared_params()
+		Ok(self
+			.shared_params()
 			.base_path()
-			.or_else(|_| Ok(self.base_path.clone().map(Into::into)))
+			.ok()
+			.flatten()
+			.or_else(|| self.base_path.clone().map(Into::into)))
 	}
 
 	fn role(&self, is_dev: bool) -> Result<sc_service::Role> {


### PR DESCRIPTION
# Description

When running the centrifuge-chain locally, if no `base-path` is provided to the relay chain args then a random temp directory is used which can cause inconsistent behavior such as the chain not producing blocks due to invalid/stale data in the db.

## Changes and Descriptions

The changes in this PR aim at handling the case where `shared_params().base_path()` is a `Result(None)` which results in the behavior described above.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Tested by running the chain locally and confirming that the `base_path` set in the init script is used for the relay chain.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
