### PR TITLE
Rewards: liquidity using gap & remove pallet-timestamp dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7469,7 +7469,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "num-traits",
- "pallet-timestamp",
  "parity-scale-codec 3.4.0",
  "scale-info",
  "sp-core",

--- a/libs/mocks/src/lib.rs
+++ b/libs/mocks/src/lib.rs
@@ -4,6 +4,7 @@ mod fees;
 mod permissions;
 mod pools;
 mod rewards;
+mod time;
 
 pub use change_guard::pallet_mock_change_guard;
 pub use data::pallet as pallet_mock_data;
@@ -11,6 +12,7 @@ pub use fees::pallet as pallet_mock_fees;
 pub use permissions::pallet as pallet_mock_permissions;
 pub use pools::pallet as pallet_mock_pools;
 pub use rewards::pallet as pallet_mock_rewards;
+pub use time::pallet as pallet_mock_time;
 
 #[cfg(test)]
 #[allow(unused)]

--- a/libs/mocks/src/time.rs
+++ b/libs/mocks/src/time.rs
@@ -1,0 +1,37 @@
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::{pallet_prelude::*, traits::Time};
+	use mock_builder::{execute_call, register_call};
+	use sp_runtime::traits::AtLeast32Bit;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type Moment: AtLeast32Bit + Parameter + Default + Copy + MaxEncodedLen;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	pub(super) type CallIds<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		<Blake2_128 as frame_support::StorageHasher>::Output,
+		mock_builder::CallId,
+	>;
+
+	impl<T: Config> Pallet<T> {
+		pub fn mock_now(f: impl Fn() -> T::Moment + 'static) {
+			register_call!(move |()| f());
+		}
+	}
+
+	impl<T: Config> Time for Pallet<T> {
+		type Moment = T::Moment;
+
+		fn now() -> Self::Moment {
+			execute_call!(())
+		}
+	}
+}

--- a/pallets/liquidity-rewards/Cargo.toml
+++ b/pallets/liquidity-rewards/Cargo.toml
@@ -25,7 +25,6 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.38" }
 
 [dev-dependencies]
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 

--- a/pallets/liquidity-rewards/src/benchmarking.rs
+++ b/pallets/liquidity-rewards/src/benchmarking.rs
@@ -1,7 +1,5 @@
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_system::RawOrigin;
-#[cfg(test)]
-use mock::MockRewards;
 use sp_runtime::traits::One;
 
 use super::*;
@@ -15,6 +13,8 @@ const CURRENCY_ID_A: u32 = 42;
 fn init_test_mock() -> impl Sized {
 	#[cfg(test)]
 	{
+		use mock::{MockRewards, MockTime};
+
 		MockRewards::mock_is_ready(|_| true);
 		MockRewards::mock_group_stake(|_| 100);
 		MockRewards::mock_reward_group(|_, _| Ok(0));
@@ -22,6 +22,7 @@ fn init_test_mock() -> impl Sized {
 		MockRewards::mock_withdraw_stake(|_, _, _| Ok(()));
 		MockRewards::mock_claim_reward(|_, _| Ok(0));
 		MockRewards::mock_attach_currency(|_, _| Ok(()));
+		MockTime::mock_now(|| 0);
 	}
 }
 

--- a/pallets/liquidity-rewards/src/mock.rs
+++ b/pallets/liquidity-rewards/src/mock.rs
@@ -21,7 +21,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system,
 		Liquidity: pallet_liquidity_rewards,
-		Timer: pallet_timestamp,
+		MockTime: cfg_mocks::pallet_mock_time,
 		MockRewards: cfg_mocks::pallet_mock_rewards,
 	}
 );
@@ -61,11 +61,8 @@ impl frame_system::Config for Test {
 	type Version = ();
 }
 
-impl pallet_timestamp::Config for Test {
-	type MinimumPeriod = ConstU64<1000>;
+impl cfg_mocks::pallet_mock_time::Config for Test {
 	type Moment = u64;
-	type OnTimestampSet = ();
-	type WeightInfo = ();
 }
 
 impl cfg_mocks::pallet_mock_rewards::Config for Test {
@@ -84,7 +81,7 @@ impl pallet_liquidity_rewards::Config for Test {
 	type MaxGroups = MaxGroups;
 	type Rewards = MockRewards;
 	type RuntimeEvent = RuntimeEvent;
-	type Timer = Timer;
+	type Timer = MockTime;
 	type Weight = u64;
 	type WeightInfo = ();
 }

--- a/pallets/liquidity-rewards/src/tests.rs
+++ b/pallets/liquidity-rewards/src/tests.rs
@@ -46,14 +46,14 @@ fn distributed_reward_change() {
 		assert_eq!(NextEpochChanges::<Test>::get().reward, Some(REWARD));
 		assert_eq!(ActiveEpochData::<Test>::get().reward, 0);
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION);
 		Liquidity::on_initialize(0);
 
 		// EPOCH 1
 		assert_eq!(NextEpochChanges::<Test>::get().reward, None);
 		assert_eq!(ActiveEpochData::<Test>::get().reward, REWARD);
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION + INITIAL_EPOCH_DURATION);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION + INITIAL_EPOCH_DURATION);
 		Liquidity::on_initialize(0);
 
 		// EPOCH 2
@@ -77,7 +77,7 @@ fn epoch_change() {
 			Some(EPOCH_DURATION)
 		);
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION);
 		Liquidity::on_initialize(0);
 
 		// EPOCH 1
@@ -87,7 +87,7 @@ fn epoch_change() {
 		);
 		assert_eq!(NextEpochChanges::<Test>::get().duration, None);
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION + EPOCH_DURATION / 2);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION + EPOCH_DURATION / 2);
 		Liquidity::on_initialize(0);
 
 		assert_eq!(
@@ -95,7 +95,7 @@ fn epoch_change() {
 			INITIAL_EPOCH_DURATION + EPOCH_DURATION
 		);
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION + EPOCH_DURATION);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION + EPOCH_DURATION);
 		Liquidity::on_initialize(0);
 
 		// EPOCH 2
@@ -118,14 +118,14 @@ fn epoch_change_from_advanced_state() {
 			EPOCH_DURATION
 		));
 
-		Timer::set_timestamp(INITIAL_TIME);
+		MockTime::mock_now(|| INITIAL_TIME);
 		Liquidity::on_initialize(0);
 
 		// EPOCH 1
 		assert_eq!(EndOfEpoch::<Test>::get(), INITIAL_TIME + EPOCH_DURATION);
 		assert_eq!(NextEpochChanges::<Test>::get().duration, None);
 
-		Timer::set_timestamp(INITIAL_TIME);
+		MockTime::mock_now(|| INITIAL_TIME);
 		Liquidity::on_initialize(0);
 
 		assert_eq!(EndOfEpoch::<Test>::get(), INITIAL_TIME + EPOCH_DURATION);
@@ -154,7 +154,7 @@ fn currency_changes() {
 			Ok(())
 		});
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION);
 		Liquidity::on_initialize(0);
 
 		// EPOCH 1
@@ -180,7 +180,7 @@ fn weight_changes() {
 			REWARD
 		));
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION);
 		Liquidity::on_initialize(0);
 
 		// EPOCH 1
@@ -204,7 +204,7 @@ fn weight_changes() {
 		);
 		assert_eq!(ActiveEpochData::<Test>::get().weights.len(), 0);
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION * 2);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION * 2);
 		Liquidity::on_initialize(0);
 
 		// The weights were configured but no used in this epoch.
@@ -235,7 +235,7 @@ fn weight_changes() {
 			Ok(rewards)
 		});
 
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION * 3);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION * 3);
 		Liquidity::on_initialize(0);
 	});
 }
@@ -289,7 +289,7 @@ fn discard_groups_exceed_max_grups() {
 				WEIGHT
 			));
 		}
-		Timer::set_timestamp(INITIAL_EPOCH_DURATION);
+		MockTime::mock_now(|| INITIAL_EPOCH_DURATION);
 		Liquidity::on_initialize(0);
 
 		// EPOCH 1

--- a/pallets/rewards/src/mechanism/gap.rs
+++ b/pallets/rewards/src/mechanism/gap.rs
@@ -180,7 +180,7 @@ pub mod pallet {
 
 		type Rate: FixedPointNumber + codec::FullCodec + TypeInfo + MaxEncodedLen;
 
-		type MaxCurrencyMovements: Get<u32> + sp_std::fmt::Debug;
+		type MaxCurrencyMovements: Get<u32>;
 	}
 
 	#[pallet::pallet]

--- a/runtime/common/src/apis/rewards.rs
+++ b/runtime/common/src/apis/rewards.rs
@@ -16,7 +16,7 @@ use sp_api::decl_runtime_apis;
 use sp_core::RuntimeDebug;
 use sp_std::vec::Vec;
 
-#[derive(Encode, Decode, Clone, TypeInfo, MaxEncodedLen, RuntimeDebug)]
+#[derive(Encode, Decode, Clone, Copy, TypeInfo, MaxEncodedLen, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum RewardDomain {
 	Block,

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1716,9 +1716,21 @@ impl<
 frame_support::parameter_types! {
 	pub const RewardsPalletId: PalletId = cfg_types::ids::BLOCK_REWARDS_PALLET_ID;
 	pub const RewardCurrency: CurrencyId = CurrencyId::Native;
-
 	#[derive(scale_info::TypeInfo)]
 	pub const MaxCurrencyMovements: u32 = 50;
+	#[derive(scale_info::TypeInfo)]
+	pub const MaxGroups: u32 = 20;
+	#[derive(scale_info::TypeInfo, Debug, PartialEq, Eq, Clone)]
+	pub const MaxChangesPerEpoch: u32 = 50;
+	pub const InitialEpochDuration: Moment = SECONDS_PER_MINUTE * 1000; // 1 min in milliseconds
+}
+
+impl pallet_rewards::mechanism::gap::Config for Runtime {
+	type Balance = Balance;
+	type DistributionId = u32;
+	type IBalance = IBalance;
+	type MaxCurrencyMovements = MaxCurrencyMovements;
+	type Rate = FixedI128;
 }
 
 impl pallet_rewards::Config<pallet_rewards::Instance1> for Runtime {
@@ -1729,13 +1741,23 @@ impl pallet_rewards::Config<pallet_rewards::Instance1> for Runtime {
 	type RewardCurrency = RewardCurrency;
 	type RewardIssuance =
 		pallet_rewards::issuance::MintReward<AccountId, Balance, CurrencyId, Tokens>;
-	type RewardMechanism = pallet_rewards::mechanism::base::Mechanism<
-		Balance,
-		IBalance,
-		FixedI128,
-		MaxCurrencyMovements,
-	>;
+	type RewardMechanism = GapRewardMechanism;
 	type RuntimeEvent = RuntimeEvent;
+}
+
+impl pallet_liquidity_rewards::Config for Runtime {
+	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
+	type Balance = Balance;
+	type CurrencyId = CurrencyId;
+	type GroupId = u32;
+	type InitialEpochDuration = InitialEpochDuration;
+	type MaxChangesPerEpoch = MaxChangesPerEpoch;
+	type MaxGroups = MaxGroups;
+	type Rewards = LiquidityRewardsBase;
+	type RuntimeEvent = RuntimeEvent;
+	type Timer = Timestamp;
+	type Weight = u64;
+	type WeightInfo = ();
 }
 
 frame_support::parameter_types! {
@@ -1759,31 +1781,6 @@ impl pallet_rewards::Config<pallet_rewards::Instance2> for Runtime {
 		SingleCurrencyMovement,
 	>;
 	type RuntimeEvent = RuntimeEvent;
-}
-
-frame_support::parameter_types! {
-	#[derive(scale_info::TypeInfo)]
-	pub const MaxGroups: u32 = 20;
-
-	#[derive(scale_info::TypeInfo, Debug, PartialEq, Eq, Clone)]
-	pub const MaxChangesPerEpoch: u32 = 50;
-
-	pub const InitialEpochDuration: BlockNumber = 1 * MINUTES;
-}
-
-impl pallet_liquidity_rewards::Config for Runtime {
-	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
-	type Balance = Balance;
-	type CurrencyId = CurrencyId;
-	type GroupId = u32;
-	type InitialEpochDuration = InitialEpochDuration;
-	type MaxChangesPerEpoch = MaxChangesPerEpoch;
-	type MaxGroups = MaxGroups;
-	type Rewards = LiquidityRewardsBase;
-	type RuntimeEvent = RuntimeEvent;
-	type Timer = Timestamp;
-	type Weight = u64;
-	type WeightInfo = ();
 }
 
 frame_support::parameter_types! {
@@ -1891,6 +1888,7 @@ construct_runtime!(
 		BlockRewards: pallet_block_rewards::{Pallet, Call, Storage, Event<T>, Config<T>} = 111,
 		TransferAllowList: pallet_transfer_allowlist::{Pallet, Call, Storage, Event<T>} = 112,
 		PriceCollector: pallet_data_collector::{Pallet, Storage} = 113,
+		GapRewardMechanism: pallet_rewards::mechanism::gap = 114,
 
 		// XCM
 		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 120,

--- a/runtime/integration-tests/src/runtime_apis/rewards.rs
+++ b/runtime/integration-tests/src/runtime_apis/rewards.rs
@@ -65,14 +65,24 @@ where
 				.expect("Depositing stake should work");
 			}
 
-			for (group_id, amount) in rewards {
-				<Rewards as DistributedRewards>::distribute_reward(amount, [group_id])
+			for (group_id, amount) in &rewards {
+				<Rewards as DistributedRewards>::distribute_reward(*amount, [*group_id])
 					.expect("Distributing rewards should work");
+			}
+
+			if let RewardDomain::Liquidity = domain {
+				/// For the gap mechanism, used by liquidity rewards,
+				/// we need another distribution to allow the participant claim
+				/// rewards
+				for (group_id, amount) in &rewards {
+					<Rewards as DistributedRewards>::distribute_reward(*amount, [*group_id])
+						.expect("Distributing rewards should work");
+				}
 			}
 		})
 		.with_api(|api, latest| {
 			let currencies = api
-				.list_currencies(&latest, domain.clone(), staker.clone())
+				.list_currencies(&latest, domain, staker.clone())
 				.expect("There should be staked currencies");
 			assert_eq!(currencies.clone().len(), 1);
 


### PR DESCRIPTION
# Description

Fixes #1416 

## Changes and Descriptions

- Replace `base` by `gap` mechanism (which requires instantiating a new pallet)
- Remove `pallet-timestamp` dependency from `pallet-rewards` using a mock.
