### PR TITLE
Add again #1299 with fix

### DIFF
--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -230,19 +230,8 @@ pub trait InterestAccrual<InterestRate, Balance, Adjustment> {
 	type NormalizedDebt: Member + Parameter + MaxEncodedLen + TypeInfo + Copy + Zero;
 	type Rates: RateCollection<InterestRate, Balance, Self::NormalizedDebt>;
 
-	/// Calculate the current debt using normalized debt * cumulative rate
-	fn current_debt(
-		interest_rate_per_year: InterestRate,
-		normalized_debt: Self::NormalizedDebt,
-	) -> Result<Balance, DispatchError>;
-
-	/// Calculate a previous debt using normalized debt * previous cumulative rate
-	///
-	/// If `when` is further in the past than the last time the
-	/// normalized debt was adjusted, this will return nonsense
-	/// (effectively "rewinding the clock" to before the value was
-	/// valid)
-	fn previous_debt(
+	/// Calculate the debt at an specific moment
+	fn calculate_debt(
 		interest_rate_per_year: InterestRate,
 		normalized_debt: Self::NormalizedDebt,
 		when: Moment,

--- a/pallets/interest-accrual/src/lib.rs
+++ b/pallets/interest-accrual/src/lib.rs
@@ -135,7 +135,7 @@ use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, CheckedAdd, CheckedSub, Saturating},
 	ArithmeticError, DispatchError, FixedPointNumber, FixedPointOperand,
 };
-use sp_std::vec::Vec;
+use sp_std::{cmp::Ordering, vec::Vec};
 
 pub mod migrations;
 pub mod weights;
@@ -290,8 +290,8 @@ pub mod pallet {
 		fn on_initialize(_: T::BlockNumber) -> Weight {
 			let then = LastUpdated::<T>::get();
 			let now = Self::now();
-			LastUpdated::<T>::set(Self::now());
-			let delta = Self::now() - then;
+			LastUpdated::<T>::set(now);
+			let delta = now - then;
 			let bits = Moment::BITS - delta.leading_zeros();
 
 			// reads: timestamp, last updated, rates vec
@@ -335,30 +335,35 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		pub fn get_current_debt(
-			interest_rate_per_year: T::InterestRate,
-			normalized_debt: T::Balance,
-		) -> Result<T::Balance, DispatchError> {
-			let rate = Self::get_rate(interest_rate_per_year)?;
-			Self::calculate_debt(normalized_debt, rate.accumulated_rate)
-				.ok_or_else(|| Error::<T>::DebtCalculationFailed.into())
-		}
-
-		pub fn get_previous_debt(
+		/// Calculate fastly the current debt using normalized debt * cumulative rate if
+		/// `when` is exactly `now` (same block). If when is in the past it recomputes
+		/// the previous cumulative rate.
+		///
+		/// If `when` is further in the past than the last time the
+		/// normalized debt was adjusted, this will return nonsense
+		/// (effectively "rewinding the clock" to before the value was
+		/// valid)
+		pub fn get_debt(
 			interest_rate_per_year: T::InterestRate,
 			normalized_debt: T::Balance,
 			when: Moment,
 		) -> Result<T::Balance, DispatchError> {
 			let rate = Self::get_rate(interest_rate_per_year)?;
 			let now = LastUpdated::<T>::get();
-			if when > now {
-				return Err(Error::<T>::NotInPast.into());
-			}
-			let delta = now - when;
-			let rate_adjustment = checked_pow(rate.interest_rate_per_sec, delta.ensure_into()?)
-				.ok_or(ArithmeticError::Overflow)?;
-			let past_rate = rate.accumulated_rate.ensure_div(rate_adjustment)?;
-			Self::calculate_debt(normalized_debt, past_rate)
+
+			let acc_rate = match when.cmp(&now) {
+				Ordering::Equal => rate.accumulated_rate,
+				Ordering::Less => {
+					let delta = now.ensure_sub(when)?;
+					let rate_adjustment =
+						checked_pow(rate.interest_rate_per_sec, delta.ensure_into()?)
+							.ok_or(ArithmeticError::Overflow)?;
+					rate.accumulated_rate.ensure_div(rate_adjustment)?
+				}
+				Ordering::Greater => return Err(Error::<T>::NotInPast.into()),
+			};
+
+			Self::calculate_debt(normalized_debt, acc_rate)
 				.ok_or_else(|| Error::<T>::DebtCalculationFailed.into())
 		}
 
@@ -510,19 +515,12 @@ impl<T: Config> InterestAccrual<T::InterestRate, T::Balance, Adjustment<T::Balan
 	type NormalizedDebt = T::Balance;
 	type Rates = RateVec<T>;
 
-	fn current_debt(
-		interest_rate_per_year: T::InterestRate,
-		normalized_debt: Self::NormalizedDebt,
-	) -> Result<T::Balance, DispatchError> {
-		Pallet::<T>::get_current_debt(interest_rate_per_year, normalized_debt)
-	}
-
-	fn previous_debt(
+	fn calculate_debt(
 		interest_rate_per_year: T::InterestRate,
 		normalized_debt: Self::NormalizedDebt,
 		when: Moment,
 	) -> Result<T::Balance, DispatchError> {
-		Pallet::<T>::get_previous_debt(interest_rate_per_year, normalized_debt, when)
+		Pallet::<T>::get_debt(interest_rate_per_year, normalized_debt, when)
 	}
 
 	fn adjust_normalized_debt(

--- a/pallets/interest-accrual/src/lib.rs
+++ b/pallets/interest-accrual/src/lib.rs
@@ -260,8 +260,6 @@ pub mod pallet {
 		DebtAdjustmentFailed,
 		/// Emits when the interest rate was not used
 		NoSuchRate,
-		/// Emits when a historic rate was asked for from the future
-		NotInPast,
 		/// Emits when a rate is not within the valid range
 		InvalidRate,
 		/// Emits when adding a new rate would exceed the storage limits
@@ -360,7 +358,10 @@ pub mod pallet {
 							.ok_or(ArithmeticError::Overflow)?;
 					rate.accumulated_rate.ensure_div(rate_adjustment)?
 				}
-				Ordering::Greater => return Err(Error::<T>::NotInPast.into()),
+				Ordering::Greater => {
+					// TODO: This is a fast fix, the correct solution should be #1304
+					rate.accumulated_rate
+				}
 			};
 
 			Self::calculate_debt(normalized_debt, acc_rate)

--- a/pallets/loans-ref/src/tests.rs
+++ b/pallets/loans-ref/src/tests.rs
@@ -47,7 +47,7 @@ mod util {
 	}
 
 	pub fn current_loan_debt(loan_id: LoanId) -> Balance {
-		get_loan(loan_id).debt(None).unwrap()
+		get_loan(loan_id).calculate_debt(now().as_secs()).unwrap()
 	}
 
 	pub fn current_loan_pv(loan_id: LoanId) -> Balance {

--- a/pallets/loans-ref/src/types.rs
+++ b/pallets/loans-ref/src/types.rs
@@ -489,23 +489,12 @@ impl<T: Config> ActiveLoan<T> {
 		&self.write_off_status
 	}
 
-	/// Returns the debt for the current loan.
-	/// If None, it returns the corresponding debt at now().
-	pub fn debt(&self, when: Option<Moment>) -> Result<T::Balance, DispatchError> {
-		// TODO: simplify this once issue
-		// https://github.com/centrifuge/centrifuge-chain/issues/1203 is merged.
-		match when {
-			Some(when) if when != T::Time::now().as_secs() => T::InterestAccrual::previous_debt(
-				self.info.interest_rate,
-				self.normalized_debt,
-				when,
-			),
-			_ => T::InterestAccrual::current_debt(self.info.interest_rate, self.normalized_debt),
-		}
+	pub fn calculate_debt(&self, when: Moment) -> Result<T::Balance, DispatchError> {
+		T::InterestAccrual::calculate_debt(self.info.interest_rate, self.normalized_debt, when)
 	}
 
 	pub fn present_value_at(&self, when: Moment) -> Result<T::Balance, DispatchError> {
-		self.present_value(self.debt(Some(when))?, when)
+		self.present_value(self.calculate_debt(when)?, when)
 	}
 
 	/// An optimized version of `ActiveLoan::present_value_at()` when last updated is now.
@@ -563,14 +552,14 @@ impl<T: Config> ActiveLoan<T> {
 		T::InterestAccrual::unreference_rate(old_interest_rate)
 	}
 
-	fn max_borrow_amount(&self) -> Result<T::Balance, DispatchError> {
+	fn max_borrow_amount(&self, when: Moment) -> Result<T::Balance, DispatchError> {
 		Ok(match self.info.restrictions.max_borrow_amount {
 			MaxBorrowAmount::UpToTotalBorrowed { advance_rate } => advance_rate
 				.ensure_mul_int(self.info.collateral_value)?
 				.saturating_sub(self.total_borrowed),
 			MaxBorrowAmount::UpToOutstandingDebt { advance_rate } => advance_rate
 				.ensure_mul_int(self.info.collateral_value)?
-				.saturating_sub(self.debt(None)?),
+				.saturating_sub(self.calculate_debt(when)?),
 		})
 	}
 
@@ -592,7 +581,7 @@ impl<T: Config> ActiveLoan<T> {
 		);
 
 		ensure!(
-			amount <= self.max_borrow_amount()?,
+			amount <= self.max_borrow_amount(now)?,
 			Error::<T>::from(BorrowLoanError::MaxAmountExceeded)
 		);
 
@@ -614,8 +603,10 @@ impl<T: Config> ActiveLoan<T> {
 	}
 
 	fn ensure_can_repay(&self, amount: T::Balance) -> Result<T::Balance, DispatchError> {
+		let now = T::Time::now().as_secs();
+
 		// Only repay until the current debt
-		let amount = amount.min(self.debt(None)?);
+		let amount = amount.min(self.calculate_debt(now)?);
 
 		match self.info.restrictions.repayments {
 			RepayRestrictions::None => (),


### PR DESCRIPTION
# Description

Adds again #1299 with a fast fix to avoid this issue: #1304

The fix consists in removing the `NotInPast` error completely, given the user the most updated debt in case `when` is one block in the "future".

**NOTE: The correct fix should be #1304**