### PR TITLE
Rewards: Liquidity epoch duration as time instead of blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7469,6 +7469,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "num-traits",
+ "pallet-timestamp",
  "parity-scale-codec 3.4.0",
  "scale-info",
  "sp-core",

--- a/pallets/liquidity-rewards/Cargo.toml
+++ b/pallets/liquidity-rewards/Cargo.toml
@@ -45,6 +45,7 @@ runtime-benchmarks = [
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
+  "cfg-mocks/runtime-benchmarks",
 ]
 std = [
   "codec/std",

--- a/pallets/liquidity-rewards/Cargo.toml
+++ b/pallets/liquidity-rewards/Cargo.toml
@@ -27,6 +27,7 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 
 cfg-mocks = { path = "../../libs/mocks" }
 

--- a/pallets/liquidity-rewards/src/benchmarking.rs
+++ b/pallets/liquidity-rewards/src/benchmarking.rs
@@ -73,7 +73,8 @@ benchmarks! {
 		init_test_mock();
 
 		Pallet::<T>::set_currency_group(RawOrigin::Root.into(), CURRENCY_ID_A.into(), GROUP_A.into()).unwrap();
-		Pallet::<T>::on_initialize(T::InitialEpochDuration::get());
+		Pallet::<T>::apply_epoch_changes(&mut Default::default()).unwrap();
+		Pallet::<T>::on_initialize(Zero::zero());
 
 	}: _(RawOrigin::Signed(caller), CURRENCY_ID_A.into(), T::Balance::zero())
 
@@ -83,7 +84,8 @@ benchmarks! {
 		init_test_mock();
 
 		Pallet::<T>::set_currency_group(RawOrigin::Root.into(), CURRENCY_ID_A.into(), GROUP_A.into()).unwrap();
-		Pallet::<T>::on_initialize(T::InitialEpochDuration::get());
+		Pallet::<T>::apply_epoch_changes(&mut Default::default()).unwrap();
+		Pallet::<T>::on_initialize(Zero::zero());
 
 	}: _(RawOrigin::Signed(caller), CURRENCY_ID_A.into(), T::Balance::zero())
 
@@ -93,7 +95,8 @@ benchmarks! {
 		init_test_mock();
 
 		Pallet::<T>::set_currency_group(RawOrigin::Root.into(), CURRENCY_ID_A.into(), GROUP_A.into()).unwrap();
-		Pallet::<T>::on_initialize(T::InitialEpochDuration::get());
+		Pallet::<T>::apply_epoch_changes(&mut Default::default()).unwrap();
+		Pallet::<T>::on_initialize(Zero::zero());
 
 	}: _(RawOrigin::Signed(caller), CURRENCY_ID_A.into())
 
@@ -101,7 +104,7 @@ benchmarks! {
 	}: _(RawOrigin::Root, REWARD.into())
 
 	set_epoch_duration {
-	}: _(RawOrigin::Root, 10.into())
+	}: _(RawOrigin::Root, MomentOf::<T>::zero())
 
 	set_group_weight {
 	}: _(RawOrigin::Root, GROUP_A.into(), WEIGHT.into())

--- a/pallets/liquidity-rewards/src/lib.rs
+++ b/pallets/liquidity-rewards/src/lib.rs
@@ -83,6 +83,16 @@ impl<T: Config> Default for EpochData<T> {
 	}
 }
 
+impl<T: Config> Clone for EpochData<T> {
+	fn clone(&self) -> Self {
+		Self {
+			duration: self.duration,
+			reward: self.reward,
+			weights: self.weights.clone(),
+		}
+	}
+}
+
 /// Type that contains the pending update.
 #[derive(
 	PartialEq, Clone, DefaultNoBound, Encode, Decode, TypeInfo, MaxEncodedLen, RuntimeDebugNoBound,
@@ -191,59 +201,72 @@ pub mod pallet {
 		MaxChangesPerEpochReached,
 	}
 
+	#[derive(Default)]
+	pub struct ChangeCounter {
+		groups: u32,
+		weights: u32,
+		currencies: u32,
+	}
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
 		fn on_initialize(_: T::BlockNumber) -> Weight {
-			let ends_on = EndOfEpoch::<T>::get();
 			let now = T::Timer::now();
-
-			if ends_on > now {
+			if now < EndOfEpoch::<T>::get() {
+				// Not ready yet to change the epoch
 				return T::DbWeight::get().reads(1);
 			}
 
-			let mut groups = 0;
-			let mut weight_changes = 0;
-			let mut currency_changes = 0;
-
+			let mut counter = ChangeCounter::default();
 			transactional::with_storage_layer(|| -> DispatchResult {
-				NextEpochChanges::<T>::try_mutate(|changes| -> DispatchResult {
-					ActiveEpochData::<T>::try_mutate(|epoch_data| {
-						groups = T::Rewards::distribute_reward_with_weights(
-							epoch_data.reward,
-							epoch_data.weights.iter().map(|(g, w)| (*g, *w)),
-						)
-						.map(|results| results.len() as u32)?;
+				let (epoch_data, last_changes) = Self::apply_epoch_changes(&mut counter)?;
 
-						for (&group_id, &weight) in &changes.weights {
-							epoch_data.weights.try_insert(group_id, weight).ok();
-							weight_changes += 1;
-						}
+				let ends_on = now.ensure_add(epoch_data.duration)?;
 
-						for (&currency_id, &group_id) in &changes.currencies {
-							T::Rewards::attach_currency(currency_id, group_id)?;
-							currency_changes += 1;
-						}
+				EndOfEpoch::<T>::set(ends_on);
 
-						epoch_data.reward = changes.reward.unwrap_or(epoch_data.reward);
-						epoch_data.duration = changes.duration.unwrap_or(epoch_data.duration);
+				Self::deposit_event(Event::NewEpoch {
+					ends_on,
+					reward: epoch_data.reward,
+					last_changes,
+				});
 
-						let ends_on = ends_on.max(now).ensure_add(epoch_data.duration)?;
-
-						EndOfEpoch::<T>::set(ends_on);
-
-						Self::deposit_event(Event::NewEpoch {
-							ends_on,
-							reward: epoch_data.reward,
-							last_changes: mem::take(changes),
-						});
-
-						Ok(())
-					})
-				})
+				Ok(())
 			})
 			.ok();
 
-			T::WeightInfo::on_initialize(groups, weight_changes, currency_changes)
+			T::WeightInfo::on_initialize(counter.groups, counter.weights, counter.currencies)
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn apply_epoch_changes(
+			counter: &mut ChangeCounter,
+		) -> Result<(EpochData<T>, EpochChanges<T>), DispatchError> {
+			NextEpochChanges::<T>::try_mutate(|changes| {
+				ActiveEpochData::<T>::try_mutate(|epoch_data| {
+					counter.groups = T::Rewards::distribute_reward_with_weights(
+						epoch_data.reward,
+						epoch_data.weights.iter().map(|(g, w)| (*g, *w)),
+					)
+					.map(|results| results.len() as u32)?;
+
+					for (&group_id, &weight) in &changes.weights {
+						epoch_data.weights.try_insert(group_id, weight).ok();
+						counter.weights += 1;
+					}
+
+					for (&currency_id, &group_id) in &changes.currencies {
+						T::Rewards::attach_currency(currency_id, group_id)?;
+						counter.currencies += 1;
+					}
+
+					epoch_data.reward = changes.reward.unwrap_or(epoch_data.reward);
+					epoch_data.duration = changes.duration.unwrap_or(epoch_data.duration);
+
+					Ok((epoch_data.clone(), mem::take(changes)))
+				})
+			})
 		}
 	}
 

--- a/pallets/liquidity-rewards/src/mock.rs
+++ b/pallets/liquidity-rewards/src/mock.rs
@@ -21,9 +21,18 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system,
 		Liquidity: pallet_liquidity_rewards,
+		Timer: pallet_timestamp,
 		MockRewards: cfg_mocks::pallet_mock_rewards,
 	}
 );
+
+frame_support::parameter_types! {
+	#[derive(scale_info::TypeInfo)]
+	pub const MaxGroups: u32 = 20;
+
+	#[derive(scale_info::TypeInfo, Debug, PartialEq, Clone)]
+	pub const MaxChangesPerEpoch: u32 = 50;
+}
 
 impl frame_system::Config for Test {
 	type AccountData = ();
@@ -52,12 +61,11 @@ impl frame_system::Config for Test {
 	type Version = ();
 }
 
-frame_support::parameter_types! {
-	#[derive(scale_info::TypeInfo)]
-	pub const MaxGroups: u32 = 20;
-
-	#[derive(scale_info::TypeInfo, Debug, PartialEq, Clone)]
-	pub const MaxChangesPerEpoch: u32 = 50;
+impl pallet_timestamp::Config for Test {
+	type MinimumPeriod = ConstU64<1000>;
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type WeightInfo = ();
 }
 
 impl cfg_mocks::pallet_mock_rewards::Config for Test {
@@ -76,6 +84,7 @@ impl pallet_liquidity_rewards::Config for Test {
 	type MaxGroups = MaxGroups;
 	type Rewards = MockRewards;
 	type RuntimeEvent = RuntimeEvent;
+	type Timer = Timer;
 	type Weight = u64;
 	type WeightInfo = ();
 }

--- a/pallets/liquidity-rewards/src/tests.rs
+++ b/pallets/liquidity-rewards/src/tests.rs
@@ -46,13 +46,15 @@ fn distributed_reward_change() {
 		assert_eq!(NextEpochChanges::<Test>::get().reward, Some(REWARD));
 		assert_eq!(ActiveEpochData::<Test>::get().reward, 0);
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		Liquidity::on_initialize(0);
 
 		// EPOCH 1
 		assert_eq!(NextEpochChanges::<Test>::get().reward, None);
 		assert_eq!(ActiveEpochData::<Test>::get().reward, REWARD);
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION + INITIAL_EPOCH_DURATION);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION + INITIAL_EPOCH_DURATION);
+		Liquidity::on_initialize(0);
 
 		// EPOCH 2
 		assert_eq!(ActiveEpochData::<Test>::get().reward, REWARD);
@@ -75,7 +77,8 @@ fn epoch_change() {
 			Some(EPOCH_DURATION)
 		);
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		Liquidity::on_initialize(0);
 
 		// EPOCH 1
 		assert_eq!(
@@ -84,14 +87,16 @@ fn epoch_change() {
 		);
 		assert_eq!(NextEpochChanges::<Test>::get().duration, None);
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION + EPOCH_DURATION / 2);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION + EPOCH_DURATION / 2);
+		Liquidity::on_initialize(0);
 
 		assert_eq!(
 			EndOfEpoch::<Test>::get(),
 			INITIAL_EPOCH_DURATION + EPOCH_DURATION
 		);
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION + EPOCH_DURATION);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION + EPOCH_DURATION);
+		Liquidity::on_initialize(0);
 
 		// EPOCH 2
 		assert_eq!(
@@ -104,7 +109,7 @@ fn epoch_change() {
 #[test]
 fn epoch_change_from_advanced_state() {
 	const EPOCH_DURATION: u64 = 42;
-	const SYSTEM_BLOCK_NUMBER: u64 = 1000;
+	const INITIAL_TIME: u64 = 1000;
 
 	new_test_ext().execute_with(|| {
 		// EPOCH 0
@@ -113,21 +118,17 @@ fn epoch_change_from_advanced_state() {
 			EPOCH_DURATION
 		));
 
-		Liquidity::on_initialize(SYSTEM_BLOCK_NUMBER);
+		Timer::set_timestamp(INITIAL_TIME);
+		Liquidity::on_initialize(0);
 
 		// EPOCH 1
-		assert_eq!(
-			EndOfEpoch::<Test>::get(),
-			SYSTEM_BLOCK_NUMBER + EPOCH_DURATION
-		);
+		assert_eq!(EndOfEpoch::<Test>::get(), INITIAL_TIME + EPOCH_DURATION);
 		assert_eq!(NextEpochChanges::<Test>::get().duration, None);
 
-		Liquidity::on_initialize(SYSTEM_BLOCK_NUMBER);
+		Timer::set_timestamp(INITIAL_TIME);
+		Liquidity::on_initialize(0);
 
-		assert_eq!(
-			EndOfEpoch::<Test>::get(),
-			SYSTEM_BLOCK_NUMBER + EPOCH_DURATION
-		);
+		assert_eq!(EndOfEpoch::<Test>::get(), INITIAL_TIME + EPOCH_DURATION);
 	});
 }
 
@@ -153,7 +154,8 @@ fn currency_changes() {
 			Ok(())
 		});
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		Liquidity::on_initialize(0);
 
 		// EPOCH 1
 		assert_eq!(
@@ -178,7 +180,8 @@ fn weight_changes() {
 			REWARD
 		));
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		Liquidity::on_initialize(0);
 
 		// EPOCH 1
 		assert_ok!(Liquidity::set_group_weight(
@@ -201,7 +204,8 @@ fn weight_changes() {
 		);
 		assert_eq!(ActiveEpochData::<Test>::get().weights.len(), 0);
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION * 2);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION * 2);
+		Liquidity::on_initialize(0);
 
 		// The weights were configured but no used in this epoch.
 		// We need one epoch more to apply those weights in the distribution.
@@ -231,7 +235,8 @@ fn weight_changes() {
 			Ok(rewards)
 		});
 
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION * 3);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION * 3);
+		Liquidity::on_initialize(0);
 	});
 }
 
@@ -284,7 +289,8 @@ fn discard_groups_exceed_max_grups() {
 				WEIGHT
 			));
 		}
-		Liquidity::on_initialize(INITIAL_EPOCH_DURATION);
+		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		Liquidity::on_initialize(0);
 
 		// EPOCH 1
 		assert_eq!(

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1781,6 +1781,7 @@ impl pallet_liquidity_rewards::Config for Runtime {
 	type MaxGroups = MaxGroups;
 	type Rewards = LiquidityRewardsBase;
 	type RuntimeEvent = RuntimeEvent;
+	type Timer = Timestamp;
 	type Weight = u64;
 	type WeightInfo = ();
 }


### PR DESCRIPTION
# Description

Fixes #1415

## Changes and Descriptions

- Changed `BlockNumber` intervals to `Moment` intervals.
- Split `on_initialize()` logic to be able to extract the epoch change logic and apply it in benchmarks (required now).
