### PR TITLE
Change pool-system event names

### DIFF
--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -203,7 +203,7 @@ impl<T: Config> PoolMutate<T::AccountId, T::PoolId> for Pallet<T> {
 
 		Pool::<T>::insert(pool_id, pool_details.clone());
 
-		Self::deposit_event(Event::PoolCreated {
+		Self::deposit_event(Event::Created {
 			admin: admin.clone(),
 			depositor,
 			pool_id,

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -397,7 +397,7 @@ pub mod pallet {
 				T::MaxTokenSymbolLength,
 			>,
 		},
-		/// An Pool was updated.
+		/// A pool was updated.
 		Updated {
 			id: T::PoolId,
 			old: PoolEssence<

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -383,7 +383,7 @@ pub mod pallet {
 			pool_id: T::PoolId,
 			epoch_id: T::EpochId,
 		},
-		/// An Pool was created.
+		/// A pool was created.
 		Created {
 			admin: T::AccountId,
 			depositor: T::AccountId,

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -384,7 +384,7 @@ pub mod pallet {
 			epoch_id: T::EpochId,
 		},
 		/// An Pool was created.
-		PoolCreated {
+		Created {
 			admin: T::AccountId,
 			depositor: T::AccountId,
 			pool_id: T::PoolId,
@@ -398,7 +398,7 @@ pub mod pallet {
 			>,
 		},
 		/// An Pool was updated.
-		PoolUpdated {
+		Updated {
 			id: T::PoolId,
 			old: PoolEssence<
 				T::CurrencyId,
@@ -1040,7 +1040,7 @@ pub mod pallet {
 					}
 				}
 
-				Self::deposit_event(Event::PoolUpdated {
+				Self::deposit_event(Event::Updated {
 					id: *pool_id,
 					old: old_pool,
 					new: pool


### PR DESCRIPTION
closes #1130

# Description
Updates the naming from pool-system events. 

* `PoolSystem::PoolCreated` -> `PoolSystem::Created`
* `PoolSystem::PoolUpdated` -> `PoolSystem::Updated`

## Changes and Descriptions
This is needed before we release as this is hard to change afterwards in our indexing logic.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
