### PR TITLE
fix: order id storage in do_collect_redeem

### DIFF
--- a/pallets/investments/src/lib.rs
+++ b/pallets/investments/src/lib.rs
@@ -814,7 +814,7 @@ where
 				};
 				let mut collection = RedeemCollection::<T::Amount>::from_order(order);
 				let mut collected_ids = Vec::new();
-				let cur_order_id = InvestOrderId::<T>::get(investment_id);
+				let cur_order_id = RedeemOrderId::<T>::get(investment_id);
 				let last_processed_order_id = min(
 					order
 						.submitted_at()


### PR DESCRIPTION
# Description

Fixes incorrect storage read of investment order id instead of the the redemption one during `do_collect_redeem`.

Not sure if it is sufficient to leave additional unit tests to the ones introduced in #1364 or whether we should try to bake this into the existing investments ones. I took a quick peek and did not have an immediate idea. AFAICS, we are testing investment and redemptions in the same scope which makes sense. This then might have lead to the investment id being higher than the `order.submitted_at()` such that `RedeemCollectedForNonClearedOrderId` does not happen: https://github.com/centrifuge/centrifuge-chain/blob/73609360c1c378a895c706dd42d9f480dfc6f987/pallets/investments/src/lib.rs#L826

When I tested this in isolation solely for redemptions in #1364, I could not get past the above line as `cur_order_id` could of course not be bumped if it points to an investment.

## Context

See [DAO Slack message](https://centrifugedao.slack.com/archives/C04HCK98KLL/p1686745223438149).

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works: Handled in #1364 
