### PR TITLE
Loans: Change price type from `Balance` to `Rate`

### DIFF
--- a/pallets/loans-ref/src/benchmarking.rs
+++ b/pallets/loans-ref/src/benchmarking.rs
@@ -76,7 +76,7 @@ where
 	T::Pool:
 		PoolBenchmarkHelper<PoolId = PoolIdOf<T>, AccountId = T::AccountId, Balance = T::Balance>,
 	PriceCollectionOf<T>: DataCollection<T::PriceId, Data = PriceResultOf<T>>,
-	T::PriceRegistry: DataFeeder<T::PriceId, T::Balance, T::AccountId>,
+	T::PriceRegistry: DataFeeder<T::PriceId, T::Rate, T::AccountId>,
 {
 	#[cfg(test)]
 	fn config_mocks() {
@@ -94,7 +94,7 @@ where
 		MockPools::mock_benchmark_give_ausd(|_, _| {});
 		MockPrices::mock_feed_value(|_, _, _| Ok(()));
 		MockPrices::mock_register_id(|_, _| Ok(()));
-		MockPrices::mock_collection(|_| MockDataCollection::new(|_| Ok((0, 0))));
+		MockPrices::mock_collection(|_| MockDataCollection::new(|_| Ok(Default::default())));
 	}
 
 	fn prepare_benchmark() -> PoolIdOf<T> {
@@ -236,7 +236,7 @@ where
 			// This restriction no longer exists once
 			// https://github.com/open-web3-stack/open-runtime-module-library/pull/920 is merged
 			let feeder = account("feeder", i, 0);
-			T::PriceRegistry::feed_value(feeder, price_id, 0.into()).unwrap();
+			T::PriceRegistry::feed_value(feeder, price_id, Default::default()).unwrap();
 			T::PriceRegistry::register_id(&price_id, &pool_id).unwrap();
 		}
 
@@ -264,7 +264,7 @@ benchmarks! {
 		T::PriceId: From<u32>,
 		T::Pool: PoolBenchmarkHelper<PoolId = PoolIdOf<T>, AccountId = T::AccountId, Balance = T::Balance>,
 		PriceCollectionOf<T>: DataCollection<T::PriceId, Data = PriceResultOf<T>>,
-		T::PriceRegistry: DataFeeder<T::PriceId, T::Balance, T::AccountId>,
+		T::PriceRegistry: DataFeeder<T::PriceId, T::Rate, T::AccountId>,
 	}
 
 	create {

--- a/pallets/loans-ref/src/lib.rs
+++ b/pallets/loans-ref/src/lib.rs
@@ -112,7 +112,7 @@ pub mod pallet {
 	>>::PoolId;
 
 	pub type AssetOf<T> = (<T as Config>::CollectionId, <T as Config>::ItemId);
-	pub type PriceOf<T> = (<T as Config>::Balance, Moment);
+	pub type PriceOf<T> = (<T as Config>::Rate, Moment);
 	pub type PriceResultOf<T> = Result<PriceOf<T>, DispatchError>;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);

--- a/pallets/loans-ref/src/mock.rs
+++ b/pallets/loans-ref/src/mock.rs
@@ -186,8 +186,8 @@ impl pallet_mock_permissions::Config for Runtime {
 impl pallet_mock_data::Config for Runtime {
 	type Collection = pallet_mock_data::util::MockDataCollection<PriceId, Self::Data>;
 	type CollectionId = PoolId;
-	type Data = Result<(Balance, Moment), DispatchError>;
-	type DataElem = Balance;
+	type Data = Result<(Rate, Moment), DispatchError>;
+	type DataElem = Rate;
 	type DataId = PriceId;
 	#[cfg(feature = "runtime-benchmarks")]
 	type MaxCollectionSize = MaxActiveLoansPerPool;

--- a/pallets/loans-ref/src/util.rs
+++ b/pallets/loans-ref/src/util.rs
@@ -46,14 +46,14 @@ impl<T: Config> DataRegistry<T::PriceId, PoolIdOf<T>> for NoPriceRegistry<T> {
 	}
 }
 
-impl<T: Config> DataProvider<T::PriceId, T::Balance> for NoPriceRegistry<T> {
-	fn get(_: &T::PriceId) -> Option<T::Balance> {
+impl<T: Config> DataProvider<T::PriceId, T::Rate> for NoPriceRegistry<T> {
+	fn get(_: &T::PriceId) -> Option<T::Rate> {
 		None
 	}
 }
 
-impl<T: Config> DataFeeder<T::PriceId, T::Balance, T::AccountId> for NoPriceRegistry<T> {
-	fn feed_value(_: T::AccountId, _: T::PriceId, _: T::Balance) -> DispatchResult {
+impl<T: Config> DataFeeder<T::PriceId, T::Rate, T::AccountId> for NoPriceRegistry<T> {
+	fn feed_value(_: T::AccountId, _: T::PriceId, _: T::Rate) -> DispatchResult {
 		Err(DEFAULT_ERR)
 	}
 }

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1333,7 +1333,7 @@ impl orml_oracle::Config for Runtime {
 	type Members = runtime_common::oracle::benchmarks_util::Members;
 	type OnNewData = PriceCollector;
 	type OracleKey = OracleKey;
-	type OracleValue = Balance;
+	type OracleValue = Rate;
 	type RootOperatorAccountId = RootOperatorOraclePrice;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
@@ -1342,7 +1342,7 @@ impl orml_oracle::Config for Runtime {
 
 impl pallet_data_collector::Config for Runtime {
 	type CollectionId = PoolId;
-	type Data = Balance;
+	type Data = Rate;
 	type DataId = OracleKey;
 	type DataProvider = runtime_common::oracle::DataProviderBridge<PriceOracle>;
 	type MaxCollectionSize = MaxCollectionSize;


### PR DESCRIPTION
# Description

Although a price can be represented as a `Balance` or as a `Rate`, it seems a more appropriated and standardized way to do it as a `Rate`. This PR does the change.