### PR TITLE
Synchronize ensure module with Substrate

### DIFF
--- a/libs/traits/src/ops.rs
+++ b/libs/traits/src/ops.rs
@@ -1,296 +1,88 @@
-use sp_runtime::traits::Zero;
+pub use ensure::{
+	Ensure, EnsureAdd, EnsureAddAssign, EnsureDiv, EnsureDivAssign, EnsureFixedPointNumber,
+	EnsureFrom, EnsureInto, EnsureMul, EnsureMulAssign, EnsureOp, EnsureOpAssign, EnsureSub,
+	EnsureSubAssign,
+};
 
-/// Numerical Sign
-#[derive(Clone, Copy, PartialEq)]
-pub enum NumSign {
-	/// A negative value
-	Negative,
-
-	/// A positive/zero value
-	Positive,
-}
-
-/// Request the signum of a number.
-pub trait Signum: PartialOrd + Zero + Copy {
-	/// Get the signum.
-	fn signum(&self) -> NumSign {
-		if *self < Self::zero() {
-			NumSign::Negative
-		} else {
-			NumSign::Positive
-		}
-	}
-}
-
-impl<T: PartialOrd + Zero + Copy> Signum for T {}
-
-/// Arithmetic operations with safe error handling.
-///
-/// This module provide a more readable way to do safe arithmetics, turning this:
-///
-/// ```ignore
-/// self.my_value = self.my_value.checked_sub(other_value).ok_or(ArithmeticError::Overflow)?;
-/// ```
-///
-/// into this:
-///
-/// ```ignore
-/// self.my_value.ensure_sub_assign(other_value)?;
-/// ```
-///
-/// And choose the correct [`ArithmeticError`] it should return in case of fail.
-///
-/// The *EnsureOps* family functions follows the same behavior as *CheckedOps* but
-/// returning an [`ArithmeticError`] instead of `None`.
-///
-/// [`ArithmeticError`]: sp_runtime::ArithmeticError
-pub mod ensure {
+mod ensure {
 	use sp_runtime::{
-		traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub},
+		traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero},
 		ArithmeticError, FixedPointNumber, FixedPointOperand,
 	};
 
-	use super::{NumSign, Signum};
-
-	/// Performs addition that returns `ArithmeticError` instead of wrapping around on overflow.
-	pub trait EnsureAdd: CheckedAdd + Signum {
-		/// Adds two numbers, checking for overflow.
-		/// If overflow happens, `ArithmeticError` is returned.
-		///
-		/// Similar to [`CheckedAdd::checked_add()`] but returning an `ArithmeticError` error
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureAdd;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     u32::MAX.ensure_add(1)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     i32::MIN.ensure_add(-1)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// ```
+	/// Performs addition that returns [`ArithmeticError`] instead of wrapping around on overflow.
+	pub trait EnsureAdd: CheckedAdd + PartialOrd + Zero + Copy {
 		fn ensure_add(self, v: Self) -> Result<Self, ArithmeticError> {
 			self.checked_add(&v).ok_or_else(|| error::equivalent(v))
 		}
 	}
 
-	/// Performs subtraction that returns `ArithmeticError` instead of wrapping around on underflow.
-	pub trait EnsureSub: CheckedSub + Signum {
-		/// Subtracts two numbers, checking for overflow.
-		/// If overflow happens, `ArithmeticError` is returned.
-		///
-		/// Similar to [`CheckedSub::checked_sub()`] but returning an `ArithmeticError` error
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureSub;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     0u32.ensure_sub(1)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     i32::MAX.ensure_sub(-1)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// ```
+	/// Performs subtraction that returns [`ArithmeticError`] instead of wrapping around on
+	/// underflow.
+	pub trait EnsureSub: CheckedSub + PartialOrd + Zero + Copy {
 		fn ensure_sub(self, v: Self) -> Result<Self, ArithmeticError> {
 			self.checked_sub(&v).ok_or_else(|| error::inverse(v))
 		}
 	}
 
-	/// Performs multiplication that returns `ArithmeticError` instead of wrapping around on overflow.
-	pub trait EnsureMul: CheckedMul + Signum {
-		/// Multiplies two numbers, checking for overflow. If overflow happens,
-		/// `ArithmeticError` is returned.
-		///
-		/// Similar to [`CheckedMul::checked_mul()`] but returning an `ArithmeticError` error
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureMul;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     u32::MAX.ensure_mul(2)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     i32::MAX.ensure_mul(-2)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// ```
+	/// Performs multiplication that returns [`ArithmeticError`] instead of wrapping around on
+	/// overflow.
+	pub trait EnsureMul: CheckedMul + PartialOrd + Zero + Copy {
 		fn ensure_mul(self, v: Self) -> Result<Self, ArithmeticError> {
 			self.checked_mul(&v)
 				.ok_or_else(|| error::multiplication(self, v))
 		}
 	}
 
-	/// Performs division that returns `ArithmeticError` instead of wrapping around on overflow.
-	pub trait EnsureDiv: CheckedDiv + Signum {
-		/// Divides two numbers, checking for overflow.
-		/// If overflow happens, `ArithmeticError` is returned.
-		///
-		/// Similar to [`CheckedDiv::checked_div()`] but returning an `ArithmeticError` error
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureDiv;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-		///
-		/// fn extrinsic_zero() -> DispatchResult {
-		///     1.ensure_div(0)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     FixedI64::from(i64::MIN).ensure_div(FixedI64::from(-1))?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// ```
+	/// Performs division that returns [`ArithmeticError`] instead of wrapping around on overflow.
+	pub trait EnsureDiv: CheckedDiv + PartialOrd + Zero + Copy {
 		fn ensure_div(self, v: Self) -> Result<Self, ArithmeticError> {
 			self.checked_div(&v).ok_or_else(|| error::division(self, v))
 		}
 	}
 
-	impl<T: CheckedAdd + Signum> EnsureAdd for T {}
-	impl<T: CheckedSub + Signum> EnsureSub for T {}
-	impl<T: CheckedMul + Signum> EnsureMul for T {}
-	impl<T: CheckedDiv + Signum> EnsureDiv for T {}
+	impl<T: CheckedAdd + PartialOrd + Zero + Copy> EnsureAdd for T {}
+	impl<T: CheckedSub + PartialOrd + Zero + Copy> EnsureSub for T {}
+	impl<T: CheckedMul + PartialOrd + Zero + Copy> EnsureMul for T {}
+	impl<T: CheckedDiv + PartialOrd + Zero + Copy> EnsureDiv for T {}
 
-	/// Performs self addition that returns `ArithmeticError` instead of wrapping around on overflow.
+	/// Meta trait that supports all immutable arithmetic `Ensure*` operations
+	pub trait EnsureOp: EnsureAdd + EnsureSub + EnsureMul + EnsureDiv {}
+	impl<T: EnsureAdd + EnsureSub + EnsureMul + EnsureDiv> EnsureOp for T {}
+
+	/// Performs self addition that returns [`ArithmeticError`] instead of wrapping around on
+	/// overflow.
 	pub trait EnsureAddAssign: EnsureAdd {
-		/// Adds two numbers overwriting the left hand one, checking for overflow.
-		/// If overflow happens, `ArithmeticError` is returned.
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureAddAssign;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     let mut max = u32::MAX;
-		///     max.ensure_add_assign(1)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     let mut max = i32::MIN;
-		///     max.ensure_add_assign(-1)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// ```
-		fn ensure_add_assign(&mut self, v: Self) -> Result<&mut Self, ArithmeticError> {
+		fn ensure_add_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
 			*self = self.ensure_add(v)?;
-			Ok(self)
+			Ok(())
 		}
 	}
 
-	/// Performs self subtraction that returns `ArithmeticError` instead of wrapping around on underflow.
+	/// Performs self subtraction that returns [`ArithmeticError`] instead of wrapping around on
+	/// underflow.
 	pub trait EnsureSubAssign: EnsureSub {
-		/// Subtracts two numbers overwriting the left hand one, checking for overflow.
-		/// If overflow happens, `ArithmeticError` is returned.
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureSubAssign;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     let mut zero: u32 = 0;
-		///     zero.ensure_sub_assign(1)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     let mut zero = i32::MAX;
-		///     zero.ensure_sub_assign(-1)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// ```
-		fn ensure_sub_assign(&mut self, v: Self) -> Result<&mut Self, ArithmeticError> {
+		fn ensure_sub_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
 			*self = self.ensure_sub(v)?;
-			Ok(self)
+			Ok(())
 		}
 	}
 
-	/// Performs self multiplication that returns `ArithmeticError` instead of wrapping around on overflow.
+	/// Performs self multiplication that returns [`ArithmeticError`] instead of wrapping around on
+	/// overflow.
 	pub trait EnsureMulAssign: EnsureMul {
-		/// Multiplies two numbers overwriting the left hand one, checking for overflow.
-		/// If overflow happens, `ArithmeticError` is returned.
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureMulAssign;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     let mut max = u32::MAX;
-		///     max.ensure_mul_assign(2)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     let mut max = i32::MAX;
-		///     max.ensure_mul_assign(-2)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// ```
-		fn ensure_mul_assign(&mut self, v: Self) -> Result<&mut Self, ArithmeticError> {
+		fn ensure_mul_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
 			*self = self.ensure_mul(v)?;
-			Ok(self)
+			Ok(())
 		}
 	}
 
-	/// Performs self division that returns `ArithmeticError` instead of wrapping around on overflow.
+	/// Performs self division that returns [`ArithmeticError`] instead of wrapping around on
+	/// overflow.
 	pub trait EnsureDivAssign: EnsureDiv {
-		/// Divides two numbers overwriting the left hand one, checking for overflow.
-		/// If overflow happens, `ArithmeticError` is returned.
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureDivAssign;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-		///
-		/// fn extrinsic_zero() -> DispatchResult {
-		///     let mut one = 1;
-		///     one.ensure_div_assign(0)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     let mut min = FixedI64::from(i64::MIN);
-		///     min.ensure_div_assign(FixedI64::from(-1))?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// ```
-		fn ensure_div_assign(&mut self, v: Self) -> Result<&mut Self, ArithmeticError> {
+		fn ensure_div_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
 			*self = self.ensure_div(v)?;
-			Ok(self)
+			Ok(())
 		}
 	}
 
@@ -299,30 +91,22 @@ pub mod ensure {
 	impl<T: EnsureMul> EnsureMulAssign for T {}
 	impl<T: EnsureDiv> EnsureDivAssign for T {}
 
-	/// Extends `FixedPointNumber with` the Ensure family functions.
+	/// Meta trait that supports all assigned arithmetic `Ensure*` operations
+	pub trait EnsureOpAssign:
+		EnsureAddAssign + EnsureSubAssign + EnsureMulAssign + EnsureDivAssign
+	{
+	}
+	impl<T: EnsureAddAssign + EnsureSubAssign + EnsureMulAssign + EnsureDivAssign> EnsureOpAssign
+		for T
+	{
+	}
+
+	/// Meta trait that supports all arithmetic operations
+	pub trait Ensure: EnsureOp + EnsureOpAssign {}
+	impl<T: EnsureOp + EnsureOpAssign> Ensure for T {}
+
+	/// Extends [`FixedPointNumber`] with the Ensure family functions.
 	pub trait EnsureFixedPointNumber: FixedPointNumber {
-		/// Creates `self` from a rational number. Equal to `n / d`.
-		///
-		/// Returns `ArithmeticError` if `d == 0` or `n / d` exceeds accuracy.
-		///
-		/// Similar to [`FixedPointNumber::checked_from_rational()`] but returning an `ArithmeticError` error
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureFixedPointNumber;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-		///
-		/// fn extrinsic_zero() -> DispatchResult {
-		///     FixedI64::ensure_from_rational(1, 0)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     FixedI64::ensure_from_rational(i64::MAX, -1)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// ```
 		fn ensure_from_rational<N: FixedPointOperand, D: FixedPointOperand>(
 			n: N,
 			d: D,
@@ -331,56 +115,11 @@ pub mod ensure {
 				.ok_or_else(|| error::division(n, d))
 		}
 
-		/// Ensure multiplication for integer type `N`. Equal to `self * n`.
-		///
-		/// Returns `ArithmeticError` if the result does not fit in `N`.
-		///
-		/// Similar to [`FixedPointNumber::checked_mul_int()`] but returning an ArithmeticError error
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureFixedPointNumber;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     FixedI64::from(i64::MAX).ensure_mul_int(2)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     FixedI64::from(i64::MAX).ensure_mul_int(-2)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// ```
 		fn ensure_mul_int<N: FixedPointOperand>(self, n: N) -> Result<N, ArithmeticError> {
 			self.checked_mul_int(n)
 				.ok_or_else(|| error::multiplication(self, n))
 		}
 
-		/// Ensure division for integer type `N`. Equal to `self / d`.
-		///
-		/// Returns `ArithmeticError` if the result does not fit in `N` or `d == 0`.
-		///
-		/// Similar to [`FixedPointNumber::checked_div_int()`] but returning an `ArithmeticError` error
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureFixedPointNumber;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError, FixedI64};
-		///
-		/// fn extrinsic_zero() -> DispatchResult {
-		///     FixedI64::from(1).ensure_div_int(0)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     FixedI64::from(i64::MIN).ensure_div_int(-1)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero.into()));
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// ```
 		fn ensure_div_int<D: FixedPointOperand>(self, d: D) -> Result<D, ArithmeticError> {
 			self.checked_div_int(d)
 				.ok_or_else(|| error::division(self, d))
@@ -389,89 +128,86 @@ pub mod ensure {
 
 	impl<T: FixedPointNumber> EnsureFixedPointNumber for T {}
 
-	/// Similar to [`TryFrom`] but returning an `ArithmeticError` error.
-	pub trait EnsureFrom<T: Signum>: TryFrom<T> + Signum {
-		/// Performs the conversion returning an `ArithmeticError` if fails.
-		///
-		/// Similar to [`TryFrom::try_from()`] but returning an `ArithmeticError` error
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureFrom;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     let byte: u8 = u8::ensure_from(256u16)?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     let byte: i8 = i8::ensure_from(-129i16)?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// ```
+	/// Similar to [`TryFrom`] but returning an [`ArithmeticError`] error.
+	pub trait EnsureFrom<T: PartialOrd + Zero + Copy>:
+		TryFrom<T> + PartialOrd + Zero + Copy
+	{
 		fn ensure_from(other: T) -> Result<Self, ArithmeticError> {
 			Self::try_from(other).map_err(|_| error::equivalent(other))
 		}
 	}
 
-	/// Similar to [`TryInto`] but returning an `ArithmeticError` error.
-	pub trait EnsureInto<T: Signum>: TryInto<T> + Signum {
-		/// Performs the conversion returning an `ArithmeticError` if fails.
-		///
-		/// Similar to [`TryInto::try_into()`] but returning an `ArithmeticError` error
-		///
-		/// ```
-		/// use cfg_traits::ops::ensure::EnsureInto;
-		/// use sp_runtime::{DispatchResult, ArithmeticError, DispatchError};
-		///
-		/// fn extrinsic_overflow() -> DispatchResult {
-		///     let byte: u8 = 256u16.ensure_into()?;
-		///     Ok(())
-		/// }
-		///
-		/// fn extrinsic_underflow() -> DispatchResult {
-		///     let byte: i8 = (-129i16).ensure_into()?;
-		///     Ok(())
-		/// }
-		///
-		/// assert_eq!(extrinsic_overflow(), Err(ArithmeticError::Overflow.into()));
-		/// assert_eq!(extrinsic_underflow(), Err(ArithmeticError::Underflow.into()));
-		/// ```
+	/// Similar to [`TryInto`] but returning an [`ArithmeticError`] error.
+	pub trait EnsureInto<T: PartialOrd + Zero + Copy>:
+		TryInto<T> + PartialOrd + Zero + Copy
+	{
 		fn ensure_into(self) -> Result<T, ArithmeticError> {
 			self.try_into().map_err(|_| error::equivalent(self))
 		}
 	}
 
-	impl<T: TryFrom<S> + Signum, S: Signum> EnsureFrom<S> for T {}
-	impl<T: TryInto<S> + Signum, S: Signum> EnsureInto<S> for T {}
+	impl<T: TryFrom<S> + PartialOrd + Zero + Copy, S: PartialOrd + Zero + Copy> EnsureFrom<S> for T {}
+	impl<T: TryInto<S> + PartialOrd + Zero + Copy, S: PartialOrd + Zero + Copy> EnsureInto<S> for T {}
 
 	mod error {
-		use super::{ArithmeticError, NumSign, Signum};
+		use super::{ArithmeticError, Zero};
 
-		pub fn equivalent<R: Signum>(r: R) -> ArithmeticError {
-			match r.signum() {
-				NumSign::Negative => ArithmeticError::Underflow,
-				NumSign::Positive => ArithmeticError::Overflow,
+		#[derive(PartialEq)]
+		enum Signum {
+			Negative,
+			Positive,
+		}
+
+		impl<T: PartialOrd + Zero> From<T> for Signum {
+			fn from(value: T) -> Self {
+				if value < Zero::zero() {
+					Signum::Negative
+				} else {
+					Signum::Positive
+				}
 			}
 		}
 
-		pub fn inverse<R: Signum>(r: R) -> ArithmeticError {
-			match r.signum() {
-				NumSign::Negative => ArithmeticError::Overflow,
-				NumSign::Positive => ArithmeticError::Underflow,
+		impl sp_std::ops::Mul for Signum {
+			type Output = Self;
+
+			fn mul(self, rhs: Self) -> Self {
+				if self != rhs {
+					Signum::Negative
+				} else {
+					Signum::Positive
+				}
 			}
 		}
 
-		pub fn multiplication<L: Signum, R: Signum>(l: L, r: R) -> ArithmeticError {
-			match l.signum() != r.signum() {
-				true => ArithmeticError::Underflow,
-				false => ArithmeticError::Overflow,
+		pub fn equivalent<R: PartialOrd + Zero + Copy>(r: R) -> ArithmeticError {
+			match Signum::from(r) {
+				Signum::Negative => ArithmeticError::Underflow,
+				Signum::Positive => ArithmeticError::Overflow,
 			}
 		}
 
-		pub fn division<N: Signum, D: Signum>(n: N, d: D) -> ArithmeticError {
+		pub fn inverse<R: PartialOrd + Zero + Copy>(r: R) -> ArithmeticError {
+			match Signum::from(r) {
+				Signum::Negative => ArithmeticError::Overflow,
+				Signum::Positive => ArithmeticError::Underflow,
+			}
+		}
+
+		pub fn multiplication<L: PartialOrd + Zero + Copy, R: PartialOrd + Zero + Copy>(
+			l: L,
+			r: R,
+		) -> ArithmeticError {
+			match Signum::from(l) * Signum::from(r) {
+				Signum::Negative => ArithmeticError::Underflow,
+				Signum::Positive => ArithmeticError::Overflow,
+			}
+		}
+
+		pub fn division<N: PartialOrd + Zero + Copy, D: PartialOrd + Zero + Copy>(
+			n: N,
+			d: D,
+		) -> ArithmeticError {
 			if d.is_zero() {
 				ArithmeticError::DivisionByZero
 			} else {

--- a/libs/traits/src/rewards.rs
+++ b/libs/traits/src/rewards.rs
@@ -18,7 +18,7 @@ use sp_runtime::{
 };
 use sp_std::vec::Vec;
 
-use crate::ops::ensure::{EnsureAdd, EnsureFixedPointNumber};
+use crate::ops::{EnsureAdd, EnsureFixedPointNumber};
 
 /// Abstraction over a distribution reward groups.
 pub trait GroupRewards {

--- a/pallets/liquidity-rewards/src/lib.rs
+++ b/pallets/liquidity-rewards/src/lib.rs
@@ -41,7 +41,7 @@ pub mod weights;
 mod benchmarking;
 
 pub use cfg_traits::{
-	ops::ensure::{EnsureAdd, EnsureAddAssign},
+	ops::{EnsureAdd, EnsureAddAssign},
 	rewards::{AccountRewards, CurrencyGroupChange, DistributedRewards, GroupRewards},
 };
 use frame_support::{

--- a/pallets/rewards/src/mechanism/base.rs
+++ b/pallets/rewards/src/mechanism/base.rs
@@ -1,4 +1,4 @@
-use cfg_traits::ops::ensure::{
+use cfg_traits::ops::{
 	EnsureAdd, EnsureAddAssign, EnsureFixedPointNumber, EnsureFrom, EnsureInto, EnsureSub,
 	EnsureSubAssign,
 };
@@ -48,10 +48,7 @@ where
 		let tally_to_apply = self.get_tally_from_rpt_changes(rpt_changes)?;
 
 		self.reward_tally.ensure_add_assign(tally_to_apply)?;
-		self.last_currency_movement = rpt_changes
-			.len()
-			.try_into()
-			.map_err(|_| ArithmeticError::Overflow)?;
+		self.last_currency_movement = rpt_changes.len().ensure_into()?;
 
 		Ok(())
 	}

--- a/pallets/rewards/src/mechanism/deferred.rs
+++ b/pallets/rewards/src/mechanism/deferred.rs
@@ -1,4 +1,4 @@
-use cfg_traits::ops::ensure::{
+use cfg_traits::ops::{
 	EnsureAdd, EnsureAddAssign, EnsureFixedPointNumber, EnsureInto, EnsureSub, EnsureSubAssign,
 };
 use frame_support::{pallet_prelude::*, traits::tokens};
@@ -204,7 +204,8 @@ pub mod pallet {
 
 			group.distribution_id = LastDistributionId::<T>::try_mutate(
 				|distribution_id| -> Result<T::DistributionId, DispatchError> {
-					Ok(*distribution_id.ensure_add_assign(One::one())?)
+					distribution_id.ensure_add_assign(One::one())?;
+					Ok(*distribution_id)
 				},
 			)?;
 

--- a/pallets/rewards/src/mechanism/gap.rs
+++ b/pallets/rewards/src/mechanism/gap.rs
@@ -1,4 +1,4 @@
-use cfg_traits::ops::ensure::{
+use cfg_traits::ops::{
 	EnsureAdd, EnsureAddAssign, EnsureFixedPointNumber, EnsureFrom, EnsureInto, EnsureSub,
 	EnsureSubAssign,
 };
@@ -105,11 +105,7 @@ impl<T: Config> Account<T> {
 			self.pending_stake = T::Balance::zero();
 		}
 
-		self.last_currency_movement = currency
-			.rpt_changes
-			.len()
-			.try_into()
-			.map_err(|_| ArithmeticError::Overflow)?;
+		self.last_currency_movement = currency.rpt_changes.len().ensure_into()?;
 		self.distribution_id = group.distribution_id;
 
 		Ok(())
@@ -243,7 +239,8 @@ pub mod pallet {
 
 			group.distribution_id = LastDistributionId::<T>::try_mutate(
 				|distribution_id| -> Result<T::DistributionId, DispatchError> {
-					Ok(*distribution_id.ensure_add_assign(One::one())?)
+					distribution_id.ensure_add_assign(One::one())?;
+					Ok(*distribution_id)
 				},
 			)?;
 


### PR DESCRIPTION
# Description

After merging the `ensure` module in Substrate, some minor things have changed from our current `ensure` module. This PR prepares our repo for a smooth upgrade.

The only required change to make it works is to substitute the import path `cfg_traits::ops` with `sp_arithmetic::traits`

## Type of change

- Refactor

# How Has This Been Tested?

```sh
cargo test -p cfg-traits
cargo test -p pallet-rewards
cargo test -p pallet-liquidity-rewards
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
