### PR TITLE
Added `MutatedActiveLoan` storage for PoV optimization

### DIFF
--- a/libs/traits/src/ops.rs
+++ b/libs/traits/src/ops.rs
@@ -4,6 +4,24 @@ pub use ensure::{
 	EnsureSubAssign,
 };
 
+pub mod storage {
+	use sp_runtime::{traits::Get, BoundedVec};
+
+	pub trait BoundedVecExt<T> {
+		/// Same as [`BoundedVec::try_push()`] but returns a reference to the pushed element in the
+		/// vector
+		fn try_push_fetch(&mut self, element: T) -> Result<&mut T, T>;
+	}
+
+	impl<T, S: Get<u32>> BoundedVecExt<T> for BoundedVec<T, S> {
+		fn try_push_fetch(&mut self, element: T) -> Result<&mut T, T> {
+			let len = self.len();
+			self.try_push(element)?;
+			Ok(self.get_mut(len).expect("This can not fail. qed"))
+		}
+	}
+}
+
 mod ensure {
 	use sp_runtime::{
 		traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero},

--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -401,10 +401,10 @@ pub mod pallet {
 				Some(created_loan) => {
 					Self::ensure_loan_borrower(&who, created_loan.borrower())?;
 
-					let mut active_loan = created_loan.activate(loan_id)?;
+					let mut active_loan = created_loan.activate()?;
 					active_loan.borrow(amount)?;
 
-					Self::insert_active_loan(pool_id, active_loan)?
+					Self::insert_active_loan(pool_id, loan_id, active_loan)?
 				}
 				None => {
 					Self::update_active_loan(pool_id, loan_id, |loan| {
@@ -728,6 +728,7 @@ pub mod pallet {
 
 		fn insert_active_loan(
 			pool_id: PoolIdOf<T>,
+			loan_id: T::LoanId,
 			loan: ActiveLoan<T>,
 		) -> Result<u32, DispatchError> {
 			PortfolioValuation::<T>::try_mutate(pool_id, |portfolio| {
@@ -738,7 +739,7 @@ pub mod pallet {
 
 				ActiveLoans::<T>::try_mutate(pool_id, |active_loans| {
 					active_loans
-						.try_insert(loan.loan_id(), (loan, last_updated))
+						.try_insert(loan_id, (loan, last_updated))
 						.map_err(|_| Error::<T>::MaxActiveLoansReached)?;
 
 					Ok(active_loans.len().ensure_into()?)

--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -57,7 +57,7 @@ pub use weights::WeightInfo;
 pub mod pallet {
 	use cfg_primitives::Moment;
 	use cfg_traits::{
-		ops::{EnsureAdd, EnsureAddAssign, EnsureInto, EnsureSub},
+		ops::{storage::BoundedVecExt, EnsureAdd, EnsureAddAssign, EnsureInto, EnsureSub},
 		InterestAccrual, Permissions, PoolInspect, PoolNAV, PoolReserve,
 	};
 	use cfg_types::{
@@ -801,13 +801,9 @@ pub mod pallet {
 									.clone();
 
 								mutated_loans
-									.try_push((loan_id, loan, portfolio.last_updated()))
-									.map_err(|_| Error::<T>::MaxActiveLoansReached)?;
-
-								mutated_loans
-									.get_mut(mutated_loans.len().ensure_sub(1)?)
+									.try_push_fetch((loan_id, loan, portfolio.last_updated()))
 									.map(|(_, loan, last_updated)| (loan, last_updated))
-									.ok_or(DispatchError::Other("unreachable"))?
+									.map_err(|_| Error::<T>::MaxActiveLoansReached)?
 							}
 						};
 

--- a/pallets/loans-ref/src/tests.rs
+++ b/pallets/loans-ref/src/tests.rs
@@ -6,7 +6,7 @@ use sp_runtime::traits::BadOrigin;
 
 use super::{
 	mock::*,
-	pallet::{ActiveLoans, Error, LastLoanId, PortfolioValuation},
+	pallet::{ActiveLoans, Error, LastLoanId, MutatedActiveLoans, PortfolioValuation},
 	types::{
 		ActiveLoan, BorrowLoanError, CloseLoanError, CreateLoanError, LoanInfo, MaxBorrowAmount,
 		WriteOffState, WriteOffStatus, WrittenOffError,
@@ -35,11 +35,16 @@ mod util {
 	}
 
 	pub fn get_loan(loan_id: LoanId) -> ActiveLoan<Runtime> {
-		ActiveLoans::<Runtime>::get(POOL_A)
-			.get(&loan_id)
-			.unwrap()
-			.clone()
-			.0
+		match MutatedActiveLoans::<Runtime>::get(POOL_A)
+			.into_iter()
+			.find(|(id, _, _)| *id == loan_id)
+		{
+			Some((_, loan, _)) => loan,
+			None => ActiveLoans::<Runtime>::get(POOL_A)
+				.get(&loan_id)
+				.unwrap()
+				.clone(),
+		}
 	}
 
 	pub fn portfolio_valuation() -> Balance {

--- a/pallets/loans-ref/src/tests.rs
+++ b/pallets/loans-ref/src/tests.rs
@@ -36,9 +36,9 @@ mod util {
 
 	pub fn get_loan(loan_id: LoanId) -> ActiveLoan<Runtime> {
 		ActiveLoans::<Runtime>::get(POOL_A)
-			.into_iter()
-			.find(|(loan, _)| loan.loan_id() == loan_id)
+			.get(&loan_id)
 			.unwrap()
+			.clone()
 			.0
 	}
 

--- a/pallets/loans-ref/src/types.rs
+++ b/pallets/loans-ref/src/types.rs
@@ -394,8 +394,8 @@ impl<T: Config> CreatedLoan<T> {
 		&self.borrower
 	}
 
-	pub fn activate(self, loan_id: T::LoanId) -> Result<ActiveLoan<T>, DispatchError> {
-		ActiveLoan::new(loan_id, self.info, self.borrower, T::Time::now().as_secs())
+	pub fn activate(self) -> Result<ActiveLoan<T>, DispatchError> {
+		ActiveLoan::new(self.info, self.borrower, T::Time::now().as_secs())
 	}
 
 	pub fn close(self) -> Result<(ClosedLoan<T>, T::AccountId), DispatchError> {
@@ -437,9 +437,6 @@ impl<T: Config> ClosedLoan<T> {
 #[derive(Encode, Decode, Clone, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 pub struct ActiveLoan<T: Config> {
-	/// Id of this loan
-	loan_id: T::LoanId,
-
 	/// Loan information
 	info: LoanInfoOf<T>,
 
@@ -464,13 +461,11 @@ pub struct ActiveLoan<T: Config> {
 
 impl<T: Config> ActiveLoan<T> {
 	pub fn new(
-		loan_id: T::LoanId,
 		info: LoanInfoOf<T>,
 		borrower: T::AccountId,
 		now: Moment,
 	) -> Result<Self, DispatchError> {
 		Ok(ActiveLoan {
-			loan_id,
 			info: LoanInfo {
 				interest_rate: T::InterestAccrual::reference_yearly_rate(info.interest_rate)?,
 				..info
@@ -482,10 +477,6 @@ impl<T: Config> ActiveLoan<T> {
 			total_borrowed: T::Balance::zero(),
 			total_repaid: T::Balance::zero(),
 		})
-	}
-
-	pub fn loan_id(&self) -> T::LoanId {
-		self.loan_id
 	}
 
 	pub fn borrower(&self) -> &T::AccountId {


### PR DESCRIPTION
# Description

Fixes #1193

### Tasks
- [x] Implementation
- [x] Test passing
- [ ] Update benchmarks


## Changes and Descriptions

- Added new storage `MutatedActiveLoans`.
- Remove not needed `loan_id` from `ActiveLoan`.

## Type of change

- Breaking change