### PR TITLE
Added fuzzy test. Modified return type for distributions methods. 

### DIFF
--- a/pallets/liquidity-rewards/src/benchmarking.rs
+++ b/pallets/liquidity-rewards/src/benchmarking.rs
@@ -29,7 +29,7 @@ fn init_test_mock_with_expectations() -> impl Sized {
 		ctx1.expect().return_const(100u64);
 
 		let ctx2 = MockRewards::reward_group_context();
-		ctx2.expect().return_const(Ok(()));
+		ctx2.expect().return_const(Ok(0));
 
 		let ctx3 = MockRewards::deposit_stake_context();
 		ctx3.expect().return_const(Ok(()));

--- a/pallets/liquidity-rewards/src/tests.rs
+++ b/pallets/liquidity-rewards/src/tests.rs
@@ -238,7 +238,7 @@ fn weight_changes() {
 						_ => unreachable!(),
 					}
 			})
-			.returning(|_, _| Ok(()));
+			.returning(|_, rewards| Ok(rewards));
 
 		Liquidity::on_initialize(INITIAL_EPOCH_DURATION * 3);
 	});

--- a/pallets/rewards/src/lib.rs
+++ b/pallets/rewards/src/lib.rs
@@ -223,22 +223,25 @@ pub mod pallet {
 			T::RewardMechanism::is_ready(&group)
 		}
 
-		fn reward_group(group_id: Self::GroupId, reward: Self::Balance) -> DispatchResult {
+		fn reward_group(
+			group_id: Self::GroupId,
+			reward: Self::Balance,
+		) -> Result<Self::Balance, DispatchError> {
 			Groups::<T, I>::try_mutate(group_id, |group| {
-				let reward = T::RewardMechanism::reward_group(group, reward)?;
+				let reward_to_mint = T::RewardMechanism::reward_group(group, reward)?;
 
 				T::Currency::mint_into(
 					T::RewardCurrency::get(),
 					&T::PalletId::get().into_account_truncating(),
-					reward,
+					reward_to_mint,
 				)?;
 
 				Self::deposit_event(Event::GroupRewarded {
 					group_id,
-					amount: reward,
+					amount: reward_to_mint,
 				});
 
-				Ok(())
+				Ok(reward_to_mint)
 			})
 		}
 

--- a/pallets/rewards/src/tests.rs
+++ b/pallets/rewards/src/tests.rs
@@ -1,6 +1,6 @@
+mod command_based;
 mod common;
 mod currency_movement;
-mod fuzzy;
 
 use cfg_traits::rewards::DistributedRewards;
 use frame_support::{assert_noop, assert_ok, traits::fungibles::Inspect};

--- a/pallets/rewards/src/tests.rs
+++ b/pallets/rewards/src/tests.rs
@@ -1,5 +1,6 @@
 mod common;
 mod currency_movement;
+mod fuzzy;
 
 use cfg_traits::rewards::DistributedRewards;
 use frame_support::{assert_noop, assert_ok, traits::fungibles::Inspect};

--- a/pallets/rewards/src/tests/command_based.rs
+++ b/pallets/rewards/src/tests/command_based.rs
@@ -1,3 +1,6 @@
+//! mod to build fuzzy tests based on commands that needs to be processed
+//! without modify the invariants
+
 use std::collections::BTreeSet;
 
 use super::*;
@@ -92,47 +95,43 @@ where
 	});
 }
 
-mod fuzzy {
-	use super::*;
+/// A sample that emulates a fuzzer that only generates and tests one hardcoded command combination
+/// from the following matrix:
+///
+/// | Action     | Participants | Calls  | Total  |
+/// |-           |-             |-       |-       |
+/// | stake      | A, B         | 2      | 4      |
+/// | unstake    | A, B         | 2      | 4      |
+/// | claim      | A, B         | 2      | 4      |
+/// | distribute |  -           | 2      | 2      |
+///
+/// It uses 1 group, 1 domain and 1 currency.
+/// It uses the `base` mechanism.
+#[test]
+fn silly_sample_for_fuzzer() {
+	const DOM_CURR: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::A);
+	const AMOUNT_A1: u64 = 100;
+	const AMOUNT_B1: u64 = 200;
+	const AMOUNT_A2: u64 = 300;
+	const AMOUNT_B2: u64 = 400;
 
-	/// A fuzzer that only generates and tests one hardcoded command combination
-	/// from the next matrix:
-	///
-	/// | Action     | Participants | Calls  | Total  |
-	/// |-           |-             |-       |-       |
-	/// | stake      | A, B         | 2      | 4      |
-	/// | unstake    | A, B         | 2      | 4      |
-	/// | claim      | A, B         | 2      | 4      |
-	/// | distribute |  -           | 2      | 2      |
-	///
-	/// It uses 1 group, 1 domain and 1 currency.
-	/// It uses the `base` mechanism.
-	#[test]
-	fn silly_fuzzer() {
-		const DOM_CURR: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::A);
-		const AMOUNT_A1: u64 = 100;
-		const AMOUNT_B1: u64 = 200;
-		const AMOUNT_A2: u64 = 300;
-		const AMOUNT_B2: u64 = 400;
+	let commands = [
+		Command::AttachCurrency(DOM_CURR, GROUP_1),
+		Command::Stake(DOM_CURR, USER_A, AMOUNT_A1),
+		Command::Stake(DOM_CURR, USER_A, AMOUNT_A2),
+		Command::Stake(DOM_CURR, USER_B, AMOUNT_B1),
+		Command::Stake(DOM_CURR, USER_B, AMOUNT_B2),
+		Command::Distribute(vec![GROUP_1], REWARD),
+		Command::Claim(DOM_CURR, USER_A),
+		Command::Claim(DOM_CURR, USER_B),
+		Command::Unstake(DOM_CURR, USER_A, AMOUNT_A1),
+		Command::Unstake(DOM_CURR, USER_A, AMOUNT_A2),
+		Command::Unstake(DOM_CURR, USER_B, AMOUNT_B1),
+		Command::Unstake(DOM_CURR, USER_B, AMOUNT_B2),
+		Command::Claim(DOM_CURR, USER_A),
+		Command::Claim(DOM_CURR, USER_B),
+		Command::Distribute(vec![GROUP_1], REWARD),
+	];
 
-		let commands = [
-			Command::AttachCurrency(DOM_CURR, GROUP_1),
-			Command::Stake(DOM_CURR, USER_A, AMOUNT_A1),
-			Command::Stake(DOM_CURR, USER_A, AMOUNT_A2),
-			Command::Stake(DOM_CURR, USER_B, AMOUNT_B1),
-			Command::Stake(DOM_CURR, USER_B, AMOUNT_B2),
-			Command::Distribute(vec![GROUP_1], REWARD),
-			Command::Claim(DOM_CURR, USER_A),
-			Command::Claim(DOM_CURR, USER_B),
-			Command::Unstake(DOM_CURR, USER_A, AMOUNT_A1),
-			Command::Unstake(DOM_CURR, USER_A, AMOUNT_A2),
-			Command::Unstake(DOM_CURR, USER_B, AMOUNT_B1),
-			Command::Unstake(DOM_CURR, USER_B, AMOUNT_B2),
-			Command::Claim(DOM_CURR, USER_A),
-			Command::Claim(DOM_CURR, USER_B),
-			Command::Distribute(vec![GROUP_1], REWARD),
-		];
-
-		evaluate_sample::<Rewards1>(commands);
-	}
+	evaluate_sample::<Rewards1>(commands);
 }

--- a/pallets/rewards/src/tests/fuzzy.rs
+++ b/pallets/rewards/src/tests/fuzzy.rs
@@ -1,0 +1,138 @@
+use std::collections::BTreeSet;
+
+use super::*;
+
+type Account = u64;
+type Balance = u64;
+type Group = u32;
+
+#[derive(Clone)]
+enum Command {
+	AttachCurrency((DomainId, CurrencyId), Group),
+	Stake((DomainId, CurrencyId), Account, Balance),
+	Unstake((DomainId, CurrencyId), Account, Balance),
+	Claim((DomainId, CurrencyId), Account),
+	Distribute(Vec<Group>, Balance),
+}
+
+struct TestState<Rewards> {
+	total_distributed: Balance,
+	accounts_used: BTreeSet<Account>,
+	_reward_system_t: std::marker::PhantomData<Rewards>,
+}
+
+impl<Rewards> Default for TestState<Rewards> {
+	fn default() -> Self {
+		Self {
+			total_distributed: 0,
+			accounts_used: BTreeSet::default(),
+			_reward_system_t: Default::default(),
+		}
+	}
+}
+
+impl<Rewards> TestState<Rewards>
+where
+	Rewards: DistributedRewards<GroupId = u32, Balance = Balance>
+		+ AccountRewards<Account, Balance = Balance, CurrencyId = (DomainId, CurrencyId)>,
+{
+	fn apply_command(&mut self, command: Command) -> DispatchResult {
+		match command {
+			Command::AttachCurrency(dom_curr, group) => {
+				Rewards1::attach_currency(dom_curr, group)?;
+			}
+			Command::Stake(dom_curr, account, amount) => {
+				Rewards::deposit_stake(dom_curr, &account, amount)?;
+				self.accounts_used.insert(account);
+			}
+			Command::Unstake(dom_curr, account, amount) => {
+				Rewards::withdraw_stake(dom_curr, &account, amount)?;
+				self.accounts_used.insert(account);
+			}
+			Command::Claim(dom_curr, account) => {
+				Rewards::claim_reward(dom_curr, &account)?;
+				self.accounts_used.insert(account);
+			}
+			Command::Distribute(groups, reward) => {
+				self.total_distributed += Rewards::distribute_reward(reward, groups)?
+					.iter()
+					.filter_map(|e| e.ok())
+					.fold(0, |acc, group_reward| acc + group_reward);
+			}
+		};
+
+		Ok(())
+	}
+
+	/// Checks the system invariant. Valid for `base` and `gap` mechanisms
+	fn validate(&mut self) {
+		let total_claimed = self.accounts_used.iter().fold(0, |acc, account| {
+			acc + free_balance(CurrencyId::Reward, account)
+		});
+
+		assert_eq!(self.total_distributed, total_claimed + rewards_account());
+	}
+}
+
+fn evaluate_sample<Rewards>(commands: impl IntoIterator<Item = Command>)
+where
+	Rewards: DistributedRewards<GroupId = u32, Balance = Balance>
+		+ AccountRewards<Account, Balance = Balance, CurrencyId = (DomainId, CurrencyId)>,
+{
+	new_test_ext().execute_with(|| {
+		let mut state = TestState::<Rewards>::default();
+
+		for command in commands {
+			// We do not care if we fail applying the command.
+			// We only care if the invariant is preserved even if we fail doing it.
+			state.apply_command(command.clone()).ok();
+		}
+
+		state.validate();
+	});
+}
+
+mod fuzzy {
+	use super::*;
+
+	/// A fuzzer that only generates and tests one hardcoded command combination
+	/// from the next matrix:
+	///
+	/// | Action     | Participants | Calls  | Total  |
+	/// |-           |-             |-       |-       |
+	/// | stake      | A, B         | 2      | 4      |
+	/// | unstake    | A, B         | 2      | 4      |
+	/// | claim      | A, B         | 2      | 4      |
+	/// | distribute |  -           | 2      | 2      |
+	///
+	/// It uses 1 group, 1 domain and 1 currency.
+	/// It uses the `base` mechanism.
+	#[test]
+	fn silly_fuzzer() {
+		const DOM_CURR: (DomainId, CurrencyId) = (DomainId::D1, CurrencyId::A);
+		const AMOUNT_A1: u64 = 100;
+		const AMOUNT_B1: u64 = 200;
+		const AMOUNT_A2: u64 = 300;
+		const AMOUNT_B2: u64 = 400;
+
+		let commands = [
+			Command::AttachCurrency(DOM_CURR, GROUP_1),
+			Command::Stake(DOM_CURR, USER_A, AMOUNT_A1),
+			Command::Stake(DOM_CURR, USER_A, AMOUNT_A2),
+			Command::Stake(DOM_CURR, USER_B, AMOUNT_B1),
+			Command::Stake(DOM_CURR, USER_B, AMOUNT_B2),
+			Command::Distribute(vec![GROUP_1], REWARD),
+			Command::Claim(DOM_CURR, USER_A),
+			Command::Claim(DOM_CURR, USER_B),
+			Command::Unstake(DOM_CURR, USER_A, AMOUNT_A1),
+			Command::Unstake(DOM_CURR, USER_A, AMOUNT_A2),
+			Command::Unstake(DOM_CURR, USER_B, AMOUNT_B1),
+			Command::Unstake(DOM_CURR, USER_B, AMOUNT_B2),
+			Command::Claim(DOM_CURR, USER_A),
+			Command::Claim(DOM_CURR, USER_B),
+			Command::Distribute(vec![GROUP_1], REWARD),
+		];
+
+		evaluate_sample::<Rewards1>(commands);
+	}
+}


### PR DESCRIPTION
# Description

This PR adds a basic fuzzy schema with the target of testing all possible combinations done in `pallet-rewards`.

Fixes #1184

## Changes and Descriptions

### `pallet-rewards`

Added a `fuzzy` module to create fuzzy tests.

### `cfg-traits` 

- Modify the return type of distribution methods, in order to give more accurate information about what happens when it distributes. i.e be able to know the exactly minted reward. **The internal logic has no change.**
- `reward_group()` now returns the minted balance.

## Type of change

- Testing
- Internal API change (not external)

# How Has This Been Tested?

```sh
cargo test -p cfg-traits
cargo test -p pallet-rewards
cargo test -p pallet-liquidity
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
