### PR TITLE
Mock builder: Support nested mock calls

### DIFF
--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -235,6 +235,20 @@
 //!
 //! If types for the closure of `mock_*` method and trait method don't match,
 //! you will obtain a runtime error in your tests.
+//!
+//! ## Mock Patterns
+//!
+//! ### Storage pattern
+//!
+//! In some cases it's pretty common making a mock that returns a value that was
+//! set previously by another mock. For this case you can define your "getter"
+//! mock inside the definition of the "setter" mock, as follows:
+//!
+//! ```ignore
+//! MyMock::mock_set(|value| MyMock::mock_get(move || value));
+//! ```
+//!
+//! Any call to `get()` will return the last value given to `set()`.
 
 /// Provide functions for register/execute calls
 pub mod storage;

--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -239,7 +239,6 @@
 //! ## Mock Patterns
 //!
 //! ### Storage pattern
-//!
 //! In some cases it's pretty common making a mock that returns a value that was
 //! set previously by another mock. For this case you can define your "getter"
 //! mock inside the definition of the "setter" mock, as follows:
@@ -249,6 +248,25 @@
 //! ```
 //!
 //! Any call to `get()` will return the last value given to `set()`.
+//!
+//! ### Check internal calls are ordered
+//! If you want to test some mocks method are calle in some order, you can
+//! define them nested, in the expected order they must be called
+//!
+//! ```ignore
+//! MyMock::mock_first(|| {
+//!     MyMock::mock_second(|| {
+//!         MyMock::mock_third(|| {
+//!             //...
+//!         })
+//!     })
+//! });
+//!
+//!
+//! // The next method only will be succesful
+//! // if it makes the internal calls in order
+//! MyPallet::calls_first_second_third();
+//! ```
 
 /// Provide functions for register/execute calls
 pub mod storage;


### PR DESCRIPTION
# Description

Now you can define mocks inside mock executions. It unlocks the set-get mock pattern, meaning you can return what you've previously set in another mock. In other words, you will always get the last you've set.

```rust
MyMock::mock_set(|value| MyMock::mock_get(move || value));
```

## Changes and Descriptions
- Implementation
- Docs
- Tests
