### PR TITLE
Fix Algol parachain ID

### DIFF
--- a/res/algol-spec.json
+++ b/res/algol-spec.json
@@ -15,7 +15,7 @@
     "tokenSymbol": "ALGL"
   },
   "relay_chain": "rococo-local",
-  "para_id": 2089,
+  "para_id": 2088,
   "codeSubstitutes": {},
   "genesis": {
     "runtime": {
@@ -24,7 +24,7 @@
       },
       "parachainSystem": null,
       "parachainInfo": {
-        "parachainId": 2089
+        "parachainId": 2088
       },
       "balances": {
         "balances": [


### PR DESCRIPTION
The intent for Algol was that it would be like Catalyst:
* parachain ID == Altair ID
* EVM chain ID == (Altair ID) + 1

Due to a typo (or a bad copy and paste), the parachain ID ended up equal to the EVM chain ID.
