### PR TITLE
Build CI test in debug

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -17,9 +17,9 @@ rustup --version
 cargo --version
 
 case $TARGET in
-	build-node)
-		cargo build --release "$@"
-		;;
+  build-node)
+    cargo build --release "$@"
+    ;;
 
   build-runtime)
     export RUSTC_VERSION=$RUST_TOOLCHAIN
@@ -36,7 +36,7 @@ case $TARGET in
     ;;
 
   integration)
-    RUST_MIN_STACK=8388608 cargo test --release --package runtime-integration-tests
+    RUST_MIN_STACK=8388608 cargo test --package runtime-integration-tests
     ;;
 
   fmt)

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -28,7 +28,7 @@ and another one to verify how it works in a more real environment as a parachain
 The following command will run the unit and integration tests:
 
 ```bash
-cargo +nightly test --workspace --release --features runtime-benchmarks,try-runtime
+cargo test --workspace --features runtime-benchmarks,try-runtime
 ```
 
 ### Environment tests
@@ -84,7 +84,7 @@ You can play with it from the parachain client, make transfers, inspect events, 
 ## Linting
 
 ### Source code
-Lint the source code with `cargo +nightly fmt`. This excludes certain paths (defined in `rustfmt.toml`) that we want to stay as close as possible to `paritytech/substrate` to simplify upgrading to new releases.
+Lint the source code with `cargo fmt`. This excludes certain paths (defined in `rustfmt.toml`) that we want to stay as close as possible to `paritytech/substrate` to simplify upgrading to new releases.
 
 ### Cargo.toml files
 1. Install [taplo](https://github.com/tamasfe/taplo) with `cargo install taplo-cli`.


### PR DESCRIPTION
## Changes and Descriptions

- Remove `--release` in doc places where it is not really needed.
- Remove `--release` from integration tests.
- Remove `+nightly` from some docs because it seems not to be needed. The toolchain config should choose the right compiler channel.

Addition over https://github.com/centrifuge/centrifuge-chain/pull/1238