### PR TITLE
Add call-remarked pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6953,6 +6953,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-call-remarked"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-utility",
+ "parity-scale-codec 3.4.0",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech//substrate?rev=bcff60a227d455d95b4712b6cb356ce56b1ff672#bcff60a227d455d95b4712b6cb356ce56b1ff672"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "pallets/anchors",
   "pallets/bridge",
   "pallets/block-rewards",
+  "pallets/call-remarked",
   "pallets/connectors",
   "pallets/connectors-gateway",
   "pallets/connectors-gateway/routers",

--- a/pallets/call-remarked/Cargo.toml
+++ b/pallets/call-remarked/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+authors = ["Centrifuge <admin@centrifuge.io>"]
+description = "Pallet to remark calls"
+edition = "2021"
+license = "LGPL-3.0"
+name = "pallet-call-remarked"
+repository = "https://github.com/centrifuge/centrifuge-chain"
+version = "1.0.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", default-features = false, version = "3.0.0", features = ["derive"] }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
+
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "scale-info/std",
+  "frame-support/std",
+  "frame-system/std",
+  "sp-arithmetic/std",
+  "sp-runtime/std",
+  "sp-std/std",
+  "pallet-utility/std",
+]

--- a/pallets/call-remarked/src/lib.rs
+++ b/pallets/call-remarked/src/lib.rs
@@ -1,0 +1,41 @@
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config + pallet_utility::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		type Remark: Parameter;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Stored data off chain.
+		Remark { remark: T::Remark },
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Index and store data off chain.
+		#[pallet::call_index(0)]
+		#[pallet::weight(10_000_000)]
+		pub fn remark_call(
+			origin: OriginFor<T>,
+			call: <T as pallet_utility::Config>::RuntimeCall,
+			remark: T::Remark,
+		) -> DispatchResultWithPostInfo {
+			let info = <pallet_utility::Pallet<T>>::batch_all(origin, vec![call]);
+
+			Self::deposit_event(Event::Remark { remark });
+
+			info
+		}
+	}
+}


### PR DESCRIPTION
# Description

Proof of concept for #1409 where we do not need to copy `pallet-utility`.

[Slack explanation](https://centrifugedao.slack.com/archives/C05DX0RH1T3/p1691147844607099)