### PR TITLE
mock-builder: Main documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,19 +31,19 @@ jobs:
         with:
           command: doc
           args: --all --no-deps
-      
+
       - name: Build Documentation failed
         if: always() && steps.build_docs.outcome == 'failure'
         run: echo ":::error::cargo doc --all --no-deps failed"
         # Job will stop here and the check will be red if Build documentation failed
 
       - name: Create Index file
-        if: github.ref == 'ref/head/main'
+        if: github.ref == 'refs/heads/main'
         run: ./ci/create_index_for_rust_docs.sh
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'ref/head/main'
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -29,19 +29,19 @@
 //! the associated types of your pallet `Config`.
 //!
 //! Then, you are mostly forced to use other pallet configurations
-//! geting a [tight coupling](https://docs.substrate.io/build/pallet-coupling/)
+//! getting a [tight coupling](https://docs.substrate.io/build/pallet-coupling/)
 //! with them. It has some downsides:
 //! - You need to learn how to configure other pallets.
 //! - You need to know how those pallets work, because they affect directly the
 //!   behavior of the pallet you're testing.
 //! - The way they work can give you non-completed tests. It means that some
-//!   paths of your pallet can no be tested because some dependency works in a
+//!   paths of your pallet can not be tested because some dependency works in a
 //!   specific way.
 //! - You need a lot of effort maintaining your tests because each time one
 //!   dependency changes, it can easily break your tests.
 //!
 //! This doesn't scale well. Frequently some pallet dependencies need in turn to
-//! configure their own dependent pallets, making this problem even worst.
+//! configure their own dependent pallets, making this problem even worse.
 //!
 //! This is why mocking is so important. It lets you get rid of all these
 //! dependencies and related issues, obtaining **loose coupling tests**.
@@ -54,8 +54,8 @@
 //! ## *Mock pallet* usage
 //!
 //! Suppose that in our pallet, which we'll call it `my_pallet`, we have an
-//! associated type in our `Config`, which implements a `TraitA` and `TraitB`
-//! traits. Those traits are defined as follows:
+//! associated type in our `Config`, which implements traits `TraitA` and
+//! `TraitB`. Those traits are defined as follows:
 //!
 //! ```no_run
 //! trait TraitA {
@@ -136,8 +136,8 @@
 //! that allow you to build a *mock pallet*.
 //!
 //! - [`register_call!()`] registers a closure where you can define the
-//! mock behavior for that method. The method who register the closure must have
-//! the name of the trait method you want to mock with the prefix `mock_`.
+//! mock behavior for that method. The method which registers the closure must
+//! have the name of the trait method you want to mock prefixed with `mock_`.
 //!
 //! - [`execute_call!()`] is placed in the trait method implementation and will
 //!   call the closure previously registered by [`register_call!()`]
@@ -233,7 +233,7 @@
 //! }
 //! ```
 //!
-//! If types for the closure of `mock_*` method and trait method doesn't match,
+//! If types for the closure of `mock_*` method and trait method don't match,
 //! you will obtain a runtime error in your tests.
 
 /// Provide functions for register/execute calls

--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -71,7 +71,7 @@
 //! }
 //! ```
 //!
-//! We have a real huge pallet that implements a specific behavior for those
+//! We have a really huge pallet that implements a specific behavior for those
 //! traits, but we want to get rid of such dependency so we [generate a *mock
 //! pallet*](#mock-pallet-creation), we'll call it `pallet_mock_dep`.
 //!
@@ -199,10 +199,10 @@
 //!
 //!     #[pallet::storage]
 //!     pub(super) type CallIds<T: Config> = StorageMap<
-//!     	_,
-//!     	Blake2_128Concat,
-//!     	<Blake2_128 as frame_support::StorageHasher>::Output,
-//!     	mock_builder::CallId,
+//!         _,
+//!         Blake2_128Concat,
+//!         <Blake2_128 as frame_support::StorageHasher>::Output,
+//!         mock_builder::CallId,
 //!     >;
 //!
 //!     impl<T: Config> Pallet<T> {

--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -11,10 +11,139 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-//! Offer utilities to create custom pallet mocks for generic traits.
+//! `mock-builder` allows you to create *mock pallets*.
+//! A *mock pallet* is a regular pallet that implements some traits whose
+//! behavior can be implemented on the fly by closures. They are perfect for
+//! testing because they allow you to customize each test case, getting
+//! organized and accurate tests for your pallet. *Mock pallet* is not just a
+//! trait mocked, it's a whole pallet that can implement one or more traits and
+//! can be added to runtimes.
 //!
-//! [`register_call!()`] and [`execute_call!()`] expect the following storage in
-//! the pallet. It's safe to just copy and paste in your pallet mock.
+//! # Motivation
+//!
+//! Pallets have dependencies. Programming in a
+//! [loosely coupled](https://docs.substrate.io/build/pallet-coupling)
+//! way is great for getting rid of those dependencies for the implementation.
+//! Nevertheless, those dependencies still exist in testing because when the
+//! `mock.rs` file is defined, you're forced to give some implementations for
+//! the associated types of your pallet `Config`.
+//!
+//! Then, you are mostly forced to use other pallet configurations
+//! geting a [tight coupling](https://docs.substrate.io/build/pallet-coupling/)
+//! with them. It has some downsides:
+//! - You need to learn how to configure other pallets.
+//! - You need to know how those pallets work, because they affect directly the
+//!   behavior of the pallet you're testing.
+//! - The way they work can give you non-completed tests. It means that some
+//!   paths of your pallet can no be tested because some dependency works in a
+//!   specific way.
+//! - You need a lot of effort maintaining your tests because each time one
+//!   dependency changes, it can easily break your tests.
+//!
+//! This doesn't scale well. Frequently some pallet dependencies need in turn to
+//! configure their own dependent pallets, making this problem even worst.
+//!
+//! This is why mocking is so important. It lets you get rid of all these
+//! dependencies and related issues, obtaining **loose coupling tests**.
+//!
+//! There are other crates focusing on this problem,
+//! such as [`mockall`](https://docs.rs/mockall/latest/mockall/),
+//! but they mock traits. Instead, this crate gives you an entire pallet
+//! ready to use in any runtime, implementing the number of traits you specify.
+//!
+//! ## *Mock pallet* usage
+//!
+//! Suppose that in our pallet, which we'll call it `my_pallet`, we have an
+//! associated type in our `Config`, which implements a `TraitA` and `TraitB`
+//! traits. Those traits are defined as follows:
+//!
+//! ```no_run
+//! trait TraitA {
+//!     type AssocA;
+//!
+//!     fn foo() -> Self::AssocA;
+//! }
+//!
+//! trait TraitB {
+//!     type AssocB;
+//!
+//!     fn bar(a: u64, b: Self::AssocB) -> u32;
+//! }
+//! ```
+//!
+//! We have a real huge pallet that implements a specific behavior for those
+//! traits, but we want to get rid of such dependency so we [generate a *mock
+//! pallet*](#mock-pallet-creation), we'll call it `pallet_mock_dep`.
+//!
+//! We can add this *mock pallet* to the runtime as usual:
+//!
+//! ```ignore
+//! frame_support::construct_runtime!(
+//!     pub enum Runtime where
+//!         Block = Block,
+//!         NodeBlock = Block,
+//!         UncheckedExtrinsic = UncheckedExtrinsic,
+//!     {
+//!         System: frame_system,
+//!         MockDep: pallet_mock_dep,
+//!         MyPallet: my_pallet,
+//!     }
+//! );
+//! ```
+//!
+//! And we configure it as a regular pallet:
+//!
+//! ```ignore
+//! impl pallet_mock_dep::Config for Runtime {
+//!     type AssocA = bool;
+//!     type AssocB = u8;
+//! }
+//! ```
+//!
+//! Later in our use case, we can give a behavior for both `foo()` and `bar()`
+//! methods in their analogous methods `mock_foo()` and `mock_bar()` which
+//! accept a closure.
+//!
+//! ```ignore
+//! #[test]
+//! fn correct() {
+//!     new_test_ext().execute_with(|| {
+//!         MockDep::mock_foo(|| true);
+//!         MockDep::mock_bar(|a, b| {
+//!             assert_eq!(a, 42);
+//!             assert_eq!(b, false);
+//!             23
+//!         });
+//!
+//!         // This method will call foo() and bar() under the hood, running the
+//!         // closures we just have defined.
+//!         MyPallet::my_call();
+//!     });
+//! }
+//! ```
+//!
+//! Take a look to the [pallet tests](`tests/pallet.rs`) to have a user view of
+//! how to use a *mock pallet*. It supports any kind of trait, with reference
+//! parameters and generics at trait level and method level.
+//!
+//! ## Mock pallet creation
+//!
+//! **NOTE: There is a working progress on this part to generate *mock pallets*
+//! automatically using procedural macros. Once done, all this part can be
+//! auto-generated.**
+//!
+//! This crate exports two macros [`register_call!()`] and [`execute_call!()`]
+//! that allow you to build a *mock pallet*.
+//!
+//! - [`register_call!()`] registers a closure where you can define the
+//! mock behavior for that method. The method who register the closure must have
+//! the name of the trait method you want to mock with the prefix `mock_`.
+//!
+//! - [`execute_call!()`] is placed in the trait method implementation and will
+//!   call the closure previously registered by [`register_call!()`]
+//!
+//! The only condition to use these macros is to have the following storage in
+//! the pallet (it's safe to just copy and paste this snippet in your pallet):
 //!
 //! ```no_run
 //! # #[frame_support::pallet]
@@ -37,8 +166,75 @@
 //! # }
 //! ```
 //!
-//! Take a look to the [pallet tests](`tests/pallet.rs`) to have a user view of
-//! how to use this crate.
+//! Following the above example, generating a *mock pallet* for both `TraitA`
+//! and `TraitB` is done as follows:
+//!
+//! ```no_run
+//! #[frame_support::pallet]
+//! pub mod pallet {
+//!     # trait TraitA {
+//!     #     type AssocA;
+//!     #
+//!     #     fn foo() -> Self::AssocA;
+//!     # }
+//!     #
+//!     # trait TraitB {
+//!     #     type AssocB;
+//!     #
+//!     #     fn bar(a: u64, b: Self::AssocB) -> u32;
+//!     # }
+//!
+//!     use frame_support::pallet_prelude::*;
+//!     use mock_builder::{execute_call, register_call};
+//!
+//!     #[pallet::config]
+//!     pub trait Config: frame_system::Config {
+//!         type AssocA;
+//!         type AssocB;
+//!     }
+//!
+//!     #[pallet::pallet]
+//!     #[pallet::generate_store(pub(super) trait Store)]
+//!     pub struct Pallet<T>(_);
+//!
+//!     #[pallet::storage]
+//!     pub(super) type CallIds<T: Config> = StorageMap<
+//!     	_,
+//!     	Blake2_128Concat,
+//!     	<Blake2_128 as frame_support::StorageHasher>::Output,
+//!     	mock_builder::CallId,
+//!     >;
+//!
+//!     impl<T: Config> Pallet<T> {
+//!         fn mock_foo(f: impl Fn() -> T::AssocA + 'static) {
+//!             register_call!(move |()| f())
+//!         }
+//!
+//!         fn mock_bar(f: impl Fn(u64, T::AssocB) -> u32 + 'static) {
+//!             register_call!(move |(a, b)| f(a, b))
+//!         }
+//!     }
+//!
+//!     impl<T: Config> TraitA for Pallet<T> {
+//!         type AssocA = T::AssocA;
+//!
+//!         fn foo() -> Self::AssocA {
+//!             execute_call!(())
+//!         }
+//!     }
+//!
+//!     impl<T: Config> TraitB for Pallet<T> {
+//!         type AssocB = T::AssocB;
+//!
+//!         fn bar(a: u64, b: Self::AssocB) -> u32 {
+//!             execute_call!((a, b))
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! If types for the closure of `mock_*` method and trait method doesn't match,
+//! you will obtain a runtime error in your tests.
 
 /// Provide functions for register/execute calls
 pub mod storage;
@@ -93,7 +289,7 @@ where
 }
 
 /// Register a mock function into the mock function storage.
-/// Same as `register()` but with using the locator who calls this macro.
+/// Same as `register()` but it uses as locator who calls this macro.
 #[macro_export]
 macro_rules! register_call {
 	($f:expr) => {{
@@ -102,7 +298,7 @@ macro_rules! register_call {
 }
 
 /// Execute a function from the function storage.
-/// Same as `execute()` but with using the locator who calls this macro.
+/// Same as `execute()` but it uses as locator who calls this macro.
 #[macro_export]
 macro_rules! execute_call {
 	($input:expr) => {{


### PR DESCRIPTION
# Description

This PR adds the main documentation with examples for understanding and using `mock-builder`.