### PR TITLE
Loans: Add unchecked amount support

### DIFF
--- a/pallets/loans-ref/src/benchmarking.rs
+++ b/pallets/loans-ref/src/benchmarking.rs
@@ -174,6 +174,7 @@ where
 			pool_id,
 			loan_id,
 			COLLATERAL_VALUE.into(),
+			0.into(),
 		)
 		.unwrap();
 	}
@@ -264,7 +265,7 @@ benchmarks! {
 		let loan_id = Helper::<T>::create_loan(pool_id, u16::MAX.into());
 		Helper::<T>::borrow_loan(pool_id, loan_id);
 
-	}: _(RawOrigin::Signed(borrower), pool_id, loan_id, 10.into())
+	}: _(RawOrigin::Signed(borrower), pool_id, loan_id, 10.into(), 0.into())
 
 	write_off {
 		let n in 1..T::MaxActiveLoansPerPool::get() - 1;

--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -307,6 +307,7 @@ pub mod pallet {
 			pool_id: PoolIdOf<T>,
 			loan_id: T::LoanId,
 			amount: T::Balance,
+			unchecked_amount: T::Balance,
 		},
 		/// A loan was written off
 		WrittenOff {
@@ -509,6 +510,7 @@ pub mod pallet {
 				pool_id,
 				loan_id,
 				amount,
+				unchecked_amount,
 			});
 
 			Ok(())

--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -494,12 +494,13 @@ pub mod pallet {
 			pool_id: PoolIdOf<T>,
 			loan_id: T::LoanId,
 			amount: T::Balance,
+			unchecked_amount: T::Balance,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
 			let (amount, _count) = Self::update_active_loan(pool_id, loan_id, |loan| {
 				Self::ensure_loan_borrower(&who, loan.borrower())?;
-				loan.repay(amount)
+				loan.repay(amount, unchecked_amount)
 			})?;
 
 			T::Pool::deposit(pool_id, who, amount)?;

--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -482,12 +482,13 @@ pub mod pallet {
 		/// Transfers amount borrowed to the pool reserve.
 		///
 		/// The origin must be the borrower of the loan.
-		/// If the repaying amount is more than current debt, only current debt
-		/// is transferred. The borrow action should fulfill the borrow
-		/// restrictions configured at [`types::LoanRestrictions`]. The `amount`
-		/// will be transferred from borrower to pool reserve. The portfolio
-		/// valuation of the pool is updated to reflect the new present value of
-		/// the loan.
+		/// The repay action should fulfill the repay restrictions
+		/// configured at [`types::RepayRestrictions`].
+		/// If the repaying `amount` is more than current debt, only current
+		/// debt is transferred. This does not apply to `unchecked_amount`,
+		/// which can be used to repay more than the outstanding debt.
+		/// The portfolio  valuation of the pool is updated to reflect the new
+		/// present value of the loan.
 		#[pallet::weight(T::WeightInfo::repay(T::MaxActiveLoansPerPool::get()))]
 		#[pallet::call_index(2)]
 		pub fn repay(

--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -504,7 +504,8 @@ pub mod pallet {
 				loan.repay(amount, unchecked_amount)
 			})?;
 
-			T::Pool::deposit(pool_id, who, amount)?;
+			let deposit_amount = amount.ensure_add(unchecked_amount)?;
+			T::Pool::deposit(pool_id, who, deposit_amount)?;
 
 			Self::deposit_event(Event::<T>::Repaid {
 				pool_id,

--- a/pallets/loans-ref/src/loan.rs
+++ b/pallets/loans-ref/src/loan.rs
@@ -382,7 +382,7 @@ impl<T: Config> ActiveLoan<T> {
 			ActivePricing::External(inner) => inner.adjust_debt(Adjustment::Decrease(amount))?,
 		}
 
-		Ok(amount.ensure_add(unchecked_amount)?)
+		Ok(amount)
 	}
 
 	pub fn write_off(&mut self, new_status: &WriteOffStatus<T::Rate>) -> DispatchResult {

--- a/pallets/loans-ref/src/tests.rs
+++ b/pallets/loans-ref/src/tests.rs
@@ -184,6 +184,7 @@ mod util {
 			POOL_A,
 			loan_id,
 			repay_amount,
+			0,
 		)
 		.expect("successful repaying");
 
@@ -762,7 +763,8 @@ mod repay_loan {
 					RuntimeOrigin::signed(BORROWER),
 					POOL_A,
 					loan_id,
-					COLLATERAL_VALUE
+					COLLATERAL_VALUE,
+					0,
 				),
 				Error::<Runtime>::LoanNotActiveOrNotFound
 			);
@@ -775,7 +777,13 @@ mod repay_loan {
 			config_mocks(COLLATERAL_VALUE);
 
 			assert_noop!(
-				Loans::repay(RuntimeOrigin::signed(BORROWER), POOL_A, 0, COLLATERAL_VALUE),
+				Loans::repay(
+					RuntimeOrigin::signed(BORROWER),
+					POOL_A,
+					0,
+					COLLATERAL_VALUE,
+					0
+				),
 				Error::<Runtime>::LoanNotActiveOrNotFound
 			);
 		});
@@ -793,7 +801,8 @@ mod repay_loan {
 					RuntimeOrigin::signed(OTHER_BORROWER),
 					POOL_A,
 					loan_id,
-					COLLATERAL_VALUE
+					COLLATERAL_VALUE,
+					0
 				),
 				Error::<Runtime>::NotLoanBorrower
 			);
@@ -814,7 +823,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE
+				COLLATERAL_VALUE,
+				0
 			));
 		});
 	}
@@ -830,7 +840,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE / 2
+				COLLATERAL_VALUE / 2,
+				0
 			));
 			assert_eq!(0, util::current_loan_debt(loan_id));
 		});
@@ -847,7 +858,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE
+				COLLATERAL_VALUE,
+				0
 			));
 			assert_eq!(0, util::current_loan_debt(loan_id));
 		});
@@ -864,7 +876,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE * 2
+				COLLATERAL_VALUE * 2,
+				0
 			));
 		});
 	}
@@ -887,7 +900,8 @@ mod repay_loan {
 					RuntimeOrigin::signed(BORROWER),
 					POOL_A,
 					loan_id,
-					COLLATERAL_VALUE / 2
+					COLLATERAL_VALUE / 2,
+					0
 				),
 				Error::<Runtime>::from(RepayLoanError::Restriction) // Full amount
 			);
@@ -897,13 +911,14 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE
+				COLLATERAL_VALUE,
+				0
 			));
 
 			let extra = 1;
 			config_mocks(0);
 			assert_noop!(
-				Loans::repay(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, extra),
+				Loans::repay(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, extra, 0),
 				Error::<Runtime>::from(RepayLoanError::Restriction) // Only once
 			);
 		});
@@ -920,7 +935,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE / 2
+				COLLATERAL_VALUE / 2,
+				0
 			));
 			assert_eq!(COLLATERAL_VALUE / 2, util::current_loan_debt(loan_id));
 
@@ -928,7 +944,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE / 2
+				COLLATERAL_VALUE / 2,
+				0
 			));
 			assert_eq!(0, util::current_loan_debt(loan_id));
 
@@ -939,7 +956,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				extra
+				extra,
+				0
 			));
 		});
 	}
@@ -955,7 +973,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE / 2
+				COLLATERAL_VALUE / 2,
+				0
 			));
 
 			advance_time(YEAR / 2);
@@ -972,7 +991,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE / 2
+				COLLATERAL_VALUE / 2,
+				0
 			));
 
 			// Because of the interest, it has no fully repaid, we need an extra payment.
@@ -984,7 +1004,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				still_to_pay
+				still_to_pay,
+				0
 			));
 
 			assert_eq!(0, util::current_loan_debt(loan_id));
@@ -1008,7 +1029,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE
+				COLLATERAL_VALUE,
+				0
 			));
 
 			advance_time(YEAR);
@@ -1028,7 +1050,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				PRICE_VALUE * QUANTITY
+				PRICE_VALUE * QUANTITY,
+				0
 			));
 
 			assert_eq!(0, util::current_loan_debt(loan_id));
@@ -1048,7 +1071,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				(PRICE_VALUE * 2) * QUANTITY
+				(PRICE_VALUE * 2) * QUANTITY,
+				0
 			));
 
 			assert_eq!(0, util::current_loan_debt(loan_id));
@@ -1068,7 +1092,8 @@ mod repay_loan {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				PRICE_VALUE * QUANTITY
+				PRICE_VALUE * QUANTITY,
+				0
 			));
 
 			assert_eq!(0, util::current_loan_debt(loan_id));
@@ -1088,10 +1113,32 @@ mod repay_loan {
 					RuntimeOrigin::signed(BORROWER),
 					POOL_A,
 					loan_id,
-					PRICE_VALUE * QUANTITY - 1
+					PRICE_VALUE * QUANTITY - 1,
+					0
 				),
 				Error::<Runtime>::AmountNotMultipleOfPrice
 			);
+		});
+	}
+
+	#[test]
+	fn with_unchecked_repayment() {
+		new_test_ext().execute_with(|| {
+			let loan_id = util::create_loan(util::base_internal_loan());
+			util::borrow_loan(loan_id, COLLATERAL_VALUE);
+
+			config_mocks(COLLATERAL_VALUE);
+			assert_ok!(Loans::repay(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				loan_id,
+				0,
+				COLLATERAL_VALUE,
+			),);
+
+			// Nothing repaid with unchecked amount,
+			// so I still have the whole amount as debt
+			assert_eq!(COLLATERAL_VALUE, util::current_loan_debt(loan_id));
 		});
 	}
 }

--- a/runtime/integration-tests/src/utils/loans.rs
+++ b/runtime/integration-tests/src/utils/loans.rs
@@ -187,6 +187,7 @@ pub fn repay_call(pool_id: PoolId, loan_id: LoanId, amount: Balance) -> RuntimeC
 		pool_id,
 		loan_id,
 		amount,
+        0,
 	})
 }
 

--- a/runtime/integration-tests/src/utils/loans.rs
+++ b/runtime/integration-tests/src/utils/loans.rs
@@ -182,12 +182,17 @@ pub fn borrow_call(pool_id: PoolId, loan_id: LoanId, amount: Balance) -> Runtime
 	})
 }
 
-pub fn repay_call(pool_id: PoolId, loan_id: LoanId, amount: Balance) -> RuntimeCall {
+pub fn repay_call(
+	pool_id: PoolId,
+	loan_id: LoanId,
+	amount: Balance,
+	unchecked_amount: Balance,
+) -> RuntimeCall {
 	RuntimeCall::Loans(LoansCall::repay {
 		pool_id,
 		loan_id,
 		amount,
-        0,
+		unchecked_amount,
 	})
 }
 


### PR DESCRIPTION
# Description

- Added `unchecked_amount` in `repay()` extrinsic
- Added `total_repaid_unchecked` to `ActiveLoan` struct.

Fixes #1352
