### PR TITLE
Loans: write off policy though ChangeGuard

### DIFF
--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -13,6 +13,7 @@
 
 use cfg_primitives::CFG;
 use cfg_traits::{
+	changes::ChangeGuard,
 	data::{DataCollection, DataRegistry},
 	InterestAccrual, Permissions, PoolBenchmarkHelper,
 };
@@ -67,6 +68,31 @@ type MaxCollectionSizeOf<T> = <<T as Config>::PriceRegistry as DataRegistry<
 	PoolIdOf<T>,
 >>::MaxCollectionSize;
 
+#[cfg(test)]
+fn config_mocks() {
+	use cfg_mocks::pallet_mock_data::util::MockDataCollection;
+
+	use crate::tests::mock::{MockChangeGuard, MockPermissions, MockPools, MockPrices, Runtime};
+
+	MockPermissions::mock_add(|_, _, _| Ok(()));
+	MockPermissions::mock_has(|_, _, _| true);
+	MockPools::mock_pool_exists(|_| true);
+	MockPools::mock_account_for(|_| 0);
+	MockPools::mock_withdraw(|_, _, _| Ok(()));
+	MockPools::mock_deposit(|_, _, _| Ok(()));
+	MockPools::mock_benchmark_create_pool(|_, _| {});
+	MockPools::mock_benchmark_give_ausd(|_, _| {});
+	MockPrices::mock_feed_value(|_, _, _| Ok(()));
+	MockPrices::mock_register_id(|_, _| Ok(()));
+	MockPrices::mock_collection(|_| MockDataCollection::new(|_| Ok(Default::default())));
+	MockChangeGuard::mock_note(|_, _| Ok(sp_core::H256::default()));
+	MockChangeGuard::mock_released(|_, _| {
+		Ok(LoanChangeOf::<Runtime>::Policy(
+			Helper::<Runtime>::create_policy(),
+		))
+	});
+}
+
 struct Helper<T>(sp_std::marker::PhantomData<T>);
 impl<T: Config> Helper<T>
 where
@@ -80,28 +106,9 @@ where
 	PriceCollectionOf<T>: DataCollection<T::PriceId, Data = PriceResultOf<T>>,
 	T::PriceRegistry: DataFeeder<T::PriceId, T::Rate, T::AccountId>,
 {
-	#[cfg(test)]
-	fn config_mocks() {
-		use cfg_mocks::pallet_mock_data::util::MockDataCollection;
-
-		use crate::tests::mock::{MockPermissions, MockPools, MockPrices};
-
-		MockPermissions::mock_add(|_, _, _| Ok(()));
-		MockPermissions::mock_has(|_, _, _| true);
-		MockPools::mock_pool_exists(|_| true);
-		MockPools::mock_account_for(|_| 0);
-		MockPools::mock_withdraw(|_, _, _| Ok(()));
-		MockPools::mock_deposit(|_, _, _| Ok(()));
-		MockPools::mock_benchmark_create_pool(|_, _| {});
-		MockPools::mock_benchmark_give_ausd(|_, _| {});
-		MockPrices::mock_feed_value(|_, _, _| Ok(()));
-		MockPrices::mock_register_id(|_, _| Ok(()));
-		MockPrices::mock_collection(|_| MockDataCollection::new(|_| Ok(Default::default())));
-	}
-
 	fn prepare_benchmark() -> PoolIdOf<T> {
 		#[cfg(test)]
-		Self::config_mocks();
+		config_mocks();
 
 		let pool_id = Default::default();
 
@@ -208,15 +215,31 @@ where
 		.unwrap()
 	}
 
-	fn set_policy(pool_id: PoolIdOf<T>) {
+	fn propose_policy(pool_id: PoolIdOf<T>) -> T::Hash {
 		let pool_admin = account::<T::AccountId>("pool_admin", 0, 0);
-
-		Pallet::<T>::update_write_off_policy(
+		Pallet::<T>::propose_write_off_policy(
 			RawOrigin::Signed(pool_admin).into(),
 			pool_id,
 			Self::create_policy(),
 		)
 		.unwrap();
+
+		// We need to call noted again
+		// (that is idempotent for the same change and instant)
+		// to obtain the ChangeId used previously.
+		T::ChangeGuard::note(
+			pool_id,
+			LoanChangeOf::<T>::Policy(Self::create_policy()).into(),
+		)
+		.unwrap()
+	}
+
+	fn set_policy(pool_id: PoolIdOf<T>) {
+		let change_id = Self::propose_policy(pool_id);
+
+		let any = account::<T::AccountId>("any", 0, 0);
+		Pallet::<T>::apply_write_off_policy(RawOrigin::Signed(any).into(), pool_id, change_id)
+			.unwrap();
 	}
 
 	fn expire_loan(pool_id: PoolIdOf<T>, loan_id: T::LoanId) {
@@ -332,20 +355,27 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(borrower), pool_id, loan_id)
 
-	update_write_off_policy {
+	propose_write_off_policy {
 		let pool_admin = account("pool_admin", 0, 0);
 		let pool_id = Helper::<T>::prepare_benchmark();
 		let policy = Helper::<T>::create_policy();
 
 	}: _(RawOrigin::Signed(pool_admin), pool_id, policy)
 
+	apply_write_off_policy {
+		let any = account("any", 0, 0);
+		let pool_id = Helper::<T>::prepare_benchmark();
+		let change_id = Helper::<T>::propose_policy(pool_id);
+
+	}: _(RawOrigin::Signed(any), pool_id, change_id)
+
 	update_portfolio_valuation {
 		let n in 1..Helper::<T>::max_active_loans();
 
-		let borrower = account("borrower", 0, 0);
+		let any = account("any", 0, 0);
 		let pool_id = Helper::<T>::initialize_active_state(n);
 
-	}: _(RawOrigin::Signed(borrower), pool_id)
+	}: _(RawOrigin::Signed(any), pool_id)
 	verify {
 		assert!(Pallet::<T>::portfolio_valuation(pool_id).value() > Zero::zero());
 	}

--- a/pallets/loans/src/tests/mock.rs
+++ b/pallets/loans/src/tests/mock.rs
@@ -59,6 +59,19 @@ pub const POOL_B: PoolId = 2;
 pub const POOL_A_ACCOUNT: AccountId = 10;
 pub const POOL_OTHER_ACCOUNT: AccountId = 100;
 
+pub const COLLATERAL_VALUE: Balance = 10000;
+pub const DEFAULT_INTEREST_RATE: f64 = 0.5;
+pub const POLICY_PERCENTAGE: f64 = 0.5;
+pub const POLICY_PENALTY: f64 = 0.5;
+pub const REGISTER_PRICE_ID: PriceId = 42;
+pub const UNREGISTER_PRICE_ID: PriceId = 88;
+pub const PRICE_VALUE: Rate = Rate::from_u32(1000);
+pub const QUANTITY: Balance = 20;
+pub const CHANGE_ID: ChangeId = H256::repeat_byte(0x42);
+
+/// Used where the error comes from other pallet impl. unknown from the tests
+pub const DEPENDENCY_ERROR: DispatchError = DispatchError::Other("dependency error");
+
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 
@@ -96,6 +109,7 @@ frame_support::construct_runtime!(
 
 frame_support::parameter_types! {
 	pub const MaxActiveLoansPerPool: u32 = 5;
+	#[derive(PartialEq, Debug)]
 	pub const MaxWriteOffPolicySize: u32 = 4;
 }
 

--- a/pallets/loans/src/tests/mod.rs
+++ b/pallets/loans/src/tests/mod.rs
@@ -2,9 +2,8 @@ use std::time::Duration;
 
 use cfg_mocks::pallet_mock_data::util::MockDataCollection;
 use cfg_types::permissions::{PermissionScope, PoolRole, Role};
-use frame_support::{assert_noop, assert_ok};
-use sp_core::H256;
-use sp_runtime::{traits::BadOrigin, DispatchError, FixedPointNumber};
+use frame_support::{assert_noop, assert_ok, storage::bounded_vec::BoundedVec};
+use sp_runtime::{traits::BadOrigin, FixedPointNumber};
 
 use super::{
 	entities::{
@@ -25,19 +24,6 @@ use super::{
 		WrittenOffError,
 	},
 };
-
-const COLLATERAL_VALUE: Balance = 10000;
-const DEFAULT_INTEREST_RATE: f64 = 0.5;
-const POLICY_PERCENTAGE: f64 = 0.5;
-const POLICY_PENALTY: f64 = 0.5;
-const REGISTER_PRICE_ID: PriceId = 42;
-const UNREGISTER_PRICE_ID: PriceId = 88;
-const PRICE_VALUE: Rate = Rate::from_u32(1000);
-const QUANTITY: Balance = 20;
-const CHANGE_ID: ChangeId = H256::repeat_byte(0x42);
-
-/// Used where the error comes from other pallet impl. unknown from the tests
-const DEPENDENCY_ERROR: DispatchError = DispatchError::Other("dependency error");
 
 pub mod mock;
 use mock::*;

--- a/pallets/loans/src/types/mod.rs
+++ b/pallets/loans/src/types/mod.rs
@@ -15,13 +15,15 @@
 
 use cfg_primitives::Moment;
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::{PalletError, RuntimeDebug};
+use frame_support::{storage::bounded_vec::BoundedVec, PalletError, RuntimeDebug};
 use scale_info::TypeInfo;
+use sp_runtime::traits::Get;
 
 pub mod policy;
 pub mod portfolio;
 pub mod valuation;
 
+use policy::WriteOffRule;
 use valuation::ValuationMethod;
 
 /// Error related to loan creation
@@ -187,6 +189,7 @@ pub enum LoanMutation<Rate> {
 
 /// Change description
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebug, MaxEncodedLen)]
-pub enum Change<LoanId, Rate> {
+pub enum Change<LoanId, Rate, MaxRules: Get<u32>> {
 	Loan(LoanId, LoanMutation<Rate>),
+	Policy(BoundedVec<WriteOffRule<Rate>, MaxRules>),
 }


### PR DESCRIPTION
# Description

Fixes #1386 

## Changes and Descriptions

- [x] Updated/Added two new extrinsics:
  - `propose_write_off_policy()`
  - `apply_write_off_policy()`
- [x] `pallet loans` tests
- [x] `pallet-loans` benchmarks
- [ ] Runtime common changes to adapt the new loan's change to Requirements.
- [ ] Benchmarks running correctly from for real runtimes. 
  - We would need some `pallet-pool-system` benchmark utility to enable this through the `PoolBenchmark` trait.
