### PR TITLE
Mock-builder with generic methods support

### DIFF
--- a/libs/mock-builder/Cargo.toml
+++ b/libs/mock-builder/Cargo.toml
@@ -10,9 +10,11 @@ version = "0.0.1"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[dependencies]
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 scale-info = { version = "2.3.0", features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }

--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -87,7 +87,7 @@ where
 		.expect(&format!("Mock was not found. Location: {location:?}"));
 
 	storage::execute_call(call_id, input).expect(&format!(
-		"Mock was found but the its input/output types differ than {location:?}"
+		"Mock was found but its input/output types differ. Location: {location:?}"
 	))
 }
 

--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -86,8 +86,8 @@ where
 	let call_id = Map::try_get(location.hash::<Blake2_128>())
 		.unwrap_or_else(|_| panic!("Mock was not found. Location: {location:?}"));
 
-	storage::execute_call(call_id, input).unwrap_or_else(|| {
-		panic!("Mock was found but its input/output types differ. Location: {location:?}")
+	storage::execute_call(call_id, input).unwrap_or_else(|err| {
+		panic!("{err}. Location: {location:?}");
 	})
 }
 

--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -84,11 +84,11 @@ where
 		.append_type_signature::<I, O>();
 
 	let call_id = Map::try_get(location.hash::<Blake2_128>())
-		.expect(&format!("Mock was not found. Location: {location:?}"));
+		.unwrap_or_else(|_| panic!("Mock was not found. Location: {location:?}"));
 
-	storage::execute_call(call_id, input).expect(&format!(
-		"Mock was found but its input/output types differ. Location: {location:?}"
-	))
+	storage::execute_call(call_id, input).unwrap_or_else(|| {
+		panic!("Mock was found but its input/output types differ. Location: {location:?}")
+	})
 }
 
 /// Register a mock function into the mock function storage.

--- a/libs/mock-builder/src/location.rs
+++ b/libs/mock-builder/src/location.rs
@@ -37,7 +37,7 @@ impl FunctionLocation {
 	pub fn normalize(self) -> Self {
 		let (path, name) = self.0.rsplit_once("::").expect("always ::");
 		let path = path
-			.strip_prefix("<")
+			.strip_prefix('<')
 			.map(|trait_path| trait_path.split_once(" as").expect("always ' as'").0)
 			.unwrap_or(path);
 
@@ -47,10 +47,12 @@ impl FunctionLocation {
 	/// Remove the prefix from the function name.
 	pub fn strip_name_prefix(self, prefix: &str) -> Self {
 		let (path, name) = self.0.rsplit_once("::").expect("always ::");
-		let name = name.strip_prefix(prefix).expect(&format!(
-			"Function '{name}' should have a '{prefix}' prefix. Location: {}",
-			self.0
-		));
+		let name = name.strip_prefix(prefix).unwrap_or_else(|| {
+			panic!(
+				"Function '{name}' should have a '{prefix}' prefix. Location: {}",
+				self.0
+			)
+		});
 
 		Self(format!("{}::{}", path, name))
 	}

--- a/libs/mock-builder/src/location.rs
+++ b/libs/mock-builder/src/location.rs
@@ -89,7 +89,7 @@ mod tests {
 			FunctionLocation::from(|| ())
 		}
 
-		fn mock_generic_method<A: Into<i32>, B: Into<u32>>() -> FunctionLocation {
+		fn mock_generic_method<A: Into<i32>>(_: impl Into<u32>) -> FunctionLocation {
 			FunctionLocation::from(|| ())
 		}
 	}
@@ -112,7 +112,7 @@ mod tests {
 		);
 
 		assert_eq!(
-			Example::mock_generic_method::<i8, u8>().0,
+			Example::mock_generic_method::<i8>(0u8).0,
 			format!("{PREFIX}::Example::mock_generic_method")
 		);
 

--- a/libs/mock-builder/src/location.rs
+++ b/libs/mock-builder/src/location.rs
@@ -5,12 +5,12 @@ use frame_support::StorageHasher;
 pub struct FunctionLocation(String);
 
 impl FunctionLocation {
-	/// Creates a location for the function who has create the given clousure used as a locator
+	/// Creates a location for the function which created the given closure used as a locator
 	pub fn from<F: Fn()>(_: F) -> Self {
 		let location = std::any::type_name::<F>();
 		let location = &location[..location.len() - "::{{closure}}".len()];
 
-		// Remove generic attributes from signature if it has
+		// Remove generic attributes from signature if it has any
 		let location = location
 			.ends_with('>')
 			.then(|| {

--- a/libs/mock-builder/src/location.rs
+++ b/libs/mock-builder/src/location.rs
@@ -1,0 +1,158 @@
+use frame_support::StorageHasher;
+
+/// Absolute string identification of function.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FunctionLocation(String);
+
+impl FunctionLocation {
+	/// Creates a location for the function who has create the given clousure used as a locator
+	pub fn from<F: Fn()>(_: F) -> Self {
+		let location = std::any::type_name::<F>();
+		let location = &location[..location.len() - "::{{closure}}".len()];
+
+		// Remove generic attributes from signature if it has
+		let location = location
+			.ends_with('>')
+			.then(|| {
+				let mut count = 0;
+				for (i, c) in location.chars().rev().enumerate() {
+					if c == '>' {
+						count += 1;
+					} else if c == '<' {
+						count -= 1;
+						if count == 0 {
+							return location.split_at(location.len() - i - 1).0;
+						}
+					}
+				}
+				panic!("Expected '<' symbol to close '>'");
+			})
+			.unwrap_or(location);
+
+		Self(location.into())
+	}
+
+	/// Normalize the location, allowing to identify the function
+	/// no matter if it belongs to a trait or not.
+	pub fn normalize(self) -> Self {
+		let (path, name) = self.0.rsplit_once("::").expect("always ::");
+		let path = path
+			.strip_prefix("<")
+			.map(|trait_path| trait_path.split_once(" as").expect("always ' as'").0)
+			.unwrap_or(path);
+
+		Self(format!("{}::{}", path, name))
+	}
+
+	/// Remove the prefix from the function name.
+	pub fn strip_name_prefix(self, prefix: &str) -> Self {
+		let (path, name) = self.0.rsplit_once("::").expect("always ::");
+		let name = name.strip_prefix(prefix).expect(&format!(
+			"Function '{name}' should have a '{prefix}' prefix. Location: {}",
+			self.0
+		));
+
+		Self(format!("{}::{}", path, name))
+	}
+
+	/// Add a representation of the function input and output types
+	pub fn append_type_signature<I, O>(self) -> Self {
+		Self(format!(
+			"{}:{}->{}",
+			self.0,
+			std::any::type_name::<I>(),
+			std::any::type_name::<O>(),
+		))
+	}
+
+	/// Generate a hash of the location
+	pub fn hash<Hasher: StorageHasher>(&self) -> Hasher::Output {
+		Hasher::hash(self.0.as_bytes())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const PREFIX: &str = "mock_builder::location::tests";
+
+	trait TraitExample {
+		fn method() -> FunctionLocation;
+		fn generic_method<A: Into<i32>>(_: impl Into<u32>) -> FunctionLocation;
+	}
+
+	struct Example;
+
+	impl Example {
+		fn mock_method() -> FunctionLocation {
+			FunctionLocation::from(|| ())
+		}
+
+		fn mock_generic_method<A: Into<i32>, B: Into<u32>>() -> FunctionLocation {
+			FunctionLocation::from(|| ())
+		}
+	}
+
+	impl TraitExample for Example {
+		fn method() -> FunctionLocation {
+			FunctionLocation::from(|| ())
+		}
+
+		fn generic_method<A: Into<i32>>(_: impl Into<u32>) -> FunctionLocation {
+			FunctionLocation::from(|| ())
+		}
+	}
+
+	#[test]
+	fn function_location() {
+		assert_eq!(
+			Example::mock_method().0,
+			format!("{PREFIX}::Example::mock_method")
+		);
+
+		assert_eq!(
+			Example::mock_generic_method::<i8, u8>().0,
+			format!("{PREFIX}::Example::mock_generic_method")
+		);
+
+		assert_eq!(
+			Example::method().0,
+			format!("<{PREFIX}::Example as {PREFIX}::TraitExample>::method")
+		);
+
+		assert_eq!(
+			Example::generic_method::<i8>(0u8).0,
+			format!("<{PREFIX}::Example as {PREFIX}::TraitExample>::generic_method")
+		);
+	}
+
+	#[test]
+	fn normalized_function_location() {
+		assert_eq!(
+			Example::mock_method().normalize().0,
+			format!("{PREFIX}::Example::mock_method")
+		);
+
+		assert_eq!(
+			Example::method().normalize().0,
+			format!("{PREFIX}::Example::method")
+		);
+	}
+
+	#[test]
+	fn striped_function_location() {
+		assert_eq!(
+			Example::mock_method().strip_name_prefix("mock_").0,
+			format!("{PREFIX}::Example::method")
+		);
+	}
+
+	#[test]
+	fn appended_type_signature() {
+		assert_eq!(
+			Example::mock_method().append_type_signature::<i8, u8>().0,
+			format!("{PREFIX}::Example::mock_method:i8->u8")
+		);
+	}
+}

--- a/libs/mock-builder/src/storage.rs
+++ b/libs/mock-builder/src/storage.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, cell::RefCell, collections::HashMap};
+use std::{any::Any, cell::RefCell, collections::HashMap, fmt};
 
 /// Identify a call in the call storage
 pub type CallId = u64;
@@ -20,6 +20,25 @@ impl<Input: 'static, Output: 'static> Callable for CallWrapper<Input, Output> {
 	}
 }
 
+#[derive(Debug, PartialEq)]
+pub enum Error {
+	CallNotFound,
+	TypeNotMatch,
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(
+			f,
+			"{}",
+			match self {
+				Error::CallNotFound => "Trying to call a function that is not registered",
+				Error::TypeNotMatch => "The function is registered but the type mismatches",
+			}
+		)
+	}
+}
+
 /// Register a call into the call storage.
 /// The registered call can be uniquely identified by the returned `CallId`.
 pub fn register_call<F: Fn(Args) -> R + 'static, Args: 'static, R: 'static>(f: F) -> CallId {
@@ -32,13 +51,14 @@ pub fn register_call<F: Fn(Args) -> R + 'static, Args: 'static, R: 'static>(f: F
 }
 
 /// Execute a call from the call storage identified by a `call_id`.
-pub fn execute_call<Args: 'static, R: 'static>(call_id: CallId, args: Args) -> Option<R> {
+pub fn execute_call<Args: 'static, R: 'static>(call_id: CallId, args: Args) -> Result<R, Error> {
 	CALLS.with(|state| {
 		let registry = &*state.borrow();
-		let call = registry.get(&call_id).unwrap();
+		let call = registry.get(&call_id).ok_or(Error::CallNotFound)?;
 		call.as_any()
 			.downcast_ref::<CallWrapper<Args, R>>()
 			.map(|wrapper| wrapper.0(args))
+			.ok_or(Error::TypeNotMatch)
 	})
 }
 
@@ -52,7 +72,7 @@ mod tests {
 		let call_id_1 = register_call(func_1);
 		let result = execute_call::<_, usize>(call_id_1, 2u8);
 
-		assert_eq!(result, Some(46));
+		assert_eq!(result, Ok(46));
 	}
 
 	#[test]
@@ -61,7 +81,7 @@ mod tests {
 		let call_id_1 = register_call(func_1);
 		let result = execute_call::<_, usize>(call_id_1, 'a');
 
-		assert_eq!(result, None);
+		assert_eq!(result, Err(Error::TypeNotMatch));
 	}
 
 	#[test]
@@ -70,14 +90,16 @@ mod tests {
 		let call_id_1 = register_call(func_1);
 		let result = execute_call::<_, char>(call_id_1, 2u8);
 
-		assert_eq!(result, None);
+		assert_eq!(result, Err(Error::TypeNotMatch));
 	}
 
 	#[test]
-	#[should_panic]
 	fn no_registered() {
 		let call_id_1 = 42;
 
-		let _ = execute_call::<_, usize>(call_id_1, 2u8);
+		assert_eq!(
+			execute_call::<_, usize>(call_id_1, 2u8),
+			Err(Error::CallNotFound)
+		);
 	}
 }

--- a/libs/mock-builder/src/storage.rs
+++ b/libs/mock-builder/src/storage.rs
@@ -1,0 +1,85 @@
+use std::{any::Any, cell::RefCell, collections::HashMap};
+
+/// Identify a call in the call storage
+pub type CallId = u64;
+
+trait Callable {
+	fn as_any(&self) -> &dyn Any;
+}
+
+thread_local! {
+	static CALLS: RefCell<HashMap<CallId, Box<dyn Callable>>>
+		= RefCell::new(HashMap::default());
+}
+
+struct CallWrapper<Input, Output>(Box<dyn Fn(Input) -> Output>);
+
+impl<Input: 'static, Output: 'static> Callable for CallWrapper<Input, Output> {
+	fn as_any(&self) -> &dyn Any {
+		self
+	}
+}
+
+/// Register a call into the call storage.
+/// The registered call can be uniquely identified by the returned `CallId`.
+pub fn register_call<F: Fn(Args) -> R + 'static, Args: 'static, R: 'static>(f: F) -> CallId {
+	CALLS.with(|state| {
+		let registry = &mut *state.borrow_mut();
+		let call_id = registry.len() as u64;
+		registry.insert(call_id, Box::new(CallWrapper(Box::new(f))));
+		call_id
+	})
+}
+
+/// Execute a call from the call storage identified by a `call_id`.
+pub fn execute_call<Args: 'static, R: 'static>(call_id: CallId, args: Args) -> Result<R, ()> {
+	CALLS.with(|state| {
+		let registry = &*state.borrow();
+		let call = registry.get(&call_id).unwrap();
+		Ok(call
+			.as_any()
+			.downcast_ref::<CallWrapper<Args, R>>()
+			.ok_or(())?
+			.0(args))
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn correct_type() {
+		let func_1 = |n: u8| -> usize { 23 * n as usize };
+		let call_id_1 = register_call(func_1);
+		let result = execute_call::<_, usize>(call_id_1, 2u8);
+
+		assert_eq!(result, Ok(46));
+	}
+
+	#[test]
+	fn different_input_type() {
+		let func_1 = |n: u8| -> usize { 23 * n as usize };
+		let call_id_1 = register_call(func_1);
+		let result = execute_call::<_, usize>(call_id_1, 'a');
+
+		assert_eq!(result, Err(()));
+	}
+
+	#[test]
+	fn different_output_type() {
+		let func_1 = |n: u8| -> usize { 23 * n as usize };
+		let call_id_1 = register_call(func_1);
+		let result = execute_call::<_, char>(call_id_1, 2u8);
+
+		assert_eq!(result, Err(()));
+	}
+
+	#[test]
+	#[should_panic]
+	fn no_registered() {
+		let call_id_1 = 42;
+
+		let _ = execute_call::<_, usize>(call_id_1, 2u8);
+	}
+}


### PR DESCRIPTION
# Description

This PR gives to `mock-builder` the capability of mocking methods with generic bounds

Fixes #1316

## Changes and Descriptions
- Added function identification with generics
- Fully refactorized to reduce macro usage and allows better organization
- Better error descriptions of what is going wrong.
- Added new tests
