### PR TITLE
Rewards: Implement distribution to groups with no stake

### DIFF
--- a/libs/traits/src/rewards.rs
+++ b/libs/traits/src/rewards.rs
@@ -28,6 +28,10 @@ pub trait GroupRewards {
 	/// Type used to identify the group
 	type GroupId;
 
+	/// Check if the group is ready to be rewarded.
+	/// Most of the cases it means that the group has stake that should be rewarded.
+	fn is_ready(group_id: Self::GroupId) -> bool;
+
 	/// Reward a group distributing the reward amount proportionally to all associated accounts.
 	/// This method is called by distribution method only when the group has some stake.
 	fn reward_group(group_id: Self::GroupId, reward: Self::Balance) -> DispatchResult;
@@ -82,22 +86,21 @@ where
 		let groups = groups.into_iter();
 		let total_weight = groups
 			.clone()
-			.filter(|(group_id, _)| !Self::group_stake(group_id.clone()).is_zero())
+			.filter(|(group_id, _)| Self::is_ready(group_id.clone()))
 			.map(|(_, weight)| weight)
 			.try_fold(Weight::zero(), |a, b| a.ensure_add(b))?;
 
-		if total_weight.is_zero() {
-			return Ok(Vec::default());
-		}
-
 		Ok(groups
-			.filter(|(group_id, _)| !Self::group_stake(group_id.clone()).is_zero())
 			.map(|(group_id, weight)| {
 				let result = (|| {
-					let reward_rate = FixedU128::checked_from_rational(weight, total_weight)
-						.ok_or(ArithmeticError::DivisionByZero)?;
+					let group_reward = if Self::is_ready(group_id.clone()) {
+						let reward_rate = FixedU128::checked_from_rational(weight, total_weight)
+							.ok_or(ArithmeticError::DivisionByZero)?;
 
-					let group_reward = reward_rate.ensure_mul_int(reward)?;
+						reward_rate.ensure_mul_int(reward)?
+					} else {
+						Self::Balance::zero()
+					};
 
 					Self::reward_group(group_id.clone(), group_reward)
 				})();
@@ -205,10 +208,13 @@ pub mod mock {
 			type Balance = Balance;
 			type GroupId = GroupId;
 
+			fn is_ready(group_id: <Self as GroupRewards>::GroupId) -> bool;
+
 			fn reward_group(
 				group_id: <Self as GroupRewards>::GroupId,
 				reward: <Self as GroupRewards>::Balance
 			) -> DispatchResult;
+
 			fn group_stake(group_id: <Self as GroupRewards>::GroupId) -> <Self as GroupRewards>::Balance;
 		}
 
@@ -287,18 +293,21 @@ mod test {
 	fn distribute_zero() {
 		let _m = mock::lock();
 
-		let ctx1 = MockDistributionRewards::group_stake_context();
-		ctx1.expect().times(8).returning(|group_id| match group_id {
-			GroupId::Empty => 0,
-			_ => 100,
+		let ctx0 = MockDistributionRewards::is_ready_context();
+		ctx0.expect().times(8).returning(|group_id| match group_id {
+			GroupId::Empty => false,
+			_ => true,
 		});
+
+		let ctx1 = MockDistributionRewards::group_stake_context();
+		ctx1.expect().never();
 
 		let ctx2 = MockDistributionRewards::reward_group_context();
 		ctx2.expect()
-			.times(3)
+			.times(4)
 			.withf(|_, reward| *reward == REWARD_ZERO)
 			.returning(|group_id, _| match group_id {
-				GroupId::Err => Err(ArithmeticError::DivisionByZero.into()),
+				GroupId::Err => Err(DispatchError::Other("issue")),
 				_ => Ok(()),
 			});
 
@@ -307,13 +316,16 @@ mod test {
 				REWARD_ZERO,
 				[GroupId::Empty, GroupId::Err, GroupId::A, GroupId::B]
 			),
-			vec![(GroupId::Err, ArithmeticError::DivisionByZero.into())]
+			vec![(GroupId::Err, DispatchError::Other("issue"))]
 		);
 	}
 
 	#[test]
 	fn distribute_to_nothing() {
 		let _m = mock::lock();
+
+		let ctx0 = MockDistributionRewards::is_ready_context();
+		ctx0.expect().never();
 
 		let ctx1 = MockDistributionRewards::group_stake_context();
 		ctx1.expect().never();
@@ -328,30 +340,32 @@ mod test {
 	}
 
 	#[test]
-	fn distribute() {
+	fn distribute_same() {
 		let _m = mock::lock();
 
-		let ctx1 = MockDistributionRewards::group_stake_context();
-		ctx1.expect().times(8).returning(|group_id| match group_id {
-			GroupId::Empty => 0,
-			_ => 100,
+		let ctx0 = MockDistributionRewards::is_ready_context();
+		ctx0.expect().times(8).returning(|group_id| match group_id {
+			GroupId::Empty => false,
+			_ => true,
 		});
+
+		let ctx1 = MockDistributionRewards::group_stake_context();
+		ctx1.expect().never();
 
 		let ctx2 = MockDistributionRewards::reward_group_context();
 		ctx2.expect()
-			.times(3)
+			.times(4)
 			.withf(|group_id, reward| {
 				*reward
 					== match group_id {
-						GroupId::Empty => unreachable!(),
+						GroupId::Empty => 0,
 						GroupId::Err => REWARD / 3,
 						GroupId::A => REWARD / 3,
 						GroupId::B => REWARD / 3,
 					}
 			})
 			.returning(|group_id, _| match group_id {
-				GroupId::Empty => unreachable!(),
-				GroupId::Err => Err(ArithmeticError::DivisionByZero.into()),
+				GroupId::Err => Err(DispatchError::Other("issue")),
 				_ => Ok(()),
 			});
 
@@ -360,7 +374,7 @@ mod test {
 				REWARD,
 				[GroupId::Empty, GroupId::Err, GroupId::A, GroupId::B]
 			),
-			vec![(GroupId::Err, ArithmeticError::DivisionByZero.into())]
+			vec![(GroupId::Err, DispatchError::Other("issue"))]
 		);
 	}
 
@@ -368,27 +382,29 @@ mod test {
 	fn distribute_with_weights() {
 		let _m = mock::lock();
 
-		let ctx1 = MockDistributionRewards::group_stake_context();
-		ctx1.expect().times(8).returning(|group_id| match group_id {
-			GroupId::Empty => 0,
-			_ => 100,
+		let ctx0 = MockDistributionRewards::is_ready_context();
+		ctx0.expect().times(8).returning(|group_id| match group_id {
+			GroupId::Empty => false,
+			_ => true,
 		});
+
+		let ctx1 = MockDistributionRewards::group_stake_context();
+		ctx1.expect().never();
 
 		let ctx2 = MockDistributionRewards::reward_group_context();
 		ctx2.expect()
-			.times(3)
+			.times(4)
 			.withf(|group_id, reward| {
 				*reward
 					== match group_id {
-						GroupId::Empty => unreachable!(),
+						GroupId::Empty => 0,
 						GroupId::Err => 20 * REWARD / 90,
 						GroupId::A => 30 * REWARD / 90,
 						GroupId::B => 40 * REWARD / 90,
 					}
 			})
 			.returning(|group_id, _| match group_id {
-				GroupId::Empty => unreachable!(),
-				GroupId::Err => Err(ArithmeticError::DivisionByZero.into()),
+				GroupId::Err => Err(DispatchError::Other("issue")),
 				_ => Ok(()),
 			});
 
@@ -402,7 +418,7 @@ mod test {
 					(GroupId::B, 40u32)
 				]
 			),
-			vec![(GroupId::Err, ArithmeticError::DivisionByZero.into())]
+			vec![(GroupId::Err, DispatchError::Other("issue"))]
 		);
 	}
 }

--- a/pallets/liquidity-rewards/src/benchmarking.rs
+++ b/pallets/liquidity-rewards/src/benchmarking.rs
@@ -22,6 +22,9 @@ fn init_test_mock_with_expectations() -> impl Sized {
 	let mock = {
 		let lock = cfg_traits::rewards::mock::lock();
 
+		let ctx0 = MockRewards::is_ready_context();
+		ctx0.expect().return_const(true);
+
 		let ctx1 = MockRewards::group_stake_context();
 		ctx1.expect().return_const(100u64);
 
@@ -40,7 +43,7 @@ fn init_test_mock_with_expectations() -> impl Sized {
 		let ctx6 = MockRewards::attach_currency_context();
 		ctx6.expect().return_const(Ok(()));
 
-		(lock, ctx1, ctx2, ctx3, ctx4, ctx5, ctx6)
+		(lock, ctx0, ctx1, ctx2, ctx3, ctx4, ctx5, ctx6)
 	};
 
 	mock

--- a/pallets/liquidity-rewards/src/tests.rs
+++ b/pallets/liquidity-rewards/src/tests.rs
@@ -183,8 +183,8 @@ fn weight_changes() {
 			Some(&WEIGHT_2)
 		);
 
-		let ctx1 = MockRewards::group_stake_context();
-		ctx1.expect().return_const(100u64);
+		let ctx1 = MockRewards::is_ready_context();
+		ctx1.expect().return_const(true);
 
 		let ctx2 = MockRewards::reward_group_context();
 		ctx2.expect()

--- a/pallets/rewards/src/lib.rs
+++ b/pallets/rewards/src/lib.rs
@@ -218,6 +218,11 @@ pub mod pallet {
 		type Balance = BalanceOf<T, I>;
 		type GroupId = T::GroupId;
 
+		fn is_ready(group_id: Self::GroupId) -> bool {
+			let group = Groups::<T, I>::get(group_id);
+			T::RewardMechanism::is_ready(&group)
+		}
+
 		fn reward_group(group_id: Self::GroupId, reward: Self::Balance) -> DispatchResult {
 			Groups::<T, I>::try_mutate(group_id, |group| {
 				let reward = T::RewardMechanism::reward_group(group, reward)?;

--- a/pallets/rewards/src/mechanism.rs
+++ b/pallets/rewards/src/mechanism.rs
@@ -12,6 +12,10 @@ pub trait RewardMechanism {
 	type Balance: Balance;
 	type MaxCurrencyMovements: Get<u32>;
 
+	/// Check if the group is ready to be rewarded.
+	/// Most of the cases it means that the group has stake that should be rewarded.
+	fn is_ready(group: &Self::Group) -> bool;
+
 	/// Reward the group mutating the group entity.
 	fn reward_group(
 		group: &mut Self::Group,

--- a/pallets/rewards/src/mechanism/deferred.rs
+++ b/pallets/rewards/src/mechanism/deferred.rs
@@ -179,19 +179,28 @@ pub mod pallet {
 		type Group = Group<T>;
 		type MaxCurrencyMovements = T::MaxCurrencyMovements;
 
+		fn is_ready(group: &Self::Group) -> bool {
+			group.base.total_stake > Self::Balance::zero()
+		}
+
 		fn reward_group(
 			group: &mut Self::Group,
 			amount: Self::Balance,
 		) -> Result<Self::Balance, DispatchError> {
-			let reward = amount.ensure_add(group.lost_reward)?;
+			let mut reward_used = Self::Balance::zero();
 
-			base::Mechanism::<T::Balance, T::IBalance, T::Rate, T::MaxCurrencyMovements>::reward_group(
-				&mut group.base,
-				reward,
-			)?;
+			if group.base.total_stake > Self::Balance::zero() {
+				let reward = amount.ensure_add(group.lost_reward)?;
+				base::Mechanism::<T::Balance, T::IBalance, T::Rate, T::MaxCurrencyMovements>::reward_group(
+                    &mut group.base,
+                    reward,
+                )?;
 
-			group.lost_reward = T::Balance::zero();
-			group.last_rate = T::Rate::ensure_from_rational(reward, group.base.total_stake)?;
+				group.lost_reward = T::Balance::zero();
+				group.last_rate = T::Rate::ensure_from_rational(reward, group.base.total_stake)?;
+
+				reward_used = reward
+			}
 
 			group.distribution_id = LastDistributionId::<T>::try_mutate(
 				|distribution_id| -> Result<T::DistributionId, DispatchError> {
@@ -199,7 +208,7 @@ pub mod pallet {
 				},
 			)?;
 
-			Ok(amount)
+			Ok(reward_used)
 		}
 
 		fn deposit_stake(
@@ -207,7 +216,7 @@ pub mod pallet {
 			currency: &mut Self::Currency,
 			group: &mut Self::Group,
 			amount: Self::Balance,
-		) -> Result<(), DispatchError> {
+		) -> DispatchResult {
 			account.update_rewarded_stake(group, currency);
 
 			base::Mechanism::deposit_stake(
@@ -223,7 +232,7 @@ pub mod pallet {
 			currency: &mut Self::Currency,
 			group: &mut Self::Group,
 			amount: Self::Balance,
-		) -> Result<(), DispatchError> {
+		) -> DispatchResult {
 			account.update_rewarded_stake(group, currency);
 
 			let rewarded_amount = {


### PR DESCRIPTION
# Description

Fixes #1140

## Changes and Descriptions

- Add `is_ready()` method.
- Modify mock to support that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```sh
cargo test -p cfg-traits
cargo test -p pallet-rewards
cargo test -p pallet-liquidity-rewards
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
