### PR TITLE
Fix individual compilation issue

### DIFF
--- a/libs/primitives/Cargo.toml
+++ b/libs/primitives/Cargo.toml
@@ -42,4 +42,5 @@ std = [
   'frame-system/std',
   'pallet-collective/std',
   'sp-consensus-aura/std',
+  'cumulus-primitives-core/std',
 ]


### PR DESCRIPTION
# Description

A lack of std dependency avoids compiling some pallets individually, showing the following error:

```
error: cannot find macro `format` in this scope
  --> /Users/luis/.cargo/git/checkouts/substrate-f4423eebfa0046a3/5ea6d95/primitives/authority-discovery/src/lib.rs:26:2
   |
26 |     app_crypto!(sr25519, AUTHORITY_DISCOVERY);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: consider importing this macro:
           scale_info::prelude::format
   = note: this error originates in the macro `$crate::app_crypto_public_common_if_std` which comes from the expansion of the macro `app_crypto` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: use of undeclared crate or module `std`
...
```

This PR adds the lost feature to fix it