### PR TITLE
Use max policy for write off benchmarks

### DIFF
--- a/pallets/loans-ref/src/benchmarking.rs
+++ b/pallets/loans-ref/src/benchmarking.rs
@@ -137,16 +137,28 @@ where
 	fn set_policy(pool_id: PoolIdOf<T>) {
 		let pool_admin = account::<T::AccountId>("pool_admin", 0, 0);
 
+		// Worst case policy where you need to iterate for the whole policy.
+		let policy = [
+			vec![
+				WriteOffState {
+					overdue_days: u32::MAX,
+					percentage: T::Rate::zero(),
+					penalty: T::Rate::zero(),
+				};
+				T::MaxWriteOffPolicySize::get() as usize - 1
+			],
+			vec![WriteOffState {
+				overdue_days: 0, // Last element is overdue
+				percentage: T::Rate::zero(),
+				penalty: T::Rate::zero(),
+			}],
+		]
+		.concat();
+
 		Pallet::<T>::update_write_off_policy(
 			RawOrigin::Signed(pool_admin).into(),
 			pool_id,
-			vec![WriteOffState {
-				overdue_days: 0,
-				percentage: T::Rate::zero(),
-				penalty: T::Rate::zero(),
-			}]
-			.try_into()
-			.unwrap(),
+			policy.try_into().unwrap(),
 		)
 		.unwrap();
 	}
@@ -233,6 +245,7 @@ benchmarks! {
 		let pool_id = Helper::<T>::initialize_active_state(n);
 		let loan_id = Helper::<T>::create_loan(pool_id, u16::MAX.into());
 		Helper::<T>::borrow_loan(pool_id, loan_id);
+		Helper::<T>::set_policy(pool_id);
 
 	}: _(RawOrigin::Signed(loan_admin), pool_id, loan_id, T::Rate::zero(), T::Rate::zero())
 


### PR DESCRIPTION
# Description

`write_off` and `admin_write_off` search in the policy to get the correct state. We need to assume the biggest possible policy before performing the benchmark.