### PR TITLE
Fix: Failing integration tests

### DIFF
--- a/runtime/integration-tests/src/pools/pool_starts.rs
+++ b/runtime/integration-tests/src/pools/pool_starts.rs
@@ -29,7 +29,6 @@ use crate::{
 };
 
 #[tokio::test]
-#[ignore = "Test being fixed by Cosmin/Frederik"]
 async fn create_loan() {
 	let mut env = {
 		let mut genesis = Storage::default();

--- a/runtime/integration-tests/src/utils/env.rs
+++ b/runtime/integration-tests/src/utils/env.rs
@@ -372,7 +372,9 @@ impl TestEnv {
 					EventRange::Latest => self.events_relay(latest),
 					EventRange::All => {
 						let mut events = Vec::new();
-						for block in 0..latest + 1 {
+						// We MUST NOT query events at genesis block, as this triggers
+						// a panic. Hence, start at 1.
+						for block in 1..latest + 1 {
 							events.extend(self.events_relay(block)?)
 						}
 
@@ -400,7 +402,9 @@ impl TestEnv {
 						EventRange::Latest => self.events_centrifuge(latest),
 						EventRange::All => {
 							let mut events = Vec::new();
-							for block in 0..latest + 1 {
+							// We MUST NOT query events at genesis block, as this triggers
+							// a panic. Hence, start at 1.
+							for block in 1..latest + 1 {
 								events.extend(self.events_centrifuge(block)?)
 							}
 


### PR DESCRIPTION
# Description
The logic previously fetched events at block zero, which where simply not existing as not populated. Substrate changed to panicking now, when somebody does this. This change fetches events only starting at block 1.

