### PR TITLE
fix: get para_id from chain spec extension

### DIFF
--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -46,9 +46,11 @@ use xcm::{
 const POLKADOT_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 
 /// Specialized `ChainSpec` instances for our runtimes.
-pub type AltairChainSpec = sc_service::GenericChainSpec<altair_runtime::GenesisConfig>;
-pub type CentrifugeChainSpec = sc_service::GenericChainSpec<centrifuge_runtime::GenesisConfig>;
-pub type DevelopmentChainSpec = sc_service::GenericChainSpec<development_runtime::GenesisConfig>;
+pub type AltairChainSpec = sc_service::GenericChainSpec<altair_runtime::GenesisConfig, Extensions>;
+pub type CentrifugeChainSpec =
+	sc_service::GenericChainSpec<centrifuge_runtime::GenesisConfig, Extensions>;
+pub type DevelopmentChainSpec =
+	sc_service::GenericChainSpec<development_runtime::GenesisConfig, Extensions>;
 
 /// Helper function to generate a crypto pair from seed
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
@@ -64,9 +66,9 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 #[serde(deny_unknown_fields)]
 pub struct Extensions {
 	/// The relay chain of the Parachain.
-	pub relay_chain: String,
+	pub relay_chain: Option<String>,
 	/// The id of the Parachain.
-	pub para_id: u32,
+	pub para_id: Option<u32>,
 }
 
 impl Extensions {
@@ -112,10 +114,16 @@ where
 }
 
 pub fn centrifuge_config() -> CentrifugeChainSpec {
-	CentrifugeChainSpec::from_json_bytes(
+	let mut spec = CentrifugeChainSpec::from_json_bytes(
 		&include_bytes!("../res/genesis/centrifuge-genesis-spec-raw.json")[..],
 	)
-	.unwrap()
+	.unwrap();
+	let extension = spec.extensions_mut();
+	*extension = Extensions {
+		relay_chain: Some("polkadot".into()),
+		para_id: Some(2031),
+	};
+	spec
 }
 
 pub fn centrifuge_staging(para_id: ParaId) -> CentrifugeChainSpec {
@@ -169,7 +177,10 @@ pub fn centrifuge_staging(para_id: ParaId) -> CentrifugeChainSpec {
 		Some("centrifuge"),
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -210,7 +221,10 @@ pub fn centrifuge_dev(para_id: ParaId) -> CentrifugeChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -241,13 +255,23 @@ pub fn centrifuge_local(para_id: ParaId) -> CentrifugeChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
 pub fn catalyst_config() -> CentrifugeChainSpec {
-	CentrifugeChainSpec::from_json_bytes(&include_bytes!("../res/catalyst-spec-raw.json")[..])
-		.unwrap()
+	let mut spec =
+		CentrifugeChainSpec::from_json_bytes(&include_bytes!("../res/catalyst-spec-raw.json")[..])
+			.unwrap();
+	let extension = spec.extensions_mut();
+	*extension = Extensions {
+		relay_chain: Some("rococo-local".into()),
+		para_id: Some(2031),
+	};
+	spec
 }
 
 pub fn catalyst_staging(para_id: ParaId) -> CentrifugeChainSpec {
@@ -304,7 +328,10 @@ pub fn catalyst_staging(para_id: ParaId) -> CentrifugeChainSpec {
 		Some("catalyst"),
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -335,15 +362,24 @@ pub fn catalyst_local(para_id: ParaId) -> CentrifugeChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
 pub fn altair_config() -> AltairChainSpec {
-	AltairChainSpec::from_json_bytes(
+	let mut spec = AltairChainSpec::from_json_bytes(
 		&include_bytes!("../res/genesis/altair-genesis-spec-raw.json")[..],
 	)
-	.unwrap()
+	.unwrap();
+	let extension = spec.extensions_mut();
+	*extension = Extensions {
+		relay_chain: Some("kusama".into()),
+		para_id: Some(2088),
+	};
+	spec
 }
 
 pub fn altair_staging(para_id: ParaId) -> AltairChainSpec {
@@ -395,7 +431,10 @@ pub fn altair_staging(para_id: ParaId) -> AltairChainSpec {
 		Some("altair"),
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -436,7 +475,10 @@ pub fn altair_dev(para_id: ParaId) -> AltairChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -467,12 +509,23 @@ pub fn altair_local(para_id: ParaId) -> AltairChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
 pub fn antares_config() -> AltairChainSpec {
-	AltairChainSpec::from_json_bytes(&include_bytes!("../res/antares-spec-raw.json")[..]).unwrap()
+	let mut spec =
+		AltairChainSpec::from_json_bytes(&include_bytes!("../res/antares-spec-raw.json")[..])
+			.unwrap();
+	let extension = spec.extensions_mut();
+	*extension = Extensions {
+		relay_chain: Some("rococo-local".into()),
+		para_id: Some(2088),
+	};
+	spec
 }
 
 pub fn antares_staging(para_id: ParaId) -> AltairChainSpec {
@@ -530,7 +583,10 @@ pub fn antares_staging(para_id: ParaId) -> AltairChainSpec {
 		Some("antares"),
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -561,16 +617,34 @@ pub fn antares_local(para_id: ParaId) -> AltairChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
 pub fn algol_config() -> AltairChainSpec {
-	AltairChainSpec::from_json_bytes(&include_bytes!("../res/algol-spec.json")[..]).unwrap()
+	let mut spec =
+		AltairChainSpec::from_json_bytes(&include_bytes!("../res/algol-spec.json")[..]).unwrap();
+	let extension = spec.extensions_mut();
+	*extension = Extensions {
+		relay_chain: Some("rococo-local".into()),
+		para_id: Some(2088),
+	};
+	spec
 }
 
 pub fn charcoal_config() -> AltairChainSpec {
-	AltairChainSpec::from_json_bytes(&include_bytes!("../res/charcoal-spec-raw.json")[..]).unwrap()
+	let mut spec =
+		AltairChainSpec::from_json_bytes(&include_bytes!("../res/charcoal-spec-raw.json")[..])
+			.unwrap();
+	let extension = spec.extensions_mut();
+	*extension = Extensions {
+		relay_chain: Some("rococo-local".into()),
+		para_id: Some(2088),
+	};
+	spec
 }
 
 pub fn charcoal_staging(para_id: ParaId) -> AltairChainSpec {
@@ -622,7 +696,10 @@ pub fn charcoal_staging(para_id: ParaId) -> AltairChainSpec {
 		Some("charcoal"),
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -653,7 +730,10 @@ pub fn charcoal_local(para_id: ParaId) -> AltairChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -688,7 +768,10 @@ pub fn demo(para_id: ParaId) -> DevelopmentChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -719,7 +802,10 @@ pub fn development(para_id: ParaId) -> DevelopmentChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 
@@ -750,7 +836,10 @@ pub fn development_local(para_id: ParaId) -> DevelopmentChainSpec {
 		None,
 		None,
 		Some(properties),
-		Default::default(),
+		Extensions {
+			relay_chain: Some("rococo-local".into()),
+			para_id: Some(para_id.into()),
+		},
 	)
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -144,7 +144,7 @@ impl RelayChainCli {
 		relay_chain_args: impl Iterator<Item = &'a String>,
 	) -> Self {
 		let extension = chain_spec::Extensions::try_get(&*para_config.chain_spec);
-		let chain_id = extension.map(|e| e.relay_chain.clone());
+		let chain_id = extension.and_then(|e| e.relay_chain.clone());
 		let base_path = para_config
 			.base_path
 			.as_ref()

--- a/src/command.rs
+++ b/src/command.rs
@@ -444,7 +444,8 @@ pub fn run() -> Result<()> {
 				);
 
 				let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
-					.map(|e| e.para_id).unwrap_or_else(|| cli.parachain_id.unwrap_or(10001));
+					.map(|e| e.para_id.unwrap_or_else(|| cli.parachain_id.expect("Could not find parachain ID in CLI.")))
+					.expect("Could not find parachain ID in chain spec extension.");
 
 				let id = ParaId::from(para_id);
 


### PR DESCRIPTION
# Description

Today, I was debugging a block production issue on Altair with a collator (StakerSpace). This resulted in the discovery, that we do not make use of the `Extensions` struct which can be optionally added to the chain spec by setting an Extension to the  `sc_service::GenericChainSpec<runtime::GenesisConfig, Extension` which we currently do not such that it defaults to `NoExtension`:

```rust
pub type AltairChainSpec = sc_service::GenericChainSpec<altair_runtime::GenesisConfig>;

pub struct Extensions {
	/// The relay chain of the Parachain.
	pub relay_chain: String,
	/// The id of the Parachain.
	pub para_id: u32,
}
```

This definitely is not a critical issue but it leaves our start node command in a limbo in which we still depend on setting the  `parachain-id` which was [deprecated on Cumulus end of 2021](https://github.com/paritytech/cumulus/pull/739). By defaulting to an ambiguous parachain id `10001`, any node operator can run into issues debugging the block production failure as other chains do not support `parachain-id` CLI option anymore. AFAICT, most node operators copy paste their start commands. Moreover, we are lacking documentation.

**There are multiple options how to solve this, this PR just drafts one of the options with the goal to prevent having to update existing chain specs.** 

1. We just remove the default unwrapping to `10001` and soon™️ write collator documentation which makes aware of our dependency to the `parachain-id` CLI. This could create issues at some point, e.g. if new commands depend on information provided from the Chainspec Extension.
2. We go ahead with the approach of the PR. Please note that this is not the default Substrate "recommended code" as I made both parameters of `Extensions` optional. I am also aware of the fact that the code could be optimized a bit.
```diff
pub struct Extensions {
	/// The relay chain of the Parachain.
-	pub relay_chain: String,
+	pub relay_chain: Option<String>,
	/// The id of the Parachain.
-	pub para_id: u32,
+	pub para_id: Option<u32>,
}
```
3. We fully follow Substrate/Cumulus and update our existing chainspecs for persistent chains Catalyst, Altair, Centrifuge. I fear this can create issues for node operators as all of them have to point to new chain spec. In case they are using Docker, that won't be an issue.
4. Anything our crowd intelligence can come up with.

## About this approach

Since none of the specs for our persistent chains currently includes the default `Extensions` parameters, the `from_json_bytes` method panics if we don't make both of them optional. I did not find peace with the compiler when trying to make the `Extensions` optional, e.g.

```
pub type AltairChainSpec = sc_service::GenericChainSpec<altair_runtime::GenesisConfig, Option<Extensions>>;
```

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
