### PR TITLE
Revert "InterestAccrual: Unify current & previous debt methods (#1299)"

### DIFF
--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -230,8 +230,19 @@ pub trait InterestAccrual<InterestRate, Balance, Adjustment> {
 	type NormalizedDebt: Member + Parameter + MaxEncodedLen + TypeInfo + Copy + Zero;
 	type Rates: RateCollection<InterestRate, Balance, Self::NormalizedDebt>;
 
-	/// Calculate the debt at an specific moment
-	fn calculate_debt(
+	/// Calculate the current debt using normalized debt * cumulative rate
+	fn current_debt(
+		interest_rate_per_year: InterestRate,
+		normalized_debt: Self::NormalizedDebt,
+	) -> Result<Balance, DispatchError>;
+
+	/// Calculate a previous debt using normalized debt * previous cumulative rate
+	///
+	/// If `when` is further in the past than the last time the
+	/// normalized debt was adjusted, this will return nonsense
+	/// (effectively "rewinding the clock" to before the value was
+	/// valid)
+	fn previous_debt(
 		interest_rate_per_year: InterestRate,
 		normalized_debt: Self::NormalizedDebt,
 		when: Moment,

--- a/pallets/loans-ref/src/tests.rs
+++ b/pallets/loans-ref/src/tests.rs
@@ -47,7 +47,7 @@ mod util {
 	}
 
 	pub fn current_loan_debt(loan_id: LoanId) -> Balance {
-		get_loan(loan_id).calculate_debt(now().as_secs()).unwrap()
+		get_loan(loan_id).debt(None).unwrap()
 	}
 
 	pub fn current_loan_pv(loan_id: LoanId) -> Balance {

--- a/pallets/loans-ref/src/types.rs
+++ b/pallets/loans-ref/src/types.rs
@@ -489,12 +489,23 @@ impl<T: Config> ActiveLoan<T> {
 		&self.write_off_status
 	}
 
-	pub fn calculate_debt(&self, when: Moment) -> Result<T::Balance, DispatchError> {
-		T::InterestAccrual::calculate_debt(self.info.interest_rate, self.normalized_debt, when)
+	/// Returns the debt for the current loan.
+	/// If None, it returns the corresponding debt at now().
+	pub fn debt(&self, when: Option<Moment>) -> Result<T::Balance, DispatchError> {
+		// TODO: simplify this once issue
+		// https://github.com/centrifuge/centrifuge-chain/issues/1203 is merged.
+		match when {
+			Some(when) if when != T::Time::now().as_secs() => T::InterestAccrual::previous_debt(
+				self.info.interest_rate,
+				self.normalized_debt,
+				when,
+			),
+			_ => T::InterestAccrual::current_debt(self.info.interest_rate, self.normalized_debt),
+		}
 	}
 
 	pub fn present_value_at(&self, when: Moment) -> Result<T::Balance, DispatchError> {
-		self.present_value(self.calculate_debt(when)?, when)
+		self.present_value(self.debt(Some(when))?, when)
 	}
 
 	/// An optimized version of `ActiveLoan::present_value_at()` when last updated is now.
@@ -552,14 +563,14 @@ impl<T: Config> ActiveLoan<T> {
 		T::InterestAccrual::unreference_rate(old_interest_rate)
 	}
 
-	fn max_borrow_amount(&self, when: Moment) -> Result<T::Balance, DispatchError> {
+	fn max_borrow_amount(&self) -> Result<T::Balance, DispatchError> {
 		Ok(match self.info.restrictions.max_borrow_amount {
 			MaxBorrowAmount::UpToTotalBorrowed { advance_rate } => advance_rate
 				.ensure_mul_int(self.info.collateral_value)?
 				.saturating_sub(self.total_borrowed),
 			MaxBorrowAmount::UpToOutstandingDebt { advance_rate } => advance_rate
 				.ensure_mul_int(self.info.collateral_value)?
-				.saturating_sub(self.calculate_debt(when)?),
+				.saturating_sub(self.debt(None)?),
 		})
 	}
 
@@ -581,7 +592,7 @@ impl<T: Config> ActiveLoan<T> {
 		);
 
 		ensure!(
-			amount <= self.max_borrow_amount(now)?,
+			amount <= self.max_borrow_amount()?,
 			Error::<T>::from(BorrowLoanError::MaxAmountExceeded)
 		);
 
@@ -603,10 +614,8 @@ impl<T: Config> ActiveLoan<T> {
 	}
 
 	fn ensure_can_repay(&self, amount: T::Balance) -> Result<T::Balance, DispatchError> {
-		let now = T::Time::now().as_secs();
-
 		// Only repay until the current debt
-		let amount = amount.min(self.calculate_debt(now)?);
+		let amount = amount.min(self.debt(None)?);
 
 		match self.info.restrictions.repayments {
 			RepayRestrictions::None => (),


### PR DESCRIPTION
This reverts commit 2e43d973feee09a00a149de68b4ff2d3337dada1.

# Description
We have a "logical" bug in the `pallet-interest-accrual` that was just discoverd via the above changes. As the issue is not urgent we will revert the above and find a solution for the found problem later. 

See: https://kflabs.slack.com/archives/C04HJN404RK/p1680624251541219

## Changes and Descriptions
* Revert 2e43d973feee09a00a149de68b4ff2d3337dada1

