### PR TITLE
ci: disable docker nix build

### DIFF
--- a/.github/workflows/docker-nix.yml
+++ b/.github/workflows/docker-nix.yml
@@ -1,31 +1,31 @@
-name: docker
-on:
-  push:
-    branches: [main, 'release-v**']
-jobs:
-  docker:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-        target: [".#dockerImage", ".#dockerImageFastRuntime"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: cachix/install-nix-action@v17
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.10.3/install
-      - name: Build Docker image
-        run: |
-          nix build --no-allow-dirty -L ${{ matrix.target }}
-          docker load < result
-      - name: Login to Docker Hub
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: List images
-        run: docker images
-      - name: Push image to Docker Hub
-        run: docker push --all-tags --quiet centrifugeio/centrifuge-chain
+# name: docker
+# on:
+#   push:
+#     branches: [main, 'release-v**']
+# jobs:
+#   docker:
+#     strategy:
+#       matrix:
+#         os: [ ubuntu-latest ]
+#         target: [".#dockerImage", ".#dockerImageFastRuntime"]
+#     runs-on: ${{ matrix.os }}
+#     steps:
+#       - uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 0
+#       - uses: cachix/install-nix-action@v17
+#         with:
+#           install_url: https://releases.nixos.org/nix/nix-2.10.3/install
+#       - name: Build Docker image
+#         run: |
+#           nix build --no-allow-dirty -L ${{ matrix.target }}
+#           docker load < result
+#       - name: Login to Docker Hub
+#         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+#         with:
+#           username: ${{ secrets.DOCKER_HUB_USERNAME }}
+#           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+#       - name: List images
+#         run: docker images
+#       - name: Push image to Docker Hub
+#         run: docker push --all-tags --quiet centrifugeio/centrifuge-chain

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,7 +3,7 @@
 set -eux
 
 RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-nightly-2022-11-14}"
-SRTOOL_VERSION="${SRTOOL_VERSION:-1.64.0}"
+SRTOOL_VERSION="${SRTOOL_VERSION:-1.66.1-0.9.25}"
 PACKAGE="${PACKAGE:-centrifuge-runtime}" # Need to replicate job for all runtimes
 RUNTIME="${RUNTIME:-centrifuge}"
 


### PR DESCRIPTION
# Description

* Disables docker nix build CI action which seems to be the root of our CI failing to push new docker images
* Bumps srtool to its latest version v1.66.1-0.9.25 from v1.64.0

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
