### PR TITLE
refactor: `TrancheTokenPrice` trait

### DIFF
--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -1,7 +1,7 @@
 #[frame_support::pallet]
 pub mod pallet {
 	use cfg_primitives::Moment;
-	use cfg_traits::{PoolInspect, PoolReserve, PriceValue};
+	use cfg_traits::{PoolInspect, PoolReserve, PriceValue, TrancheTokenPrice};
 	use codec::{Decode, Encode, MaxEncodedLen};
 	use frame_support::pallet_prelude::*;
 	use mock_builder::{execute_call, register_call};
@@ -43,13 +43,6 @@ pub mod pallet {
 		}
 
 		pub fn tranche_exists(f: impl Fn(T::PoolId, T::TrancheId) -> bool + 'static) {
-			register_call!(move |(a, b)| f(a, b));
-		}
-
-		pub fn get_tranche_token_price(
-			f: impl Fn(T::PoolId, T::TrancheId) -> Option<PriceValue<T::CurrencyId, T::Rate, Moment>>
-				+ 'static,
-		) {
 			register_call!(move |(a, b)| f(a, b));
 		}
 
@@ -96,19 +89,26 @@ pub mod pallet {
 			execute_call!((a, b))
 		}
 
-		fn get_tranche_token_price(
-			a: T::PoolId,
-			b: T::TrancheId,
-		) -> Option<PriceValue<T::CurrencyId, T::Rate, Moment>> {
-			execute_call!((a, b))
-		}
-
 		fn account_for(a: T::PoolId) -> T::AccountId {
 			execute_call!(a)
 		}
 
 		fn currency_for(a: T::PoolId) -> Option<T::CurrencyId> {
 			execute_call!(a)
+		}
+	}
+
+	impl<T: Config> TrancheTokenPrice<T::AccountId, T::CurrencyId> for Pallet<T> {
+		type Moment = Moment;
+		type PoolId = T::PoolId;
+		type Rate = T::Rate;
+		type TrancheId = T::TrancheId;
+
+		fn get(
+			a: T::PoolId,
+			b: T::TrancheId,
+		) -> Option<PriceValue<T::CurrencyId, T::Rate, Moment>> {
+			execute_call!((a, b))
 		}
 	}
 

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -119,15 +119,7 @@ pub trait PoolNAV<PoolId, Amount> {
 /// A trait that support pool inspection operations such as pool existence
 /// checks and pool admin of permission set.
 pub trait PoolInspect<AccountId, CurrencyId> {
-	type PoolId: Parameter
-		+ Member
-		+ Debug
-		+ Copy
-		+ Default
-		+ TypeInfo
-		+ Encode
-		+ Decode
-		+ MaxEncodedLen;
+	type PoolId;
 	type TrancheId;
 	type Rate;
 	type Moment;

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -128,7 +128,7 @@ pub trait PoolInspect<AccountId, CurrencyId> {
 		+ Encode
 		+ Decode
 		+ MaxEncodedLen;
-	type TrancheId: Parameter + Member + Debug + Copy + Default + TypeInfo + MaxEncodedLen;
+	type TrancheId;
 	type Rate;
 	type Moment;
 
@@ -145,16 +145,8 @@ pub trait PoolInspect<AccountId, CurrencyId> {
 
 /// Get the latest price for a given tranche token
 pub trait TrancheTokenPrice<AccountId, CurrencyId> {
-	type PoolId: Parameter
-		+ Member
-		+ Debug
-		+ Copy
-		+ Default
-		+ TypeInfo
-		+ Encode
-		+ Decode
-		+ MaxEncodedLen;
-	type TrancheId: Parameter + Member + Debug + Copy + Default + TypeInfo + MaxEncodedLen;
+	type PoolId;
+	type TrancheId;
 	type Rate;
 	type Moment;
 

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -146,18 +146,17 @@ pub trait PoolInspect<AccountId, CurrencyId> {
 /// Get the latest price for a given tranche token
 pub trait TrancheTokenPrice<AccountId, CurrencyId> {
 	type PoolId: Parameter
-	+ Member
-	+ Debug
-	+ Copy
-	+ Default
-	+ TypeInfo
-	+ Encode
-	+ Decode
-	+ MaxEncodedLen;
+		+ Member
+		+ Debug
+		+ Copy
+		+ Default
+		+ TypeInfo
+		+ Encode
+		+ Decode
+		+ MaxEncodedLen;
 	type TrancheId: Parameter + Member + Debug + Copy + Default + TypeInfo + MaxEncodedLen;
 	type Rate;
 	type Moment;
-
 
 	fn get(
 		pool_id: Self::PoolId,

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -159,7 +159,6 @@ pub trait TrancheTokenPrice<AccountId, CurrencyId> {
 	type Moment;
 
 
-	// todo(nuno): move all codebase from `get_tranche_token_price`
 	fn get(
 		pool_id: Self::PoolId,
 		tranche_id: Self::TrancheId,

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -135,16 +135,35 @@ pub trait PoolInspect<AccountId, CurrencyId> {
 	/// check if the pool exists
 	fn pool_exists(pool_id: Self::PoolId) -> bool;
 	fn tranche_exists(pool_id: Self::PoolId, tranche_id: Self::TrancheId) -> bool;
-	fn get_tranche_token_price(
-		pool_id: Self::PoolId,
-		tranche_id: Self::TrancheId,
-	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>>;
 
 	/// Get the account used for the given `pool_id`.
 	fn account_for(pool_id: Self::PoolId) -> AccountId;
 
-	// Get the currency used for the given `pool_id`.
+	/// Get the currency used for the given `pool_id`.
 	fn currency_for(pool_id: Self::PoolId) -> Option<CurrencyId>;
+}
+
+/// Get the latest price for a given tranche token
+pub trait TrancheTokenPrice<AccountId, CurrencyId> {
+	type PoolId: Parameter
+	+ Member
+	+ Debug
+	+ Copy
+	+ Default
+	+ TypeInfo
+	+ Encode
+	+ Decode
+	+ MaxEncodedLen;
+	type TrancheId: Parameter + Member + Debug + Copy + Default + TypeInfo + MaxEncodedLen;
+	type Rate;
+	type Moment;
+
+
+	// todo(nuno): move all codebase from `get_tranche_token_price`
+	fn get(
+		pool_id: Self::PoolId,
+		tranche_id: Self::TrancheId,
+	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>>;
 }
 
 /// Variants for valid Pool updates to send out as events

--- a/pallets/connectors/src/inbound.rs
+++ b/pallets/connectors/src/inbound.rs
@@ -25,7 +25,7 @@ use sp_runtime::{
 	DispatchResult,
 };
 
-use crate::{pallet::Error, Config, GeneralCurrencyIndexOf, Pallet, PoolIdOf, TrancheIdOf};
+use crate::{pallet::Error, Config, GeneralCurrencyIndexOf, Pallet};
 
 impl<T: Config> Pallet<T> {
 	/// Executes a transfer from another domain exclusively for
@@ -51,8 +51,8 @@ impl<T: Config> Pallet<T> {
 	/// Assumes that the amount of tranche tokens has been locked in the
 	/// `DomainLocator` account of the origination domain beforehand.
 	pub fn handle_tranche_tokens_transfer(
-		pool_id: PoolIdOf<T>,
-		tranche_id: TrancheIdOf<T>,
+		pool_id: T::PoolId,
+		tranche_id: T::TrancheId,
 		sending_domain: DomainAddress,
 		receiver: T::AccountId,
 		amount: <T as Config>::Balance,
@@ -86,8 +86,8 @@ impl<T: Config> Pallet<T> {
 	/// Directly mints the additional investment amount into the investor
 	/// account.
 	pub fn handle_increase_invest_order(
-		pool_id: PoolIdOf<T>,
-		tranche_id: TrancheIdOf<T>,
+		pool_id: T::PoolId,
+		tranche_id: T::TrancheId,
 		investor: T::AccountId,
 		currency_index: GeneralCurrencyIndexOf<T>,
 		amount: <T as Config>::Balance,
@@ -115,8 +115,8 @@ impl<T: Config> Pallet<T> {
 	/// delayed until the execution of the investment, e.g. at least until the
 	/// next epoch transition.
 	pub fn handle_decrease_invest_order(
-		pool_id: PoolIdOf<T>,
-		tranche_id: TrancheIdOf<T>,
+		pool_id: T::PoolId,
+		tranche_id: T::TrancheId,
 		investor: T::AccountId,
 		currency_index: GeneralCurrencyIndexOf<T>,
 		amount: <T as Config>::Balance,
@@ -151,8 +151,8 @@ impl<T: Config> Pallet<T> {
 	/// Assumes that the amount of tranche tokens has been locked in the
 	/// `DomainLocator` account of the origination domain beforehand.
 	pub fn handle_increase_redemption(
-		pool_id: PoolIdOf<T>,
-		tranche_id: TrancheIdOf<T>,
+		pool_id: T::PoolId,
+		tranche_id: T::TrancheId,
 		investor: T::AccountId,
 		amount: <T as Config>::Balance,
 		sending_domain: DomainAddress,
@@ -185,8 +185,8 @@ impl<T: Config> Pallet<T> {
 	/// delayed until the execution of the redemption, e.g. at least until the
 	/// next epoch transition.
 	pub fn handle_decrease_redemption(
-		pool_id: PoolIdOf<T>,
-		tranche_id: TrancheIdOf<T>,
+		pool_id: T::PoolId,
+		tranche_id: T::TrancheId,
 		investor: T::AccountId,
 		currency_index: GeneralCurrencyIndexOf<T>,
 		amount: <T as Config>::Balance,
@@ -219,8 +219,8 @@ impl<T: Config> Pallet<T> {
 	/// id. If any amounts are not fulfilled, they are directly appended to the
 	/// next active order for this investment.
 	pub fn handle_collect_investment(
-		pool_id: PoolIdOf<T>,
-		tranche_id: TrancheIdOf<T>,
+		pool_id: T::PoolId,
+		tranche_id: T::TrancheId,
 		investor: T::AccountId,
 	) -> DispatchResult {
 		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
@@ -237,8 +237,8 @@ impl<T: Config> Pallet<T> {
 	/// id. If any amounts are not fulfilled, they are directly appended to the
 	/// next active order for this investment.
 	pub fn handle_collect_redemption(
-		pool_id: PoolIdOf<T>,
-		tranche_id: TrancheIdOf<T>,
+		pool_id: T::PoolId,
+		tranche_id: T::TrancheId,
 		investor: T::AccountId,
 	) -> DispatchResult {
 		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;

--- a/pallets/connectors/src/lib.rs
+++ b/pallets/connectors/src/lib.rs
@@ -13,9 +13,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use core::convert::TryFrom;
 
-use cfg_traits::{
-	connectors::{InboundQueue, OutboundQueue},
-};
+use cfg_traits::connectors::{InboundQueue, OutboundQueue};
 use cfg_types::{
 	domain_address::{Domain, DomainAddress},
 	tokens::GeneralCurrencyIndex,
@@ -66,8 +64,13 @@ pub enum ParachainId {
 }
 
 // Type aliases
-pub type MessageOf<T> =
-	Message<Domain, <T as Config>::PoolId, <T as Config>::TrancheId, <T as Config>::Balance, <T as Config>::Rate>;
+pub type MessageOf<T> = Message<
+	Domain,
+	<T as Config>::PoolId,
+	<T as Config>::TrancheId,
+	<T as Config>::Balance,
+	<T as Config>::Rate,
+>;
 
 pub type CurrencyIdOf<T> = <T as Config>::CurrencyId;
 
@@ -78,13 +81,16 @@ pub type GeneralCurrencyIndexOf<T> =
 
 #[frame_support::pallet]
 pub mod pallet {
-	use codec::HasCompact;
 	use cfg_primitives::Moment;
-	use cfg_traits::{CurrencyInspect, Investment, InvestmentCollector, Permissions, PoolInspect, TrancheCurrency, TrancheTokenPrice};
+	use cfg_traits::{
+		CurrencyInspect, Investment, InvestmentCollector, Permissions, PoolInspect,
+		TrancheCurrency, TrancheTokenPrice,
+	};
 	use cfg_types::{
 		permissions::{PermissionScope, PoolRole, Role},
 		tokens::{ConnectorsWrappedToken, CustomMetadata},
 	};
+	use codec::HasCompact;
 	use frame_support::{pallet_prelude::*, traits::UnixTime};
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::traits::Zero;
@@ -115,20 +121,20 @@ pub mod pallet {
 			+ MaxEncodedLen;
 
 		type PoolId: Member
-		+ Parameter
-		+ Default
-		+ Copy
-		+ HasCompact
-		+ MaxEncodedLen
-		+ core::fmt::Debug;
+			+ Parameter
+			+ Default
+			+ Copy
+			+ HasCompact
+			+ MaxEncodedLen
+			+ core::fmt::Debug;
 
 		type TrancheId: Member
-		+ Parameter
-		+ Default
-		+ Copy
-		+ MaxEncodedLen
-		+ TypeInfo
-		+ From<[u8; 16]>;
+			+ Parameter
+			+ Default
+			+ Copy
+			+ MaxEncodedLen
+			+ TypeInfo
+			+ From<[u8; 16]>;
 
 		/// The fixed point number representation for higher precision.
 		type Rate: Parameter + Member + MaybeSerializeDeserialize + FixedPointNumber + TypeInfo;
@@ -140,9 +146,21 @@ pub mod pallet {
 		/// The source of truth for pool inspection operations such as its
 		/// existence, the corresponding tranche token or the investment
 		/// currency.
-		type PoolInspect: PoolInspect<Self::AccountId, CurrencyIdOf<Self>, Rate = Self::Rate, PoolId = Self::PoolId, TrancheId = Self::TrancheId>;
+		type PoolInspect: PoolInspect<
+			Self::AccountId,
+			CurrencyIdOf<Self>,
+			Rate = Self::Rate,
+			PoolId = Self::PoolId,
+			TrancheId = Self::TrancheId,
+		>;
 
-		type TrancheTokenPrice: TrancheTokenPrice<Self::AccountId, CurrencyIdOf<Self>, Rate = Self::Rate, PoolId = Self::PoolId, TrancheId = Self::TrancheId>;
+		type TrancheTokenPrice: TrancheTokenPrice<
+			Self::AccountId,
+			CurrencyIdOf<Self>,
+			Rate = Self::Rate,
+			PoolId = Self::PoolId,
+			TrancheId = Self::TrancheId,
+		>;
 
 		/// The source of truth for investment permissions.
 		type Permission: Permissions<
@@ -412,7 +430,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin.clone())?;
 
-			let price =  T::TrancheTokenPrice::get(pool_id, tranche_id)
+			let price = T::TrancheTokenPrice::get(pool_id, tranche_id)
 				.ok_or(Error::<T>::MissingTranchePrice)?
 				.price;
 

--- a/pallets/connectors/src/lib.rs
+++ b/pallets/connectors/src/lib.rs
@@ -412,8 +412,6 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin.clone())?;
 
-			// TODO(follow-up PR): Move `get_tranche_token_price` to new trait.
-			// https://centrifuge.hackmd.io/SERpps-URlG4hkOyyS94-w?both#fn-update_tranche_token_price
 			let price =  T::TrancheTokenPrice::get(pool_id, tranche_id)
 				.ok_or(Error::<T>::MissingTranchePrice)?
 				.price;

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -65,7 +65,7 @@ type MaxRateCountOf<T> = <<T as Config>::InterestAccrual as InterestAccrual<
 
 type MaxCollectionSizeOf<T> = <<T as Config>::PriceRegistry as DataRegistry<
 	<T as Config>::PriceId,
-	PoolIdOf<T>,
+	<T as Config>::PoolId,
 >>::MaxCollectionSize;
 
 #[cfg(test)]
@@ -100,11 +100,11 @@ where
 	T::ItemId: From<u16>,
 	T::PriceId: From<u32>,
 	T::Pool:
-		PoolBenchmarkHelper<PoolId = PoolIdOf<T>, AccountId = T::AccountId, Balance = T::Balance>,
+		PoolBenchmarkHelper<PoolId = T::PoolId, AccountId = T::AccountId, Balance = T::Balance>,
 	PriceCollectionOf<T>: DataCollection<T::PriceId, Data = PriceResultOf<T>>,
 	T::PriceRegistry: DataFeeder<T::PriceId, T::Rate, T::AccountId>,
 {
-	fn prepare_benchmark() -> PoolIdOf<T> {
+	fn prepare_benchmark() -> T::PoolId {
 		#[cfg(test)]
 		config_mocks();
 
@@ -161,7 +161,7 @@ where
 		}
 	}
 
-	fn create_loan(pool_id: PoolIdOf<T>, item_id: T::ItemId) -> T::LoanId {
+	fn create_loan(pool_id: T::PoolId, item_id: T::ItemId) -> T::LoanId {
 		let borrower = account("borrower", 0, 0);
 
 		T::NonFungible::mint_into(&COLLECION_ID.into(), &item_id, &borrower).unwrap();
@@ -176,7 +176,7 @@ where
 		LastLoanId::<T>::get(pool_id)
 	}
 
-	fn borrow_loan(pool_id: PoolIdOf<T>, loan_id: T::LoanId) {
+	fn borrow_loan(pool_id: T::PoolId, loan_id: T::LoanId) {
 		let borrower = account("borrower", 0, 0);
 		Pallet::<T>::borrow(
 			RawOrigin::Signed(borrower).into(),
@@ -187,7 +187,7 @@ where
 		.unwrap();
 	}
 
-	fn fully_repay_loan(pool_id: PoolIdOf<T>, loan_id: T::LoanId) {
+	fn fully_repay_loan(pool_id: T::PoolId, loan_id: T::LoanId) {
 		let borrower = account("borrower", 0, 0);
 		Pallet::<T>::repay(
 			RawOrigin::Signed(borrower).into(),
@@ -203,7 +203,7 @@ where
 		LoanMutation::InterestPayments(InterestPayments::None)
 	}
 
-	fn propose_mutation(pool_id: PoolIdOf<T>, loan_id: T::LoanId) -> T::Hash {
+	fn propose_mutation(pool_id: T::PoolId, loan_id: T::LoanId) -> T::Hash {
 		let pool_admin = account::<T::AccountId>("loan_admin", 0, 0);
 
 		Pallet::<T>::propose_loan_mutation(
@@ -238,7 +238,7 @@ where
 		.unwrap()
 	}
 
-	fn propose_policy(pool_id: PoolIdOf<T>) -> T::Hash {
+	fn propose_policy(pool_id: T::PoolId) -> T::Hash {
 		let pool_admin = account::<T::AccountId>("pool_admin", 0, 0);
 		Pallet::<T>::propose_write_off_policy(
 			RawOrigin::Signed(pool_admin).into(),
@@ -253,7 +253,7 @@ where
 		T::ChangeGuard::note(pool_id, ChangeOf::<T>::Policy(Self::create_policy()).into()).unwrap()
 	}
 
-	fn set_policy(pool_id: PoolIdOf<T>) {
+	fn set_policy(pool_id: T::PoolId) {
 		let change_id = Self::propose_policy(pool_id);
 
 		let any = account::<T::AccountId>("any", 0, 0);
@@ -261,11 +261,11 @@ where
 			.unwrap();
 	}
 
-	fn expire_loan(pool_id: PoolIdOf<T>, loan_id: T::LoanId) {
+	fn expire_loan(pool_id: T::PoolId, loan_id: T::LoanId) {
 		Pallet::<T>::expire(pool_id, loan_id).unwrap();
 	}
 
-	fn initialize_active_state(n: u32) -> PoolIdOf<T> {
+	fn initialize_active_state(n: u32) -> T::PoolId {
 		let pool_id = Self::prepare_benchmark();
 
 		for i in 1..MaxRateCountOf::<T>::get() {
@@ -306,7 +306,7 @@ benchmarks! {
 		T::CollectionId: From<u16>,
 		T::ItemId: From<u16>,
 		T::PriceId: From<u32>,
-		T::Pool: PoolBenchmarkHelper<PoolId = PoolIdOf<T>, AccountId = T::AccountId, Balance = T::Balance>,
+		T::Pool: PoolBenchmarkHelper<PoolId = T::PoolId, AccountId = T::AccountId, Balance = T::Balance>,
 		PriceCollectionOf<T>: DataCollection<T::PriceId, Data = PriceResultOf<T>>,
 		T::PriceRegistry: DataFeeder<T::PriceId, T::Rate, T::AccountId>,
 	}

--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -389,10 +389,7 @@ impl<T: Config> ActiveLoan<T> {
 		Ok(())
 	}
 
-	pub fn close(
-		self,
-		pool_id: T::PoolId,
-	) -> Result<(ClosedLoan<T>, T::AccountId), DispatchError> {
+	pub fn close(self, pool_id: T::PoolId) -> Result<(ClosedLoan<T>, T::AccountId), DispatchError> {
 		self.ensure_can_close()?;
 
 		let loan = ClosedLoan {

--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -17,7 +17,7 @@ use super::pricing::{
 	external::ExternalActivePricing, internal::InternalActivePricing, ActivePricing, Pricing,
 };
 use crate::{
-	pallet::{AssetOf, Config, Error, PoolIdOf, PriceOf},
+	pallet::{AssetOf, Config, Error, PriceOf},
 	types::{
 		policy::{WriteOffStatus, WriteOffTrigger},
 		BorrowLoanError, BorrowRestrictions, CloseLoanError, CreateLoanError, LoanMutation,
@@ -85,7 +85,7 @@ impl<T: Config> CreatedLoan<T> {
 		&self.borrower
 	}
 
-	pub fn activate(self, pool_id: PoolIdOf<T>) -> Result<ActiveLoan<T>, DispatchError> {
+	pub fn activate(self, pool_id: T::PoolId) -> Result<ActiveLoan<T>, DispatchError> {
 		ActiveLoan::new(pool_id, self.info, self.borrower, T::Time::now().as_secs())
 	}
 
@@ -165,7 +165,7 @@ pub struct ActiveLoan<T: Config> {
 
 impl<T: Config> ActiveLoan<T> {
 	pub fn new(
-		pool_id: PoolIdOf<T>,
+		pool_id: T::PoolId,
 		info: LoanInfo<T>,
 		borrower: T::AccountId,
 		now: Moment,
@@ -391,7 +391,7 @@ impl<T: Config> ActiveLoan<T> {
 
 	pub fn close(
 		self,
-		pool_id: PoolIdOf<T>,
+		pool_id: T::PoolId,
 	) -> Result<(ClosedLoan<T>, T::AccountId), DispatchError> {
 		self.ensure_can_close()?;
 

--- a/pallets/loans/src/entities/pricing/external.rs
+++ b/pallets/loans/src/entities/pricing/external.rs
@@ -14,7 +14,7 @@ use sp_runtime::{
 	DispatchError, DispatchResult,
 };
 
-use crate::pallet::{Config, Error, PoolIdOf, PriceOf};
+use crate::pallet::{Config, Error, PriceOf};
 
 /// Define the max borrow amount of a loan
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebug, MaxEncodedLen)]
@@ -55,7 +55,7 @@ pub struct ExternalActivePricing<T: Config> {
 }
 
 impl<T: Config> ExternalActivePricing<T> {
-	pub fn new(info: ExternalPricing<T>, pool_id: PoolIdOf<T>) -> Result<Self, DispatchError> {
+	pub fn new(info: ExternalPricing<T>, pool_id: T::PoolId) -> Result<Self, DispatchError> {
 		T::PriceRegistry::register_id(&info.price_id, &pool_id)?;
 		Ok(Self {
 			info,
@@ -63,7 +63,7 @@ impl<T: Config> ExternalActivePricing<T> {
 		})
 	}
 
-	pub fn end(self, pool_id: PoolIdOf<T>) -> Result<ExternalPricing<T>, DispatchError> {
+	pub fn end(self, pool_id: T::PoolId) -> Result<ExternalPricing<T>, DispatchError> {
 		T::PriceRegistry::unregister_id(&self.info.price_id, &pool_id)?;
 		Ok(self.info)
 	}

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -69,6 +69,7 @@ pub use weights::WeightInfo;
 
 #[frame_support::pallet]
 pub mod pallet {
+	use codec::HasCompact;
 	use cfg_primitives::Moment;
 	use cfg_traits::{
 		self,
@@ -112,13 +113,8 @@ pub mod pallet {
 
 	pub type PriceCollectionOf<T> = <<T as Config>::PriceRegistry as DataRegistry<
 		<T as Config>::PriceId,
-		PoolIdOf<T>,
+		<T as Config>::PoolId,
 	>>::Collection;
-
-	pub type PoolIdOf<T> = <<T as Config>::Pool as PoolInspect<
-		<T as frame_system::Config>::AccountId,
-		<T as Config>::CurrencyId,
-	>>::PoolId;
 
 	pub type AssetOf<T> = (<T as Config>::CollectionId, <T as Config>::ItemId);
 	pub type PriceOf<T> = (<T as Config>::Rate, Moment);
@@ -198,19 +194,22 @@ pub mod pallet {
 		type NonFungible: Transfer<Self::AccountId>
 			+ Inspect<Self::AccountId, CollectionId = Self::CollectionId, ItemId = Self::ItemId>;
 
+		/// The PoolId type
+		type PoolId: Member + Parameter + Default + Copy + HasCompact + MaxEncodedLen;
+
 		/// Access to the pool
-		type Pool: PoolReserve<Self::AccountId, Self::CurrencyId, Balance = Self::Balance>;
+		type Pool: PoolReserve<Self::AccountId, Self::CurrencyId, Balance = Self::Balance, PoolId = Self::PoolId>;
 
 		/// Used to verify permissions of users
 		type Permissions: Permissions<
 			Self::AccountId,
-			Scope = PermissionScope<PoolIdOf<Self>, Self::CurrencyId>,
+			Scope = PermissionScope<Self::PoolId, Self::CurrencyId>,
 			Role = Role,
 			Error = DispatchError,
 		>;
 
 		/// Used to fetch and update Oracle prices
-		type PriceRegistry: DataRegistry<Self::PriceId, PoolIdOf<Self>, Data = PriceResultOf<Self>>;
+		type PriceRegistry: DataRegistry<Self::PriceId, Self::PoolId, Data = PriceResultOf<Self>>;
 
 		/// Used to calculate interest accrual for debt.
 		type InterestAccrual: InterestAccrual<
@@ -223,7 +222,7 @@ pub mod pallet {
 		/// Used to notify the runtime about changes that require special
 		/// treatment.
 		type ChangeGuard: ChangeGuard<
-			PoolId = PoolIdOf<Self>,
+			PoolId = Self::PoolId,
 			ChangeId = Self::Hash,
 			Change = Self::RuntimeChange,
 		>;
@@ -243,14 +242,14 @@ pub mod pallet {
 	/// Contains the last loan id generated
 	#[pallet::storage]
 	pub(crate) type LastLoanId<T: Config> =
-		StorageMap<_, Blake2_128Concat, PoolIdOf<T>, T::LoanId, ValueQuery>;
+		StorageMap<_, Blake2_128Concat, T::PoolId, T::LoanId, ValueQuery>;
 
 	/// Storage for loans that has been created but are not still active.
 	#[pallet::storage]
 	pub(crate) type CreatedLoan<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
-		PoolIdOf<T>,
+		T::PoolId,
 		Blake2_128Concat,
 		T::LoanId,
 		loans::CreatedLoan<T>,
@@ -267,7 +266,7 @@ pub mod pallet {
 	pub(crate) type ActiveLoans<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat,
-		PoolIdOf<T>,
+		T::PoolId,
 		BoundedVec<(T::LoanId, ActiveLoan<T>), T::MaxActiveLoansPerPool>,
 		ValueQuery,
 	>;
@@ -279,7 +278,7 @@ pub mod pallet {
 	pub(crate) type ClosedLoan<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
-		PoolIdOf<T>,
+		T::PoolId,
 		Blake2_128Concat,
 		T::LoanId,
 		loans::ClosedLoan<T>,
@@ -291,7 +290,7 @@ pub mod pallet {
 	pub(crate) type WriteOffPolicy<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat,
-		PoolIdOf<T>,
+		T::PoolId,
 		BoundedVec<WriteOffRule<T::Rate>, T::MaxWriteOffPolicySize>,
 		ValueQuery,
 	>;
@@ -302,7 +301,7 @@ pub mod pallet {
 	pub(crate) type PortfolioValuation<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat,
-		PoolIdOf<T>,
+		T::PoolId,
 		portfolio::PortfolioValuation<T::Balance, T::LoanId, T::MaxActiveLoansPerPool>,
 		ValueQuery,
 		InitialPortfolioValuation<T::Time>,
@@ -313,49 +312,49 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// A loan was created
 		Created {
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			loan_info: LoanInfo<T>,
 		},
 		/// An amount was borrowed for a loan
 		Borrowed {
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			amount: T::Balance,
 		},
 		/// An amount was repaid for a loan
 		Repaid {
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			amount: T::Balance,
 			unchecked_amount: T::Balance,
 		},
 		/// A loan was written off
 		WrittenOff {
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			status: WriteOffStatus<T::Rate>,
 		},
 		/// An active loan was mutated
 		Mutated {
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			mutation: LoanMutation<T::Rate>,
 		},
 		/// A loan was closed
 		Closed {
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			collateral: AssetOf<T>,
 		},
 		/// The Portfolio Valuation for a pool was updated.
 		PortfolioValuationUpdated {
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			valuation: T::Balance,
 			update_type: PortfolioValuationUpdateType,
 		},
 		WriteOffPolicyUpdated {
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			policy: BoundedVec<WriteOffRule<T::Rate>, T::MaxWriteOffPolicySize>,
 		},
 	}
@@ -446,7 +445,7 @@ pub mod pallet {
 		#[pallet::call_index(0)]
 		pub fn create(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			info: LoanInfo<T>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -483,7 +482,7 @@ pub mod pallet {
 		#[pallet::call_index(1)]
 		pub fn borrow(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			amount: T::Balance,
 		) -> DispatchResult {
@@ -532,7 +531,7 @@ pub mod pallet {
 		#[pallet::call_index(2)]
 		pub fn repay(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			amount: T::Balance,
 			unchecked_amount: T::Balance,
@@ -576,7 +575,7 @@ pub mod pallet {
 		#[pallet::call_index(3)]
 		pub fn write_off(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 		) -> DispatchResult {
 			ensure_signed(origin)?;
@@ -613,7 +612,7 @@ pub mod pallet {
 		#[pallet::call_index(4)]
 		pub fn admin_write_off(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			percentage: T::Rate,
 			penalty: T::Rate,
@@ -650,7 +649,7 @@ pub mod pallet {
 		#[pallet::call_index(5)]
 		pub fn propose_loan_mutation(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			mutation: LoanMutation<T::Rate>,
 		) -> DispatchResult {
@@ -678,7 +677,7 @@ pub mod pallet {
 		#[pallet::call_index(6)]
 		pub fn apply_loan_mutation(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			change_id: T::Hash,
 		) -> DispatchResult {
 			ensure_signed(origin)?;
@@ -709,7 +708,7 @@ pub mod pallet {
 		#[pallet::call_index(7)]
 		pub fn close(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -746,7 +745,7 @@ pub mod pallet {
 		#[pallet::call_index(8)]
 		pub fn propose_write_off_policy(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			policy: BoundedVec<WriteOffRule<T::Rate>, T::MaxWriteOffPolicySize>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -765,7 +764,7 @@ pub mod pallet {
 		#[pallet::call_index(9)]
 		pub fn apply_write_off_policy(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			change_id: T::Hash,
 		) -> DispatchResult {
 			ensure_signed(origin)?;
@@ -788,7 +787,7 @@ pub mod pallet {
 		#[pallet::call_index(10)]
 		pub fn update_portfolio_valuation(
 			origin: OriginFor<T>,
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 		) -> DispatchResultWithPostInfo {
 			ensure_signed(origin)?;
 			Self::ensure_pool_exists(pool_id)?;
@@ -808,7 +807,7 @@ pub mod pallet {
 			T::Time::now().as_secs()
 		}
 
-		fn ensure_role(pool_id: PoolIdOf<T>, who: &T::AccountId, role: PoolRole) -> DispatchResult {
+		fn ensure_role(pool_id: T::PoolId, who: &T::AccountId, role: PoolRole) -> DispatchResult {
 			T::Permissions::has(
 				PermissionScope::Pool(pool_id),
 				who.clone(),
@@ -834,7 +833,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		fn ensure_pool_exists(pool_id: PoolIdOf<T>) -> DispatchResult {
+		fn ensure_pool_exists(pool_id: T::PoolId) -> DispatchResult {
 			ensure!(T::Pool::pool_exists(pool_id), Error::<T>::PoolNotFound);
 			Ok(())
 		}
@@ -852,7 +851,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		fn generate_loan_id(pool_id: PoolIdOf<T>) -> Result<T::LoanId, ArithmeticError> {
+		fn generate_loan_id(pool_id: T::PoolId) -> Result<T::LoanId, ArithmeticError> {
 			LastLoanId::<T>::try_mutate(pool_id, |last_loan_id| {
 				last_loan_id.ensure_add_assign(One::one())?;
 				Ok(*last_loan_id)
@@ -860,7 +859,7 @@ pub mod pallet {
 		}
 
 		fn find_write_off_rule(
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan: &ActiveLoan<T>,
 		) -> Result<Option<WriteOffRule<T::Rate>>, DispatchError> {
 			let rules = WriteOffPolicy::<T>::get(pool_id).into_iter();
@@ -868,7 +867,7 @@ pub mod pallet {
 		}
 
 		fn get_released_change(
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			change_id: T::Hash,
 		) -> Result<ChangeOf<T>, DispatchError> {
 			T::ChangeGuard::released(pool_id, change_id)?
@@ -877,7 +876,7 @@ pub mod pallet {
 		}
 
 		fn update_portfolio_valuation_for_pool(
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 		) -> Result<(T::Balance, u32), DispatchError> {
 			let rates = T::InterestAccrual::rates();
 			let prices = T::PriceRegistry::collection(&pool_id);
@@ -901,7 +900,7 @@ pub mod pallet {
 		}
 
 		fn insert_active_loan(
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			loan: ActiveLoan<T>,
 		) -> Result<u32, DispatchError> {
@@ -925,7 +924,7 @@ pub mod pallet {
 		}
 
 		fn update_active_loan<F, R>(
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 			f: F,
 		) -> Result<(R, u32), DispatchError>
@@ -955,7 +954,7 @@ pub mod pallet {
 		}
 
 		fn take_active_loan(
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 		) -> Result<(ActiveLoan<T>, u32), DispatchError> {
 			ActiveLoans::<T>::try_mutate(pool_id, |active_loans| {
@@ -972,7 +971,7 @@ pub mod pallet {
 		}
 
 		fn get_active_loan(
-			pool_id: PoolIdOf<T>,
+			pool_id: T::PoolId,
 			loan_id: T::LoanId,
 		) -> Result<(ActiveLoan<T>, u32), DispatchError> {
 			let active_loans = ActiveLoans::<T>::get(pool_id);
@@ -987,7 +986,7 @@ pub mod pallet {
 
 		#[cfg(feature = "runtime-benchmarks")]
 		/// Set the maturity date of the loan to this instant.
-		pub fn expire(pool_id: PoolIdOf<T>, loan_id: T::LoanId) -> DispatchResult {
+		pub fn expire(pool_id: T::PoolId, loan_id: T::LoanId) -> DispatchResult {
 			Self::update_active_loan(pool_id, loan_id, |loan| {
 				loan.set_maturity(T::Time::now().as_secs());
 				Ok(())
@@ -997,23 +996,23 @@ pub mod pallet {
 	}
 
 	// TODO: This implementation can be cleaned once #908 be solved
-	impl<T: Config> PoolNAV<PoolIdOf<T>, T::Balance> for Pallet<T>
+	impl<T: Config> PoolNAV<T::PoolId, T::Balance> for Pallet<T>
 	where
 		PriceCollectionOf<T>: DataCollection<T::PriceId, Data = PriceResultOf<T>>,
 	{
 		type ClassId = T::ItemId;
 		type RuntimeOrigin = T::RuntimeOrigin;
 
-		fn nav(pool_id: PoolIdOf<T>) -> Option<(T::Balance, Moment)> {
+		fn nav(pool_id: T::PoolId) -> Option<(T::Balance, Moment)> {
 			let portfolio = PortfolioValuation::<T>::get(pool_id);
 			Some((portfolio.value(), portfolio.last_updated()))
 		}
 
-		fn update_nav(pool_id: PoolIdOf<T>) -> Result<T::Balance, DispatchError> {
+		fn update_nav(pool_id: T::PoolId) -> Result<T::Balance, DispatchError> {
 			Ok(Self::update_portfolio_valuation_for_pool(pool_id)?.0)
 		}
 
-		fn initialise(_: OriginFor<T>, _: PoolIdOf<T>, _: T::ItemId) -> DispatchResult {
+		fn initialise(_: OriginFor<T>, _: T::PoolId, _: T::ItemId) -> DispatchResult {
 			// This Loans implementation does not need to initialize explicitally.
 			Ok(())
 		}

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -69,7 +69,6 @@ pub use weights::WeightInfo;
 
 #[frame_support::pallet]
 pub mod pallet {
-	use codec::HasCompact;
 	use cfg_primitives::Moment;
 	use cfg_traits::{
 		self,
@@ -81,6 +80,7 @@ pub mod pallet {
 		adjustments::Adjustment,
 		permissions::{PermissionScope, PoolRole, Role},
 	};
+	use codec::HasCompact;
 	use entities::loans::{self, ActiveLoan, LoanInfo};
 	use frame_support::{
 		pallet_prelude::*,
@@ -198,7 +198,12 @@ pub mod pallet {
 		type PoolId: Member + Parameter + Default + Copy + HasCompact + MaxEncodedLen;
 
 		/// Access to the pool
-		type Pool: PoolReserve<Self::AccountId, Self::CurrencyId, Balance = Self::Balance, PoolId = Self::PoolId>;
+		type Pool: PoolReserve<
+			Self::AccountId,
+			Self::CurrencyId,
+			Balance = Self::Balance,
+			PoolId = Self::PoolId,
+		>;
 
 		/// Used to verify permissions of users
 		type Permissions: Permissions<

--- a/pallets/loans/src/migrations/nuke.rs
+++ b/pallets/loans/src/migrations/nuke.rs
@@ -20,7 +20,7 @@ mod old {
 	/// If this storage is not found, the nuking process is aborted.
 	#[storage_alias]
 	pub(crate) type NextLoanId<T: Config> =
-		StorageMap<Pallet<T>, Blake2_128Concat, PoolIdOf<T>, u128, ValueQuery>;
+		StorageMap<Pallet<T>, Blake2_128Concat, <T as Config>::PoolId, u128, ValueQuery>;
 }
 
 /// This migration nukes all storages from the pallet individually.

--- a/pallets/loans/src/tests/mock.rs
+++ b/pallets/loans/src/tests/mock.rs
@@ -228,6 +228,7 @@ impl pallet_loans::Config for Runtime {
 	type MaxWriteOffPolicySize = MaxWriteOffPolicySize;
 	type NonFungible = Uniques;
 	type Permissions = MockPermissions;
+	type PoolId = PoolId;
 	type Pool = MockPools;
 	type PriceId = PriceId;
 	type PriceRegistry = MockPrices;

--- a/pallets/loans/src/tests/mock.rs
+++ b/pallets/loans/src/tests/mock.rs
@@ -228,8 +228,8 @@ impl pallet_loans::Config for Runtime {
 	type MaxWriteOffPolicySize = MaxWriteOffPolicySize;
 	type NonFungible = Uniques;
 	type Permissions = MockPermissions;
-	type PoolId = PoolId;
 	type Pool = MockPools;
+	type PoolId = PoolId;
 	type PriceId = PriceId;
 	type PriceRegistry = MockPrices;
 	type Rate = Rate;

--- a/pallets/loans/src/util.rs
+++ b/pallets/loans/src/util.rs
@@ -19,7 +19,7 @@ use orml_traits::{DataFeeder, DataProvider};
 use sp_runtime::{DispatchError, DispatchResult};
 use sp_std::marker::PhantomData;
 
-use crate::pallet::{ChangeOf, Config, PoolIdOf, PriceResultOf};
+use crate::pallet::{ChangeOf, Config, PriceResultOf};
 
 const DEFAULT_PRICE_ERR: DispatchError =
 	DispatchError::Other("No configured price registry for pallet-loans");
@@ -27,7 +27,7 @@ const DEFAULT_PRICE_ERR: DispatchError =
 /// Type used to configure the pallet without a price registry
 pub struct NoPriceRegistry<T>(PhantomData<T>);
 
-impl<T: Config> DataRegistry<T::PriceId, PoolIdOf<T>> for NoPriceRegistry<T> {
+impl<T: Config> DataRegistry<T::PriceId, T::PoolId> for NoPriceRegistry<T> {
 	type Collection = NoPriceCollection<T>;
 	type Data = PriceResultOf<T>;
 	#[cfg(feature = "runtime-benchmarks")]
@@ -37,15 +37,15 @@ impl<T: Config> DataRegistry<T::PriceId, PoolIdOf<T>> for NoPriceRegistry<T> {
 		Err(DEFAULT_PRICE_ERR)
 	}
 
-	fn collection(_: &PoolIdOf<T>) -> Self::Collection {
+	fn collection(_: &T::PoolId) -> Self::Collection {
 		NoPriceCollection(PhantomData::default())
 	}
 
-	fn register_id(_: &T::PriceId, _: &PoolIdOf<T>) -> DispatchResult {
+	fn register_id(_: &T::PriceId, _: &T::PoolId) -> DispatchResult {
 		Err(DEFAULT_PRICE_ERR)
 	}
 
-	fn unregister_id(_: &T::PriceId, _: &PoolIdOf<T>) -> DispatchResult {
+	fn unregister_id(_: &T::PriceId, _: &T::PoolId) -> DispatchResult {
 		Err(DEFAULT_PRICE_ERR)
 	}
 }
@@ -81,13 +81,13 @@ pub struct NoLoanChanges<T>(PhantomData<T>);
 impl<T: Config> ChangeGuard for NoLoanChanges<T> {
 	type Change = ChangeOf<T>;
 	type ChangeId = T::Hash;
-	type PoolId = PoolIdOf<T>;
+	type PoolId = T::PoolId;
 
-	fn note(_: PoolIdOf<T>, _: Self::Change) -> Result<Self::ChangeId, DispatchError> {
+	fn note(_: T::PoolId, _: Self::Change) -> Result<Self::ChangeId, DispatchError> {
 		Err(DEFAULT_CHANGE_ERR)
 	}
 
-	fn released(_: PoolIdOf<T>, _: Self::ChangeId) -> Result<Self::Change, DispatchError> {
+	fn released(_: T::PoolId, _: Self::ChangeId) -> Result<Self::Change, DispatchError> {
 		Err(DEFAULT_CHANGE_ERR)
 	}
 }

--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -10,10 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_traits::{
-	changes::ChangeGuard, CurrencyPair, InvestmentAccountant, PoolUpdateGuard, PriceValue,
-	TrancheCurrency, UpdateState,
-};
+use cfg_traits::{changes::ChangeGuard, CurrencyPair, InvestmentAccountant, PoolUpdateGuard, PriceValue, TrancheCurrency, TrancheTokenPrice, UpdateState};
 use cfg_types::{epoch::EpochState, investments::InvestmentInfo};
 use frame_support::traits::Contains;
 use sp_runtime::traits::Hash;
@@ -43,7 +40,22 @@ impl<T: Config> PoolInspect<T::AccountId, T::CurrencyId> for Pallet<T> {
 			.is_some()
 	}
 
-	fn get_tranche_token_price(
+	fn account_for(pool_id: Self::PoolId) -> T::AccountId {
+		PoolLocator { pool_id }.into_account_truncating()
+	}
+
+	fn currency_for(pool_id: Self::PoolId) -> Option<T::CurrencyId> {
+		Pool::<T>::get(pool_id).map(|pool| pool.currency)
+	}
+}
+
+impl<T: Config> TrancheTokenPrice<T::AccountId, T::CurrencyId> for Pallet<T> {
+	type Moment = Moment;
+	type PoolId = T::PoolId;
+	type Rate = T::Rate;
+	type TrancheId = T::TrancheId;
+
+	fn get(
 		pool_id: Self::PoolId,
 		tranche_id: Self::TrancheId,
 	) -> Option<PriceValue<T::CurrencyId, T::Rate, Moment>> {
@@ -80,14 +92,6 @@ impl<T: Config> PoolInspect<T::AccountId, T::CurrencyId> for Pallet<T> {
 			price,
 			last_updated: nav_last_updated,
 		})
-	}
-
-	fn account_for(pool_id: Self::PoolId) -> T::AccountId {
-		PoolLocator { pool_id }.into_account_truncating()
-	}
-
-	fn currency_for(pool_id: Self::PoolId) -> Option<T::CurrencyId> {
-		Pool::<T>::get(pool_id).map(|pool| pool.currency)
 	}
 }
 

--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -10,7 +10,10 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_traits::{changes::ChangeGuard, CurrencyPair, InvestmentAccountant, PoolUpdateGuard, PriceValue, TrancheCurrency, TrancheTokenPrice, UpdateState};
+use cfg_traits::{
+	changes::ChangeGuard, CurrencyPair, InvestmentAccountant, PoolUpdateGuard, PriceValue,
+	TrancheCurrency, TrancheTokenPrice, UpdateState,
+};
 use cfg_types::{epoch::EpochState, investments::InvestmentInfo};
 use frame_support::traits::Contains;
 use sp_runtime::traits::Hash;

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -35,8 +35,8 @@ use crate::{
 		calculate_risk_buffers, EpochExecutionTranche, EpochExecutionTranches, Tranche,
 		TrancheInput, TrancheSolution, TrancheType, Tranches,
 	},
-	BoundedVec, Change, Config, EpochExecution, EpochExecutionInfo, Error, Pool,
-	PoolState, UnhealthyState,
+	BoundedVec, Change, Config, EpochExecution, EpochExecutionInfo, Error, Pool, PoolState,
+	UnhealthyState,
 };
 
 const AUSD_CURRENCY_ID: CurrencyId = CurrencyId::ForeignAsset(1);
@@ -713,8 +713,8 @@ fn epoch() {
 			<Runtime as frame_system::Config>::AccountId,
 			<Runtime as Config>::CurrencyId,
 		>>::get(0, SeniorTrancheId::get())
-			.unwrap()
-			.price;
+		.unwrap()
+		.price;
 		assert_eq!(pool.tranches.residual_tranche().unwrap().debt, 0);
 		assert_eq!(
 			pool.tranches.residual_tranche().unwrap().reserve,

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -10,7 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_traits::{PoolMutate, TrancheCurrency as TrancheCurrencyT};
+use cfg_traits::{PoolMutate, TrancheCurrency as TrancheCurrencyT, TrancheTokenPrice};
 use cfg_types::{
 	epoch::EpochState,
 	fixed_point::Rate,
@@ -35,7 +35,7 @@ use crate::{
 		calculate_risk_buffers, EpochExecutionTranche, EpochExecutionTranches, Tranche,
 		TrancheInput, TrancheSolution, TrancheType, Tranches,
 	},
-	BoundedVec, Change, Config, EpochExecution, EpochExecutionInfo, Error, Pool, PoolInspect,
+	BoundedVec, Change, Config, EpochExecution, EpochExecutionInfo, Error, Pool,
 	PoolState, UnhealthyState,
 };
 
@@ -571,10 +571,10 @@ fn epoch() {
 		));
 
 		assert_eq!(
-			<PoolSystem as PoolInspect<
+			<PoolSystem as TrancheTokenPrice<
 				<Runtime as frame_system::Config>::AccountId,
 				<Runtime as Config>::CurrencyId,
-			>>::get_tranche_token_price(0, SeniorTrancheId::get())
+			>>::get(0, SeniorTrancheId::get())
 			.unwrap()
 			.price,
 			Rate::one()
@@ -709,7 +709,10 @@ fn epoch() {
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 
 		let pool = PoolSystem::pool(0).unwrap();
-		let senior_price = PoolSystem::get_tranche_token_price(0, SeniorTrancheId::get())
+		let senior_price = <PoolSystem as TrancheTokenPrice<
+			<Runtime as frame_system::Config>::AccountId,
+			<Runtime as Config>::CurrencyId,
+		>>::get(0, SeniorTrancheId::get())
 			.unwrap()
 			.price;
 		assert_eq!(pool.tranches.residual_tranche().unwrap().debt, 0);
@@ -733,10 +736,10 @@ fn epoch() {
 		);
 
 		assert_eq!(
-			<PoolSystem as PoolInspect<
+			<PoolSystem as TrancheTokenPrice<
 				<Runtime as frame_system::Config>::AccountId,
 				<Runtime as Config>::CurrencyId,
-			>>::get_tranche_token_price(0, SeniorTrancheId::get())
+			>>::get(0, SeniorTrancheId::get())
 			.unwrap()
 			.price,
 			Rate::from_inner(1004126524122317386524000000)

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1317,6 +1317,7 @@ impl pallet_loans::Config for Runtime {
 	type MaxWriteOffPolicySize = MaxWriteOffPolicySize;
 	type NonFungible = Uniques;
 	type Permissions = Permissions;
+	type PoolId = PoolId;
 	type Pool = PoolSystem;
 	type PriceId = OracleKey;
 	type PriceRegistry = PriceCollector;

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1317,8 +1317,8 @@ impl pallet_loans::Config for Runtime {
 	type MaxWriteOffPolicySize = MaxWriteOffPolicySize;
 	type NonFungible = Uniques;
 	type Permissions = Permissions;
-	type PoolId = PoolId;
 	type Pool = PoolSystem;
+	type PoolId = PoolId;
 	type PriceId = OracleKey;
 	type PriceRegistry = PriceCollector;
 	type Rate = Rate;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1628,8 +1628,8 @@ impl pallet_loans::Config for Runtime {
 	type MaxWriteOffPolicySize = MaxWriteOffPolicySize;
 	type NonFungible = Uniques;
 	type Permissions = Permissions;
-	type PoolId = PoolId;
 	type Pool = PoolSystem;
+	type PoolId = PoolId;
 	type PriceId = OracleKey;
 	type PriceRegistry = PriceCollector;
 	type Rate = Rate;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1628,6 +1628,7 @@ impl pallet_loans::Config for Runtime {
 	type MaxWriteOffPolicySize = MaxWriteOffPolicySize;
 	type NonFungible = Uniques;
 	type Permissions = Permissions;
+	type PoolId = PoolId;
 	type Pool = PoolSystem;
 	type PriceId = OracleKey;
 	type PriceRegistry = PriceCollector;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1375,8 +1375,8 @@ impl pallet_loans::Config for Runtime {
 	type MaxWriteOffPolicySize = MaxWriteOffPolicySize;
 	type NonFungible = Uniques;
 	type Permissions = Permissions;
-	type PoolId = PoolId;
 	type Pool = PoolSystem;
+	type PoolId = PoolId;
 	type PriceId = OracleKey;
 	type PriceRegistry = PriceCollector;
 	type Rate = Rate;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1375,6 +1375,7 @@ impl pallet_loans::Config for Runtime {
 	type MaxWriteOffPolicySize = MaxWriteOffPolicySize;
 	type NonFungible = Uniques;
 	type Permissions = Permissions;
+	type PoolId = PoolId;
 	type Pool = PoolSystem;
 	type PriceId = OracleKey;
 	type PriceRegistry = PriceCollector;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -24,10 +24,7 @@ pub use cfg_primitives::{
 	constants::*,
 	types::{PoolId, *},
 };
-use cfg_traits::{
-	CurrencyPrice, OrderManager, Permissions as PermissionsT, PoolInspect, PoolNAV,
-	PoolUpdateGuard, PreConditions, PriceValue, TrancheCurrency as _,
-};
+use cfg_traits::{CurrencyPrice, OrderManager, Permissions as PermissionsT, PoolNAV, PoolUpdateGuard, PreConditions, PriceValue, TrancheCurrency as _, TrancheTokenPrice};
 use cfg_types::{
 	consts::pools::*,
 	domain_address::Domain,
@@ -1154,10 +1151,10 @@ impl CurrencyPrice<CurrencyId> for CurrencyPriceSource {
 	) -> Option<PriceValue<CurrencyId, Self::Rate, Self::Moment>> {
 		match base {
 			CurrencyId::Tranche(pool_id, tranche_id) => {
-				match <pallet_pool_system::Pallet<Runtime> as PoolInspect<
+				match <pallet_pool_system::Pallet<Runtime> as TrancheTokenPrice<
 				AccountId,
 				CurrencyId,
-			>>::get_tranche_token_price(pool_id, tranche_id) {
+			>>::get(pool_id, tranche_id) {
 					// If a specific quote is requested, this needs to match the actual quote.
 					Some(price) if Some(price.pair.quote) != quote => None,
 					Some(price) => Some(price),
@@ -1580,12 +1577,15 @@ impl pallet_connectors::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
+	type PoolId = PoolId;
+	type TrancheId = TrancheId;
 	type CurrencyId = CurrencyId;
 	type ForeignInvestment = Investments;
 	type GeneralCurrencyPrefix = cfg_primitives::connectors::GeneralCurrencyPrefix;
 	type OutboundQueue = DummyOutboundQueue;
 	type Permission = Permissions;
 	type PoolInspect = PoolSystem;
+	type TrancheTokenPrice = PoolSystem;
 	type Rate = Rate;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -24,7 +24,10 @@ pub use cfg_primitives::{
 	constants::*,
 	types::{PoolId, *},
 };
-use cfg_traits::{CurrencyPrice, OrderManager, Permissions as PermissionsT, PoolNAV, PoolUpdateGuard, PreConditions, PriceValue, TrancheCurrency as _, TrancheTokenPrice};
+use cfg_traits::{
+	CurrencyPrice, OrderManager, Permissions as PermissionsT, PoolNAV, PoolUpdateGuard,
+	PreConditions, PriceValue, TrancheCurrency as _, TrancheTokenPrice,
+};
 use cfg_types::{
 	consts::pools::*,
 	domain_address::Domain,
@@ -1152,9 +1155,10 @@ impl CurrencyPrice<CurrencyId> for CurrencyPriceSource {
 		match base {
 			CurrencyId::Tranche(pool_id, tranche_id) => {
 				match <pallet_pool_system::Pallet<Runtime> as TrancheTokenPrice<
-				AccountId,
-				CurrencyId,
-			>>::get(pool_id, tranche_id) {
+					AccountId,
+					CurrencyId,
+				>>::get(pool_id, tranche_id)
+				{
 					// If a specific quote is requested, this needs to match the actual quote.
 					Some(price) if Some(price.pair.quote) != quote => None,
 					Some(price) => Some(price),
@@ -1577,20 +1581,20 @@ impl pallet_connectors::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
-	type PoolId = PoolId;
-	type TrancheId = TrancheId;
 	type CurrencyId = CurrencyId;
 	type ForeignInvestment = Investments;
 	type GeneralCurrencyPrefix = cfg_primitives::connectors::GeneralCurrencyPrefix;
 	type OutboundQueue = DummyOutboundQueue;
 	type Permission = Permissions;
+	type PoolId = PoolId;
 	type PoolInspect = PoolSystem;
-	type TrancheTokenPrice = PoolSystem;
 	type Rate = Rate;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;
 	type TrancheCurrency = TrancheCurrency;
+	type TrancheId = TrancheId;
+	type TrancheTokenPrice = PoolSystem;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
Addresses this bit of the Connectors v2 spec:

> Currently the trait PoolInspect also contains the get_tranche_token_price. A few arguments for refactoring
> 
> - Naming is misleading. Actually, it is computing the price
> - The trait should not be bloated. It is not inspecting here.
> - Implement something like trait TranchePricer or so
> - Maybe even store calculate prices, BUT NOT really sure if this is useful


Note: Leaving the last point since it's an optimisation that we don't need at the moment.