### PR TITLE
Interest accrual API only with yearly rates

### DIFF
--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -233,7 +233,7 @@ pub trait InterestAccrual<InterestRate, Balance, Adjustment> {
 
 	/// Calculate the current debt using normalized debt * cumulative rate
 	fn current_debt(
-		interest_rate_per_sec: InterestRate,
+		interest_rate_per_year: InterestRate,
 		normalized_debt: Self::NormalizedDebt,
 	) -> Result<Balance, DispatchError>;
 
@@ -244,14 +244,14 @@ pub trait InterestAccrual<InterestRate, Balance, Adjustment> {
 	/// (effectively "rewinding the clock" to before the value was
 	/// valid)
 	fn previous_debt(
-		interest_rate_per_sec: InterestRate,
+		interest_rate_per_year: InterestRate,
 		normalized_debt: Self::NormalizedDebt,
 		when: Moment,
 	) -> Result<Balance, DispatchError>;
 
 	/// Increase or decrease the normalized debt
 	fn adjust_normalized_debt(
-		interest_rate_per_sec: InterestRate,
+		interest_rate_per_year: InterestRate,
 		normalized_debt: Self::NormalizedDebt,
 		adjustment: Adjustment,
 	) -> Result<Self::NormalizedDebt, DispatchError>;

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -263,23 +263,11 @@ pub trait InterestAccrual<InterestRate, Balance, Adjustment> {
 		normalized_debt: Self::NormalizedDebt,
 	) -> Result<Self::NormalizedDebt, DispatchError>;
 
-	/// Indicate that a yearly rate is in use
-	///
-	/// Validates that the rate is allowed, and converts it to a per-second rate for future operations
-	fn reference_yearly_rate(
-		interest_rate_per_year: InterestRate,
-	) -> Result<InterestRate, DispatchError>;
-
-	/// Indicate that a rate is in use
-	fn reference_rate(interest_rate_per_sec: InterestRate) -> DispatchResult;
+	/// Validate and indicate that a yearly rate is in use
+	fn reference_rate(interest_rate_per_year: InterestRate) -> DispatchResult;
 
 	/// Indicate that a rate is no longer in use
-	fn unreference_rate(interest_rate_per_sec: InterestRate) -> DispatchResult;
-
-	/// Verifies a yearly additive rate and converts it to a per-second additive rate
-	fn convert_additive_rate_to_per_sec(
-		interset_rate_per_year: InterestRate,
-	) -> Result<InterestRate, DispatchError>;
+	fn unreference_rate(interest_rate_per_year: InterestRate) -> DispatchResult;
 
 	/// Returns a collection of pre-computed rates to perform multiple operations with
 	fn rates() -> Self::Rates;

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -269,6 +269,9 @@ pub trait InterestAccrual<InterestRate, Balance, Adjustment> {
 	/// Indicate that a rate is no longer in use
 	fn unreference_rate(interest_rate_per_year: InterestRate) -> DispatchResult;
 
+	/// Ask if the rate is valid to use by the implementation
+	fn validate_rate(interest_rate_per_year: InterestRate) -> DispatchResult;
+
 	/// Returns a collection of pre-computed rates to perform multiple operations with
 	fn rates() -> Self::Rates;
 }

--- a/pallets/interest-accrual/src/lib.rs
+++ b/pallets/interest-accrual/src/lib.rs
@@ -155,6 +155,12 @@ mod test_utils;
 
 pub use pallet::*;
 
+// TODO: This "magic" number can be removed: tracking issue #1297
+// For now it comes from `pallet-loans` demands:
+// possible interest rates < 1 plus a penalty from [0, 1].
+// Which in the worst cases could be near to 2.
+const MAX_INTEREST_RATE: u32 = 2; // Which corresponds to 200%.
+
 // Type aliases
 type RateDetailsOf<T> = RateDetails<<T as Config>::InterestRate>;
 
@@ -486,8 +492,9 @@ pub mod pallet {
 			interest_rate_per_year: T::InterestRate,
 		) -> DispatchResult {
 			let four_decimals = T::InterestRate::saturating_from_integer(10000);
+			let maximum = T::InterestRate::saturating_from_integer(MAX_INTEREST_RATE);
 			ensure!(
-				interest_rate_per_year <= T::InterestRate::saturating_from_integer(2)
+				interest_rate_per_year <= maximum
 					&& interest_rate_per_year >= Zero::zero()
 					&& (interest_rate_per_year.saturating_mul(four_decimals)).frac()
 						== Zero::zero(),

--- a/pallets/interest-accrual/src/lib.rs
+++ b/pallets/interest-accrual/src/lib.rs
@@ -435,7 +435,7 @@ pub mod pallet {
 				match rate {
 					Some(rate) => Ok(rate.reference_count.ensure_add_assign(1)?),
 					None => {
-						Self::validate_rate(interest_rate_per_year)?;
+						Self::validate_interest_rate(interest_rate_per_year)?;
 
 						let new_rate = RateDetailsOf::<T> {
 							interest_rate_per_sec,
@@ -482,10 +482,12 @@ pub mod pallet {
 				.ok_or_else(|| Error::<T>::NoSuchRate.into())
 		}
 
-		pub(crate) fn validate_rate(interest_rate_per_year: T::InterestRate) -> DispatchResult {
+		pub(crate) fn validate_interest_rate(
+			interest_rate_per_year: T::InterestRate,
+		) -> DispatchResult {
 			let four_decimals = T::InterestRate::saturating_from_integer(10000);
 			ensure!(
-				interest_rate_per_year <= One::one()
+				interest_rate_per_year <= T::InterestRate::saturating_from_integer(2)
 					&& interest_rate_per_year >= Zero::zero()
 					&& (interest_rate_per_year.saturating_mul(four_decimals)).frac()
 						== Zero::zero(),
@@ -538,6 +540,10 @@ impl<T: Config> InterestAccrual<T::InterestRate, T::Balance, Adjustment<T::Balan
 
 	fn unreference_rate(interest_rate_per_year: T::InterestRate) -> sp_runtime::DispatchResult {
 		Pallet::<T>::unreference_interest_rate(interest_rate_per_year)
+	}
+
+	fn validate_rate(interest_rate_per_year: T::InterestRate) -> sp_runtime::DispatchResult {
+		Pallet::<T>::validate_interest_rate(interest_rate_per_year)
 	}
 
 	fn rates() -> Self::Rates {

--- a/pallets/interest-accrual/src/migrations.rs
+++ b/pallets/interest-accrual/src/migrations.rs
@@ -94,7 +94,12 @@ pub mod v2 {
 			.map_err(|_| "Error decoding pre-upgrade state")?;
 
 			for (rate_per_sec, old_rate) in old_rates.into_iter().flatten() {
-				let new_rate = Pallet::<T>::get_rate(rate_per_sec)
+				let rate_per_year = rate_per_sec
+					.checked_sub(&One::one())
+					.unwrap()
+					.saturating_mul(T::InterestRate::saturating_from_integer(SECONDS_PER_YEAR));
+
+				let new_rate = Pallet::<T>::get_rate(rate_per_year)
 					.map_err(|_| "Expected rate not found in new state")?;
 				if new_rate.accumulated_rate != old_rate.accumulated_rate {
 					return Err("Accumulated rate was not correctly migrated");

--- a/pallets/interest-accrual/src/tests.rs
+++ b/pallets/interest-accrual/src/tests.rs
@@ -28,10 +28,10 @@ fn test_rate_validation() {
 	let normal_rate = Rate::saturating_from_rational(5, 100);
 	let too_many_decimals = Rate::saturating_from_rational(55, 100000);
 
-	assert!(Pallet::<Runtime>::validate_rate(high_rate).is_err());
-	assert!(Pallet::<Runtime>::validate_rate(min_rate).is_ok());
-	assert!(Pallet::<Runtime>::validate_rate(normal_rate).is_ok());
-	assert!(Pallet::<Runtime>::validate_rate(One::one()).is_ok());
-	assert!(Pallet::<Runtime>::validate_rate(Zero::zero()).is_ok());
-	assert!(Pallet::<Runtime>::validate_rate(too_many_decimals).is_err());
+	assert!(Pallet::<Runtime>::validate_interest_rate(high_rate).is_err());
+	assert!(Pallet::<Runtime>::validate_interest_rate(min_rate).is_ok());
+	assert!(Pallet::<Runtime>::validate_interest_rate(normal_rate).is_ok());
+	assert!(Pallet::<Runtime>::validate_interest_rate(One::one()).is_ok());
+	assert!(Pallet::<Runtime>::validate_interest_rate(Zero::zero()).is_ok());
+	assert!(Pallet::<Runtime>::validate_interest_rate(too_many_decimals).is_err());
 }

--- a/pallets/interest-accrual/src/tests.rs
+++ b/pallets/interest-accrual/src/tests.rs
@@ -23,15 +23,15 @@ use crate::{
 
 #[test]
 fn test_rate_validation() {
-	let max_rate = Rate::saturating_from_rational(9999, 10000);
+	let high_rate = Rate::saturating_from_rational(300000, 10000);
 	let min_rate = Rate::saturating_from_rational(1, 10000);
 	let normal_rate = Rate::saturating_from_rational(5, 100);
 	let too_many_decimals = Rate::saturating_from_rational(55, 100000);
 
-	assert!(Pallet::<Runtime>::validate_rate(max_rate).is_ok());
+	assert!(Pallet::<Runtime>::validate_rate(high_rate).is_ok());
 	assert!(Pallet::<Runtime>::validate_rate(min_rate).is_ok());
 	assert!(Pallet::<Runtime>::validate_rate(normal_rate).is_ok());
-	assert!(Pallet::<Runtime>::validate_rate(One::one()).is_err());
+	assert!(Pallet::<Runtime>::validate_rate(One::one()).is_ok());
 	assert!(Pallet::<Runtime>::validate_rate(Zero::zero()).is_ok());
 	assert!(Pallet::<Runtime>::validate_rate(too_many_decimals).is_err());
 }

--- a/pallets/interest-accrual/src/tests.rs
+++ b/pallets/interest-accrual/src/tests.rs
@@ -28,7 +28,7 @@ fn test_rate_validation() {
 	let normal_rate = Rate::saturating_from_rational(5, 100);
 	let too_many_decimals = Rate::saturating_from_rational(55, 100000);
 
-	assert!(Pallet::<Runtime>::validate_rate(high_rate).is_ok());
+	assert!(Pallet::<Runtime>::validate_rate(high_rate).is_err());
 	assert!(Pallet::<Runtime>::validate_rate(min_rate).is_ok());
 	assert!(Pallet::<Runtime>::validate_rate(normal_rate).is_ok());
 	assert!(Pallet::<Runtime>::validate_rate(One::one()).is_ok());

--- a/pallets/loans-ref/src/benchmarking.rs
+++ b/pallets/loans-ref/src/benchmarking.rs
@@ -171,7 +171,7 @@ where
 		for i in 1..MaxRateCountOf::<T>::get() {
 			// First `i` (i=0) used by the loan's interest rate.
 			let rate = T::Rate::saturating_from_rational(i + 1, 5000);
-			T::InterestAccrual::reference_yearly_rate(rate).unwrap();
+			T::InterestAccrual::reference_rate(rate).unwrap();
 		}
 
 		let pool_id = Self::prepare_benchmark();

--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -523,7 +523,7 @@ pub mod pallet {
 
 			let status = WriteOffStatus {
 				percentage,
-				penalty: Self::to_rate_per_sec(penalty)?,
+				penalty,
 			};
 
 			let _count = Self::update_active_loan(pool_id, loan_id, |loan| {
@@ -586,16 +586,11 @@ pub mod pallet {
 		pub fn update_write_off_policy(
 			origin: OriginFor<T>,
 			pool_id: PoolIdOf<T>,
-			mut policy: BoundedVec<WriteOffState<T::Rate>, T::MaxWriteOffPolicySize>,
+			policy: BoundedVec<WriteOffState<T::Rate>, T::MaxWriteOffPolicySize>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::ensure_role(pool_id, &who, PoolRole::PoolAdmin)?;
 			Self::ensure_pool_exists(pool_id)?;
-
-			policy.iter_mut().try_for_each(|state| -> DispatchResult {
-				state.penalty = Self::to_rate_per_sec(state.penalty)?;
-				Ok(())
-			})?;
 
 			WriteOffPolicy::<T>::insert(pool_id, policy.clone());
 
@@ -674,10 +669,6 @@ pub mod pallet {
 				last_loan_id.ensure_add_assign(One::one())?;
 				Ok(*last_loan_id)
 			})
-		}
-
-		fn to_rate_per_sec(rate_per_year: T::Rate) -> Result<T::Rate, DispatchError> {
-			T::InterestAccrual::convert_additive_rate_to_per_sec(rate_per_year)
 		}
 
 		fn find_write_off_state(

--- a/pallets/loans-ref/src/tests.rs
+++ b/pallets/loans-ref/src/tests.rs
@@ -999,10 +999,7 @@ mod write_off_loan {
 			assert_eq!(
 				WriteOffStatus {
 					percentage: Rate::from_float(POLICY_PERCENTAGE),
-					penalty: Rate::from_float(
-						// TODO: Simplify when issue #1189 is merged
-						POLICY_PENALTY / cfg_primitives::SECONDS_PER_YEAR as f64
-					),
+					penalty: Rate::from_float(POLICY_PENALTY),
 				},
 				*util::get_loan(loan_id).write_off_status()
 			);
@@ -1037,10 +1034,7 @@ mod write_off_loan {
 			assert_eq!(
 				WriteOffStatus {
 					percentage: Rate::from_float(POLICY_PERCENTAGE + 0.1),
-					penalty: Rate::from_float(
-						// TODO: Simplify when issue #1189 is merged
-						(POLICY_PENALTY + 0.1) / cfg_primitives::SECONDS_PER_YEAR as f64
-					),
+					penalty: Rate::from_float(POLICY_PENALTY + 0.1),
 				},
 				*util::get_loan(loan_id).write_off_status()
 			);

--- a/pallets/loans-ref/src/types.rs
+++ b/pallets/loans-ref/src/types.rs
@@ -142,7 +142,7 @@ pub struct WriteOffState<Rate> {
 	pub percentage: Rate,
 
 	/// Additional interest that accrues on the written off loan as penalty
-	pub penalty: Rate, //TODO: migration: per sec -> per year
+	pub penalty: Rate,
 }
 
 impl<Rate> WriteOffState<Rate>
@@ -191,7 +191,7 @@ pub struct WriteOffStatus<Rate> {
 	pub percentage: Rate,
 
 	/// Additional interest that accrues on the written down loan as penalty per sec
-	pub penalty: Rate, //TODO: migration: per sec -> per year
+	pub penalty: Rate,
 }
 
 impl<Rate> WriteOffStatus<Rate>
@@ -408,7 +408,7 @@ pub struct ClosedLoan<T: Config> {
 	closed_at: T::BlockNumber,
 
 	/// Loan information
-	info: LoanInfo<AssetOf<T>, T::Balance, T::Rate>, //TODO: migration: interest rate: "per sec" -> "per year"
+	info: LoanInfo<AssetOf<T>, T::Balance, T::Rate>,
 
 	/// Total borrowed amount of this loan
 	total_borrowed: T::Balance,
@@ -431,7 +431,7 @@ pub struct ActiveLoan<T: Config> {
 	loan_id: T::LoanId,
 
 	/// Loan information
-	info: LoanInfoOf<T>, //TODO: migration: interest rate: "per sec" -> "per year"
+	info: LoanInfoOf<T>,
 
 	/// Borrower account that created this loan
 	borrower: T::AccountId,

--- a/pallets/loans-ref/src/valuation.rs
+++ b/pallets/loans-ref/src/valuation.rs
@@ -35,7 +35,7 @@ pub struct DiscountedCashFlow<Rate> {
 	pub loss_given_default: Rate,
 
 	/// Rate per year of return used to discount future cash flows back to their present value.
-	pub discount_rate: Rate, //TODO: migration: per sec -> per year
+	pub discount_rate: Rate,
 }
 
 impl<Rate: FixedPointNumber> DiscountedCashFlow<Rate> {


### PR DESCRIPTION
# Description

Modify `InterestAccrual` to expose only an `interest_rate_per_year` parameter. No more interest rates per sec to handle. UI free from converting rates to show the correct yearly rates.

Fixes #1189

## Changes and Descriptions

- The same storage is used. No migration is required for `interest-accrual`.
- The rate representation changes on the `pallet-loans` side, the type is the same but the value is stored diferently, so **it will require a migration if centrifuge release is launched before this**.
- This yearly simplification allows removing a couple of methods from `InterestAccrual` trait.

## Requirements
- [x] Blocked by https://github.com/centrifuge/centrifuge-chain/pull/1266