### PR TITLE
Release Centrifuge 1019 & Altair 1027

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "altair-runtime"
-version = "0.10.26"
+version = "0.10.27"
 dependencies = [
  "cfg-primitives",
  "cfg-traits",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "centrifuge-chain"
-version = "0.10.26"
+version = "0.10.27"
 dependencies = [
  "altair-runtime",
  "async-trait",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "centrifuge-runtime"
-version = "0.10.18"
+version = "0.10.19"
 dependencies = [
  "cfg-primitives",
  "cfg-traits",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "development-runtime"
-version = "0.10.19"
+version = "0.10.20"
 dependencies = [
  "cfg-primitives",
  "cfg-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centrifuge-chain"
-version = "0.10.26"
+version = "0.10.27"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 description = "Centrifuge chain implementation in Rust."
 build = "build.rs"

--- a/runtime/altair/Cargo.toml
+++ b/runtime/altair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "altair-runtime"
-version = "0.10.26"
+version = "0.10.27"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -128,13 +128,13 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("altair"),
 	impl_name: create_runtime_str!("altair"),
 	authoring_version: 1,
-	spec_version: 1026,
+	spec_version: 1027,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
 	#[cfg(feature = "disable-runtime-api")]
 	apis: version::create_apis_vec![[]],
-	transaction_version: 1,
+	transaction_version: 2,
 	state_version: 0,
 };
 

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centrifuge-runtime"
-version = "0.10.18"
+version = "0.10.19"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -132,13 +132,13 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge"),
 	impl_name: create_runtime_str!("centrifuge"),
 	authoring_version: 1,
-	spec_version: 1018,
+	spec_version: 1019,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
 	#[cfg(feature = "disable-runtime-api")]
 	apis: version::create_apis_vec![[]],
-	transaction_version: 1,
+	transaction_version: 2,
 	state_version: 0,
 };
 

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "development-runtime"
-version = "0.10.19"
+version = "0.10.20"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -135,13 +135,13 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge-devel"),
 	impl_name: create_runtime_str!("centrifuge-devel"),
 	authoring_version: 1,
-	spec_version: 1019,
+	spec_version: 1020,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
 	#[cfg(feature = "disable-runtime-api")]
 	apis: version::create_apis_vec![[]],
-	transaction_version: 1,
+	transaction_version: 2,
 	state_version: 0,
 };
 


### PR DESCRIPTION
# Description

* Release candidate for Altair `1027`
* Release candidate for Centrifuge `1019`
* Bump Node version to `0.10.27`

## TODO

- [ ] Update benchmarks