### PR TITLE
ethereum-allowlist: Add allowlist pallet for Ethereum contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,6 +2689,7 @@ dependencies = [
  "pallet-democracy",
  "pallet-elections-phragmen",
  "pallet-ethereum",
+ "pallet-ethereum-allowlist",
  "pallet-ethereum-transaction",
  "pallet-evm",
  "pallet-evm-chain-id",
@@ -7292,6 +7293,22 @@ dependencies = [
  "parity-scale-codec 3.4.0",
  "rlp",
  "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-ethereum-allowlist"
+version = "1.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec 3.4.0",
+ "scale-info",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
   "pallets/collator-allowlist",
   "pallets/crowdloan-claim",
   "pallets/crowdloan-reward",
+  "pallets/ethereum-allowlist",
   "pallets/ethereum-transaction",
   "pallets/fees",
   "pallets/interest-accrual",

--- a/pallets/ethereum-allowlist/Cargo.toml
+++ b/pallets/ethereum-allowlist/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "pallet-ethereum-allowlist"
+authors = ["Centrifuge <admin@centrifuge.io>"]
+description = "Ethereum allowlist pallet"
+edition = "2021"
+license = "LGPL-3.0"
+repository = "https://github.com/centrifuge/centrifuge-chain"
+version = "1.0.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
+
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.38" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+
+[dev-dependencies]
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.38" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = true, branch = "polkadot-v0.9.38" }
+
+[features]
+default = ["std"]
+runtime-benchmarks = [
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+  "sp-runtime/runtime-benchmarks",
+]
+std = [
+  "codec/std",
+  "scale-info/std",
+  "frame-support/std",
+  "frame-system/std",
+  "sp-runtime/std",
+  "sp-std/std",
+  "sp-core/std",
+  "frame-benchmarking/std",
+]
+try-runtime = [
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
+  "sp-runtime/try-runtime",
+]

--- a/pallets/ethereum-allowlist/src/lib.rs
+++ b/pallets/ethereum-allowlist/src/lib.rs
@@ -1,0 +1,118 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
+use frame_system::pallet_prelude::*;
+pub use pallet::*;
+use sp_core::{H160, H256};
+pub use weights::*;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub mod weights;
+
+/// This pallet is used as an allowlist for Ethereum contracts that can be
+/// created by an Ethereum account on the Centrifuge chain.
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// Origin used when adding/remove code hashes to an Ethereum account.
+		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// Weight information.
+		type WeightInfo: WeightInfo;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub (super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	/// Storage for the hashes of the Ethereum contract byte codes that an
+	/// Ethereum account is allowed to create.
+	#[pallet::storage]
+	pub type AccountCodeHashes<T: Config> =
+		StorageDoubleMap<_, Blake2_128Concat, H160, Blake2_128Concat, H256, (), ValueQuery>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub (super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Code hash added.
+		CodeHashAdded { account: H160, code_hash: H256 },
+		/// Code hash removed.
+		CodeHashRemoved { account: H160, code_hash: H256 },
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The code hash already exists.
+		CodeHashAlreadyExists,
+		/// The code hash was not found in storage.
+		CodeHashNotFound,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Add a code hash for a specific account to the storage.
+		#[pallet::weight(T::WeightInfo::add_code_hash())]
+		#[pallet::call_index(0)]
+		pub fn add_code_hash(
+			origin: OriginFor<T>,
+			account: H160,
+			code_hash: H256,
+		) -> DispatchResult {
+			T::AdminOrigin::ensure_origin(origin)?;
+
+			ensure!(
+				!AccountCodeHashes::<T>::contains_key(account, code_hash),
+				Error::<T>::CodeHashAlreadyExists,
+			);
+
+			AccountCodeHashes::<T>::insert(account, code_hash, ());
+
+			Self::deposit_event(Event::CodeHashAdded { account, code_hash });
+
+			Ok(())
+		}
+
+		/// Remove a code hash from storage.
+		#[pallet::weight(T::WeightInfo::remove_code_hash())]
+		#[pallet::call_index(1)]
+		pub fn remove_code_hash(
+			origin: OriginFor<T>,
+			account: H160,
+			code_hash: H256,
+		) -> DispatchResult {
+			T::AdminOrigin::ensure_origin(origin)?;
+
+			ensure!(
+				AccountCodeHashes::<T>::contains_key(account, code_hash),
+				Error::<T>::CodeHashNotFound,
+			);
+
+			AccountCodeHashes::<T>::remove(account, code_hash);
+
+			Self::deposit_event(Event::CodeHashRemoved { account, code_hash });
+
+			Ok(())
+		}
+	}
+}

--- a/pallets/ethereum-allowlist/src/mock.rs
+++ b/pallets/ethereum-allowlist/src/mock.rs
@@ -1,0 +1,92 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+use frame_support::parameter_types;
+use frame_system as system;
+use frame_system::EnsureRoot;
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+};
+
+use crate::{self as pallet_ethereum_allowlist, Config};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		EthereumAllowList: pallet_ethereum_allowlist,
+	}
+);
+
+// System config
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const SS58Prefix: u8 = 42;
+}
+
+pub type Balance = u128;
+
+impl system::Config for Runtime {
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type AccountId = u64;
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockHashCount = BlockHashCount;
+	type BlockLength = ();
+	type BlockNumber = u64;
+	type BlockWeights = ();
+	type DbWeight = ();
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type Header = Header;
+	type Index = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type OnKilledAccount = ();
+	type OnNewAccount = ();
+	type OnSetCode = ();
+	type PalletInfo = PalletInfo;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+	type SS58Prefix = SS58Prefix;
+	type SystemWeightInfo = ();
+	type Version = ();
+}
+
+impl Config for Runtime {
+	type AdminOrigin = EnsureRoot<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut ext: sp_io::TestExternalities = system::GenesisConfig::default()
+		.build_storage::<Runtime>()
+		.unwrap()
+		.into();
+
+	// Ensure that we set a block number otherwise no events would be deposited.
+	ext.execute_with(|| frame_system::Pallet::<Runtime>::set_block_number(1));
+
+	ext
+}

--- a/pallets/ethereum-allowlist/src/tests.rs
+++ b/pallets/ethereum-allowlist/src/tests.rs
@@ -1,0 +1,139 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+use frame_support::{assert_noop, assert_ok, dispatch::RawOrigin};
+use sp_runtime::{testing::H256, DispatchError::BadOrigin};
+
+use super::*;
+use crate::mock::{RuntimeEvent as MockEvent, *};
+
+mod utils {
+	use super::*;
+
+	pub fn event_exists<E: Into<MockEvent>>(e: E) {
+		let e: MockEvent = e.into();
+		assert!(frame_system::Pallet::<Runtime>::events()
+			.iter()
+			.any(|ev| ev.event == e));
+	}
+}
+
+use utils::*;
+
+mod add_code_hash {
+	use super::*;
+
+	#[test]
+	fn success() {
+		new_test_ext().execute_with(|| {
+			let account = H160::from_low_u64_be(1);
+			let code_hash = H256::from_low_u64_be(2);
+
+			assert_ok!(EthereumAllowList::add_code_hash(
+				RuntimeOrigin::root(),
+				account,
+				code_hash,
+			));
+
+			event_exists(Event::<Runtime>::CodeHashAdded { account, code_hash });
+		});
+	}
+
+	#[test]
+	fn invalid_origin() {
+		new_test_ext().execute_with(|| {
+			let account = H160::from_low_u64_be(1);
+			let code_hash = H256::from_low_u64_be(2);
+
+			assert_noop!(
+				EthereumAllowList::add_code_hash(RawOrigin::Signed(1).into(), account, code_hash,),
+				BadOrigin,
+			);
+		});
+	}
+
+	#[test]
+	fn code_hash_already_exists() {
+		new_test_ext().execute_with(|| {
+			let account = H160::from_low_u64_be(1);
+			let code_hash = H256::from_low_u64_be(2);
+
+			assert_ok!(EthereumAllowList::add_code_hash(
+				RuntimeOrigin::root(),
+				account,
+				code_hash,
+			));
+
+			assert_noop!(
+				EthereumAllowList::add_code_hash(RuntimeOrigin::root(), account, code_hash,),
+				Error::<Runtime>::CodeHashAlreadyExists,
+			);
+		});
+	}
+}
+
+mod remove_code_hash {
+	use super::*;
+
+	#[test]
+	fn success() {
+		new_test_ext().execute_with(|| {
+			let account = H160::from_low_u64_be(1);
+			let code_hash = H256::from_low_u64_be(2);
+
+			assert_ok!(EthereumAllowList::add_code_hash(
+				RuntimeOrigin::root(),
+				account,
+				code_hash,
+			));
+
+			assert_ok!(EthereumAllowList::remove_code_hash(
+				RuntimeOrigin::root(),
+				account,
+				code_hash,
+			));
+
+			event_exists(Event::<Runtime>::CodeHashRemoved { account, code_hash });
+		});
+	}
+
+	#[test]
+	fn invalid_origin() {
+		new_test_ext().execute_with(|| {
+			let account = H160::from_low_u64_be(1);
+			let code_hash = H256::from_low_u64_be(2);
+
+			assert_noop!(
+				EthereumAllowList::remove_code_hash(
+					RawOrigin::Signed(1).into(),
+					account,
+					code_hash,
+				),
+				BadOrigin,
+			);
+		});
+	}
+
+	#[test]
+	fn code_hash_not_found() {
+		new_test_ext().execute_with(|| {
+			let account = H160::from_low_u64_be(1);
+			let code_hash = H256::from_low_u64_be(2);
+
+			assert_noop!(
+				EthereumAllowList::remove_code_hash(RuntimeOrigin::root(), account, code_hash,),
+				Error::<Runtime>::CodeHashNotFound,
+			);
+		});
+	}
+}

--- a/pallets/ethereum-allowlist/src/weights.rs
+++ b/pallets/ethereum-allowlist/src/weights.rs
@@ -1,0 +1,29 @@
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// This file is part of Centrifuge chain project.
+
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+use frame_support::weights::Weight;
+
+pub trait WeightInfo {
+	fn add_code_hash() -> Weight;
+	fn remove_code_hash() -> Weight;
+}
+
+impl WeightInfo for () {
+	fn add_code_hash() -> Weight {
+		Weight::zero()
+	}
+
+	fn remove_code_hash() -> Weight {
+		Weight::zero()
+	}
+}

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -124,6 +124,7 @@ pallet-connectors-gateway = { path = "../../pallets/connectors-gateway", default
 pallet-crowdloan-claim = { path = "../../pallets/crowdloan-claim", default-features = false }
 pallet-crowdloan-reward = { path = "../../pallets/crowdloan-reward", default-features = false }
 pallet-data-collector = { path = "../../pallets/data-collector", default-features = false }
+pallet-ethereum-allowlist = { path = "../../pallets/ethereum-allowlist", default-features = false }
 pallet-ethereum-transaction = { path = "../../pallets/ethereum-transaction", default-features = false }
 pallet-fees = { path = "../../pallets/fees", default-features = false }
 pallet-interest-accrual = { path = "../../pallets/interest-accrual", default-features = false }
@@ -200,6 +201,7 @@ std = [
   "pallet-democracy/std",
   "pallet-elections-phragmen/std",
   "pallet-ethereum/std",
+  "pallet-ethereum-allowlist/std",
   "pallet-ethereum-transaction/std",
   "pallet-evm/std",
   "pallet-evm-precompile-dispatch/std",
@@ -293,6 +295,7 @@ runtime-benchmarks = [
   "pallet-crowdloan-reward/runtime-benchmarks",
   "pallet-data-collector/runtime-benchmarks",
   "pallet-ethereum/runtime-benchmarks",
+  "pallet-ethereum-allowlist/runtime-benchmarks",
   "pallet-ethereum-transaction/runtime-benchmarks",
   "pallet-evm/runtime-benchmarks",
   "pallet-fees/runtime-benchmarks",
@@ -422,6 +425,7 @@ try-runtime = [
   "pallet-evm-chain-id/try-runtime",
   "pallet-base-fee/try-runtime",
   "pallet-ethereum/try-runtime",
+  "pallet-ethereum-allowlist/try-runtime",
   "pallet-ethereum-transaction/try-runtime",
   "fp-self-contained/try-runtime",
   "runtime-common/try-runtime",

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1657,6 +1657,12 @@ impl pallet_sudo::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 }
 
+impl pallet_ethereum_allowlist::Config for Runtime {
+	type AdminOrigin = EnsureRootOr<AllOfCouncil>;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+}
+
 parameter_types! {
 	pub const MaxKeys: u32 = 10;
 	pub const DefaultKeyDeposit: Balance = 100 * CFG;
@@ -1934,8 +1940,9 @@ construct_runtime!(
 		TransferAllowList: pallet_transfer_allowlist::{Pallet, Call, Storage, Event<T>} = 112,
 		PriceCollector: pallet_data_collector::{Pallet, Storage} = 113,
 		GapRewardMechanism: pallet_rewards::mechanism::gap = 114,
-		ConnectorsGateway: pallet_connectors_gateway::{Pallet, Call, Storage, Event<T>, Origin } = 115,
+		ConnectorsGateway: pallet_connectors_gateway::{Pallet, Call, Storage, Event<T>, Origin} = 115,
 		OrderBook: pallet_order_book::{Pallet, Call, Storage, Event<T>} = 116,
+		EthereumAllowlist: pallet_ethereum_allowlist::{Pallet, Call, Storage, Event<T>} = 117,
 
 		// XCM
 		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 120,


### PR DESCRIPTION
# Description

Adds a new pallet that serves as an allowlist for contracts that can be added by an Ethereum account.

This pallet will be used when processing an EVM `create` call to ensure that no contract is created if the account and the hash of the contract code is not in the allowlist.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
