### PR TITLE
Remove taplo task from tests job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,6 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           default: true
-      # We use Taplo to format our Cargo.toml files.
-      - name: Install taplo
-        uses: actions-rs/install@v0.1
-        with:
-          crate: taplo-cli
-          version: 0.7.2
-          use-tool-cache: true
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c
       - name: Run tests
         run: ./ci/script.sh


### PR DESCRIPTION
# Description

The Taplo task is already in the `Lints` job. We could alleviate the longer job around 5-7 min removing it from this.

Related issue: #1263
