### PR TITLE
Loans: interest rate value stored without penalty

### DIFF
--- a/pallets/loans-ref/src/loan.rs
+++ b/pallets/loans-ref/src/loan.rs
@@ -368,7 +368,7 @@ impl<T: Config> ActiveLoan<T> {
 
 	pub fn write_off(&mut self, new_status: &WriteOffStatus<T::Rate>) -> DispatchResult {
 		if let ActivePricing::Internal(inner) = &mut self.pricing {
-			inner.update_penalty(new_status.penalty)?;
+			inner.set_penalty(new_status.penalty)?;
 		}
 
 		self.write_off_percentage = new_status.percentage;

--- a/pallets/loans-ref/src/types/policy.rs
+++ b/pallets/loans-ref/src/types/policy.rs
@@ -12,11 +12,13 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::Moment;
-use cfg_traits::ops::{EnsureAdd, EnsureSub};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{storage::bounded_btree_set::BoundedBTreeSet, RuntimeDebug};
 use scale_info::TypeInfo;
-use sp_runtime::{traits::Get, DispatchError};
+use sp_runtime::{
+	traits::{Get, Zero},
+	DispatchError,
+};
 use sp_std::collections::btree_set::BTreeSet;
 use strum::EnumCount;
 
@@ -137,7 +139,7 @@ pub struct WriteOffStatus<Rate> {
 
 impl<Rate> WriteOffStatus<Rate>
 where
-	Rate: Ord + EnsureAdd + EnsureSub,
+	Rate: Ord + Zero + Copy,
 {
 	pub fn compose_max(&self, other: &WriteOffStatus<Rate>) -> WriteOffStatus<Rate> {
 		Self {


### PR DESCRIPTION
# Description

In the previous pallet loan refactor, we modified the loan's interest rate to carry on the penalty with it. This works, but I think it has some downsides:

- From an understanding point of view, all `LoanInfo` attributes from the creation are immutable. Nevertheless, `interest_rate` is mutable under write-off actions, which can be ackward.
- With the future loans modification feature, having a modified `interest_rate` with the penalty makes things harder to handle and understand. 

This PR reverts that change. Originally it was done so because it was difficult to know where to use the `interest_rate` and where to use the `interest_rate_with_penalty`. Nevertheless, after oracle's refactor, we have all `interest_rate` computations under the same place, and now it is easier to manage.

**NOTE: This can imply a migration and a UI change to correctly show the `interest_rate` and the penalty. However, both things should be easy to do.**
