### PR TITLE
Fix default timestamp for portfolio valuation

### DIFF
--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -253,13 +253,8 @@ pub mod pallet {
 	/// Stores the portfolio valuation associated to each pool
 	#[pallet::storage]
 	#[pallet::getter(fn portfolio_valuation)]
-	pub(crate) type PortfolioValuation<T: Config> = StorageMap<
-		_,
-		Blake2_128Concat,
-		PoolIdOf<T>,
-		types::PortfolioValuation<T::Balance>,
-		ValueQuery,
-	>;
+	pub(crate) type PortfolioValuation<T: Config> =
+		StorageMap<_, Blake2_128Concat, PoolIdOf<T>, types::PortfolioValuation<T>, ValueQuery>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -734,7 +729,7 @@ pub mod pallet {
 
 		fn update_portfolio_valuation_with_pv(
 			pool_id: PoolIdOf<T>,
-			portfolio: &mut types::PortfolioValuation<T::Balance>,
+			portfolio: &mut types::PortfolioValuation<T>,
 			old_pv: T::Balance,
 			new_pv: T::Balance,
 		) -> DispatchResult {


### PR DESCRIPTION
# Description

The `last_updated` field of portfolio valuation is only updating when the valuations are computed. This is ok, nevertheless, if a loan is added to a pool, and modified, it will affect the portfolio valuation without updating the `last_updated`, which by default will be created with `0` instead of `now()`

This means that if some entity call `nav()`, before computing once the portfolio valuation, it will obtain an incorrect time (?). Not sure if this is a possible case or if we always call the `update_portfolio_valuation()` at least once.

Until I see it, the `pool-system` is protected when closing the epoch giving an `NAVTooOld` error, but that means the epoch can not be closed (unless `update_porfolio_valuation()` is called).

If it is a security issue, I understand we need to deliver a fix soon. In case not, and we can live with it, this will be fixed properly in the [Oracle Valuation PR](1311)