### PR TITLE
proxy: Add utility pallet access to PodOperation proxy

### DIFF
--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -544,9 +544,12 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				RuntimeCall::Keystore(pallet_keystore::Call::add_keys { .. })
 					| RuntimeCall::Keystore(pallet_keystore::Call::revoke_keys { .. })
 			),
-			ProxyType::PodOperation => {
-				matches!(c, RuntimeCall::Uniques(..) | RuntimeCall::Anchor(..))
-			}
+			ProxyType::PodOperation => matches!(
+				c,
+				RuntimeCall::Uniques(..)
+					| RuntimeCall::Anchor(..)
+					| RuntimeCall::Utility(pallet_utility::Call::batch_all { .. })
+			),
 			// This type of proxy is used only for authenticating with the centrifuge POD,
 			// having it here also allows us to validate authentication with on-chain data.
 			ProxyType::PodAuth => false,


### PR DESCRIPTION
# Description

In an effort to speed up the process of NFT minting in the POD, we would need to batch a couple of extrinsics. 

This change is meant to allow the POD operator to use the utility batch call on behalf of the identity that is minting the NFT.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by running all the available test suites in the centrifuge POD.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I rebased on the latest `main` branch
