### PR TITLE
Develop 1020

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "development-runtime"
-version = "0.10.19"
+version = "0.10.20"
 dependencies = [
  "cfg-primitives",
  "cfg-traits",

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
             };
 
             # This is a hash of all the Cargo dependencies, for reproducibility.
-            cargoSha256 = "sha256-h4Vlu7ilGD8MtewSaNC6k5EsM2SS1UyzM6UxIYC5ECE=";
+            cargoSha256 = "sha256-/BvSFCr+9W87lz7yZJuZeU9ewrShAkdgmS+TW2y6TIY=";
 
             nativeBuildInputs = with pkgs; [ clang git-mock pkg-config ];
             buildInputs = with pkgs; [ openssl ] ++ (

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "development-runtime"
-version = "0.10.19"
+version = "0.10.20"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge-devel"),
 	impl_name: create_runtime_str!("centrifuge-devel"),
 	authoring_version: 1,
-	spec_version: 1019,
+	spec_version: 1020,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
@@ -1814,18 +1814,10 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	UpgradeDev1019,
+	UpgradeDev1020,
 >;
 
-type UpgradeDev1019 = SchedulerMigrationV4;
-
-// Migration for scheduler pallet to move from a plain Call to a CallOrHash.
-pub struct SchedulerMigrationV4;
-impl frame_support::traits::OnRuntimeUpgrade for SchedulerMigrationV4 {
-	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		Scheduler::migrate_v3_to_v4()
-	}
-}
+type UpgradeDev1020 = pallet_pool_system::migrations::v1::Migration<Runtime, MaxSizeMetadata>;
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {


### PR DESCRIPTION
# Description

* Adds missing migration (#1285) to develop runtime
* Bumps spec version to `1020` required for the runtime upgrade execution

Fixes 
* Pools not being decodable by runtime in `1019` spec version

## How to test
This bump already successfully fixed the Dev chain.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
