### PR TITLE
Run unit tests in debug mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,18 @@ jobs:
         if: ${{ matrix.os }} == 'ubuntu-latest'
         run: |
           echo "Pre cleanup"
+          echo "Listing 100 largest packages"
+          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
           df -h
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y azure-cli google-cloud-sdk microsoft-edge-stable google-chrome-stable firefox powershell mono-devel
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          df -h
+          echo "Removing large directories"
+          rm -rf /usr/share/dotnet/
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          echo "Post cleanup"
           df -h
           sudo apt-get install protobuf-compiler
       - name: Check out code

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -32,7 +32,7 @@ case $TARGET in
     ;;
 
   tests)
-    RUST_MIN_STACK=8388608 cargo test --workspace --release --features runtime-benchmarks,try-runtime --exclude runtime-integration-tests
+    RUST_MIN_STACK=8388608 cargo test --workspace --features runtime-benchmarks,try-runtime --exclude runtime-integration-tests
     ;;
 
   integration)

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -17,9 +17,9 @@ rustup --version
 cargo --version
 
 case $TARGET in
-	build-node)
-		cargo build --release "$@"
-		;;
+  build-node)
+    cargo build --release "$@"
+    ;;
 
   build-runtime)
     export RUSTC_VERSION=$RUST_TOOLCHAIN
@@ -36,7 +36,7 @@ case $TARGET in
     ;;
 
   integration)
-    RUST_MIN_STACK=8388608 cargo test --release --package runtime-integration-tests
+    RUST_MIN_STACK=8388608 cargo test --package runtime-integration-tests
     ;;
 
   fmt)

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -28,7 +28,7 @@ and another one to verify how it works in a more real environment as a parachain
 The following command will run the unit and integration tests:
 
 ```bash
-cargo +nightly test --workspace --release --features runtime-benchmarks,try-runtime
+cargo test --workspace --features runtime-benchmarks,try-runtime
 ```
 
 ### Environment tests
@@ -84,7 +84,7 @@ You can play with it from the parachain client, make transfers, inspect events, 
 ## Linting
 
 ### Source code
-Lint the source code with `cargo +nightly fmt`. This excludes certain paths (defined in `rustfmt.toml`) that we want to stay as close as possible to `paritytech/substrate` to simplify upgrading to new releases.
+Lint the source code with `cargo fmt`. This excludes certain paths (defined in `rustfmt.toml`) that we want to stay as close as possible to `paritytech/substrate` to simplify upgrading to new releases.
 
 ### Cargo.toml files
 1. Install [taplo](https://github.com/tamasfe/taplo) with `cargo install taplo-cli`.

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -477,7 +477,7 @@ benchmarks! {
 		let now = TimestampPallet::<T>::get().into();
 		let after_one_year = now + math::seconds_per_year() * 1000;
 		let amount = (40 * CURRENCY).into();
-		set_block_number_timestamp::<T>(Default::default(), after_one_year.into());
+		set_block_number_timestamp::<T>(One::one(), after_one_year.into());
 		InterestAccrualPallet::<T>::on_initialize(0u32.into());
 	}:borrow(RawOrigin::Signed(loan_owner.clone()), pool_id, loan_id, amount)
 	verify {
@@ -504,7 +504,7 @@ benchmarks! {
 		// set timestamp to around 2+ years
 		let now = TimestampPallet::<T>::get().into();
 		let after_maturity = now + (2 * math::seconds_per_year() + math::seconds_per_day()) * 1000;
-		set_block_number_timestamp::<T>(Default::default(), after_maturity.into());
+		set_block_number_timestamp::<T>(One::one(), after_maturity.into());
 		InterestAccrualPallet::<T>::on_initialize(0u32.into());
 		let amount = (100 * CURRENCY).into();
 	}:_(RawOrigin::Signed(loan_owner.clone()), pool_id, loan_id, amount)
@@ -552,7 +552,7 @@ benchmarks! {
 		let now = TimestampPallet::<T>::get().into();
 		let after_maturity = now + (2 * math::seconds_per_year() + 130 * math::seconds_per_day()) * 1000;
 		// add write off groups
-		set_block_number_timestamp::<T>(Default::default(), after_maturity.into());
+		set_block_number_timestamp::<T>(One::one(), after_maturity.into());
 		InterestAccrualPallet::<T>::on_initialize(0u32.into());
 	}:_(RawOrigin::Signed(loan_owner.clone()), pool_id, loan_id)
 	verify {
@@ -582,7 +582,7 @@ benchmarks! {
 		let now = TimestampPallet::<T>::get().into();
 		let after_maturity = now + (2 * math::seconds_per_year() + 130 * math::seconds_per_day()) * 1000;
 		// add write off groups
-		set_block_number_timestamp::<T>(Default::default(), after_maturity.into());
+		set_block_number_timestamp::<T>(One::one(), after_maturity.into());
 		InterestAccrualPallet::<T>::on_initialize(0u32.into());
 		let percentage = Rate::saturating_from_rational(100, 100).into();
 		let penalty_interest_rate_per_year = Rate::saturating_from_rational(1, 100).into();
@@ -606,7 +606,7 @@ benchmarks! {
 		// set timestamp to around 2 year
 		let now = TimestampPallet::<T>::get().into();
 		let after_two_years = now + 2 * math::seconds_per_year() * 1000;
-		set_block_number_timestamp::<T>(Default::default(), after_two_years.into());
+		set_block_number_timestamp::<T>(One::one(), after_two_years.into());
 		InterestAccrualPallet::<T>::on_initialize(0u32.into());
 		// repay all. sent more than current debt
 		let owner_balance: <T as ORMLConfig>::Balance = (1000 * CURRENCY).into();
@@ -648,7 +648,7 @@ benchmarks! {
 		// set timestamp to around 2 year
 		let now = TimestampPallet::<T>::get().into();
 		let after_two_years = now + (2 * math::seconds_per_year() + 130 * math::seconds_per_day()) * 1000;
-		set_block_number_timestamp::<T>(Default::default(), after_two_years.into());
+		set_block_number_timestamp::<T>(One::one(), after_two_years.into());
 		InterestAccrualPallet::<T>::on_initialize(0u32.into());
 		// add write off groups
 		add_test_write_off_groups::<T>(pool_id, risk_admin::<T>());
@@ -703,7 +703,7 @@ benchmarks! {
 		// set timestamp to around 1 year
 		let now = TimestampPallet::<T>::get().into();
 		let after_one_month = now + math::seconds_per_day() * 30 * 1000;
-		set_block_number_timestamp::<T>(Default::default(), after_one_month.into());
+		set_block_number_timestamp::<T>(One::one(), after_one_month.into());
 		InterestAccrualPallet::<T>::on_initialize(0u32.into());
 		// add write off groups
 		add_test_write_off_groups::<T>(pool_id, risk_admin::<T>());


### PR DESCRIPTION
# Description

Removes `--release` from our testing script for running unit tests. On my laptop this is 8 minutes faster. In CI where there is less parallelism, I expect that number to be larger.

## Type of change

- [x] CI cleanup

# How Has This Been Tested?

Ran tests locally

# Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I rebased on the latest `main` branch
