### PR TITLE
Runtime: add `RuntimeChange` version for fast runtimes

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -472,4 +472,44 @@ pub mod changes {
 			Ok(loan_change)
 		}
 	}
+
+	pub mod fast {
+		use pallet_pool_system::pool_types::changes::Requirement;
+
+		use super::*;
+
+		const SECONDS_PER_WEEK: u32 = 60;
+
+		#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+		pub struct RuntimeChange<T: pallet_loans::Config>(super::RuntimeChange<T>);
+
+		impl<T: pallet_loans::Config> From<RuntimeChange<T>> for PoolChangeProposal {
+			fn from(runtime_change: RuntimeChange<T>) -> Self {
+				PoolChangeProposal::new(
+					PoolChangeProposal::from(runtime_change.0)
+						.requirements()
+						.map(|req| match req {
+							Requirement::DelayTime(_) => Requirement::DelayTime(SECONDS_PER_WEEK),
+							req => req,
+						}),
+				)
+			}
+		}
+
+		/// Used for building CfgChanges in pallet-loans
+		impl<T: pallet_loans::Config> From<LoansChangeOf<T>> for RuntimeChange<T> {
+			fn from(loan_change: LoansChangeOf<T>) -> RuntimeChange<T> {
+				Self(loan_change.into())
+			}
+		}
+
+		/// Used for recovering LoanChange in pallet-loans
+		impl<T: pallet_loans::Config> TryInto<LoansChangeOf<T>> for RuntimeChange<T> {
+			type Error = DispatchError;
+
+			fn try_into(self) -> Result<LoansChangeOf<T>, DispatchError> {
+				self.0.try_into()
+			}
+		}
+	}
 }

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1035,7 +1035,7 @@ impl pallet_pool_system::Config for Runtime {
 	type PoolDeposit = PoolDeposit;
 	type PoolId = PoolId;
 	type Rate = Rate;
-	type RuntimeChange = runtime_common::changes::RuntimeChange<Runtime>;
+	type RuntimeChange = runtime_common::changes::fast::RuntimeChange<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;
@@ -1382,7 +1382,7 @@ impl pallet_loans::Config for Runtime {
 	type PriceId = OracleKey;
 	type PriceRegistry = PriceCollector;
 	type Rate = Rate;
-	type RuntimeChange = runtime_common::changes::RuntimeChange<Runtime>;
+	type RuntimeChange = runtime_common::changes::fast::RuntimeChange<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type WeightInfo = weights::pallet_loans::WeightInfo<Self>;


### PR DESCRIPTION
# Description

Another solution for #1466 that it does not imply changes in deployment/scripts.

## Changes and Descriptions

- Add a `RuntimeChange` wrapper that modifies delay times for "fast" runtime versions. Each runtime can choose between using `RuntimeChange` or `fast::RuntimeChange` depending on their configuration.
