### PR TITLE
Runtime: Remove week delay for fast runtimes in RuntimeChange

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,7 @@ try-runtime = [
 ]
 
 fast-runtime = [
+  "runtime-common/fast-runtime",
   "altair-runtime/fast-runtime",
   "centrifuge-runtime/fast-runtime",
   "development-runtime/fast-runtime",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -144,3 +144,6 @@ try-runtime = [
   "pallet-evm-chain-id/try-runtime",
   "fp-self-contained/try-runtime",
 ]
+
+# Set timing constants (e.g. session period) to faster versions to speed up testing.
+fast-runtime = []

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -414,7 +414,7 @@ pub mod changes {
 			#[cfg(not(feature = "fast-runtime"))]
 			use cfg_primitives::SECONDS_PER_WEEK;
 			#[cfg(feature = "fast-runtime")]
-			const SECONDS_PER_WEEK: u64 = 0;
+			const SECONDS_PER_WEEK: u64 = 120;
 
 			use pallet_loans::types::{InternalMutation, LoanMutation};
 			use pallet_pool_system::pool_types::changes::Requirement;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -411,7 +411,11 @@ pub mod changes {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	impl<T: pallet_loans::Config> From<RuntimeChange<T>> for PoolChangeProposal {
 		fn from(RuntimeChange::Loan(loans_change): RuntimeChange<T>) -> Self {
+			#[cfg(not(feature = "fast-runtime"))]
 			use cfg_primitives::SECONDS_PER_WEEK;
+			#[cfg(feature = "fast-runtime")]
+			const SECONDS_PER_WEEK: u64 = 0;
+
 			use pallet_loans::types::{InternalMutation, LoanMutation};
 			use pallet_pool_system::pool_types::changes::Requirement;
 			use sp_std::vec;


### PR DESCRIPTION
# Description

Currently, Apps need to wait 1 entire week to test some `RuntimeChange`s. This is undesirable.
If `development` node is compiled with `fast-runtime`, this limitation is removed and can be done instantly.

## Changes and Descriptions

- Enable `fast-runtime` for `runtime-common`
- Disable week delay for `RuntimeChange`.
