### PR TITLE
altair: CrossChainTransferabilityMigration version check

### DIFF
--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -49,7 +49,11 @@ mod asset_registry {
 
 	impl OnRuntimeUpgrade for CrossChainTransferabilityMigration {
 		fn on_runtime_upgrade() -> Weight {
-			if VERSION.spec_version != 1028 {
+			// Only run this migration up to Altair 1028, the version in which we expect this
+			// migration to be executed. By being inclusive to lower versions (e.g. 1027) we
+			// are able to test the migration with try-runtime without needing to temporarily
+			// bump Altair's spec_version.
+			if VERSION.spec_version > 1028 {
 				return Weight::zero();
 			}
 


### PR DESCRIPTION
Backport from https://github.com/centrifuge/centrifuge-chain/pull/1343, were @wischli reported the migration was failing when trying it out with `try-runtime`.

The issue being that the version check only allows the migration to run under Altair v1028, the version in which we expect the migration to actually be executed along with the respective the runtime upgrade. The issue is that it won't run until we bump the spec_version, making it impossible to test it without manually and temporarily bump Altair's `spec_version` to satisfy the check.