### PR TITLE
Loans: Support for benchmarking prices

### DIFF
--- a/libs/mocks/src/data.rs
+++ b/libs/mocks/src/data.rs
@@ -10,6 +10,8 @@ pub mod pallet {
 		type CollectionId;
 		type Collection: DataCollection<Self::DataId>;
 		type Data;
+		#[cfg(feature = "runtime-benchmarks")]
+		type MaxCollectionSize: Get<u32>;
 	}
 
 	#[pallet::pallet]
@@ -49,6 +51,8 @@ pub mod pallet {
 	impl<T: Config> DataRegistry<T::DataId, T::CollectionId> for Pallet<T> {
 		type Collection = T::Collection;
 		type Data = T::Data;
+		#[cfg(feature = "runtime-benchmarks")]
+		type MaxCollectionSize = T::MaxCollectionSize;
 
 		fn get(a: &T::DataId) -> T::Data {
 			execute_call!(a)

--- a/libs/traits/src/data.rs
+++ b/libs/traits/src/data.rs
@@ -22,6 +22,10 @@ pub trait DataRegistry<DataId, CollectionId> {
 	/// Represents a data
 	type Data;
 
+	/// Identify the max number a collection can reach.
+	#[cfg(feature = "runtime-benchmarks")]
+	type MaxCollectionSize: sp_runtime::traits::Get<u32>;
+
 	/// Return the last data value for a data id
 	fn get(data_id: &DataId) -> Self::Data;
 

--- a/pallets/data-collector/Cargo.toml
+++ b/pallets/data-collector/Cargo.toml
@@ -44,3 +44,6 @@ std = [
   "cfg-traits/std",
   "orml-traits/std",
 ]
+runtime-benchmarks = [
+  "cfg-traits/runtime-benchmarks",
+]

--- a/pallets/data-collector/src/lib.rs
+++ b/pallets/data-collector/src/lib.rs
@@ -109,7 +109,7 @@ pub mod pallet {
 		type Collection = CachedCollection<T, I>;
 		type Data = Result<DataValueOf<T, I>, DispatchError>;
 		#[cfg(feature = "runtime-benchmarks")]
-		type MaxCollectionSize = MaxCollectionSize;
+		type MaxCollectionSize = T::MaxCollectionSize;
 
 		fn get(data_id: &T::DataId) -> Self::Data {
 			T::DataProvider::get_no_op(data_id)

--- a/pallets/data-collector/src/lib.rs
+++ b/pallets/data-collector/src/lib.rs
@@ -108,6 +108,8 @@ pub mod pallet {
 	impl<T: Config<I>, I: 'static> DataRegistry<T::DataId, T::CollectionId> for Pallet<T, I> {
 		type Collection = CachedCollection<T, I>;
 		type Data = Result<DataValueOf<T, I>, DispatchError>;
+		#[cfg(feature = "runtime-benchmarks")]
+		type MaxCollectionSize = MaxCollectionSize;
 
 		fn get(data_id: &T::DataId) -> Self::Data {
 			T::DataProvider::get_no_op(data_id)

--- a/pallets/loans-ref/src/mock.rs
+++ b/pallets/loans-ref/src/mock.rs
@@ -188,6 +188,8 @@ impl pallet_mock_data::Config for Runtime {
 	type CollectionId = PoolId;
 	type Data = Result<(Balance, Moment), DispatchError>;
 	type DataId = PriceId;
+	#[cfg(feature = "runtime-benchmarks")]
+	type MaxCollectionSize = MaxActiveLoansPerPool;
 }
 
 impl pallet_loans::Config for Runtime {

--- a/pallets/loans-ref/src/util.rs
+++ b/pallets/loans-ref/src/util.rs
@@ -25,6 +25,8 @@ pub struct NoPriceRegistry<T>(PhantomData<T>);
 impl<T: Config> DataRegistry<T::PriceId, PoolIdOf<T>> for NoPriceRegistry<T> {
 	type Collection = NoPriceCollection<T>;
 	type Data = PriceResultOf<T>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type MaxCollectionSize = sp_runtime::traits::ConstU32<0>;
 
 	fn get(_: &T::PriceId) -> Self::Data {
 		Err(DEFAULT_ERR)


### PR DESCRIPTION
# Description

- Added a `MaxCollectionSize` associated type that is only used under `runtime-benchmarks`.

By now, I think always using the maximum size of a price collection in benchmarks is ok. In comparison with the work done in `portfolio_valuation` over each `ActiveLoan`, deserializing once a small or a big vector of prices should not affect too much the final value.

If in the future, we need to struggle more with the benchmarks, we can add this as a variable parameter.

Associated to #1279