### PR TITLE
Update pallet pool-system with ensure methods

### DIFF
--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -15,7 +15,10 @@
 #![feature(thread_local)]
 
 use cfg_primitives::Moment;
-use cfg_traits::{Permissions, PoolInspect, PoolMutate, PoolNAV, PoolReserve};
+use cfg_traits::{
+	ops::{EnsureAdd, EnsureAddAssign, EnsureFixedPointNumber, EnsureSub, EnsureSubAssign},
+	Permissions, PoolInspect, PoolMutate, PoolNAV, PoolReserve,
+};
 use cfg_types::{
 	orders::SummarizedOrders,
 	permissions::{PermissionScope, PoolRole, Role},
@@ -571,9 +574,7 @@ pub mod pallet {
 				);
 
 				let submission_period_epoch = pool.epoch.current;
-				let total_assets = nav
-					.checked_add(&pool.reserve.total)
-					.ok_or::<DispatchError>(ArithmeticError::Overflow.into())?;
+				let total_assets = nav.ensure_add(pool.reserve.total)?;
 
 				pool.start_next_epoch(now)?;
 
@@ -862,20 +863,14 @@ pub mod pallet {
 
 			tranches.combine_with_residual_top(prices, |tranche, price| {
 				let invest_order = T::Investments::process_invest_orders(tranche.currency)?;
-				acc_invest_orders = acc_invest_orders
-					.checked_add(&invest_order.amount)
-					.ok_or(ArithmeticError::Overflow)?;
+				acc_invest_orders.ensure_add_assign(invest_order.amount)?;
 				invest_orders.push(invest_order.amount);
 
 				// Redeem order is denominated in the `TrancheCurrency`. Hence, we need to convert them into `PoolCurrency`
 				// denomination
 				let redeem_order = T::Investments::process_redeem_orders(tranche.currency)?;
-				let redeem_amount_in_pool_currency = price
-					.checked_mul_int(redeem_order.amount)
-					.ok_or(ArithmeticError::Overflow)?;
-				acc_redeem_orders = acc_redeem_orders
-					.checked_add(&redeem_amount_in_pool_currency)
-					.ok_or(ArithmeticError::Overflow)?;
+				let redeem_amount_in_pool_currency = price.ensure_mul_int(redeem_order.amount)?;
+				acc_redeem_orders.ensure_add_assign(redeem_amount_in_pool_currency)?;
 				redeem_orders.push(redeem_amount_in_pool_currency);
 
 				Ok(())
@@ -943,15 +938,9 @@ pub mod pallet {
 				.checked_add(&epoch.reserve)
 				.ok_or(Error::<T>::InvalidSolution)?;
 
-			// Mostly a sanity check. This is catched above.
-			ensure!(
-				currency_available.checked_sub(&acc_redeem).is_some(),
-				Error::<T>::InsufficientCurrency
-			);
-
 			let new_reserve = currency_available
 				.checked_sub(&acc_redeem)
-				.expect("Ensures ensures there is enough liquidity in the reserve. qed.");
+				.ok_or(Error::<T>::InsufficientCurrency)?;
 
 			Self::validate_pool_constraints(
 				PoolState::Healthy,
@@ -1142,23 +1131,14 @@ pub mod pallet {
 			pool.execute_previous_epoch()?;
 
 			let executed_amounts = epoch.tranches.fulfillment_cash_flows(solution)?;
-			let total_assets = pool
-				.reserve
-				.total
-				.checked_add(&epoch.nav)
-				.ok_or(ArithmeticError::Overflow)?;
+			let total_assets = pool.reserve.total.ensure_add(epoch.nav)?;
 			let tranche_ratios = epoch.tranches.combine_with_residual_top(
 				&executed_amounts,
-				|tranche, (invest, redeem)| {
-					tranche
-						.supply
-						.checked_add(invest)
-						.ok_or(ArithmeticError::Overflow)?
-						.checked_sub(redeem)
-						.ok_or(ArithmeticError::Underflow.into())
-						.map(|tranche_asset| {
-							Perquintill::from_rational(tranche_asset, total_assets)
-						})
+				|tranche, &(invest, redeem)| {
+					Ok(Perquintill::from_rational(
+						tranche.supply.ensure_add(invest)?.ensure_sub(redeem)?,
+						total_assets,
+					))
 				},
 			)?;
 
@@ -1185,11 +1165,7 @@ pub mod pallet {
 				let pool = pool.as_mut().ok_or(Error::<T>::NoSuchPool)?;
 				let now = Self::now();
 
-				pool.reserve.total = pool
-					.reserve
-					.total
-					.checked_add(&amount)
-					.ok_or(ArithmeticError::Overflow)?;
+				pool.reserve.total.ensure_add_assign(amount)?;
 
 				let mut remaining_amount = amount;
 				for tranche in pool.tranches.non_residual_top_slice_mut() {
@@ -1206,16 +1182,11 @@ pub mod pallet {
 					//       the "debt" of a residual tranche. More correctly they do NOT have a debt
 					//       but are rather entitled to the "left-overs".
 					tranche.debt = tranche.debt.saturating_sub(tranche_amount);
-					tranche.reserve = tranche
-						.reserve
-						.checked_add(&tranche_amount)
-						.ok_or(ArithmeticError::Overflow)?;
+					tranche.reserve.ensure_add_assign(tranche_amount)?;
 
 					// NOTE: In case there is an error in the ratios this might be critical. Hence,
 					//       we check here and error out
-					remaining_amount = remaining_amount
-						.checked_sub(&tranche_amount)
-						.ok_or(ArithmeticError::Underflow)?;
+					remaining_amount.ensure_sub_assign(tranche_amount)?;
 				}
 
 				// TODO: Add a debug log here and/or a debut_assert maybe even an error if remaining_amount != 0 at this point!
@@ -1264,10 +1235,7 @@ pub mod pallet {
 					};
 
 					tranche.reserve -= tranche_amount;
-					tranche.debt = tranche
-						.debt
-						.checked_add(&tranche_amount)
-						.ok_or(ArithmeticError::Overflow)?;
+					tranche.debt.ensure_add_assign(tranche_amount)?;
 
 					remaining_amount -= tranche_amount;
 				}

--- a/pallets/pool-system/src/pool_types.rs
+++ b/pallets/pool-system/src/pool_types.rs
@@ -11,6 +11,7 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::Moment;
+use cfg_traits::ops::{EnsureAdd, EnsureSub};
 use cfg_types::epoch::EpochState;
 use codec::{Decode, Encode};
 use frame_support::{
@@ -23,7 +24,7 @@ use scale_info::TypeInfo;
 use sp_arithmetic::traits::{BaseArithmetic, Unsigned};
 use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, One, Zero},
-	ArithmeticError, FixedPointNumber, FixedPointOperand, TypeId,
+	FixedPointNumber, FixedPointOperand, TypeId,
 };
 use sp_std::{cmp::PartialEq, vec::Vec};
 
@@ -65,20 +66,14 @@ where
 		// Update the total/available reserve for the new total value of the pool
 		let mut acc_investments = Balance::zero();
 		let mut acc_redemptions = Balance::zero();
-		for (invest, redeem) in executed_amounts.iter() {
-			acc_investments = acc_investments
-				.checked_add(invest)
-				.ok_or(ArithmeticError::Overflow)?;
-			acc_redemptions = acc_redemptions
-				.checked_add(redeem)
-				.ok_or(ArithmeticError::Overflow)?;
+		for &(invest, redeem) in executed_amounts.iter() {
+			acc_investments = acc_investments.ensure_add(invest)?;
+			acc_redemptions = acc_redemptions.ensure_add(redeem)?;
 		}
 		self.total = self
 			.total
-			.checked_add(&acc_investments)
-			.ok_or(ArithmeticError::Overflow)?
-			.checked_sub(&acc_redemptions)
-			.ok_or(ArithmeticError::Underflow)?;
+			.ensure_add(acc_investments)?
+			.ensure_sub(acc_redemptions)?;
 
 		Ok(())
 	}
@@ -208,7 +203,7 @@ impl<CurrencyId, TrancheCurrency, EpochId, Balance, Rate, MetaSize, Weight, Tran
 	> where
 	Balance: FixedPointOperand + BaseArithmetic + Unsigned + From<u64>,
 	CurrencyId: Copy,
-	EpochId: BaseArithmetic,
+	EpochId: BaseArithmetic + Copy,
 	MetaSize: Get<u32> + Copy,
 	PoolId: Copy + Encode,
 	Rate: FixedPointNumber<Inner = Balance>,
@@ -217,7 +212,7 @@ impl<CurrencyId, TrancheCurrency, EpochId, Balance, Rate, MetaSize, Weight, Tran
 	Weight: Copy + From<u128>,
 {
 	pub fn start_next_epoch(&mut self, now: Moment) -> DispatchResult {
-		self.epoch.current += One::one();
+		self.epoch.current.ensure_add(One::one())?;
 		self.epoch.last_closed = now;
 		// TODO: Remove and set state rather to EpochClosing or similar
 		// Set available reserve to 0 to disable originations while the epoch is closed but not executed

--- a/pallets/pool-system/src/solution.rs
+++ b/pallets/pool-system/src/solution.rs
@@ -10,6 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+use cfg_traits::ops::{EnsureAdd, EnsureAddAssign, EnsureFixedPointNumber, EnsureMul, EnsureSub};
 use frame_support::sp_runtime::traits::Convert;
 use sp_arithmetic::traits::Unsigned;
 use sp_runtime::ArithmeticError;
@@ -135,7 +136,7 @@ impl<Balance> EpochSolution<Balance> {
 		tranches: &EpochExecutionTranches<Balance, BalanceRatio, Weight, TrancheCurrency>,
 	) -> Result<Balance, DispatchError>
 	where
-		Balance: Zero + Copy + BaseArithmetic + Unsigned + From<u64>,
+		Balance: Copy + BaseArithmetic + Unsigned + From<u64>,
 		Weight: Copy + From<u128> + Convert<Weight, Balance>,
 		BalanceRatio: Copy,
 	{
@@ -143,33 +144,27 @@ impl<Balance> EpochSolution<Balance> {
 			.iter()
 			.zip(tranches.residual_top_slice())
 			.zip(tranches.calculate_weights())
-			.fold(
-				(Some(Balance::zero()), Some(Balance::zero())),
+			.try_fold(
+				(Balance::zero(), Balance::zero()),
 				|(invest_score, redeem_score),
-				 ((solution, tranches), (invest_weight, redeem_weight))| {
-					(
-						invest_score.and_then(|score| {
-							solution
-								.invest_fulfillment
-								.mul_floor(tranches.invest)
-								.checked_mul(&Weight::convert(invest_weight))
-								.and_then(|score_tranche| score.checked_add(&score_tranche))
-						}),
-						redeem_score.and_then(|score| {
-							solution
-								.redeem_fulfillment
-								.mul_floor(tranches.redeem)
-								.checked_mul(&Weight::convert(redeem_weight))
-								.and_then(|score_tranche| score.checked_add(&score_tranche))
-						}),
-					)
+				 ((solution, tranches), (invest_weight, redeem_weight))|
+				 -> Result<_, DispatchError> {
+					Ok((
+						solution
+							.invest_fulfillment
+							.mul_floor(tranches.invest)
+							.ensure_mul(Weight::convert(invest_weight))?
+							.ensure_add(invest_score)?,
+						solution
+							.redeem_fulfillment
+							.mul_floor(tranches.redeem)
+							.ensure_mul(Weight::convert(redeem_weight))?
+							.ensure_add(redeem_score)?,
+					))
 				},
-			);
+			)?;
 
-		invest_score
-			.zip(redeem_score)
-			.and_then(|(invest_score, redeem_score)| invest_score.checked_add(&redeem_score))
-			.ok_or(ArithmeticError::Overflow.into())
+		Ok(invest_score.ensure_add(redeem_score)?)
 	}
 
 	/// Scores a solution and returns a healthy solution as a result.
@@ -224,12 +219,12 @@ impl<Balance> EpochSolution<Balance> {
 						.iter()
 						.zip(risk_buffers)
 						.map(|(tranche, risk_buffer)| {
-							tranche.min_risk_buffer.checked_sub(&risk_buffer).map(
-								|div: Perquintill| div.saturating_reciprocal_mul(Balance::one()),
-							)
+							Ok(tranche
+								.min_risk_buffer
+								.ensure_sub(risk_buffer)?
+								.saturating_reciprocal_mul(Balance::one()))
 						})
-						.collect::<Option<Vec<_>>>()
-						.ok_or(ArithmeticError::Overflow)?,
+						.collect::<Result<Vec<_>, ArithmeticError>>()?,
 				)
 			} else {
 				None
@@ -239,34 +234,21 @@ impl<Balance> EpochSolution<Balance> {
 			let mut acc_invest = Balance::zero();
 			let mut acc_redeem = Balance::zero();
 			tranches.combine_with_residual_top(solution, |tranche, solution| {
-				acc_invest = solution
-					.invest_fulfillment
-					.mul_floor(tranche.invest)
-					.checked_add(&acc_invest)
-					.ok_or(ArithmeticError::Overflow)?;
+				acc_invest
+					.ensure_add_assign(solution.invest_fulfillment.mul_floor(tranche.invest))?;
 
-				acc_redeem = solution
-					.invest_fulfillment
-					.mul_floor(tranche.redeem)
-					.checked_add(&acc_redeem)
-					.ok_or(ArithmeticError::Overflow)?;
+				acc_redeem
+					.ensure_add_assign(solution.invest_fulfillment.mul_floor(tranche.redeem))?;
+
 				Ok(())
 			})?;
 
-			let new_reserve = reserve
-				.checked_add(&acc_invest)
-				.ok_or(ArithmeticError::Overflow)?
-				.checked_sub(&acc_redeem)
-				.ok_or(ArithmeticError::Underflow)?;
+			let new_reserve = reserve.ensure_add(acc_invest)?.ensure_sub(acc_redeem)?;
 
 			// Score: 1 / (new reserve - max reserve)
 			// A higher score means the distance to the max reserve is smaller
-			let reserve_diff = new_reserve
-				.checked_sub(&max_reserve)
-				.ok_or(ArithmeticError::Underflow)?;
-			let score = BalanceRatio::one()
-				.checked_div_int(reserve_diff)
-				.ok_or(ArithmeticError::Overflow)?;
+			let reserve_diff = new_reserve.ensure_sub(max_reserve)?;
+			let score = BalanceRatio::one().ensure_div_int(reserve_diff)?;
 
 			Some(score)
 		} else {
@@ -413,23 +395,17 @@ where
 		.residual_top_slice()
 		.iter()
 		.zip(solution)
-		.fold(Some(Balance::zero()), |sum, (tranche, solution)| {
-			sum.and_then(|sum| {
-				sum.checked_add(&solution.invest_fulfillment.mul_floor(tranche.invest))
-			})
-		})
-		.ok_or(ArithmeticError::Overflow)?;
+		.try_fold(Balance::zero(), |sum, (tranche, solution)| {
+			sum.ensure_add(solution.invest_fulfillment.mul_floor(tranche.invest))
+		})?;
 
 	let acc_redeem: Balance = epoch_tranches
 		.residual_top_slice()
 		.iter()
 		.zip(solution)
-		.fold(Some(Balance::zero()), |sum, (tranche, solution)| {
-			sum.and_then(|sum| {
-				sum.checked_add(&solution.redeem_fulfillment.mul_floor(tranche.redeem))
-			})
-		})
-		.ok_or(ArithmeticError::Overflow)?;
+		.try_fold(Balance::zero(), |sum, (tranche, solution)| {
+			sum.ensure_add(solution.redeem_fulfillment.mul_floor(tranche.redeem))
+		})?;
 
 	let new_tranche_supplies = epoch_tranches.supplies_with_fulfillment(solution)?;
 	let tranche_prices = epoch_tranches.prices();


### PR DESCRIPTION
# Description

Add `ensure_ops` methods to `pallet-pool-system` when it improves readability. This doesn't change any behavior.

Issue #1153 

## Changes and Descriptions

- Simplify some maths operations with `ensure_ops` methods.
- Other minor math simplifications

## Type of change 
- Refactor (non-breaking change)

# How Has This Been Tested?

```sh
cargo test -p pallet-pool-system
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
