### PR TITLE
Altair migration to remove previous pallet-loans storage

### DIFF
--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -82,6 +82,7 @@ pub(crate) mod test_utils;
 pub mod functions;
 pub mod loan_type;
 pub mod math;
+pub mod migrations;
 pub mod types;
 pub mod weights;
 

--- a/pallets/loans/src/migrations.rs
+++ b/pallets/loans/src/migrations.rs
@@ -1,0 +1,36 @@
+use frame_support::{storage, traits::OnRuntimeUpgrade, weights::Weight};
+use sp_std::vec::Vec;
+
+use crate::*;
+
+pub struct Migration<T>(sp_std::marker::PhantomData<T>);
+
+impl<T: Config> OnRuntimeUpgrade for Migration<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+		ensure!(
+			ClosedLoans::<T>::iter_values().count() == 1,
+			"There is not a closed loan"
+		);
+
+		Ok(Vec::new())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		let loans_module = b"4c82a580ac33cceba8ed9766387f22b7";
+		let _ = storage::unhashed::clear_prefix(loans_module, None, None);
+
+		// Should be one/few elements per storage map in `pallet-loans`. The next number should be
+		// enough.
+		Weight::from_ref_time(200_000_000)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_: Vec<u8>) -> Result<(), &'static str> {
+		ensure!(
+			ClosedLoans::<T>::iter_values().count() == 0,
+			"There is still a closed loan"
+		);
+		Ok(())
+	}
+}

--- a/pallets/loans/src/migrations.rs
+++ b/pallets/loans/src/migrations.rs
@@ -1,4 +1,5 @@
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
+#[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;
 
 use crate::*;

--- a/pallets/loans/src/migrations.rs
+++ b/pallets/loans/src/migrations.rs
@@ -1,36 +1,88 @@
-use frame_support::{storage, traits::OnRuntimeUpgrade, weights::Weight};
+use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 use sp_std::vec::Vec;
 
 use crate::*;
 
+/// This migration nukes all storages from the pallet individually.
 pub struct Migration<T>(sp_std::marker::PhantomData<T>);
 
 impl<T: Config> OnRuntimeUpgrade for Migration<T> {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+		// The current state from altair when this migration should be done has only one element
+		// in each store.
+		ensure!(
+			PoolToLoanNftClass::<T>::iter_values().count() == 1,
+			"Err PoolToLoanNftClass"
+		);
+		ensure!(
+			LoanNftClassToPool::<T>::iter_values().count() == 1,
+			"Err LoanNftClassToPool"
+		);
+		ensure!(
+			NextLoanId::<T>::iter_values().count() == 1,
+			"Err NextLoanId"
+		);
+		ensure!(Loan::<T>::iter_values().count() == 1, "Err Loan");
+		ensure!(
+			ActiveLoans::<T>::iter_values().count() == 1,
+			"Err ActiveLoans"
+		);
 		ensure!(
 			ClosedLoans::<T>::iter_values().count() == 1,
-			"There is not a closed loan"
+			"Err ClosedLoans"
+		);
+		ensure!(PoolNAV::<T>::iter_values().count() == 1, "Err PoolNAV");
+		ensure!(
+			PoolWriteOffGroups::<T>::iter_values().count() == 1,
+			"Err PoolWriteOffGroups "
 		);
 
 		Ok(Vec::new())
 	}
 
 	fn on_runtime_upgrade() -> Weight {
-		let loans_module = b"4c82a580ac33cceba8ed9766387f22b7";
-		let _ = storage::unhashed::clear_prefix(loans_module, None, None);
+		let _ = PoolToLoanNftClass::<T>::clear(1, None);
+		let _ = LoanNftClassToPool::<T>::clear(1, None);
+		let _ = NextLoanId::<T>::clear(1, None);
+		let _ = Loan::<T>::clear(1, None);
+		let _ = ActiveLoans::<T>::clear(1, None);
+		let _ = ClosedLoans::<T>::clear(1, None);
+		let _ = PoolNAV::<T>::clear(1, None);
+		let _ = PoolWriteOffGroups::<T>::clear(1, None);
 
-		// Should be one/few elements per storage map in `pallet-loans`. The next number should be
-		// enough.
-		Weight::from_ref_time(200_000_000)
+		T::DbWeight::get().writes(8)
 	}
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(_: Vec<u8>) -> Result<(), &'static str> {
 		ensure!(
-			ClosedLoans::<T>::iter_values().count() == 0,
-			"There is still a closed loan"
+			PoolToLoanNftClass::<T>::iter_values().count() == 0,
+			"Exists PoolToLoanNftClass"
 		);
+		ensure!(
+			LoanNftClassToPool::<T>::iter_values().count() == 0,
+			"Exists LoanNftClassToPool"
+		);
+		ensure!(
+			NextLoanId::<T>::iter_values().count() == 0,
+			"Exists NextLoanId"
+		);
+		ensure!(Loan::<T>::iter_values().count() == 0, "Exists Loan");
+		ensure!(
+			ActiveLoans::<T>::iter_values().count() == 0,
+			"Exists ActiveLoans"
+		);
+		ensure!(
+			ClosedLoans::<T>::iter_values().count() == 0,
+			"Exists ClosedLoans"
+		);
+		ensure!(PoolNAV::<T>::iter_values().count() == 0, "Exists PoolNAV");
+		ensure!(
+			PoolWriteOffGroups::<T>::iter_values().count() == 0,
+			"Exists PoolWriteOffGroups"
+		);
+
 		Ok(())
 	}
 }

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1496,13 +1496,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(
-		pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
-		pallet_preimage::migration::v1::Migration<Runtime>,
-		pallet_democracy::migrations::v1::Migration<Runtime>,
-		pallet_scheduler::migration::v3::MigrateToV4<Runtime>,
-		pallet_interest_accrual::migrations::v2::Migration<Runtime>,
-	),
+	pallet_loans::migrations::Migration<Runtime>,
 >;
 
 #[cfg(not(feature = "disable-runtime-api"))]

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1496,7 +1496,10 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	pallet_loans::migrations::Migration<Runtime>,
+	(
+		pallet_interest_accrual::migrations::v2::Migration<Runtime>,
+		pallet_loans::migrations::Migration<Runtime>,
+	),
 >;
 
 #[cfg(not(feature = "disable-runtime-api"))]


### PR DESCRIPTION
# Description

Fixes #1281

## Changes and Descriptions

- Added migration to remove all storages of `pallet-loans`. 
- ✅ Tested against `altair` using:
  ```sh
  RUST_LOG=runtime=trace,try-runtime::cli=trace,executor=trace cargo run --release --features try-runtime try-runtime --execution Native --chain altair-local --no-spec-check-panic on-runtime-upgrade live --uri wss://fullnode.altair.centrifuge.io:443
  ```
