### PR TITLE
Add benchmark CI job for fast checks

### DIFF
--- a/.github/workflows/benchmark-check.yml
+++ b/.github/workflows/benchmark-check.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches: [main, 'release-v**']
+  pull_request:
+name: Check Benchmarks
+jobs:
+  tests:
+    name: ${{ matrix.target }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        target: [benchmark-test]
+        runtime: [development, altair, centrifuge]
+    runs-on: ${{ matrix.os }}
+    env:
+      RUST_TOOLCHAIN: "nightly-2022-05-09"
+    steps:
+      - name: Prep build on Ubuntu
+        if: ${{ matrix.os }} == 'ubuntu-latest'
+        run: |
+          echo "Pre cleanup"
+          df -h
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          echo "Post cleanup"
+          df -h
+          sudo apt-get install protobuf-compiler
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          default: true
+      - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c
+      - name: Run fast benchmarks
+        run: ./ci/script.sh
+        env:
+          TARGET: ${{ matrix.target }}
+          RUNTIME: ${{ matrix.runtime }}

--- a/.github/workflows/benchmark-check.yml
+++ b/.github/workflows/benchmark-check.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [benchmark-test]
+        target: [benchmark-check]
         runtime: [development, altair, centrifuge]
     runs-on: ${{ matrix.os }}
     env:

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -53,5 +53,9 @@ case $TARGET in
 
   benchmark)
     ./scripts/runtime_benchmarks.sh $RUNTIME
+    ;;
+
+  benchmark-check)
+    ./scripts/check_benchmarks.sh $RUNTIME
 
 esac

--- a/scripts/check_benchmarks.sh
+++ b/scripts/check_benchmarks.sh
@@ -1,0 +1,46 @@
+set -eu
+
+runtime=$1
+
+run_benchmark() {
+  pallet=$1
+
+  cmd="target/release/centrifuge-chain benchmark pallet \
+    --chain="${chain}" \
+    --steps=2 \
+    --repeat=1 \
+    --pallet="${pallet}" \
+    --extrinsic=* \
+    --execution=wasm \
+    --wasm-execution=compiled \
+    --heap-pages=4096"
+
+    echo "Running benchmark for pallet '${pallet}'"
+    echo "${cmd}"
+    ${cmd}
+}
+
+if [[ $runtime == "development" ]];
+then
+  chain="development-local"
+elif [[ $runtime == "centrifuge" ]];
+then
+  chain="centrifuge-dev"
+elif [[ $runtime == "altair" ]];
+then
+  chain="altair-dev"
+else
+  echo "Unknown runtime. Aborting!"
+  exit 1;
+fi
+
+cargo build --release --features runtime-benchmarks
+
+all_pallets=$(
+  ./target/release/centrifuge-chain benchmark pallet --list --chain="${chain}" | tail -n+2 | cut -d',' -f1 | sort | uniq
+)
+
+for pallet in $all_pallets
+do
+    run_benchmark $pallet
+done


### PR DESCRIPTION
# Description

This job does not generate weights, it only checks fastly for all runtimes if benchmarks work/compile.

You can test the script locally as follows for fast benchmark checks (it takes around 10-15s to check all runtime benchmarks once it's compiled):

```sh
./scripts/check_benchmarks.sh <runtime>
```

Being `<runtime>` the following possible values: `development`, `altair`, `centrifuge`

Fixes #1268

## Changes and Descriptions

- New script
- New CI job
