### PR TITLE
Rewards: All-in test. Fix gap movement

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
               body: `:clock1: Running Benchmarks for \`${{steps.parse-runtime.outputs.result}}\` :clock1:`
             })
             return comment.data.id
-      - name: Free space on Ubuntu
+      - name: Prep build on Ubuntu
         run: |
           echo "Pre cleanup"
           df -h
@@ -83,7 +83,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `
-              :white_check_mark: Uploaded benchmarks for: \`${{steps.parse-runtime.outputs.result}}\` :white_check_mark: 
+              :white_check_mark: Uploaded benchmarks for: \`${{steps.parse-runtime.outputs.result}}\` :white_check_mark:
               Find the artifact here: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
               `
             })

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get remove -y '^llvm-.*'
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y 'mysql.*'
-          sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell
+          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell
           sudo apt-get autoremove -y
           sudo apt-get clean
           df -h

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Prep build on Ubuntu
+        run: |
+          sudo apt-get install protobuf-compiler
+
       - name: Install latest nightly
         uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746
         with:

--- a/pallets/rewards/src/tests.rs
+++ b/pallets/rewards/src/tests.rs
@@ -6,13 +6,13 @@ use frame_support::{assert_noop, assert_ok, traits::fungibles::Inspect};
 
 use super::{mock::*, *};
 
-const GROUP_A: u32 = 1;
-const GROUP_B: u32 = 2;
-const GROUP_C: u32 = 3;
+const GROUP_1: u32 = 1;
+const GROUP_2: u32 = 2;
+const GROUP_3: u32 = 3;
 
-const DOM_1_CURRENCY_A: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::A);
-const DOM_1_CURRENCY_B: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::B);
-const DOM_1_CURRENCY_C: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::C);
+const DOM_1_CURRENCY_X: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::A);
+const DOM_1_CURRENCY_Y: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::B);
+const DOM_1_CURRENCY_Z: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::C);
 const DOM_1_CURRENCY_M: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::M);
 
 const STAKE_A: u64 = 100;
@@ -70,5 +70,127 @@ mod mechanism {
 
 		common_tests!(Rewards3, Instance3, MechanismKind::Gap);
 		currency_movement_tests!(Rewards3, Instance3, MechanismKind::Gap);
+
+		use Rewards3 as Rewards;
+
+		// The all_in test follows the next order, making claims for each distribution:
+		//
+		//        D0     |     D1    |          D2           |     D3    |    D4    |  D5
+		// G1 -----------------------------------------------------------------------------
+		//     Stake X A | Stake Z A | MOVE Z ·              | Stake M A | MOVE X · |
+		//               |           |        ·              |           |        · |
+		//               |           |        v              |           |        v |
+		// G2 -----------------------------------------------------------------------------
+		//     Stake Y B |           |         Unstake Z A/2 |           |          |
+		//
+		#[test]
+		fn all_in() {
+			new_test_ext().execute_with(|| {
+				assert_ok!(Rewards::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+				assert_ok!(Rewards::attach_currency(DOM_1_CURRENCY_Y, GROUP_2));
+				assert_ok!(Rewards::attach_currency(DOM_1_CURRENCY_Z, GROUP_1));
+
+				assert_ok!(Rewards::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+				assert_ok!(Rewards::deposit_stake(DOM_1_CURRENCY_Y, &USER_B, STAKE_B));
+
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_X, &USER_A), 0);
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_Y, &USER_B), 0);
+
+				// DISTRIBUTION 1
+				assert_ok!(Rewards::distribute_reward(
+					REWARD,
+					[GROUP_1, GROUP_2, GROUP_3]
+				));
+
+				assert_ok!(Rewards::deposit_stake(DOM_1_CURRENCY_Z, &USER_A, STAKE_A));
+
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_X, &USER_A), 0);
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_Y, &USER_B), 0);
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_Z, &USER_A), 0);
+
+				// DISTRIBUTION 2
+				assert_ok!(Rewards::distribute_reward(
+					REWARD,
+					[GROUP_1, GROUP_2, GROUP_3]
+				));
+
+				// MOVEMENT Z
+				assert_ok!(Rewards::attach_currency(DOM_1_CURRENCY_Z, GROUP_2));
+
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_X, &USER_A), REWARD / 2);
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_Y, &USER_B), REWARD / 2);
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_Z, &USER_A), 0);
+
+				assert_ok!(Rewards::withdraw_stake(
+					DOM_1_CURRENCY_Z,
+					&USER_A,
+					STAKE_A / 2
+				));
+
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_Z, &USER_A), 0);
+
+				// DISTRIBUTION 3
+				assert_ok!(Rewards::distribute_reward(
+					REWARD,
+					[GROUP_1, GROUP_2, GROUP_3]
+				));
+
+				assert_ok!(Rewards::attach_currency(DOM_1_CURRENCY_M, GROUP_1));
+
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_X, &USER_A), REWARD / 2);
+				assert_ok!(
+					Rewards::claim_reward(DOM_1_CURRENCY_Y, &USER_B),
+					(REWARD / 2) * STAKE_B / (STAKE_A / 2 + STAKE_B)
+				);
+				assert_ok!(
+					Rewards::claim_reward(DOM_1_CURRENCY_Z, &USER_A),
+					(REWARD / 2) * (STAKE_A / 2) / (STAKE_A / 2 + STAKE_B)
+				);
+
+				assert_ok!(Rewards::deposit_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_A));
+
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_M, &USER_A), 0);
+
+				// DISTRIBUTION 4
+				assert_ok!(Rewards::distribute_reward(
+					REWARD,
+					[GROUP_1, GROUP_2, GROUP_3]
+				));
+
+				// MOVEMENT X
+				assert_ok!(Rewards::attach_currency(DOM_1_CURRENCY_X, GROUP_2));
+
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_X, &USER_A), REWARD / 2);
+				assert_ok!(
+					Rewards::claim_reward(DOM_1_CURRENCY_Y, &USER_B),
+					(REWARD / 2) * STAKE_B / (STAKE_A / 2 + STAKE_B)
+				);
+				assert_ok!(
+					Rewards::claim_reward(DOM_1_CURRENCY_Z, &USER_A),
+					(REWARD / 2) * (STAKE_A / 2) / (STAKE_A / 2 + STAKE_B)
+				);
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_M, &USER_A), 0);
+
+				// DISTRIBUTION 5
+				assert_ok!(Rewards::distribute_reward(
+					REWARD,
+					[GROUP_1, GROUP_2, GROUP_3]
+				));
+
+				assert_ok!(
+					Rewards::claim_reward(DOM_1_CURRENCY_X, &USER_A),
+					(REWARD / 2) * STAKE_A / (STAKE_A + STAKE_B + STAKE_A / 2)
+				);
+				assert_ok!(
+					Rewards::claim_reward(DOM_1_CURRENCY_Y, &USER_B),
+					(REWARD / 2) * STAKE_B / (STAKE_A + STAKE_B + STAKE_A / 2)
+				);
+				assert_ok!(
+					Rewards::claim_reward(DOM_1_CURRENCY_Z, &USER_A),
+					(REWARD / 2) * (STAKE_A / 2) / (STAKE_A + STAKE_B + STAKE_A / 2)
+				);
+				assert_ok!(Rewards::claim_reward(DOM_1_CURRENCY_M, &USER_A), REWARD / 2);
+			});
+		}
 	}
 }

--- a/pallets/rewards/src/tests/common.rs
+++ b/pallets/rewards/src/tests/common.rs
@@ -11,16 +11,16 @@ macro_rules! stake_common_tests {
 
 				new_test_ext().execute_with(|| {
 					// DISTRIBUTION 0
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_1));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_1));
 					assert_eq!(
 						free_balance(CurrencyId::A, &USER_A),
 						USER_INITIAL_BALANCE - STAKE_1
 					);
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					// DISTRIBUTION 1
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_2));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_2));
 					assert_eq!(
 						free_balance(CurrencyId::A, &USER_A),
 						USER_INITIAL_BALANCE - (STAKE_1 + STAKE_2)
@@ -31,9 +31,9 @@ macro_rules! stake_common_tests {
 			#[test]
 			fn all() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
 					assert_ok!($pallet::deposit_stake(
-						DOM_1_CURRENCY_A,
+						DOM_1_CURRENCY_X,
 						&USER_A,
 						USER_INITIAL_BALANCE
 					));
@@ -43,17 +43,17 @@ macro_rules! stake_common_tests {
 			#[test]
 			fn nothing() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, 0));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, 0));
 				});
 			}
 
 			#[test]
 			fn insufficient_balance() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
 					assert_noop!(
-						$pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, USER_INITIAL_BALANCE + 1),
+						$pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, USER_INITIAL_BALANCE + 1),
 						TokenError::NoFunds
 					);
 				});
@@ -76,10 +76,10 @@ macro_rules! unstake_common_tests {
 
 				new_test_ext().execute_with(|| {
 					// DISTRIBUTION 0
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_1));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_1));
 					assert_ok!($pallet::withdraw_stake(
-						DOM_1_CURRENCY_A,
+						DOM_1_CURRENCY_X,
 						&USER_A,
 						UNSTAKE_1
 					));
@@ -87,11 +87,11 @@ macro_rules! unstake_common_tests {
 						free_balance(CurrencyId::A, &USER_A),
 						USER_INITIAL_BALANCE - STAKE_1 + UNSTAKE_1
 					);
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					// DISTRIBUTION 1
 					assert_ok!($pallet::withdraw_stake(
-						DOM_1_CURRENCY_A,
+						DOM_1_CURRENCY_X,
 						&USER_A,
 						UNSTAKE_2
 					));
@@ -102,16 +102,16 @@ macro_rules! unstake_common_tests {
 			#[test]
 			fn insufficient_balance() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
 					assert_noop!(
-						$pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, 1),
+						$pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, 1),
 						TokenError::NoFunds
 					);
 
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, 1000));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, 1000));
 
 					assert_noop!(
-						$pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, 2000),
+						$pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, 2000),
 						TokenError::NoFunds
 					);
 				});
@@ -120,50 +120,50 @@ macro_rules! unstake_common_tests {
 			#[test]
 			fn exact() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
-					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 				});
 			}
 
 			#[test]
 			fn nothing() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, 0));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, 0));
 				});
 			}
 
 			#[test]
 			fn several_users() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 					assert_eq!(
 						free_balance(CurrencyId::A, &USER_A),
 						USER_INITIAL_BALANCE - STAKE_A
 					);
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					// DISTRIBUTION 1
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_B, STAKE_B));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_B, STAKE_B));
 					assert_eq!(
 						free_balance(CurrencyId::A, &USER_B),
 						USER_INITIAL_BALANCE - STAKE_B
 					);
-					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 					assert_eq!(free_balance(CurrencyId::A, &USER_A), USER_INITIAL_BALANCE);
-					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_B, STAKE_B));
+					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_B, STAKE_B));
 					assert_eq!(free_balance(CurrencyId::A, &USER_B), USER_INITIAL_BALANCE);
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					// DISTRIBUTION 2
 					assert_noop!(
-						$pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, 1),
+						$pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, 1),
 						TokenError::NoFunds
 					);
 					assert_noop!(
-						$pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_B, 1),
+						$pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_B, 1),
 						TokenError::NoFunds
 					);
 				});
@@ -182,19 +182,19 @@ macro_rules! currency_common_tests {
 			fn use_without_group() {
 				new_test_ext().execute_with(|| {
 					assert_noop!(
-						$pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, 0),
+						$pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, 0),
 						Error::<Runtime, $instance>::CurrencyWithoutGroup
 					);
 					assert_noop!(
-						$pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, 0),
+						$pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, 0),
 						Error::<Runtime, $instance>::CurrencyWithoutGroup
 					);
 					assert_noop!(
-						$pallet::compute_reward(DOM_1_CURRENCY_A, &USER_A),
+						$pallet::compute_reward(DOM_1_CURRENCY_X, &USER_A),
 						Error::<Runtime, $instance>::CurrencyWithoutGroup
 					);
 					assert_noop!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A),
 						Error::<Runtime, $instance>::CurrencyWithoutGroup
 					);
 				});
@@ -203,9 +203,9 @@ macro_rules! currency_common_tests {
 			#[test]
 			fn move_same_group_error() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
 					assert_noop!(
-						$pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A),
+						$pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1),
 						Error::<Runtime, $instance>::CurrencyInSameGroup
 					);
 				});
@@ -215,18 +215,18 @@ macro_rules! currency_common_tests {
 			fn move_max_times() {
 				new_test_ext().execute_with(|| {
 					// First attach only attach the currency, does not move it.
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, 0));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, 0));
 
 					type Mechanism = <Runtime as crate::Config<crate::$instance>>::RewardMechanism;
 					type MaxMovements = <Mechanism as RewardMechanism>::MaxCurrencyMovements;
 
 					// Waste all correct movements.
 					for i in 0..<MaxMovements as TypedGet>::get() {
-						assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, i + 1));
+						assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, i + 1));
 					}
 
 					assert_noop!(
-						$pallet::attach_currency(DOM_1_CURRENCY_A, MaxCurrencyMovements::get() + 1),
+						$pallet::attach_currency(DOM_1_CURRENCY_X, MaxCurrencyMovements::get() + 1),
 						Error::<Runtime, $instance>::CurrencyMaxMovementsReached
 					);
 				});
@@ -237,11 +237,11 @@ macro_rules! currency_common_tests {
 				new_test_ext().execute_with(|| {
 					assert_ok!($pallet::attach_currency(
 						(DomainId::D1, CurrencyId::A),
-						GROUP_A
+						GROUP_1
 					));
 					assert_ok!($pallet::attach_currency(
 						(DomainId::D2, CurrencyId::A),
-						GROUP_A
+						GROUP_1
 					));
 
 					assert_ok!($pallet::deposit_stake(
@@ -275,19 +275,19 @@ macro_rules! claim_common_tests {
 			#[test]
 			fn nothing() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
 
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), 0);
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), 0);
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), 0);
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), 0);
 					assert_eq!(
 						free_balance(CurrencyId::A, &USER_A),
 						USER_INITIAL_BALANCE - STAKE_A
 					);
 					assert_eq!(free_balance(CurrencyId::Reward, &USER_A), 0);
 
-					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), 0);
+					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), 0);
 					assert_eq!(free_balance(CurrencyId::A, &USER_A), USER_INITIAL_BALANCE);
 					assert_eq!(free_balance(CurrencyId::Reward, &USER_A), 0);
 				});
@@ -296,13 +296,13 @@ macro_rules! claim_common_tests {
 			#[test]
 			fn basic() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
 
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					if $kind != MechanismKind::Base {
-						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 					}
 
 					assert_eq!(
@@ -310,59 +310,59 @@ macro_rules! claim_common_tests {
 						choose_balance($kind, REWARD, REWARD * 2, REWARD)
 					);
 
-					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_A, &USER_A), REWARD);
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), REWARD);
+					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_X, &USER_A), REWARD);
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), REWARD);
 
 					assert_eq!(free_balance(CurrencyId::Reward, &USER_A), REWARD);
 					assert_eq!(rewards_account(), choose_balance($kind, 0, REWARD, 0));
 
-					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_A, &USER_A), 0);
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), 0);
+					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_X, &USER_A), 0);
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), 0);
 				});
 			}
 
 			#[test]
 			fn basic_with_unstake() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
 
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
-					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
+					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 
 					let reward = choose_balance($kind, REWARD, 0, 0);
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
-					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_A, &USER_A), reward);
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), reward);
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
+					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_X, &USER_A), reward);
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), reward);
 
 					assert_eq!(free_balance(CurrencyId::Reward, &USER_A), reward);
 					assert_eq!(rewards_account(), choose_balance($kind, 0, REWARD, 0));
 
-					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_A, &USER_A), 0);
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), 0);
+					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_X, &USER_A), 0);
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), 0);
 				});
 			}
 
 			#[test]
 			fn distribute_claim_distribute_claim() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 
 					if $kind != MechanismKind::Base {
-						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 					}
 
 					for _ in 0..5 {
-						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 						assert_eq!(
 							rewards_account(),
 							choose_balance($kind, REWARD, REWARD * 2, REWARD)
 						);
 
-						assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_A, &USER_A), REWARD);
-						assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), REWARD);
+						assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_X, &USER_A), REWARD);
+						assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), REWARD);
 					}
 
 					assert_eq!(free_balance(CurrencyId::Reward, &USER_A), REWARD * 5);
@@ -373,15 +373,15 @@ macro_rules! claim_common_tests {
 			#[test]
 			fn accumulative_claim() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 
 					if $kind != MechanismKind::Base {
-						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 					}
 
 					for _ in 0..5 {
-						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 					}
 
 					assert_eq!(
@@ -390,8 +390,8 @@ macro_rules! claim_common_tests {
 					);
 
 					let reward = REWARD * 5;
-					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_A, &USER_A), reward);
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), reward);
+					assert_ok!($pallet::compute_reward(DOM_1_CURRENCY_X, &USER_A), reward);
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), reward);
 
 					assert_eq!(free_balance(CurrencyId::Reward, &USER_A), reward);
 					assert_eq!(rewards_account(), choose_balance($kind, 0, REWARD, 0));
@@ -406,22 +406,22 @@ macro_rules! claim_common_tests {
 			fn claim_several_users() {
 				new_test_ext().execute_with(|| {
 					// DISTRIBUTION 0
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					// DISTRIBUTION 1
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_B, STAKE_B));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_B, STAKE_B));
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A),
 						choose_balance($kind, REWARD, 0, 0)
 					);
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_B), 0);
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_B), 0);
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					// DISTRIBUTION 2
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A),
 						choose_balance(
 							$kind,
 							REWARD * STAKE_A / (STAKE_A + STAKE_B),
@@ -430,31 +430,31 @@ macro_rules! claim_common_tests {
 						)
 					);
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_B),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_B),
 						choose_balance($kind, REWARD * STAKE_B / (STAKE_A + STAKE_B), 0, 0)
 					);
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					// DISTRIBUTION 3
-					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A),
 						REWARD * STAKE_A / (STAKE_A + STAKE_B)
 					);
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_B),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_B),
 						REWARD * STAKE_B / (STAKE_A + STAKE_B)
 					);
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 
 					// DISTRIBUTION 4
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A),
 						choose_balance($kind, REWARD * STAKE_A / (STAKE_A + STAKE_B), 0, 0)
 					);
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_B),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_B),
 						choose_balance(
 							$kind,
 							REWARD * STAKE_B / (STAKE_A + STAKE_B),

--- a/pallets/rewards/src/tests/currency_movement.rs
+++ b/pallets/rewards/src/tests/currency_movement.rs
@@ -5,16 +5,16 @@ macro_rules! currency_movement_tests {
 			use super::*;
 
 			fn currency_movement_initial_state() {
-				assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-				assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_B, GROUP_B));
-				assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_C, GROUP_C));
-				assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_A));
-				assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_B, STAKE_A));
-				assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_B, &USER_B, STAKE_B));
-				assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_C, &USER_B, STAKE_C));
+				assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+				assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_Y, GROUP_2));
+				assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_Z, GROUP_3));
+				assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_1));
+				assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_B, STAKE_A));
+				assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_Y, &USER_B, STAKE_B));
+				assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_Z, &USER_B, STAKE_C));
 				assert_ok!($pallet::distribute_reward(
 					REWARD,
-					[GROUP_A, GROUP_B, GROUP_C]
+					[GROUP_1, GROUP_2, GROUP_3]
 				));
 			}
 
@@ -52,7 +52,7 @@ macro_rules! currency_movement_tests {
 				new_test_ext().execute_with(|| {
 					currency_movement_initial_state();
 
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_B)); // MOVEMENT HERE!!
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_2)); // MOVEMENT HERE!!
 					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_M, &USER_A), 0);
 				});
 			}
@@ -62,7 +62,7 @@ macro_rules! currency_movement_tests {
 				new_test_ext().execute_with(|| {
 					currency_movement_initial_state();
 
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_B)); // MOVEMENT HERE!!
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_2)); // MOVEMENT HERE!!
 					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
 
 					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_M, &USER_A), 0);
@@ -74,13 +74,13 @@ macro_rules! currency_movement_tests {
 				new_test_ext().execute_with(|| {
 					currency_movement_initial_state();
 
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_B)); // MOVEMENT HERE!!
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_2)); // MOVEMENT HERE!!
 					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_B]));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_2]));
 
 					check_last_claim::<$pallet>(
 						$kind,
-						GROUP_B,
+						GROUP_2,
 						DOM_1_CURRENCY_M,
 						REWARD * STAKE_M / (STAKE_M + STAKE_B),
 						REWARD * STAKE_M / (STAKE_M + STAKE_B),
@@ -95,12 +95,12 @@ macro_rules! currency_movement_tests {
 					currency_movement_initial_state();
 
 					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_B)); // MOVEMENT HERE!!
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_2)); // MOVEMENT HERE!!
 
 					check_last_claim::<$pallet>(
 						$kind,
-						GROUP_B,
+						GROUP_2,
 						DOM_1_CURRENCY_M,
 						REWARD * STAKE_M / (STAKE_M + STAKE_A),
 						REWARD * STAKE_M / (STAKE_M + STAKE_A),
@@ -115,13 +115,13 @@ macro_rules! currency_movement_tests {
 					currency_movement_initial_state();
 
 					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_B)); // MOVEMENT HERE!!
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_2)); // MOVEMENT HERE!!
 					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
 
 					check_last_claim::<$pallet>(
 						$kind,
-						GROUP_B,
+						GROUP_2,
 						DOM_1_CURRENCY_M,
 						REWARD * STAKE_M / (STAKE_M + STAKE_A),
 						0,
@@ -136,13 +136,13 @@ macro_rules! currency_movement_tests {
 					currency_movement_initial_state();
 
 					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_B)); // MOVEMENT HERE!!
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_C)); // MOVEMENT HERE!!
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_2)); // MOVEMENT HERE!!
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_3)); // MOVEMENT HERE!!
 
 					check_last_claim::<$pallet>(
 						$kind,
-						GROUP_C,
+						GROUP_3,
 						DOM_1_CURRENCY_M,
 						REWARD * STAKE_M / (STAKE_M + STAKE_A),
 						REWARD * STAKE_M / (STAKE_M + STAKE_A),
@@ -157,14 +157,14 @@ macro_rules! currency_movement_tests {
 					currency_movement_initial_state();
 
 					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_B)); // MOVEMENT HERE!!
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_C)); // MOVEMENT HERE!!
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_2)); // MOVEMENT HERE!!
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_3)); // MOVEMENT HERE!!
 					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
 
 					check_last_claim::<$pallet>(
 						$kind,
-						GROUP_C,
+						GROUP_3,
 						DOM_1_CURRENCY_M,
 						REWARD * STAKE_M / (STAKE_M + STAKE_A),
 						0,
@@ -176,28 +176,28 @@ macro_rules! currency_movement_tests {
 			#[test]
 			fn stake_distribute_cross_move_claim() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_B, GROUP_B));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_Y, GROUP_2));
 
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_B, &USER_A, STAKE_B));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_Y, &USER_A, STAKE_B));
 					assert_ok!($pallet::distribute_reward_with_weights(
 						REWARD,
-						[(GROUP_A, 1u32), (GROUP_B, 4u32)]
+						[(GROUP_1, 1u32), (GROUP_2, 4u32)]
 					));
 					if $kind != MechanismKind::Base {
 						assert_ok!($pallet::distribute_reward_with_weights(
 							REWARD,
-							[(GROUP_A, 1u32), (GROUP_B, 4u32)]
+							[(GROUP_1, 1u32), (GROUP_2, 4u32)]
 						));
 					}
 
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_B)); // MOVEMENT HERE!!
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_B, GROUP_A)); // MOVEMENT HERE!!
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_2)); // MOVEMENT HERE!!
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_Y, GROUP_1)); // MOVEMENT HERE!!
 
-					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A), REWARD / 5);
+					assert_ok!($pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A), REWARD / 5);
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_B, &USER_A),
+						$pallet::claim_reward(DOM_1_CURRENCY_Y, &USER_A),
 						4 * (REWARD / 5)
 					);
 				});
@@ -206,19 +206,19 @@ macro_rules! currency_movement_tests {
 			#[test]
 			fn correct_lost_reward_after_move() {
 				new_test_ext().execute_with(|| {
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_1));
 
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_M, &USER_A, STAKE_M));
 
-					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+					assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 					if $kind != MechanismKind::Base {
-						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_A]));
+						assert_ok!($pallet::distribute_reward(REWARD, [GROUP_1]));
 					}
 
 					assert_ok!(
-						$pallet::compute_reward(DOM_1_CURRENCY_A, &USER_A),
+						$pallet::compute_reward(DOM_1_CURRENCY_X, &USER_A),
 						REWARD * STAKE_A / (STAKE_A + STAKE_M)
 					);
 					assert_ok!(
@@ -226,10 +226,10 @@ macro_rules! currency_movement_tests {
 						REWARD * STAKE_M / (STAKE_M + STAKE_A)
 					);
 
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_B)); // MOVEMENT HERE!!
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_2)); // MOVEMENT HERE!!
 
 					assert_ok!(
-						$pallet::claim_reward(DOM_1_CURRENCY_A, &USER_A),
+						$pallet::claim_reward(DOM_1_CURRENCY_X, &USER_A),
 						REWARD * STAKE_A / (STAKE_A + STAKE_M)
 					);
 					assert_ok!(
@@ -251,22 +251,22 @@ macro_rules! currency_movement_tests {
 						&(DomainId::D1, CurrencyId::M),
 					];
 
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_A, GROUP_A));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_B, GROUP_A));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_C, GROUP_A));
-					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_A));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_X, GROUP_1));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_Y, GROUP_1));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_Z, GROUP_1));
+					assert_ok!($pallet::attach_currency(DOM_1_CURRENCY_M, GROUP_1));
 
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 					assert!(expected_currency_ids[0..1]
 						.iter()
 						.all(|x| $pallet::list_currencies(USER_A).contains(x)));
 
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_B, &USER_A, STAKE_A));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_Y, &USER_A, STAKE_A));
 					assert!(expected_currency_ids[0..2]
 						.iter()
 						.all(|x| $pallet::list_currencies(USER_A).contains(x)));
 
-					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_C, &USER_A, STAKE_A));
+					assert_ok!($pallet::deposit_stake(DOM_1_CURRENCY_Z, &USER_A, STAKE_A));
 					assert!(expected_currency_ids[0..3]
 						.iter()
 						.all(|x| $pallet::list_currencies(USER_A).contains(x)));
@@ -276,7 +276,7 @@ macro_rules! currency_movement_tests {
 						.iter()
 						.all(|x| $pallet::list_currencies(USER_A).contains(x)));
 
-					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_A, &USER_A, STAKE_A));
+					assert_ok!($pallet::withdraw_stake(DOM_1_CURRENCY_X, &USER_A, STAKE_A));
 					assert_eq!($pallet::list_currencies(USER_A).len(), 4);
 				});
 			}


### PR DESCRIPTION
# Description

This PR adds a complex test for the gap reward mechanism.

Fixes #1143

## Changes and Descriptions
- Minor test constant renamed.
- Add a complex unitary test for this the gap mechanism:
```
A,B => Users
X,Y,Z,M => Currencies
Dx => Distributions
Gx => Groups

        D0     |     D1    |          D2           |     D3    |    D4    |  D5
 G1 -----------------------------------------------------------------------------
     Stake X A | Stake Z A | MOVE Z ·              | Stake M A | MOVE X · |
               |           |        ·              |           |        · |
               |           |        v              |           |        v |
 G2 -----------------------------------------------------------------------------
     Stake Y B |           |         Unstake Z A/2 |           |          |
```

- Fix gap mechanism implementation with a movement issue found in this test.
 
## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```sh
cargo test -p pallet-rewards
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
