### PR TITLE
Updated weight max proof size in primitives with const, will be updat…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "cfg-primitives"
 version = "2.0.0"
 dependencies = [
+ "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "pallet-collective",

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
             };
 
             # This is a hash of all the Cargo dependencies, for reproducibility.
-            cargoSha256 = "sha256-9zviRviP15lxp1SnYtsN1H7tcI7Bm6cI5weN/R0hxss=";
+            cargoSha256 = "sha256-tMm4gGs7RLC+DhFrvPailuR+T8cBJOtyFy5raJenoes";
 
             nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
             buildInputs = with pkgs; [ openssl ] ++ (

--- a/libs/primitives/Cargo.toml
+++ b/libs/primitives/Cargo.toml
@@ -26,6 +26,9 @@ frame-support = { git = "https://github.com/paritytech/substrate", default-featu
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.32" }
 pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.32" }
 
+# cumuluse primitives dependencies
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.32" }
+
 [features]
 default = ['std']
 runtime-benchmarks = []

--- a/libs/primitives/src/lib.rs
+++ b/libs/primitives/src/lib.rs
@@ -173,6 +173,7 @@ pub mod types {
 
 /// Common constants for all runtimes
 pub mod constants {
+	use cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE;
 	use frame_support::weights::{constants::WEIGHT_PER_SECOND, Weight};
 	use sp_runtime::Perbill;
 
@@ -209,7 +210,9 @@ pub mod constants {
 	pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 	/// We allow for 0.5 seconds of compute with a 6 second average block time.
-	pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2);
+	pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+		.saturating_div(2)
+		.set_proof_size(MAX_POV_SIZE as u64);
 
 	pub const MICRO_CFG: Balance = 1_000_000_000_000; // 10−6 	0.000001
 	pub const MILLI_CFG: Balance = 1_000 * MICRO_CFG; // 10−3 	0.001

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -132,9 +132,8 @@ pub fn native_version() -> NativeVersion {
 	}
 }
 
-const MAX_BLOCK_WEIGHT: Weight = MAXIMUM_BLOCK_WEIGHT.set_proof_size(MAX_POV_SIZE as u64);
-
 parameter_types! {
+	// we'll pull the max pov size from the relay chain in the near future
 	pub const MaximumBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const Version: RuntimeVersion = VERSION;
 	pub RuntimeBlockLength: BlockLength =
@@ -145,14 +144,14 @@ parameter_types! {
 			weights.base_extrinsic = ExtrinsicBaseWeight::get();
 		})
 		.for_class(DispatchClass::Normal, |weights| {
-			  weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAX_BLOCK_WEIGHT);
+			  weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
 		})
 		.for_class(DispatchClass::Operational, |weights| {
-			  weights.max_total = Some(MAX_BLOCK_WEIGHT);
+			  weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
 			// Operational transactions have some extra reserved space, so that they
 			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
 		weights.reserved = Some(
-			  MAX_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAX_BLOCK_WEIGHT
+			  MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
 		);
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -114,8 +114,6 @@ pub fn native_version() -> NativeVersion {
 	}
 }
 
-const MAX_BLOCK_WEIGHT: Weight = MAXIMUM_BLOCK_WEIGHT.set_proof_size(MAX_POV_SIZE as u64);
-
 parameter_types! {
 	pub const MaximumBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const Version: RuntimeVersion = VERSION;
@@ -127,14 +125,14 @@ parameter_types! {
 			weights.base_extrinsic = ExtrinsicBaseWeight::get();
 		})
 		.for_class(DispatchClass::Normal, |weights| {
-			  weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAX_BLOCK_WEIGHT);
+			  weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
 		})
 		.for_class(DispatchClass::Operational, |weights| {
-			 weights.max_total = Some(MAX_BLOCK_WEIGHT);
+			 weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
 			// Operational transactions have some extra reserved space, so that they
 			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
 			weights.reserved = Some(
-				  MAX_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAX_BLOCK_WEIGHT
+				  MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
 			);
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -143,10 +143,9 @@ pub fn native_version() -> NativeVersion {
 	}
 }
 
-const MAX_BLOCK_WEIGHT: Weight = MAXIMUM_BLOCK_WEIGHT.set_proof_size(MAX_POV_SIZE as u64);
-
 parameter_types! {
-	pub const MaximumBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
+  // we'll pull the max pov size from the relay chain in the near future
+  pub const MaximumBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const Version: RuntimeVersion = VERSION;
 	pub RuntimeBlockLength: BlockLength =
 		BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
@@ -156,14 +155,14 @@ parameter_types! {
 			weights.base_extrinsic = ExtrinsicBaseWeight::get();
 		})
 		.for_class(DispatchClass::Normal, |weights| {
-			  weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAX_BLOCK_WEIGHT);
+			  weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
 		})
 		.for_class(DispatchClass::Operational, |weights| {
-			  weights.max_total = Some(MAX_BLOCK_WEIGHT);
+			  weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
 			// Operational transactions have some extra reserved space, so that they
 			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
 			weights.reserved = Some(
-				  MAX_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAX_BLOCK_WEIGHT
+				  MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
 			);
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)


### PR DESCRIPTION
Maximum block weight proof size update.

# Description
Proof size set on maximum proof weight using culumuls/polkadot max pov size const.

This will be updated to pull from the relay chain in near future, however we're going to go with a lower risk change for the upgrade release -- https://github.com/centrifuge/centrifuge-chain/pull/1134

Fixes # 

Ensures proof size set correctly


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?



# Checklist:

- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `main` branch
