### PR TITLE
Rename `MemberListAdmin` to `InvestorAdmin`

### DIFF
--- a/libs/types/src/permissions.rs
+++ b/libs/types/src/permissions.rs
@@ -219,9 +219,7 @@ where
 				}
 				PoolRole::PoolAdmin => self.pool_admin.contains(PoolAdminRoles::POOL_ADMIN),
 				PoolRole::PricingAdmin => self.pool_admin.contains(PoolAdminRoles::PRICING_ADMIN),
-				PoolRole::InvestorAdmin => {
-					self.pool_admin.contains(PoolAdminRoles::INVESTOR_ADMIN)
-				}
+				PoolRole::InvestorAdmin => self.pool_admin.contains(PoolAdminRoles::INVESTOR_ADMIN),
 				PoolRole::LoanAdmin => self.pool_admin.contains(PoolAdminRoles::RISK_ADMIN),
 				PoolRole::TrancheInvestor(id, _) => self.tranche_investor.contains(id),
 				PoolRole::PODReadAccess => {

--- a/libs/types/src/permissions.rs
+++ b/libs/types/src/permissions.rs
@@ -37,7 +37,7 @@ pub enum PoolRole<TrancheId = [u8; 16], Moment = u64> {
 	Borrower,
 	PricingAdmin,
 	LiquidityAdmin,
-	MemberListAdmin,
+	InvestorAdmin,
 	LoanAdmin,
 	TrancheInvestor(TrancheId, Moment),
 	PODReadAccess,
@@ -219,7 +219,7 @@ where
 				}
 				PoolRole::PoolAdmin => self.pool_admin.contains(PoolAdminRoles::POOL_ADMIN),
 				PoolRole::PricingAdmin => self.pool_admin.contains(PoolAdminRoles::PRICING_ADMIN),
-				PoolRole::MemberListAdmin => {
+				PoolRole::InvestorAdmin => {
 					self.pool_admin.contains(PoolAdminRoles::MEMBER_LIST_ADMIN)
 				}
 				PoolRole::LoanAdmin => self.pool_admin.contains(PoolAdminRoles::RISK_ADMIN),
@@ -260,7 +260,7 @@ where
 				}
 				PoolRole::PoolAdmin => Ok(self.pool_admin.remove(PoolAdminRoles::POOL_ADMIN)),
 				PoolRole::PricingAdmin => Ok(self.pool_admin.remove(PoolAdminRoles::PRICING_ADMIN)),
-				PoolRole::MemberListAdmin => {
+				PoolRole::InvestorAdmin => {
 					Ok(self.pool_admin.remove(PoolAdminRoles::MEMBER_LIST_ADMIN))
 				}
 				PoolRole::LoanAdmin => Ok(self.pool_admin.remove(PoolAdminRoles::RISK_ADMIN)),
@@ -294,7 +294,7 @@ where
 				}
 				PoolRole::PoolAdmin => Ok(self.pool_admin.insert(PoolAdminRoles::POOL_ADMIN)),
 				PoolRole::PricingAdmin => Ok(self.pool_admin.insert(PoolAdminRoles::PRICING_ADMIN)),
-				PoolRole::MemberListAdmin => {
+				PoolRole::InvestorAdmin => {
 					Ok(self.pool_admin.insert(PoolAdminRoles::MEMBER_LIST_ADMIN))
 				}
 				PoolRole::LoanAdmin => Ok(self.pool_admin.insert(PoolAdminRoles::RISK_ADMIN)),
@@ -619,10 +619,10 @@ mod tests {
 
 		// Adding roles works normally
 		assert!(roles.add(Role::PoolRole(PoolRole::LiquidityAdmin)).is_ok());
-		assert!(roles.add(Role::PoolRole(PoolRole::MemberListAdmin)).is_ok());
+		assert!(roles.add(Role::PoolRole(PoolRole::InvestorAdmin)).is_ok());
 		assert!(roles.add(Role::PoolRole(PoolRole::PODReadAccess)).is_ok());
 		assert!(roles.exists(Role::PoolRole(PoolRole::LiquidityAdmin)));
-		assert!(roles.exists(Role::PoolRole(PoolRole::MemberListAdmin)));
+		assert!(roles.exists(Role::PoolRole(PoolRole::InvestorAdmin)));
 		assert!(roles.exists(Role::PoolRole(PoolRole::PODReadAccess)));
 
 		// Role exists for as long as permission is given
@@ -662,10 +662,10 @@ mod tests {
 
 		// Removing roles work normally for Non-TrancheInvestor roles
 		assert!(roles.rm(Role::PoolRole(PoolRole::LiquidityAdmin)).is_ok());
-		assert!(roles.rm(Role::PoolRole(PoolRole::MemberListAdmin)).is_ok());
+		assert!(roles.rm(Role::PoolRole(PoolRole::InvestorAdmin)).is_ok());
 		assert!(roles.rm(Role::PoolRole(PoolRole::PODReadAccess)).is_ok());
 		assert!(!roles.exists(Role::PoolRole(PoolRole::LiquidityAdmin)));
-		assert!(!roles.exists(Role::PoolRole(PoolRole::MemberListAdmin)));
+		assert!(!roles.exists(Role::PoolRole(PoolRole::InvestorAdmin)));
 		assert!(!roles.exists(Role::PoolRole(PoolRole::PODReadAccess)));
 	}
 

--- a/libs/types/src/permissions.rs
+++ b/libs/types/src/permissions.rs
@@ -93,7 +93,7 @@ bitflags::bitflags! {
 		const BORROWER  = 0b00000010;
 		const PRICING_ADMIN = 0b00000100;
 		const LIQUIDITY_ADMIN = 0b00001000;
-		const MEMBER_LIST_ADMIN = 0b00010000;
+		const INVESTOR_ADMIN = 0b00010000;
 		const RISK_ADMIN = 0b00100000;
 		const POD_READ_ACCESS = 0b01000000;
 	}
@@ -220,7 +220,7 @@ where
 				PoolRole::PoolAdmin => self.pool_admin.contains(PoolAdminRoles::POOL_ADMIN),
 				PoolRole::PricingAdmin => self.pool_admin.contains(PoolAdminRoles::PRICING_ADMIN),
 				PoolRole::InvestorAdmin => {
-					self.pool_admin.contains(PoolAdminRoles::MEMBER_LIST_ADMIN)
+					self.pool_admin.contains(PoolAdminRoles::INVESTOR_ADMIN)
 				}
 				PoolRole::LoanAdmin => self.pool_admin.contains(PoolAdminRoles::RISK_ADMIN),
 				PoolRole::TrancheInvestor(id, _) => self.tranche_investor.contains(id),
@@ -261,7 +261,7 @@ where
 				PoolRole::PoolAdmin => Ok(self.pool_admin.remove(PoolAdminRoles::POOL_ADMIN)),
 				PoolRole::PricingAdmin => Ok(self.pool_admin.remove(PoolAdminRoles::PRICING_ADMIN)),
 				PoolRole::InvestorAdmin => {
-					Ok(self.pool_admin.remove(PoolAdminRoles::MEMBER_LIST_ADMIN))
+					Ok(self.pool_admin.remove(PoolAdminRoles::INVESTOR_ADMIN))
 				}
 				PoolRole::LoanAdmin => Ok(self.pool_admin.remove(PoolAdminRoles::RISK_ADMIN)),
 				PoolRole::TrancheInvestor(id, delta) => self.tranche_investor.remove(id, delta),
@@ -295,7 +295,7 @@ where
 				PoolRole::PoolAdmin => Ok(self.pool_admin.insert(PoolAdminRoles::POOL_ADMIN)),
 				PoolRole::PricingAdmin => Ok(self.pool_admin.insert(PoolAdminRoles::PRICING_ADMIN)),
 				PoolRole::InvestorAdmin => {
-					Ok(self.pool_admin.insert(PoolAdminRoles::MEMBER_LIST_ADMIN))
+					Ok(self.pool_admin.insert(PoolAdminRoles::INVESTOR_ADMIN))
 				}
 				PoolRole::LoanAdmin => Ok(self.pool_admin.insert(PoolAdminRoles::RISK_ADMIN)),
 				PoolRole::TrancheInvestor(id, delta) => self.tranche_investor.insert(id, delta),

--- a/pallets/connectors/src/lib.rs
+++ b/pallets/connectors/src/lib.rs
@@ -390,7 +390,7 @@ pub mod pallet {
 				T::Permission::has(
 					PermissionScope::Pool(pool_id),
 					who.clone(),
-					Role::PoolRole(PoolRole::MemberListAdmin)
+					Role::PoolRole(PoolRole::InvestorAdmin)
 				),
 				BadOrigin
 			);

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1048,11 +1048,11 @@ impl
 					Role::PoolRole(..) => true,
 					_ => false,
 				},
-				Role::PoolRole(PoolRole::MemberListAdmin) => matches!(
-					*role,
-					// MemberlistAdmins can manage tranche investors
+				Role::PoolRole(PoolRole::InvestorAdmin) => match *role {
 					Role::PoolRole(PoolRole::TrancheInvestor(_, _))
-				),
+					| Role::PoolRole(PoolRole::PODReadAccess) => true,
+					_ => false,
+				},
 				Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Manager) => matches!(
 					*role,
 					Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Holder(_))

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1048,11 +1048,11 @@ impl
 					Role::PoolRole(..) => true,
 					_ => false,
 				},
-				Role::PoolRole(PoolRole::InvestorAdmin) => match *role {
+				Role::PoolRole(PoolRole::InvestorAdmin) => matches!(
+					*role,
 					Role::PoolRole(PoolRole::TrancheInvestor(_, _))
-					| Role::PoolRole(PoolRole::PODReadAccess) => true,
-					_ => false,
-				},
+						| Role::PoolRole(PoolRole::PODReadAccess)
+				),
 				Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Manager) => matches!(
 					*role,
 					Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Holder(_))

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1445,11 +1445,11 @@ impl
 					Role::PoolRole(..) => true,
 					_ => false,
 				},
-				Role::PoolRole(PoolRole::InvestorAdmin) => match *role {
+				Role::PoolRole(PoolRole::InvestorAdmin) => matches!(
+					*role,
 					Role::PoolRole(PoolRole::TrancheInvestor(_, _))
-					| Role::PoolRole(PoolRole::PODReadAccess) => true,
-					_ => false,
-				},
+						| Role::PoolRole(PoolRole::PODReadAccess)
+				),
 				Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Manager) => matches!(
 					*role,
 					Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Holder(_))

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1445,11 +1445,11 @@ impl
 					Role::PoolRole(..) => true,
 					_ => false,
 				},
-				Role::PoolRole(PoolRole::MemberListAdmin) => matches!(
-					*role,
-					// MemberlistAdmins can manage tranche investors
+				Role::PoolRole(PoolRole::InvestorAdmin) => match *role {
 					Role::PoolRole(PoolRole::TrancheInvestor(_, _))
-				),
+					| Role::PoolRole(PoolRole::PODReadAccess) => true,
+					_ => false,
+				},
 				Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Manager) => matches!(
 					*role,
 					Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Holder(_))

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1432,11 +1432,11 @@ impl
 					Role::PoolRole(..) => true,
 					_ => false,
 				},
-				Role::PoolRole(PoolRole::MemberListAdmin) => matches!(
-					*role,
-					// MemberlistAdmins can manage tranche investors
+				Role::PoolRole(PoolRole::InvestorAdmin) => match *role {
 					Role::PoolRole(PoolRole::TrancheInvestor(_, _))
-				),
+					| Role::PoolRole(PoolRole::PODReadAccess) => true,
+					_ => false,
+				},
 				Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Manager) => matches!(
 					*role,
 					Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Holder(_))

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1432,11 +1432,11 @@ impl
 					Role::PoolRole(..) => true,
 					_ => false,
 				},
-				Role::PoolRole(PoolRole::InvestorAdmin) => match *role {
+				Role::PoolRole(PoolRole::InvestorAdmin) => matches!(
+					*role,
 					Role::PoolRole(PoolRole::TrancheInvestor(_, _))
-					| Role::PoolRole(PoolRole::PODReadAccess) => true,
-					_ => false,
-				},
+						| Role::PoolRole(PoolRole::PODReadAccess)
+				),
 				Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Manager) => matches!(
 					*role,
 					Role::PermissionedCurrencyRole(PermissionedCurrencyRole::Holder(_))

--- a/runtime/integration-tests/src/utils/pools.rs
+++ b/runtime/integration-tests/src/utils/pools.rs
@@ -281,7 +281,7 @@ pub fn whitelist_admin(admin: AccountId, pool_id: PoolId) -> Vec<RuntimeCall> {
 		PoolRole::PoolAdmin,
 		admin.clone(),
 		pool_id,
-		PoolRole::MemberListAdmin,
+		PoolRole::InvestorAdmin,
 	));
 	calls.push(permission_call(
 		PoolRole::PoolAdmin,
@@ -344,7 +344,7 @@ pub fn whitelist_10_for_each_tranche_calls(pool: PoolId, num_tranches: u32) -> V
 /// Whitelist a given investor for a fiven pool and tranche for 1 year of time
 pub fn whitelist_investor_call(pool: PoolId, investor: Keyring, tranche: TrancheId) -> RuntimeCall {
 	permission_call(
-		PoolRole::MemberListAdmin,
+		PoolRole::InvestorAdmin,
 		investor.to_account_id(),
 		pool,
 		PoolRole::TrancheInvestor(tranche, SECONDS_PER_YEAR),
@@ -479,7 +479,7 @@ mod with_ext {
 		permission_for(Keyring::Admin.into(), id, PoolRole::PricingAdmin);
 		permission_for(Keyring::Admin.into(), id, PoolRole::LiquidityAdmin);
 		permission_for(Keyring::Admin.into(), id, PoolRole::LoanAdmin);
-		permission_for(Keyring::Admin.into(), id, PoolRole::MemberListAdmin);
+		permission_for(Keyring::Admin.into(), id, PoolRole::InvestorAdmin);
 		permission_for(Keyring::Admin.into(), id, PoolRole::Borrower);
 	}
 

--- a/runtime/integration-tests/src/xcm/development/tests/connectors.rs
+++ b/runtime/integration-tests/src/xcm/development/tests/connectors.rs
@@ -203,7 +203,7 @@ fn update_member() {
 			Role::PoolRole(PoolRole::PoolAdmin),
 			ALICE.into(),
 			PermissionScope::Pool(pool_id),
-			Role::PoolRole(PoolRole::MemberListAdmin),
+			Role::PoolRole(PoolRole::InvestorAdmin),
 		));
 
 		// Verify it now works
@@ -315,7 +315,7 @@ fn transfer_tranche_tokens() {
 			Role::PoolRole(PoolRole::PoolAdmin),
 			BOB.into(),
 			PermissionScope::Pool(pool_id),
-			Role::PoolRole(PoolRole::MemberListAdmin),
+			Role::PoolRole(PoolRole::InvestorAdmin),
 		));
 
 		// Call the Connectors::update_member which ensures the destination address is


### PR DESCRIPTION
Closes https://github.com/centrifuge/centrifuge-chain/issues/1328

### Changes

- Rename `MemberListAdmin` to `InvestorAdmin`  
- For all runtimes, extend the `InvestorAdmin` permissions to also include `PoolRole::PODReadAccess`.
