### PR TITLE
Add `account_for` to `PoolInspect` trait

### DIFF
--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -134,6 +134,8 @@ pub trait PoolInspect<AccountId, CurrencyId> {
 		pool_id: Self::PoolId,
 		tranche_id: Self::TrancheId,
 	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>>;
+
+	/// Get the account used for the given `pool_id`.
 	fn account_for(pool_id: Self::PoolId) -> AccountId;
 }
 

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -134,6 +134,7 @@ pub trait PoolInspect<AccountId, CurrencyId> {
 		pool_id: Self::PoolId,
 		tranche_id: Self::TrancheId,
 	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>>;
+	fn account_for(pool_id: Self::PoolId) -> AccountId;
 }
 
 /// Variants for valid Pool updates to send out as events

--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -75,6 +75,10 @@ impl<T: Config> PoolInspect<T::AccountId, T::CurrencyId> for Pallet<T> {
 			last_updated: nav_last_updated,
 		})
 	}
+
+	fn account_for(pool_id: Self::PoolId) -> T::AccountId {
+		PoolLocator { pool_id }.into_account_truncating()
+	}
 }
 
 impl<T: Config> PoolMutate<T::AccountId, T::PoolId> for Pallet<T> {


### PR DESCRIPTION
# Description

By now, if all of you agree, implemented solution 3º of the issue.

Fixes #1185 

## Changes and Descriptions

Adds `account_for` to get the account for a specific `pool_id` to the `PoolInspect` trait.

## Type of change

- Refactor

# How Has This Been Tested?

...

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
