### PR TITLE
Loans: borrow & repay method using pricing-based principal

### DIFF
--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -41,7 +41,7 @@ use crate::{
 		loans::LoanInfo,
 		pricing::{
 			internal::{InternalPricing, MaxBorrowAmount},
-			Pricing,
+			Pricing, PricingAmount, RepaidPricingAmount,
 		},
 	},
 	pallet::*,
@@ -49,7 +49,7 @@ use crate::{
 		policy::{WriteOffRule, WriteOffTrigger},
 		valuation::{DiscountedCashFlow, ValuationMethod},
 		BorrowRestrictions, InterestPayments, LoanMutation, LoanRestrictions, Maturity,
-		PayDownSchedule, RepaidAmount, RepayRestrictions, RepaymentSchedule,
+		PayDownSchedule, RepayRestrictions, RepaymentSchedule,
 	},
 };
 
@@ -189,7 +189,7 @@ where
 			RawOrigin::Signed(borrower).into(),
 			pool_id,
 			loan_id,
-			10.into(),
+			PricingAmount::Internal(10.into()),
 		)
 		.unwrap();
 	}
@@ -200,8 +200,8 @@ where
 			RawOrigin::Signed(borrower).into(),
 			pool_id,
 			loan_id,
-			RepaidAmount {
-				principal: 10.into(),
+			RepaidPricingAmount {
+				principal: PricingAmount::Internal(10.into()),
 				interest: T::Balance::max_value(),
 				unscheduled: 0.into(),
 			},
@@ -341,7 +341,7 @@ benchmarks! {
 		let pool_id = Helper::<T>::initialize_active_state(n);
 		let loan_id = Helper::<T>::create_loan(pool_id, u16::MAX.into());
 
-	}: _(RawOrigin::Signed(borrower), pool_id, loan_id, 10.into())
+	}: _(RawOrigin::Signed(borrower), pool_id, loan_id, PricingAmount::Internal(10.into()))
 
 	repay {
 		let n in 1..Helper::<T>::max_active_loans() - 1;
@@ -351,7 +351,11 @@ benchmarks! {
 		let loan_id = Helper::<T>::create_loan(pool_id, u16::MAX.into());
 		Helper::<T>::borrow_loan(pool_id, loan_id);
 
-		let repaid = RepaidAmount { principal: 10.into(), interest: 0.into(), unscheduled: 0.into() };
+		let repaid = RepaidPricingAmount {
+			principal: PricingAmount::Internal(10.into()),
+			interest: 0.into(),
+			unscheduled: 0.into()
+		};
 
 	}: _(RawOrigin::Signed(borrower), pool_id, loan_id, repaid)
 

--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -390,7 +390,7 @@ impl<T: Config> ActiveLoan<T> {
 		let amount = self.prepare_repayment(amount)?;
 
 		self.total_repaid
-			.ensure_add_assign(amount.repaid_amount()?)?;
+			.ensure_add_assign(&amount.repaid_amount()?)?;
 
 		match &mut self.pricing {
 			ActivePricing::Internal(inner) => {

--- a/pallets/loans/src/entities/pricing.rs
+++ b/pallets/loans/src/entities/pricing.rs
@@ -1,8 +1,12 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::RuntimeDebugNoBound;
 use scale_info::TypeInfo;
+use sp_runtime::{ArithmeticError, DispatchError};
 
-use crate::pallet::Config;
+use crate::{
+	pallet::{Config, Error},
+	types::RepaidAmount,
+};
 
 pub mod external;
 pub mod internal;
@@ -27,4 +31,52 @@ pub enum ActivePricing<T: Config> {
 
 	/// Internal attributes
 	External(external::ExternalActivePricing<T>),
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebugNoBound, MaxEncodedLen)]
+#[scale_info(skip_type_params(T))]
+pub enum PricingAmount<T: Config> {
+	Internal(T::Balance),
+	External(external::ExternalAmount<T>),
+}
+
+impl<T: Config> PricingAmount<T> {
+	pub fn balance(&self) -> Result<T::Balance, ArithmeticError> {
+		match self {
+			Self::Internal(amount) => Ok(*amount),
+			Self::External(external) => external.balance(),
+		}
+	}
+
+	pub fn internal(&self) -> Result<T::Balance, DispatchError> {
+		match self {
+			Self::Internal(amount) => Ok(*amount),
+			Self::External(_) => Err(Error::<T>::MismatchedPricingMethod.into()),
+		}
+	}
+
+	pub fn external(&self) -> Result<external::ExternalAmount<T>, DispatchError> {
+		match self {
+			Self::Internal(_) => Err(Error::<T>::MismatchedPricingMethod.into()),
+			Self::External(principal) => Ok(principal.clone()),
+		}
+	}
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebugNoBound, MaxEncodedLen)]
+#[scale_info(skip_type_params(T))]
+pub struct RepaidPricingAmount<T: Config> {
+	pub principal: PricingAmount<T>,
+	pub interest: T::Balance,
+	pub unscheduled: T::Balance,
+}
+
+impl<T: Config> RepaidPricingAmount<T> {
+	pub fn repaid_amount(&self) -> Result<RepaidAmount<T::Balance>, ArithmeticError> {
+		Ok(RepaidAmount {
+			principal: self.principal.balance()?,
+			interest: self.interest,
+			unscheduled: self.unscheduled,
+		})
+	}
 }

--- a/pallets/loans/src/entities/pricing/external.rs
+++ b/pallets/loans/src/entities/pricing/external.rs
@@ -26,6 +26,20 @@ pub struct ExternalAmount<T: Config> {
 }
 
 impl<T: Config> ExternalAmount<T> {
+	pub fn new(quantity: T::Rate, price: T::Balance) -> Self {
+		Self {
+			quantity,
+			settlement_price: price,
+		}
+	}
+
+	pub fn empty() -> Self {
+		Self {
+			quantity: T::Rate::zero(),
+			settlement_price: T::Balance::zero(),
+		}
+	}
+
 	pub fn balance(&self) -> Result<T::Balance, ArithmeticError> {
 		self.quantity.ensure_mul_int(self.settlement_price)
 	}
@@ -59,7 +73,7 @@ impl<T: Config> ExternalPricing<T> {
 	pub fn validate(&self) -> DispatchResult {
 		if let MaxBorrowAmount::Quantity(quantity) = self.max_borrow_amount {
 			ensure!(
-				quantity.frac().is_zero() && quantity > T::Rate::zero(),
+				quantity.frac().is_zero() && quantity >= T::Rate::zero(),
 				Error::<T>::AmountNotNaturalNumber
 			)
 		}
@@ -165,7 +179,7 @@ impl<T: Config> ExternalActivePricing<T> {
 
 		let interest_adj = quantity_adj.try_map(|quantity| -> Result<_, DispatchError> {
 			ensure!(
-				quantity.frac().is_zero() && quantity > T::Rate::zero(),
+				quantity.frac().is_zero() && quantity >= T::Rate::zero(),
 				Error::<T>::AmountNotNaturalNumber
 			);
 

--- a/pallets/loans/src/entities/pricing/external.rs
+++ b/pallets/loans/src/entities/pricing/external.rs
@@ -10,13 +10,26 @@ use frame_support::{self, ensure, RuntimeDebug, RuntimeDebugNoBound};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{EnsureAdd, EnsureFixedPointNumber, EnsureSub, Zero},
-	DispatchError, DispatchResult, FixedPointNumber,
+	ArithmeticError, DispatchError, DispatchResult, FixedPointNumber,
 };
 
 use crate::{
 	entities::interest::ActiveInterestRate,
 	pallet::{Config, Error, PriceOf},
 };
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebugNoBound, MaxEncodedLen)]
+#[scale_info(skip_type_params(T))]
+pub struct ExternalAmount<T: Config> {
+	pub quantity: T::Rate,
+	pub settlement_price: T::Balance,
+}
+
+impl<T: Config> ExternalAmount<T> {
+	pub fn balance(&self) -> Result<T::Balance, ArithmeticError> {
+		self.quantity.ensure_mul_int(self.settlement_price)
+	}
+}
 
 /// Define the max borrow amount of a loan
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebug, MaxEncodedLen)]
@@ -99,11 +112,6 @@ impl<T: Config> ExternalActivePricing<T> {
 		Ok(T::PriceRegistry::get(&self.info.price_id)?.1)
 	}
 
-	pub fn outstanding_amount(&self) -> Result<T::Balance, DispatchError> {
-		let price = self.current_price()?;
-		Ok(self.outstanding_quantity.ensure_mul_int(price)?)
-	}
-
 	pub fn current_interest(&self) -> Result<T::Balance, DispatchError> {
 		let outstanding_notional = self
 			.outstanding_quantity
@@ -114,7 +122,8 @@ impl<T: Config> ExternalActivePricing<T> {
 	}
 
 	pub fn present_value(&self) -> Result<T::Balance, DispatchError> {
-		self.outstanding_amount()
+		let price = self.current_price()?;
+		Ok(self.outstanding_quantity.ensure_mul_int(price)?)
 	}
 
 	pub fn present_value_cached<Prices>(&self, cache: &Prices) -> Result<T::Balance, DispatchError>
@@ -127,42 +136,42 @@ impl<T: Config> ExternalActivePricing<T> {
 
 	pub fn max_borrow_amount(
 		&self,
-		desired_amount: T::Balance,
+		amount: ExternalAmount<T>,
 	) -> Result<T::Balance, DispatchError> {
 		match self.info.max_borrow_amount {
 			MaxBorrowAmount::Quantity(quantity) => {
-				let price = self.current_price()?;
 				let available = quantity.ensure_sub(self.outstanding_quantity)?;
-				Ok(available.ensure_mul_int(price)?)
+				Ok(available.ensure_mul_int(amount.settlement_price)?)
 			}
-			MaxBorrowAmount::NoLimit => Ok(desired_amount),
+			MaxBorrowAmount::NoLimit => Ok(amount.balance()?),
 		}
+	}
+
+	pub fn max_repay_principal(
+		&self,
+		amount: ExternalAmount<T>,
+	) -> Result<T::Balance, DispatchError> {
+		Ok(self
+			.outstanding_quantity
+			.ensure_mul_int(amount.settlement_price)?)
 	}
 
 	pub fn adjust(
 		&mut self,
-		principal_adj: Adjustment<T::Balance>,
+		quantity_adj: Adjustment<T::Rate>,
 		interest: T::Balance,
 	) -> DispatchResult {
-		let quantity_adj = principal_adj.try_map(|principal| -> Result<_, DispatchError> {
-			let price = self.current_price()?;
-
-			let quantity = T::Rate::ensure_from_rational(principal, price)?;
-
-			ensure!(
-				quantity.frac().is_zero(),
-				Error::<T>::AmountNotMultipleOfPrice
-			);
-
-			Ok(quantity)
-		})?;
-
 		self.outstanding_quantity = quantity_adj.ensure_add(self.outstanding_quantity)?;
 
-		let interest_adj = quantity_adj.try_map(|quantity| {
-			quantity
+		let interest_adj = quantity_adj.try_map(|quantity| -> Result<_, DispatchError> {
+			ensure!(
+				quantity.frac().is_zero() && quantity > T::Rate::zero(),
+				Error::<T>::AmountNotNaturalNumber
+			);
+
+			Ok(quantity
 				.ensure_mul_int(self.info.notional)?
-				.ensure_add(interest)
+				.ensure_add(interest)?)
 		})?;
 
 		self.interest.adjust_debt(interest_adj)?;

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -29,7 +29,12 @@ fn with_wrong_loan_id() {
 		config_mocks(COLLATERAL_VALUE);
 
 		assert_noop!(
-			Loans::borrow(RuntimeOrigin::signed(BORROWER), POOL_A, 0, COLLATERAL_VALUE),
+			Loans::borrow(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				0,
+				PricingAmount::Internal(COLLATERAL_VALUE)
+			),
 			Error::<Runtime>::LoanNotActiveOrNotFound
 		);
 	});
@@ -47,7 +52,7 @@ fn from_other_borrower() {
 				RuntimeOrigin::signed(OTHER_BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE
+				PricingAmount::Internal(COLLATERAL_VALUE)
 			),
 			Error::<Runtime>::NotLoanBorrower
 		);
@@ -64,7 +69,7 @@ fn with_restriction_no_written_off() {
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			COLLATERAL_VALUE / 2
+			PricingAmount::Internal(COLLATERAL_VALUE / 2)
 		));
 
 		advance_time(YEAR + DAY);
@@ -75,7 +80,7 @@ fn with_restriction_no_written_off() {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE / 2
+				PricingAmount::Internal(COLLATERAL_VALUE / 2)
 			),
 			Error::<Runtime>::from(BorrowLoanError::Restriction)
 		);
@@ -99,7 +104,7 @@ fn with_restriction_full_once() {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE / 2 // Must be full value
+				PricingAmount::Internal(COLLATERAL_VALUE / 2) // Must be full value
 			),
 			Error::<Runtime>::from(BorrowLoanError::Restriction)
 		);
@@ -109,12 +114,17 @@ fn with_restriction_full_once() {
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			COLLATERAL_VALUE
+			PricingAmount::Internal(COLLATERAL_VALUE)
 		));
 
 		// Borrow was already done
 		assert_noop!(
-			Loans::borrow(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, 0),
+			Loans::borrow(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				loan_id,
+				PricingAmount::Internal(0)
+			),
 			Error::<Runtime>::from(BorrowLoanError::Restriction)
 		);
 	});
@@ -133,7 +143,7 @@ fn with_maturity_passed() {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				COLLATERAL_VALUE
+				PricingAmount::Internal(COLLATERAL_VALUE)
 			),
 			Error::<Runtime>::from(BorrowLoanError::MaturityDatePassed)
 		);
@@ -163,7 +173,12 @@ fn with_wrong_big_amount_internal_pricing() {
 
 			config_mocks(amount);
 			assert_noop!(
-				Loans::borrow(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, amount),
+				Loans::borrow(
+					RuntimeOrigin::signed(BORROWER),
+					POOL_A,
+					loan_id,
+					PricingAmount::Internal(amount)
+				),
 				Error::<Runtime>::from(BorrowLoanError::MaxAmountExceeded)
 			);
 		});
@@ -196,7 +211,7 @@ fn with_correct_amount_internal_pricing() {
 				RuntimeOrigin::signed(BORROWER),
 				POOL_A,
 				loan_id,
-				amount
+				PricingAmount::Internal(amount)
 			));
 			assert_eq!(amount, util::current_loan_debt(loan_id));
 		});
@@ -216,11 +231,16 @@ fn with_unregister_price_id() {
 
 		let loan_id = util::create_loan(loan);
 
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		config_mocks(amount);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		config_mocks(amount.balance().unwrap());
 
 		assert_noop!(
-			Loans::borrow(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, amount),
+			Loans::borrow(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				loan_id,
+				PricingAmount::External(amount)
+			),
 			PRICE_ID_NO_FOUND
 		);
 	});
@@ -231,11 +251,16 @@ fn with_wrong_big_amount_external_pricing() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
 
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE) + 1;
-		config_mocks(amount);
+		let amount = ExternalAmount::new(QUANTITY + 1.into(), PRICE_VALUE);
+		config_mocks(amount.balance().unwrap());
 
 		assert_noop!(
-			Loans::borrow(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, amount),
+			Loans::borrow(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				loan_id,
+				PricingAmount::External(amount)
+			),
 			Error::<Runtime>::from(BorrowLoanError::MaxAmountExceeded)
 		);
 	});
@@ -247,12 +272,17 @@ fn with_wrong_quantity_amount_external_pricing() {
 		let loan_id = util::create_loan(util::base_external_loan());
 
 		// It's not multiple of PRICE_VALUE
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE) - 1;
-		config_mocks(amount);
+		let amount = ExternalAmount::new(Rate::from_float(0.5), PRICE_VALUE);
+		config_mocks(amount.balance().unwrap());
 
 		assert_noop!(
-			Loans::borrow(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, amount),
-			Error::<Runtime>::AmountNotMultipleOfPrice
+			Loans::borrow(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				loan_id,
+				PricingAmount::External(amount)
+			),
+			Error::<Runtime>::AmountNotNaturalNumber
 		);
 	});
 }
@@ -262,14 +292,14 @@ fn with_correct_amount_external_pricing() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
 
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		config_mocks(amount);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		config_mocks(amount.balance().unwrap());
 
 		assert_ok!(Loans::borrow(
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			amount
+			PricingAmount::External(amount)
 		),);
 	});
 }
@@ -287,14 +317,14 @@ fn with_unlimited_amount_external_pricing() {
 
 		let loan_id = util::create_loan(loan);
 
-		let amount = PRICE_VALUE * 2; // But could be any value
-		config_mocks(amount);
+		let amount = ExternalAmount::new(QUANTITY /* Could be any value */, PRICE_VALUE);
+		config_mocks(amount.balance().unwrap());
 
 		assert_ok!(Loans::borrow(
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			amount
+			PricingAmount::External(amount)
 		));
 	});
 }
@@ -310,7 +340,7 @@ fn twice() {
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			COLLATERAL_VALUE / 2
+			PricingAmount::Internal(COLLATERAL_VALUE / 2)
 		));
 		assert_eq!(COLLATERAL_VALUE / 2, util::current_loan_debt(loan_id));
 
@@ -318,14 +348,19 @@ fn twice() {
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			COLLATERAL_VALUE / 2
+			PricingAmount::Internal(COLLATERAL_VALUE / 2)
 		));
 		assert_eq!(COLLATERAL_VALUE, util::current_loan_debt(loan_id));
 
 		// At this point the loan has been fully borrowed.
 		let extra = 1;
 		assert_noop!(
-			Loans::borrow(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, extra),
+			Loans::borrow(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				loan_id,
+				PricingAmount::Internal(extra)
+			),
 			Error::<Runtime>::from(BorrowLoanError::MaxAmountExceeded)
 		);
 	});
@@ -342,7 +377,7 @@ fn twice_with_elapsed_time() {
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			COLLATERAL_VALUE / 2
+			PricingAmount::Internal(COLLATERAL_VALUE / 2)
 		));
 		assert_eq!(COLLATERAL_VALUE / 2, util::current_loan_debt(loan_id));
 
@@ -360,14 +395,23 @@ fn twice_with_elapsed_time() {
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			COLLATERAL_VALUE / 2
+			PricingAmount::Internal(COLLATERAL_VALUE / 2)
 		));
 
 		// At this point the loan has been fully borrowed.
 		let extra = 1;
 		assert_noop!(
-			Loans::borrow(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id, extra),
+			Loans::borrow(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				loan_id,
+				PricingAmount::Internal(extra)
+			),
 			Error::<Runtime>::from(BorrowLoanError::MaxAmountExceeded)
 		);
 	});
 }
+
+// TODO: price_value != settlement_price
+// TODO: check error external when internal
+// TODO: check error internal when external

--- a/pallets/loans/src/tests/close_loan.rs
+++ b/pallets/loans/src/tests/close_loan.rs
@@ -25,8 +25,8 @@ fn with_wrong_borrower() {
 		);
 
 		// Make the loan active and ready to be closed
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
-		util::repay_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
+		util::repay_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		assert_noop!(
 			Loans::close(RuntimeOrigin::signed(OTHER_BORROWER), POOL_A, loan_id),
@@ -39,8 +39,8 @@ fn with_wrong_borrower() {
 fn without_fully_repaid_internal() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
-		util::repay_loan(loan_id, COLLATERAL_VALUE / 2);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
+		util::repay_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE / 2));
 
 		assert_noop!(
 			Loans::close(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id),
@@ -53,9 +53,10 @@ fn without_fully_repaid_internal() {
 fn without_fully_repaid_external() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		util::borrow_loan(loan_id, amount);
-		util::repay_loan(loan_id, amount / 2);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::External(amount));
+		let amount = ExternalAmount::new(QUANTITY / 2.into(), PRICE_VALUE);
+		util::repay_loan(loan_id, PricingAmount::External(amount));
 
 		assert_noop!(
 			Loans::close(RuntimeOrigin::signed(BORROWER), POOL_A, loan_id),
@@ -68,8 +69,8 @@ fn without_fully_repaid_external() {
 fn with_time_after_fully_repaid_internal() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
-		util::repay_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
+		util::repay_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR);
 
@@ -87,8 +88,8 @@ fn with_time_after_fully_repaid_internal() {
 fn with_fully_repaid_internal() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
-		util::repay_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
+		util::repay_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		assert_ok!(Loans::close(
 			RuntimeOrigin::signed(BORROWER),
@@ -104,9 +105,9 @@ fn with_fully_repaid_internal() {
 fn with_fully_repaid_external() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		util::borrow_loan(loan_id, amount);
-		util::repay_loan(loan_id, amount);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::External(amount.clone()));
+		util::repay_loan(loan_id, PricingAmount::External(amount));
 
 		config_mocks();
 		assert_ok!(Loans::close(

--- a/pallets/loans/src/tests/mod.rs
+++ b/pallets/loans/src/tests/mod.rs
@@ -11,9 +11,9 @@ use super::{
 	entities::{
 		loans::{ActiveLoan, LoanInfo},
 		pricing::{
-			external::{ExternalPricing, MaxBorrowAmount as ExtMaxBorrowAmount},
+			external::{ExternalAmount, ExternalPricing, MaxBorrowAmount as ExtMaxBorrowAmount},
 			internal::{InternalPricing, MaxBorrowAmount as IntMaxBorrowAmount},
-			ActivePricing, Pricing,
+			ActivePricing, Pricing, PricingAmount, RepaidPricingAmount,
 		},
 	},
 	pallet::{ActiveLoans, Error, LastLoanId, PortfolioValuation},
@@ -22,8 +22,8 @@ use super::{
 		valuation::{DiscountedCashFlow, ValuationMethod},
 		BorrowLoanError, BorrowRestrictions, Change, CloseLoanError, CreateLoanError,
 		InterestPayments, InternalMutation, LoanMutation, LoanRestrictions, Maturity,
-		MutationError, PayDownSchedule, RepaidAmount, RepayLoanError, RepayRestrictions,
-		RepaymentSchedule, WrittenOffError,
+		MutationError, PayDownSchedule, RepayLoanError, RepayRestrictions, RepaymentSchedule,
+		WrittenOffError,
 	},
 };
 

--- a/pallets/loans/src/tests/mutate_loan.rs
+++ b/pallets/loans/src/tests/mutate_loan.rs
@@ -50,7 +50,7 @@ fn without_active_loan() {
 fn with_wrong_policy_change() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, 0);
+		util::borrow_loan(loan_id, PricingAmount::Internal(0));
 
 		config_mocks(loan_id, &DEFAULT_MUTATION);
 		MockChangeGuard::mock_released(|_, _| Ok(Change::Policy(vec![].try_into().unwrap())));
@@ -66,7 +66,7 @@ fn with_wrong_policy_change() {
 fn with_wrong_permissions() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, 0);
+		util::borrow_loan(loan_id, PricingAmount::Internal(0));
 
 		config_mocks(loan_id, &DEFAULT_MUTATION);
 		assert_noop!(
@@ -98,7 +98,7 @@ mod wrong_mutation {
 	fn with_dcf() {
 		new_test_ext().execute_with(|| {
 			let loan_id = util::create_loan(util::base_internal_loan());
-			util::borrow_loan(loan_id, 0);
+			util::borrow_loan(loan_id, PricingAmount::Internal(0));
 
 			let mutation = LoanMutation::Internal(InternalMutation::ProbabilityOfDefault(
 				Rate::from_float(0.5),
@@ -121,7 +121,7 @@ mod wrong_mutation {
 	fn with_internal() {
 		new_test_ext().execute_with(|| {
 			let loan_id = util::create_loan(util::base_external_loan());
-			util::borrow_loan(loan_id, 0);
+			util::borrow_loan(loan_id, PricingAmount::External(ExternalAmount::empty()));
 
 			let mutation = LoanMutation::Internal(InternalMutation::ProbabilityOfDefault(
 				Rate::from_float(0.5),
@@ -144,7 +144,7 @@ mod wrong_mutation {
 	fn with_maturity_extension() {
 		new_test_ext().execute_with(|| {
 			let loan_id = util::create_loan(util::base_internal_loan());
-			util::borrow_loan(loan_id, 0);
+			util::borrow_loan(loan_id, PricingAmount::Internal(0));
 
 			let mutation = LoanMutation::MaturityExtension(YEAR.as_secs());
 
@@ -165,7 +165,7 @@ mod wrong_mutation {
 	fn with_interest_rate() {
 		new_test_ext().execute_with(|| {
 			let loan_id = util::create_loan(util::base_internal_loan());
-			util::borrow_loan(loan_id, 0);
+			util::borrow_loan(loan_id, PricingAmount::Internal(0));
 
 			// Too high
 			let mutation = LoanMutation::InterestRate(InterestRate::Fixed {
@@ -191,7 +191,7 @@ mod wrong_mutation {
 fn with_successful_proposal() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, 0);
+		util::borrow_loan(loan_id, PricingAmount::Internal(0));
 
 		config_mocks(loan_id, &DEFAULT_MUTATION);
 
@@ -235,7 +235,7 @@ fn with_successful_mutation_application() {
 		};
 
 		let loan_id = util::create_loan(loan);
-		util::borrow_loan(loan_id, COLLATERAL_VALUE / 2);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE / 2));
 
 		let mutations = vec![
 			// LoanMutation::InterestPayments(..), No changes, only one variant

--- a/pallets/loans/src/tests/policy.rs
+++ b/pallets/loans/src/tests/policy.rs
@@ -126,8 +126,8 @@ fn with_successful_overwriting() {
 fn with_price_outdated() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		util::borrow_loan(loan_id, amount);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::External(amount));
 
 		let policy: BoundedVec<_, _> = vec![WriteOffRule::new(
 			[WriteOffTrigger::PriceOutdated(10)],
@@ -176,7 +176,7 @@ fn with_price_outdated() {
 fn with_success() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		let policy: BoundedVec<_, _> = vec![
 			WriteOffRule::new(

--- a/pallets/loans/src/tests/portfolio_valuation.rs
+++ b/pallets/loans/src/tests/portfolio_valuation.rs
@@ -68,17 +68,17 @@ fn without_active_loans() {
 fn with_active_loans() {
 	new_test_ext().execute_with(|| {
 		let loan_1 = util::create_loan(util::base_external_loan());
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		util::borrow_loan(loan_1, amount);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		util::borrow_loan(loan_1, PricingAmount::External(amount.clone()));
 
 		let loan_2 = util::create_loan(LoanInfo {
 			collateral: ASSET_BA,
 			..util::base_internal_loan()
 		});
-		util::borrow_loan(loan_2, COLLATERAL_VALUE);
-		util::repay_loan(loan_2, COLLATERAL_VALUE / 4);
+		util::borrow_loan(loan_2, PricingAmount::Internal(COLLATERAL_VALUE));
+		util::repay_loan(loan_2, PricingAmount::Internal(COLLATERAL_VALUE / 4));
 
-		let valuation = amount + COLLATERAL_VALUE - COLLATERAL_VALUE / 4;
+		let valuation = amount.balance().unwrap() + COLLATERAL_VALUE - COLLATERAL_VALUE / 4;
 
 		expected_portfolio(valuation);
 		update_portfolio();
@@ -95,15 +95,15 @@ fn with_active_loans() {
 fn with_active_written_off_loans() {
 	new_test_ext().execute_with(|| {
 		let loan_1 = util::create_loan(util::base_external_loan());
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		util::borrow_loan(loan_1, amount);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		util::borrow_loan(loan_1, PricingAmount::External(amount));
 
 		let loan_2 = util::create_loan(LoanInfo {
 			collateral: ASSET_BA,
 			..util::base_internal_loan()
 		});
-		util::borrow_loan(loan_2, COLLATERAL_VALUE);
-		util::repay_loan(loan_2, COLLATERAL_VALUE / 4);
+		util::borrow_loan(loan_2, PricingAmount::Internal(COLLATERAL_VALUE));
+		util::repay_loan(loan_2, PricingAmount::Internal(COLLATERAL_VALUE / 4));
 
 		advance_time(YEAR + DAY);
 
@@ -119,15 +119,15 @@ fn with_active_written_off_loans() {
 fn filled_and_cleaned() {
 	new_test_ext().execute_with(|| {
 		let loan_1 = util::create_loan(util::base_external_loan());
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		util::borrow_loan(loan_1, amount);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		util::borrow_loan(loan_1, PricingAmount::External(amount.clone()));
 
 		let loan_2 = util::create_loan(LoanInfo {
 			collateral: ASSET_BA,
 			..util::base_internal_loan()
 		});
-		util::borrow_loan(loan_2, COLLATERAL_VALUE);
-		util::repay_loan(loan_2, COLLATERAL_VALUE / 2);
+		util::borrow_loan(loan_2, PricingAmount::Internal(COLLATERAL_VALUE));
+		util::repay_loan(loan_2, PricingAmount::Internal(COLLATERAL_VALUE / 2));
 
 		advance_time(YEAR + DAY);
 
@@ -135,8 +135,8 @@ fn filled_and_cleaned() {
 
 		advance_time(YEAR / 2);
 
-		util::repay_loan(loan_1, amount);
-		util::repay_loan(loan_2, COLLATERAL_VALUE / 2);
+		util::repay_loan(loan_1, PricingAmount::External(amount));
+		util::repay_loan(loan_2, PricingAmount::Internal(COLLATERAL_VALUE / 2));
 
 		advance_time(YEAR / 2);
 
@@ -154,14 +154,14 @@ fn filled_and_cleaned() {
 fn exact_and_inexact_matches() {
 	new_test_ext().execute_with(|| {
 		let loan_1 = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_1, COLLATERAL_VALUE);
+		util::borrow_loan(loan_1, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR / 2);
 		update_portfolio();
 
 		// repay_loan() should affect to the portfolio valuation with the same value as
 		// the absolute valuation of the loan
-		util::repay_loan(loan_1, COLLATERAL_VALUE / 2);
+		util::repay_loan(loan_1, PricingAmount::Internal(COLLATERAL_VALUE / 2));
 		expected_portfolio(util::current_loan_pv(loan_1));
 	});
 }

--- a/pallets/loans/src/tests/util.rs
+++ b/pallets/loans/src/tests/util.rs
@@ -136,7 +136,7 @@ pub fn create_loan(loan: LoanInfo<Runtime>) -> LoanId {
 	LastLoanId::<Runtime>::get(POOL_A)
 }
 
-pub fn borrow_loan(loan_id: LoanId, borrow_amount: Balance) {
+pub fn borrow_loan(loan_id: LoanId, borrow_amount: PricingAmount<Runtime>) {
 	MockPools::mock_withdraw(|_, _, _| Ok(()));
 	MockPrices::mock_get(|_| Ok((PRICE_VALUE, BLOCK_TIME.as_secs())));
 	MockPrices::mock_register_id(|_, _| Ok(()));
@@ -154,7 +154,7 @@ pub fn borrow_loan(loan_id: LoanId, borrow_amount: Balance) {
 	MockPrices::mock_register_id(|_, _| panic!("no register_id() mock"));
 }
 
-pub fn repay_loan(loan_id: LoanId, repay_amount: Balance) {
+pub fn repay_loan(loan_id: LoanId, repay_amount: PricingAmount<Runtime>) {
 	MockPools::mock_deposit(|_, _, _| Ok(()));
 	MockPrices::mock_get(|_| Ok((PRICE_VALUE, BLOCK_TIME.as_secs())));
 
@@ -162,7 +162,7 @@ pub fn repay_loan(loan_id: LoanId, repay_amount: Balance) {
 		RuntimeOrigin::signed(BORROWER),
 		POOL_A,
 		loan_id,
-		RepaidAmount {
+		RepaidPricingAmount {
 			principal: repay_amount,
 			interest: u128::MAX,
 			unscheduled: 0,

--- a/pallets/loans/src/tests/write_off_loan.rs
+++ b/pallets/loans/src/tests/write_off_loan.rs
@@ -12,7 +12,7 @@ fn config_mocks() {
 fn without_policy() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		assert_noop!(
 			Loans::write_off(RuntimeOrigin::signed(ANY), POOL_A, loan_id),
@@ -36,7 +36,7 @@ fn with_policy_but_not_overdue() {
 		util::set_up_policy(POLICY_PERCENTAGE, POLICY_PENALTY);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + BLOCK_TIME);
 
@@ -54,7 +54,7 @@ fn with_valid_maturity() {
 		util::set_up_policy(POLICY_PERCENTAGE, POLICY_PENALTY);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR / 2);
 
@@ -121,7 +121,7 @@ fn with_wrong_permission() {
 		util::set_up_policy(POLICY_PERCENTAGE, POLICY_PENALTY);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + DAY);
 
@@ -145,7 +145,7 @@ fn with_success() {
 		util::set_up_policy(POLICY_PERCENTAGE, POLICY_PENALTY);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + DAY);
 
@@ -163,7 +163,7 @@ fn with_admin_success() {
 		util::set_up_policy(POLICY_PERCENTAGE, POLICY_PENALTY);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + DAY);
 
@@ -213,7 +213,7 @@ fn with_admin_less_than_policy() {
 		util::set_up_policy(POLICY_PERCENTAGE, POLICY_PENALTY);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + DAY);
 
@@ -251,7 +251,7 @@ fn with_policy_change_after() {
 		util::set_up_policy(POLICY_PERCENTAGE, POLICY_PENALTY);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + DAY);
 
@@ -283,7 +283,7 @@ fn with_policy_change_after() {
 fn with_policy_change_after_admin() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		config_mocks();
 		assert_ok!(Loans::admin_write_off(
@@ -320,7 +320,7 @@ fn with_percentage_applied_internal() {
 		util::set_up_policy(POLICY_PERCENTAGE, 0.0);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + DAY);
 
@@ -346,8 +346,8 @@ fn with_percentage_applied_external() {
 		util::set_up_policy(POLICY_PERCENTAGE, 0.0);
 
 		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = QUANTITY.saturating_mul_int(PRICE_VALUE);
-		util::borrow_loan(loan_id, amount);
+		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::External(amount));
 
 		advance_time(YEAR + DAY);
 
@@ -377,7 +377,7 @@ fn with_penalty_applied() {
 		util::set_up_policy(0.0, POLICY_PENALTY);
 
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + DAY);
 
@@ -417,7 +417,7 @@ fn with_penalty_applied() {
 fn fully() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());
-		util::borrow_loan(loan_id, COLLATERAL_VALUE);
+		util::borrow_loan(loan_id, PricingAmount::Internal(COLLATERAL_VALUE));
 
 		advance_time(YEAR + DAY);
 

--- a/pallets/loans/src/types/mod.rs
+++ b/pallets/loans/src/types/mod.rs
@@ -239,7 +239,10 @@ impl<Balance: EnsureAdd + Copy> RepaidAmount<Balance> {
 			.ensure_add(self.unscheduled)
 	}
 
-	pub fn ensure_add_assign(&mut self, other: &Self) -> Result<(), ArithmeticError> {
+	pub fn ensure_add_assign(
+		&mut self,
+		other: RepaidAmount<Balance>,
+	) -> Result<(), ArithmeticError> {
 		self.principal.ensure_add_assign(other.principal)?;
 		self.interest.ensure_add_assign(other.interest)?;
 		self.unscheduled.ensure_add_assign(other.unscheduled)

--- a/pallets/loans/src/types/mod.rs
+++ b/pallets/loans/src/types/mod.rs
@@ -239,10 +239,7 @@ impl<Balance: EnsureAdd + Copy> RepaidAmount<Balance> {
 			.ensure_add(self.unscheduled)
 	}
 
-	pub fn ensure_add_assign(
-		&mut self,
-		other: RepaidAmount<Balance>,
-	) -> Result<(), ArithmeticError> {
+	pub fn ensure_add_assign(&mut self, other: &Self) -> Result<(), ArithmeticError> {
 		self.principal.ensure_add_assign(other.principal)?;
 		self.interest.ensure_add_assign(other.interest)?;
 		self.unscheduled.ensure_add_assign(other.unscheduled)

--- a/runtime/integration-tests/src/utils/loans.rs
+++ b/runtime/integration-tests/src/utils/loans.rs
@@ -23,7 +23,7 @@ use pallet_loans::{
 		loans::LoanInfo,
 		pricing::{
 			internal::{InternalPricing, MaxBorrowAmount},
-			Pricing,
+			Pricing, PricingAmount, RepaidPricingAmount,
 		},
 	},
 	types::{
@@ -182,7 +182,11 @@ pub fn create_loan_call(pool_id: PoolId, info: LoanInfo<Runtime>) -> RuntimeCall
 	RuntimeCall::Loans(LoansCall::create { pool_id, info })
 }
 
-pub fn borrow_call(pool_id: PoolId, loan_id: LoanId, amount: Balance) -> RuntimeCall {
+pub fn borrow_call(
+	pool_id: PoolId,
+	loan_id: LoanId,
+	amount: PricingAmount<Runtime>,
+) -> RuntimeCall {
 	RuntimeCall::Loans(LoansCall::borrow {
 		pool_id,
 		loan_id,
@@ -190,7 +194,11 @@ pub fn borrow_call(pool_id: PoolId, loan_id: LoanId, amount: Balance) -> Runtime
 	})
 }
 
-pub fn repay_call(pool_id: PoolId, loan_id: LoanId, amount: RepaidAmount<Balance>) -> RuntimeCall {
+pub fn repay_call(
+	pool_id: PoolId,
+	loan_id: LoanId,
+	amount: RepaidPricingAmount<Runtime>,
+) -> RuntimeCall {
 	RuntimeCall::Loans(LoansCall::repay {
 		pool_id,
 		loan_id,


### PR DESCRIPTION
# Description

Jeroen's Slack introduction to this feature is [here](https://centrifugedao.slack.com/archives/C05DX0RH1T3/p1688128534804769)

Basically, we want to write the principal in different ways depending on the pricing method. As a schema, instead of always given a `Balance` as principal in `borrow()` and `repay()` methods, we want:
```rust
enum Principal {
    Internal {
        amount: Balance
    },
    External {
        quantity: Rate,
        settlement_price: Balance,
    }
}
```

The core idea is that for external pricing, the amount that is transferred to the pool is `quantity * settlement_price`, and the `outstanding_quantity` is reduced by `quantity`.

So, with this schema:
- Amount transferred: `quantity * settlement_price`
- Amount used for calculating interest: `quantity * notional`
- Amount used for valuating the loan: `quantity * current_price`

## Changes
- [x] Implementation
- [x] Adapt testing
- [x] Adapt benchmarks
