### PR TITLE
Loans: LoanId out from ActiveLoan

### DIFF
--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -247,7 +247,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		PoolIdOf<T>,
-		BoundedVec<ActiveLoan<T>, T::MaxActiveLoansPerPool>,
+		BoundedVec<(T::LoanId, ActiveLoan<T>), T::MaxActiveLoansPerPool>,
 		ValueQuery,
 	>;
 
@@ -453,10 +453,10 @@ pub mod pallet {
 				Some(created_loan) => {
 					Self::ensure_loan_borrower(&who, created_loan.borrower())?;
 
-					let mut active_loan = created_loan.activate(pool_id, loan_id)?;
+					let mut active_loan = created_loan.activate(pool_id)?;
 					active_loan.borrow(amount)?;
 
-					Self::insert_active_loan(pool_id, active_loan)?
+					Self::insert_active_loan(pool_id, loan_id, active_loan)?
 				}
 				None => {
 					Self::update_active_loan(pool_id, loan_id, |loan| {
@@ -754,7 +754,7 @@ pub mod pallet {
 			let loans = ActiveLoans::<T>::get(pool_id);
 			let values = loans
 				.iter()
-				.map(|loan| Ok((loan.loan_id(), loan.present_value_by(&rates, &prices)?)))
+				.map(|(loan_id, loan)| Ok((*loan_id, loan.present_value_by(&rates, &prices)?)))
 				.collect::<Result<Vec<_>, DispatchError>>()?;
 
 			let value = PortfolioValuation::<T>::try_mutate(pool_id, |portfolio| {
@@ -772,10 +772,11 @@ pub mod pallet {
 
 		fn insert_active_loan(
 			pool_id: PoolIdOf<T>,
+			loan_id: T::LoanId,
 			loan: ActiveLoan<T>,
 		) -> Result<u32, DispatchError> {
 			PortfolioValuation::<T>::try_mutate(pool_id, |portfolio| {
-				portfolio.insert_elem(loan.loan_id(), loan.present_value()?)?;
+				portfolio.insert_elem(loan_id, loan.present_value()?)?;
 
 				Self::deposit_event(Event::<T>::PortfolioValuationUpdated {
 					pool_id,
@@ -785,7 +786,7 @@ pub mod pallet {
 
 				ActiveLoans::<T>::try_mutate(pool_id, |active_loans| {
 					active_loans
-						.try_push(loan)
+						.try_push((loan_id, loan))
 						.map_err(|_| Error::<T>::MaxActiveLoansReached)?;
 
 					Ok(active_loans.len().ensure_into()?)
@@ -803,9 +804,9 @@ pub mod pallet {
 		{
 			PortfolioValuation::<T>::try_mutate(pool_id, |portfolio| {
 				ActiveLoans::<T>::try_mutate(pool_id, |active_loans| {
-					let loan = active_loans
+					let (_, loan) = active_loans
 						.iter_mut()
-						.find(|loan| loan.loan_id() == loan_id)
+						.find(|(id, _)| *id == loan_id)
 						.ok_or(Error::<T>::LoanNotActiveOrNotFound)?;
 
 					let result = f(loan)?;
@@ -830,11 +831,11 @@ pub mod pallet {
 			ActiveLoans::<T>::try_mutate(pool_id, |active_loans| {
 				let index = active_loans
 					.iter()
-					.position(|loan| loan.loan_id() == loan_id)
+					.position(|(id, _)| *id == loan_id)
 					.ok_or(Error::<T>::LoanNotActiveOrNotFound)?;
 
 				Ok((
-					active_loans.swap_remove(index),
+					active_loans.swap_remove(index).1,
 					active_loans.len().ensure_into()?,
 				))
 			})

--- a/pallets/loans-ref/src/loan.rs
+++ b/pallets/loans-ref/src/loan.rs
@@ -87,18 +87,8 @@ impl<T: Config> CreatedLoan<T> {
 		&self.borrower
 	}
 
-	pub fn activate(
-		self,
-		pool_id: PoolIdOf<T>,
-		loan_id: T::LoanId,
-	) -> Result<ActiveLoan<T>, DispatchError> {
-		ActiveLoan::new(
-			pool_id,
-			loan_id,
-			self.info,
-			self.borrower,
-			T::Time::now().as_secs(),
-		)
+	pub fn activate(self, pool_id: PoolIdOf<T>) -> Result<ActiveLoan<T>, DispatchError> {
+		ActiveLoan::new(pool_id, self.info, self.borrower, T::Time::now().as_secs())
 	}
 
 	pub fn close(self) -> Result<(ClosedLoan<T>, T::AccountId), DispatchError> {
@@ -140,9 +130,6 @@ impl<T: Config> ClosedLoan<T> {
 #[derive(Encode, Decode, Clone, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 pub struct ActiveLoan<T: Config> {
-	/// Id of this loan
-	loan_id: T::LoanId,
-
 	/// Specify the repayments schedule of the loan
 	schedule: RepaymentSchedule,
 
@@ -174,13 +161,11 @@ pub struct ActiveLoan<T: Config> {
 impl<T: Config> ActiveLoan<T> {
 	pub fn new(
 		pool_id: PoolIdOf<T>,
-		loan_id: T::LoanId,
 		info: LoanInfo<T>,
 		borrower: T::AccountId,
 		now: Moment,
 	) -> Result<Self, DispatchError> {
 		Ok(ActiveLoan {
-			loan_id,
 			schedule: info.schedule,
 			collateral: info.collateral,
 			restrictions: info.restrictions,
@@ -198,10 +183,6 @@ impl<T: Config> ActiveLoan<T> {
 			total_borrowed: T::Balance::zero(),
 			total_repaid: T::Balance::zero(),
 		})
-	}
-
-	pub fn loan_id(&self) -> T::LoanId {
-		self.loan_id
 	}
 
 	pub fn borrower(&self) -> &T::AccountId {

--- a/pallets/loans-ref/src/tests.rs
+++ b/pallets/loans-ref/src/tests.rs
@@ -53,8 +53,9 @@ mod util {
 	pub fn get_loan(loan_id: LoanId) -> ActiveLoan<Runtime> {
 		ActiveLoans::<Runtime>::get(POOL_A)
 			.into_iter()
-			.find(|loan| loan.loan_id() == loan_id)
+			.find(|(id, _)| *id == loan_id)
 			.unwrap()
+			.1
 	}
 
 	pub fn current_loan_debt(loan_id: LoanId) -> Balance {


### PR DESCRIPTION
# Description

This is a nitpicky change. But ideally, a `LoanId` should not belong to the `ActiveLoan` itself. A `LoanId` is an id used to identify such a loan, and should be handled at the pallet level, not at the loan level.

To rationale this, if instead of storing the `ActiveLoans` in a `Vec`, we would store it in a `StorageMap`, we should not place the `LoanId` in the `ActiveLoan` at the very beginning, as happen currently with `CreatedLoans` and `ClosedLoans`, so how we store the loans should not affect the data they hold.
