### PR TITLE
Skip relay block number check on dev runtime

### DIFF
--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -247,7 +247,9 @@ parameter_types! {
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
-	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+	// Using AnyRelayNumber only for the development & demo environments,
+	// to be able to recover quickly from a relay chains issue
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::AnyRelayNumber;
 	type DmpMessageHandler = DmpQueue;
 	type OnSystemEvent = ();
 	type OutboundXcmpMessageSource = XcmpQueue;


### PR DESCRIPTION
# Description

For development environments sometimes test relay chains can halt producing blocks due to timing issues. In kubernetes for example, from time to time the infrastructure is restarted in an unhealthy way and this could leave the chain in a halt. 
To overcome this, usually a new relay chain is started and the parachain onboarded again from the last well known state. This will not work if the parachain expects that the relay chain block that has been imported is always incremented compare to the previous one, so changing the strategy here skips that check. 
Of course this is only acceptable in this test/dev environment case. 

This change makes recovering much easy, instead of having to rebuild a new wasm, export a new chain spec and add a block substitute for the latest finalized block in each of the collators.