### PR TITLE
Add loan actions table documentation

### DIFF
--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -14,6 +14,20 @@
 //! # Loan pallet
 //!
 //! This pallet provides functionality for managing loans on Tinlake
+//!
+//! Check the next table as an overview of the possible actions you can do for managing loans:
+//!
+//! |      Action     |   From  |    To   |      Role     | Collateral Owner |
+//! |-----------------|---------|---------|---------------|------------------|
+//! |      create     |         | Created |    Borrower   |        Yes       |
+//! |      price      | Created |  Active | PrincingAdmin |                  |
+//! |      extend     |  Active |  Active | PrincingAdmin |                  |
+//! |      borrow     |  Active |  Active |               |        Yes       |
+//! |      repay      |  Active |  Active |               |        Yes       |
+//! |    write_off    |  Active |  Active |               |                  |
+//! | admin_write_off |  Active |  Active |   LoanAdmin   |                  |
+//! |      close      |  Active |  Close  |               |        Yes       |
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -20,13 +20,12 @@
 //! |      Action     |   From  |    To   |      Role     | Collateral Owner |
 //! |-----------------|---------|---------|---------------|------------------|
 //! |      create     |         | Created |    Borrower   |        Yes       |
-//! |      price      | Created |  Active | PrincingAdmin |                  |
-//! |      extend     |  Active |  Active | PrincingAdmin |                  |
+//! |      price      | Created |  Active | PricingAdmin |                  |
 //! |      borrow     |  Active |  Active |               |        Yes       |
 //! |      repay      |  Active |  Active |               |        Yes       |
 //! |    write_off    |  Active |  Active |               |                  |
 //! | admin_write_off |  Active |  Active |   LoanAdmin   |                  |
-//! |      close      |  Active |  Close  |               |        Yes       |
+//! |      close      |  Active |  Closed  |               |        Yes       |
 
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
# Description

Add a table with the loan actions and requirements to the main `pallet-loan` docs. I think this can be helpful for a new reader of this pallet.

*I've already supposed the refactor done in #1155*

## Changes and Descriptions

- Added documentation table

## Type of change

- Documentation

# How Has This Been Tested?

```sh
cargo doc -p pallet-loans
```

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
