### PR TITLE
CollectionDataFeed: Minor changes

### DIFF
--- a/libs/mocks/src/data.rs
+++ b/libs/mocks/src/data.rs
@@ -29,7 +29,7 @@ pub mod pallet {
 			register_call!(f);
 		}
 
-		pub fn mock_cache(f: impl Fn(&T::CollectionId) -> T::Collection + 'static) {
+		pub fn mock_collection(f: impl Fn(&T::CollectionId) -> T::Collection + 'static) {
 			register_call!(f);
 		}
 
@@ -69,25 +69,21 @@ pub mod pallet {
 
 	#[cfg(feature = "std")]
 	pub mod util {
-		use std::collections::HashMap;
-
 		use super::*;
 
-		pub struct MockDataCollection<T: Config>(pub HashMap<T::DataId, T::Data>);
+		pub struct MockDataCollection<DataId, Data>(Box<dyn Fn(&DataId) -> Data>);
 
-		impl<T: Config> DataCollection<T::DataId> for MockDataCollection<T>
-		where
-			T::DataId: std::hash::Hash + Eq,
-			T::Data: Clone,
-		{
-			type Data = Result<T::Data, DispatchError>;
+		impl<DataId, Data> MockDataCollection<DataId, Data> {
+			pub fn new(f: impl Fn(&DataId) -> Data + 'static) -> Self {
+				Self(Box::new(f))
+			}
+		}
 
-			fn get(&self, data_id: &T::DataId) -> Self::Data {
-				Ok(self
-					.0
-					.get(data_id)
-					.ok_or(DispatchError::CannotLookup)?
-					.clone())
+		impl<DataId, Data> DataCollection<DataId> for MockDataCollection<DataId, Data> {
+			type Data = Data;
+
+			fn get(&self, data_id: &DataId) -> Self::Data {
+				(self.0)(data_id)
 			}
 		}
 	}

--- a/libs/traits/src/data.rs
+++ b/libs/traits/src/data.rs
@@ -1,3 +1,16 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
 use sp_runtime::DispatchResult;
 
 /// Abstraction that represents a storage where

--- a/pallets/collection-data-feed/Cargo.toml
+++ b/pallets/collection-data-feed/Cargo.toml
@@ -20,7 +20,7 @@ sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-featu
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = true, branch = "polkadot-v0.9.37" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.37" }
 
 cfg-traits = { path = "../../libs/traits", default-features = false }
 
@@ -43,15 +43,4 @@ std = [
   "sp-std/std",
   "cfg-traits/std",
   "orml-traits/std",
-]
-runtime-benchmarks = [
-  "frame-support/runtime-benchmarks",
-  "frame-system/runtime-benchmarks",
-  "sp-runtime/runtime-benchmarks",
-  "cfg-traits/runtime-benchmarks",
-]
-try-runtime = [
-  "frame-support/try-runtime",
-  "frame-system/try-runtime",
-  "cfg-traits/try-runtime",
 ]

--- a/pallets/collection-data-feed/src/lib.rs
+++ b/pallets/collection-data-feed/src/lib.rs
@@ -110,7 +110,7 @@ pub mod pallet {
 		type Data = Result<DataValueOf<T>, DispatchError>;
 
 		fn get(data_id: &T::DataId) -> Self::Data {
-			T::DataProvider::get_no_op(data_id).ok_or(Error::<T>::DataIdWithoutData.into())
+			T::DataProvider::get_no_op(data_id).ok_or_else(|| Error::<T>::DataIdWithoutData.into())
 		}
 
 		fn collection(collection_id: &T::CollectionId) -> Self::Collection {

--- a/pallets/collection-data-feed/src/lib.rs
+++ b/pallets/collection-data-feed/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Centrifuge GmbH (centrifuge.io).
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
 // This file is part of Centrifuge chain project.
 
 // Centrifuge is free software: you can redistribute it and/or modify
@@ -13,6 +13,9 @@
 
 //! Collects data from a feeder entity into collections to fastly read data in
 //! one memory access.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub use pallet::*;
 
 #[cfg(test)]
@@ -31,7 +34,7 @@ pub mod pallet {
 		DispatchError,
 	};
 
-	type DataValueOf<T> = Option<(<T as Config>::Data, <T as Config>::Moment)>;
+	type DataValueOf<T> = (<T as Config>::Data, <T as Config>::Moment);
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
@@ -91,6 +94,9 @@ pub mod pallet {
 		/// The used data ID is not in the collection.
 		DataIdNotInCollection,
 
+		/// Max collection number exceeded
+		DataIdWithoutValue,
+
 		/// Max collection size exceeded
 		MaxCollectionSize,
 
@@ -100,10 +106,10 @@ pub mod pallet {
 
 	impl<T: Config> DataRegistry<T::DataId, T::CollectionId> for Pallet<T> {
 		type Collection = CachedCollection<T>;
-		type Data = DataValueOf<T>;
+		type Data = Result<DataValueOf<T>, DispatchError>;
 
-		fn get(data_id: &T::DataId) -> DataValueOf<T> {
-			T::DataProvider::get_no_op(data_id)
+		fn get(data_id: &T::DataId) -> Self::Data {
+			T::DataProvider::get_no_op(data_id).ok_or(Error::<T>::DataIdWithoutValue.into())
 		}
 
 		fn collection(collection_id: &T::CollectionId) -> Self::Collection {
@@ -120,7 +126,7 @@ pub mod pallet {
 
 					Collection::<T>::try_mutate(collection_id, |collection| {
 						collection
-							.try_insert(data_id.clone(), Self::get(data_id))
+							.try_insert(data_id.clone(), Self::get(data_id)?)
 							.map(|_| ())
 							.map_err(|_| Error::<T>::MaxCollectionSize.into())
 					})
@@ -152,9 +158,11 @@ pub mod pallet {
 			// for Data values.
 			for collection_id in Listening::<T>::get(data_id).keys() {
 				Collection::<T>::mutate(collection_id, |collection| {
-					collection
-						.get_mut(data_id)
-						.map(|value| *value = Self::get(data_id))
+					if let Some(value) = collection.get_mut(data_id) {
+						if let Ok(new_value) = Self::get(data_id) {
+							*value = new_value;
+						}
+					}
 				});
 			}
 		}

--- a/pallets/collection-data-feed/src/lib.rs
+++ b/pallets/collection-data-feed/src/lib.rs
@@ -94,8 +94,9 @@ pub mod pallet {
 		/// The used data ID is not in the collection.
 		DataIdNotInCollection,
 
-		/// Max collection number exceeded
-		DataIdWithoutValue,
+		/// The data ID doesn't have data associated to it.
+		/// The data was never set for the Id.
+		DataIdWithoutData,
 
 		/// Max collection size exceeded
 		MaxCollectionSize,
@@ -109,7 +110,7 @@ pub mod pallet {
 		type Data = Result<DataValueOf<T>, DispatchError>;
 
 		fn get(data_id: &T::DataId) -> Self::Data {
-			T::DataProvider::get_no_op(data_id).ok_or(Error::<T>::DataIdWithoutValue.into())
+			T::DataProvider::get_no_op(data_id).ok_or(Error::<T>::DataIdWithoutData.into())
 		}
 
 		fn collection(collection_id: &T::CollectionId) -> Self::Collection {

--- a/pallets/collection-data-feed/src/mock.rs
+++ b/pallets/collection-data-feed/src/mock.rs
@@ -1,3 +1,16 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, IsInVec};
 use orml_oracle::{CombineData, DataProviderExtended};
 use sp_core::H256;

--- a/pallets/collection-data-feed/src/tests.rs
+++ b/pallets/collection-data-feed/src/tests.rs
@@ -1,3 +1,16 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
 use cfg_traits::data::{DataCollection, DataRegistry};
 use frame_support::{assert_noop, assert_ok, pallet_prelude::Hooks};
 use orml_traits::DataFeeder;
@@ -19,21 +32,24 @@ fn feed(data_id: DataId, data: Data) {
 #[test]
 fn get_no_fed_data() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(CollectionDataFeed::get(&DATA_ID), None);
+		assert_noop!(
+			CollectionDataFeed::get(&DATA_ID),
+			Error::<Runtime>::DataIdWithoutValue
+		);
 	});
 }
 
 #[test]
-fn get_fed_data() {
+fn get_feed_data() {
 	new_test_ext().execute_with(|| {
 		feed(DATA_ID, 100);
 
-		assert_eq!(CollectionDataFeed::get(&DATA_ID), Some((100, Timer::now())));
+		assert_eq!(CollectionDataFeed::get(&DATA_ID), Ok((100, Timer::now())));
 
 		advance_time(BLOCK_TIME_MS);
 		feed(DATA_ID, 200);
 
-		assert_eq!(CollectionDataFeed::get(&DATA_ID), Some((200, Timer::now())));
+		assert_eq!(CollectionDataFeed::get(&DATA_ID), Ok((200, Timer::now())));
 	});
 }
 
@@ -46,7 +62,7 @@ fn feed_and_then_register() {
 
 		assert_ok!(
 			CollectionDataFeed::collection(&COLLECTION_ID).get(&DATA_ID),
-			Some((100, Timer::now()))
+			(100, Timer::now())
 		);
 
 		advance_time(BLOCK_TIME_MS);
@@ -54,29 +70,17 @@ fn feed_and_then_register() {
 
 		assert_ok!(
 			CollectionDataFeed::collection(&COLLECTION_ID).get(&DATA_ID),
-			Some((200, Timer::now()))
+			(200, Timer::now())
 		);
 	});
 }
 
 #[test]
-fn register_and_then_feed() {
+fn register_without_feed() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(CollectionDataFeed::register_id(&DATA_ID, &COLLECTION_ID));
-
-		feed(DATA_ID, 100);
-
-		assert_ok!(
-			CollectionDataFeed::collection(&COLLECTION_ID).get(&DATA_ID),
-			Some((100, Timer::now()))
-		);
-
-		advance_time(BLOCK_TIME_MS);
-		feed(DATA_ID, 200);
-
-		assert_ok!(
-			CollectionDataFeed::collection(&COLLECTION_ID).get(&DATA_ID),
-			Some((200, Timer::now()))
+		assert_noop!(
+			CollectionDataFeed::register_id(&DATA_ID, &COLLECTION_ID),
+			Error::<Runtime>::DataIdWithoutValue
 		);
 	});
 }
@@ -127,6 +131,8 @@ fn unregister_without_register() {
 #[test]
 fn register_twice() {
 	new_test_ext().execute_with(|| {
+		feed(DATA_ID, 100);
+
 		assert_ok!(CollectionDataFeed::register_id(&DATA_ID, &COLLECTION_ID));
 
 		assert_ok!(CollectionDataFeed::register_id(&DATA_ID, &COLLECTION_ID));
@@ -145,6 +151,8 @@ fn register_twice() {
 #[test]
 fn max_collection_number() {
 	new_test_ext().execute_with(|| {
+		feed(DATA_ID, 100);
+
 		let max = MaxCollections::get() as CollectionId;
 		for i in 0..max {
 			assert_ok!(CollectionDataFeed::register_id(
@@ -165,12 +173,14 @@ fn max_collection_size() {
 	new_test_ext().execute_with(|| {
 		let max = MaxCollectionSize::get();
 		for i in 0..max {
+			feed(DATA_ID + i, 100);
 			assert_ok!(CollectionDataFeed::register_id(
 				&(DATA_ID + i),
 				&COLLECTION_ID
 			));
 		}
 
+		feed(DATA_ID + max, 100);
 		assert_noop!(
 			CollectionDataFeed::register_id(&(DATA_ID + max), &COLLECTION_ID),
 			Error::<Runtime>::MaxCollectionSize

--- a/pallets/collection-data-feed/src/tests.rs
+++ b/pallets/collection-data-feed/src/tests.rs
@@ -34,7 +34,7 @@ fn get_no_fed_data() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(
 			CollectionDataFeed::get(&DATA_ID),
-			Error::<Runtime>::DataIdWithoutValue
+			Error::<Runtime>::DataIdWithoutData
 		);
 	});
 }
@@ -80,7 +80,7 @@ fn register_without_feed() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(
 			CollectionDataFeed::register_id(&DATA_ID, &COLLECTION_ID),
-			Error::<Runtime>::DataIdWithoutValue
+			Error::<Runtime>::DataIdWithoutData
 		);
 	});
 }


### PR DESCRIPTION
# Description

Minor changes over `collection-data-feed` to prepare it for the OracleValuation feature.

## Changes and Descriptions

- Prices returned as `Result` instead of Option.
- `MockDataCollection` with user callback.
- Add license headers
- Clear unused features
