### PR TITLE
Loans: oracle price as balance

### DIFF
--- a/libs/types/src/adjustments.rs
+++ b/libs/types/src/adjustments.rs
@@ -29,9 +29,9 @@ impl<Amount> Adjustment<Amount> {
 		}
 	}
 
-	pub fn map<F>(self, f: F) -> Adjustment<Amount>
+	pub fn map<F, R>(self, f: F) -> Adjustment<R>
 	where
-		F: FnOnce(Amount) -> Amount,
+		F: FnOnce(Amount) -> R,
 	{
 		match self {
 			Adjustment::Increase(amount) => Adjustment::Increase(f(amount)),
@@ -39,9 +39,9 @@ impl<Amount> Adjustment<Amount> {
 		}
 	}
 
-	pub fn try_map<F, E>(self, f: F) -> Result<Adjustment<Amount>, E>
+	pub fn try_map<F, E, R>(self, f: F) -> Result<Adjustment<R>, E>
 	where
-		F: FnOnce(Amount) -> Result<Amount, E>,
+		F: FnOnce(Amount) -> Result<R, E>,
 	{
 		match self {
 			Adjustment::Increase(amount) => f(amount).map(Adjustment::Increase),

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -102,7 +102,7 @@ where
 	T::Pool:
 		PoolBenchmarkHelper<PoolId = T::PoolId, AccountId = T::AccountId, Balance = T::Balance>,
 	PriceCollectionOf<T>: DataCollection<T::PriceId, Data = PriceResultOf<T>>,
-	T::PriceRegistry: DataFeeder<T::PriceId, T::Rate, T::AccountId>,
+	T::PriceRegistry: DataFeeder<T::PriceId, T::Balance, T::AccountId>,
 {
 	fn prepare_benchmark() -> T::PoolId {
 		#[cfg(test)]
@@ -311,7 +311,7 @@ benchmarks! {
 		T::PriceId: From<u32>,
 		T::Pool: PoolBenchmarkHelper<PoolId = T::PoolId, AccountId = T::AccountId, Balance = T::Balance>,
 		PriceCollectionOf<T>: DataCollection<T::PriceId, Data = PriceResultOf<T>>,
-		T::PriceRegistry: DataFeeder<T::PriceId, T::Rate, T::AccountId>,
+		T::PriceRegistry: DataFeeder<T::PriceId, T::Balance, T::AccountId>,
 	}
 
 	create {

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -118,7 +118,7 @@ pub mod pallet {
 	>>::Collection;
 
 	pub type AssetOf<T> = (<T as Config>::CollectionId, <T as Config>::ItemId);
-	pub type PriceOf<T> = (<T as Config>::Rate, Moment);
+	pub type PriceOf<T> = (<T as Config>::Balance, Moment);
 	pub type PriceResultOf<T> = Result<PriceOf<T>, DispatchError>;
 	pub type ChangeOf<T> =
 		Change<<T as Config>::LoanId, <T as Config>::Rate, <T as Config>::MaxWriteOffPolicySize>;

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -216,7 +216,7 @@ fn with_unregister_price_id() {
 
 		let loan_id = util::create_loan(loan);
 
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		config_mocks(amount);
 
 		assert_noop!(
@@ -231,7 +231,7 @@ fn with_wrong_big_amount_external_pricing() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
 
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY) + 1;
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE) + 1;
 		config_mocks(amount);
 
 		assert_noop!(
@@ -247,7 +247,7 @@ fn with_wrong_quantity_amount_external_pricing() {
 		let loan_id = util::create_loan(util::base_external_loan());
 
 		// It's not multiple of PRICE_VALUE
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY) - 1;
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE) - 1;
 		config_mocks(amount);
 
 		assert_noop!(
@@ -262,7 +262,7 @@ fn with_correct_amount_external_pricing() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
 
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		config_mocks(amount);
 
 		assert_ok!(Loans::borrow(
@@ -287,7 +287,7 @@ fn with_unlimited_amount_external_pricing() {
 
 		let loan_id = util::create_loan(loan);
 
-		let amount = PRICE_VALUE.saturating_mul_int(2 /* Could be any value */);
+		let amount = PRICE_VALUE * 2; // But could be any value
 		config_mocks(amount);
 
 		assert_ok!(Loans::borrow(

--- a/pallets/loans/src/tests/close_loan.rs
+++ b/pallets/loans/src/tests/close_loan.rs
@@ -53,7 +53,7 @@ fn without_fully_repaid_internal() {
 fn without_fully_repaid_external() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 		util::repay_loan(loan_id, amount / 2);
 
@@ -104,7 +104,7 @@ fn with_fully_repaid_internal() {
 fn with_fully_repaid_external() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 		util::repay_loan(loan_id, amount);
 

--- a/pallets/loans/src/tests/create_loan.rs
+++ b/pallets/loans/src/tests/create_loan.rs
@@ -143,6 +143,26 @@ fn with_wrong_interest_rate() {
 }
 
 #[test]
+fn with_no_integer_quantity() {
+	new_test_ext().execute_with(|| {
+		config_mocks(POOL_A);
+
+		let loan = LoanInfo {
+			pricing: Pricing::External(ExternalPricing {
+				max_borrow_amount: ExtMaxBorrowAmount::Quantity(QUANTITY + Rate::from_float(0.1)),
+				..util::base_external_pricing()
+			}),
+			..util::base_external_loan()
+		};
+
+		assert_noop!(
+			Loans::create(RuntimeOrigin::signed(BORROWER), POOL_A, loan),
+			Error::<Runtime>::AmountNotMultipleOfPrice
+		);
+	});
+}
+
+#[test]
 fn with_unregister_price_id() {
 	new_test_ext().execute_with(|| {
 		config_mocks(POOL_A);

--- a/pallets/loans/src/tests/mock.rs
+++ b/pallets/loans/src/tests/mock.rs
@@ -67,9 +67,9 @@ pub const POLICY_PERCENTAGE: f64 = 0.5;
 pub const POLICY_PENALTY: f64 = 0.5;
 pub const REGISTER_PRICE_ID: PriceId = 42;
 pub const UNREGISTER_PRICE_ID: PriceId = 88;
-pub const PRICE_VALUE: Rate = Rate::from_u32(999);
-pub const NOTIONAL: Rate = Rate::from_u32(1000);
-pub const QUANTITY: Balance = 20;
+pub const PRICE_VALUE: Balance = 998;
+pub const NOTIONAL: Balance = 1000;
+pub const QUANTITY: Rate = Rate::from_rational(20, 1);
 pub const CHANGE_ID: ChangeId = H256::repeat_byte(0x42);
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
@@ -204,8 +204,8 @@ impl pallet_mock_permissions::Config for Runtime {
 impl pallet_mock_data::Config for Runtime {
 	type Collection = pallet_mock_data::util::MockDataCollection<PriceId, Self::Data>;
 	type CollectionId = PoolId;
-	type Data = Result<(Rate, Moment), DispatchError>;
-	type DataElem = Rate;
+	type Data = Result<(Balance, Moment), DispatchError>;
+	type DataElem = Balance;
 	type DataId = PriceId;
 	#[cfg(feature = "runtime-benchmarks")]
 	type MaxCollectionSize = MaxActiveLoansPerPool;

--- a/pallets/loans/src/tests/policy.rs
+++ b/pallets/loans/src/tests/policy.rs
@@ -126,7 +126,7 @@ fn with_successful_overwriting() {
 fn with_price_outdated() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 
 		let policy: BoundedVec<_, _> = vec![WriteOffRule::new(

--- a/pallets/loans/src/tests/portfolio_valuation.rs
+++ b/pallets/loans/src/tests/portfolio_valuation.rs
@@ -68,7 +68,7 @@ fn without_active_loans() {
 fn with_active_loans() {
 	new_test_ext().execute_with(|| {
 		let loan_1 = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_1, amount);
 
 		let loan_2 = util::create_loan(LoanInfo {
@@ -95,7 +95,7 @@ fn with_active_loans() {
 fn with_active_written_off_loans() {
 	new_test_ext().execute_with(|| {
 		let loan_1 = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_1, amount);
 
 		let loan_2 = util::create_loan(LoanInfo {
@@ -119,7 +119,7 @@ fn with_active_written_off_loans() {
 fn filled_and_cleaned() {
 	new_test_ext().execute_with(|| {
 		let loan_1 = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_1, amount);
 
 		let loan_2 = util::create_loan(LoanInfo {

--- a/pallets/loans/src/tests/repay_loan.rs
+++ b/pallets/loans/src/tests/repay_loan.rs
@@ -295,7 +295,7 @@ fn twice_internal() {
 fn twice_external() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 
 		config_mocks(amount / 2);
@@ -311,11 +311,11 @@ fn twice_external() {
 		));
 
 		assert_eq!(
-			NOTIONAL.saturating_mul_int(QUANTITY / 2),
+			(QUANTITY / 2.into()).saturating_mul_int(NOTIONAL),
 			util::current_loan_debt(loan_id)
 		);
 
-		let remaining = PRICE_VALUE.saturating_mul_int(QUANTITY / 2);
+		let remaining = (QUANTITY / 2.into()).saturating_mul_int(PRICE_VALUE);
 		config_mocks(remaining);
 
 		assert_ok!(Loans::repay(
@@ -395,7 +395,7 @@ fn twice_internal_with_elapsed_time() {
 fn twice_external_with_elapsed_time() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 
 		config_mocks(amount / 2);
@@ -415,12 +415,12 @@ fn twice_external_with_elapsed_time() {
 		assert_eq!(
 			util::current_debt_for(
 				util::interest_for(DEFAULT_INTEREST_RATE, YEAR / 2),
-				NOTIONAL.saturating_mul_int(QUANTITY / 2),
+				(QUANTITY / 2.into()).saturating_mul_int(NOTIONAL),
 			),
 			util::current_loan_debt(loan_id)
 		);
 
-		let remaining = PRICE_VALUE.saturating_mul_int(QUANTITY / 2);
+		let remaining = (QUANTITY / 2.into()).saturating_mul_int(PRICE_VALUE);
 		config_mocks(remaining);
 
 		assert_ok!(Loans::repay(
@@ -490,7 +490,7 @@ fn outstanding_debt_rate_no_increase_if_fully_repaid() {
 fn external_pricing_same() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 
 		config_mocks(amount);
@@ -513,11 +513,11 @@ fn external_pricing_same() {
 fn external_pricing_goes_up() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 
 		config_mocks(amount * 2);
-		MockPrices::mock_get(|_| Ok((PRICE_VALUE * 2.into(), now().as_secs())));
+		MockPrices::mock_get(|_| Ok((PRICE_VALUE * 2, now().as_secs())));
 
 		assert_ok!(Loans::repay(
 			RuntimeOrigin::signed(BORROWER),
@@ -538,13 +538,13 @@ fn external_pricing_goes_up() {
 fn external_pricing_goes_down() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 
 		config_mocks(amount / 2);
-		MockPrices::mock_get(|_| Ok((PRICE_VALUE / 2.into(), now().as_secs())));
+		MockPrices::mock_get(|_| Ok((PRICE_VALUE / 2, now().as_secs())));
 
-		let amount = (PRICE_VALUE / 2.into()).saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE / 2);
 		assert_ok!(Loans::repay(
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
@@ -564,7 +564,7 @@ fn external_pricing_goes_down() {
 fn external_pricing_with_wrong_quantity() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 
 		// It's not multiple of PRICE_VALUE

--- a/pallets/loans/src/tests/write_off_loan.rs
+++ b/pallets/loans/src/tests/write_off_loan.rs
@@ -346,7 +346,7 @@ fn with_percentage_applied_external() {
 		util::set_up_policy(POLICY_PERCENTAGE, 0.0);
 
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = PRICE_VALUE.saturating_mul_int(QUANTITY);
+		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
 		util::borrow_loan(loan_id, amount);
 
 		advance_time(YEAR + DAY);

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1277,7 +1277,7 @@ impl orml_oracle::Config for Runtime {
 	type Members = runtime_common::oracle::benchmarks_util::Members;
 	type OnNewData = PriceCollector;
 	type OracleKey = OracleKey;
-	type OracleValue = Rate;
+	type OracleValue = Balance;
 	type RootOperatorAccountId = RootOperatorOraclePrice;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
@@ -1286,7 +1286,7 @@ impl orml_oracle::Config for Runtime {
 
 impl pallet_data_collector::Config for Runtime {
 	type CollectionId = PoolId;
-	type Data = Rate;
+	type Data = Balance;
 	type DataId = OracleKey;
 	type DataProvider = runtime_common::oracle::DataProviderBridge<PriceOracle>;
 	type MaxCollectionSize = MaxCollectionSize;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1588,7 +1588,7 @@ impl orml_oracle::Config for Runtime {
 	type Members = runtime_common::oracle::benchmarks_util::Members;
 	type OnNewData = PriceCollector;
 	type OracleKey = OracleKey;
-	type OracleValue = Rate;
+	type OracleValue = Balance;
 	type RootOperatorAccountId = RootOperatorOraclePrice;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
@@ -1597,7 +1597,7 @@ impl orml_oracle::Config for Runtime {
 
 impl pallet_data_collector::Config for Runtime {
 	type CollectionId = PoolId;
-	type Data = Rate;
+	type Data = Balance;
 	type DataId = OracleKey;
 	type DataProvider = runtime_common::oracle::DataProviderBridge<PriceOracle>;
 	type MaxCollectionSize = MaxCollectionSize;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -288,13 +288,13 @@ pub mod xcm {
 }
 
 pub mod oracle {
-	use cfg_primitives::types::{AccountId, Moment};
-	use cfg_types::{fixed_point::Rate, oracles::OracleKey};
+	use cfg_primitives::types::{AccountId, Balance, Moment};
+	use cfg_types::oracles::OracleKey;
 	use orml_traits::{CombineData, DataFeeder, DataProvider, DataProviderExtended};
 	use sp_runtime::DispatchResult;
 	use sp_std::{marker::PhantomData, vec::Vec};
 
-	type OracleValue = orml_oracle::TimestampedValue<Rate, Moment>;
+	type OracleValue = orml_oracle::TimestampedValue<Balance, Moment>;
 
 	/// Always choose the last updated value in case of several values.
 	pub struct LastOracleValue;
@@ -312,19 +312,19 @@ pub mod oracle {
 		}
 	}
 
-	/// A provider that maps an `OracleValue` into a tuple `(Rate, Moment)`.
+	/// A provider that maps an `OracleValue` into a tuple `(Balance, Moment)`.
 	/// This aux type is forced because of <https://github.com/open-web3-stack/open-runtime-module-library/issues/904>
 	/// and can be removed once they fix this.
 	pub struct DataProviderBridge<OrmlOracle>(PhantomData<OrmlOracle>);
 
 	impl<OrmlOracle: DataProviderExtended<OracleKey, OracleValue>>
-		DataProviderExtended<OracleKey, (Rate, Moment)> for DataProviderBridge<OrmlOracle>
+		DataProviderExtended<OracleKey, (Balance, Moment)> for DataProviderBridge<OrmlOracle>
 	{
-		fn get_no_op(key: &OracleKey) -> Option<(Rate, Moment)> {
+		fn get_no_op(key: &OracleKey) -> Option<(Balance, Moment)> {
 			OrmlOracle::get_no_op(key).map(|OracleValue { value, timestamp }| (value, timestamp))
 		}
 
-		fn get_all_values() -> Vec<(OracleKey, Option<(Rate, Moment)>)> {
+		fn get_all_values() -> Vec<(OracleKey, Option<(Balance, Moment)>)> {
 			OrmlOracle::get_all_values()
 				.into_iter()
 				.map(|elem| {
@@ -338,18 +338,18 @@ pub mod oracle {
 		}
 	}
 
-	impl<OrmlOracle: DataProvider<OracleKey, Rate>> DataProvider<OracleKey, Rate>
+	impl<OrmlOracle: DataProvider<OracleKey, Balance>> DataProvider<OracleKey, Balance>
 		for DataProviderBridge<OrmlOracle>
 	{
-		fn get(key: &OracleKey) -> Option<Rate> {
+		fn get(key: &OracleKey) -> Option<Balance> {
 			OrmlOracle::get(key)
 		}
 	}
 
-	impl<OrmlOracle: DataFeeder<OracleKey, Rate, AccountId>> DataFeeder<OracleKey, Rate, AccountId>
-		for DataProviderBridge<OrmlOracle>
+	impl<OrmlOracle: DataFeeder<OracleKey, Balance, AccountId>>
+		DataFeeder<OracleKey, Balance, AccountId> for DataProviderBridge<OrmlOracle>
 	{
-		fn feed_value(who: AccountId, key: OracleKey, value: Rate) -> DispatchResult {
+		fn feed_value(who: AccountId, key: OracleKey, value: Balance) -> DispatchResult {
 			OrmlOracle::feed_value(who, key, value)
 		}
 	}

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1335,7 +1335,7 @@ impl orml_oracle::Config for Runtime {
 	type Members = runtime_common::oracle::benchmarks_util::Members;
 	type OnNewData = PriceCollector;
 	type OracleKey = OracleKey;
-	type OracleValue = Rate;
+	type OracleValue = Balance;
 	type RootOperatorAccountId = RootOperatorOraclePrice;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
@@ -1344,7 +1344,7 @@ impl orml_oracle::Config for Runtime {
 
 impl pallet_data_collector::Config for Runtime {
 	type CollectionId = PoolId;
-	type Data = Rate;
+	type Data = Balance;
 	type DataId = OracleKey;
 	type DataProvider = runtime_common::oracle::DataProviderBridge<PriceOracle>;
 	type MaxCollectionSize = MaxCollectionSize;


### PR DESCRIPTION
# Description

This change solves the issue, the complete Oracle support will be done in a new PR following the idea explained here: #1439 

Fixes #1447 

## Changes and Descriptions

- Change Oracle prices from `Rate` to `Balance`.
- Change quantity from `Balance` to `Rate`. Currently, it's checked that only values with integer values are valid.

**NOTE: Labeled as migration, but it does not require migration if we purge the entire `pallet-loans`.**
