### PR TITLE
Github codeowners/templates changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,16 @@
 # Centrifudge Code Owners
 
 ## Changes to .github
-.github/* @mikiquantum @mustermeiszer @branan @NunoAlexandre
+.github/* @mikiquantum @mustermeiszer @branan @NunoAlexandre @lemunozm
 
 ## Changes to ci
-ci/* @mikiquantum @mustermeiszer @branan @NunoAlexandre
+ci/* @mikiquantum @mustermeiszer @branan @NunoAlexandre @lemunozm
 
 ## Changes to the service of our chain.
 node/* @mikiquantum @mustermeiszer @branan @NunoAlexandre
 
 ## Changes to chain-specs
 node/res/* @mikiquantum @mustermeiszer @branan @NunoAlexandre @wischli
-
-## Changes to toml files
-*.toml @mikiquantum @mustermeiszer @branan @NunoAlexandre @lemunozm @wischli @cdamian @thea-leake
 
 ## Changes to specific pallets
 pallets/liquidity-pools/* @NunoAlexandre @cdamian @wischli @mustermeiszer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,8 +20,8 @@ pallets/block-rewards/* @wischli @lemunozm
 pallets/nft-sales/* @NunoAlexandre
 pallets/keystore/* @cdamian
 pallets/pool-registry/* @mustermeiszer
-pallets/pool-system/* @mustermeiszer @offerijns
-pallets/loans/* @mustermeiszer @offerijns @lemunozm
+pallets/pool-system/* @mustermeiszer @hieronx
+pallets/loans/* @mustermeiszer @hieronx @lemunozm
 pallets/interest-accrual/* @lemunozm
 pallets/investments/* @mustermeiszer
 pallets/permissions/* @mustermeiszer
@@ -38,9 +38,9 @@ libs/traits/src/changes.rs @lemunozm
 libs/traits/src/data.rs @lemunozm
 
 ## Changes to runtime
-runtime/common/* @mustermeiszer @NunoAlexandre @offerijns @lemunozm
-runtime/altair/* @mustermeiszer @NunoAlexandre @offerijns @wischli
-runtime/centrifuge/* @mustermeiszer @NunoAlexandre @offerijns @wischli
+runtime/common/* @mustermeiszer @NunoAlexandre @hieronx @lemunozm
+runtime/altair/* @mustermeiszer @NunoAlexandre @hieronx @wischli
+runtime/centrifuge/* @mustermeiszer @NunoAlexandre @hieronx @wischli
 
 ## Changes to integration tests
 runtime/integration-tests/* @mustermeiszer @NunoAlexandre @wischli @cdamian

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,34 +1,34 @@
 # Centrifudge Code Owners
 
 ## Changes to .github
-.github/* @mikiquantum @mustermeiszer @branan @NunoAlexandre @lemunozm
+.github/* @mustermeiszer @NunoAlexandre @lemunozm
 
 ## Changes to ci
-ci/* @mikiquantum @mustermeiszer @branan @NunoAlexandre @lemunozm
+ci/* @mustermeiszer @NunoAlexandre @lemunozm
 
 ## Changes to the service of our chain.
-node/* @mikiquantum @mustermeiszer @branan @NunoAlexandre
+node/* @mustermeiszer @NunoAlexandre
 
 ## Changes to chain-specs
-node/res/* @mikiquantum @mustermeiszer @branan @NunoAlexandre @wischli
+node/res/* @mustermeiszer @NunoAlexandre @wischli
 
 ## Changes to specific pallets
 pallets/liquidity-pools/* @NunoAlexandre @cdamian @wischli @mustermeiszer
-pallets/rewards/* @lemunozm @mikiquantum
-pallets/liquidity-rewards/* @lemunozm @mikiquantum
+pallets/rewards/* @lemunozm
+pallets/liquidity-rewards/* @lemunozm
 pallets/block-rewards/* @wischli @lemunozm
 pallets/nft-sales/* @NunoAlexandre
-pallets/keystore/* @cdamian @mikiquantum
+pallets/keystore/* @cdamian
 pallets/pool-registry/* @mustermeiszer
-pallets/pool-system/* @mustermeiszer @branan @offerijns
-pallets/loans/* @mustermeiszer @branan @offerijns @lemunozm
-pallets/interest-accrual/* @branan @lemunozm
+pallets/pool-system/* @mustermeiszer @offerijns
+pallets/loans/* @mustermeiszer @offerijns @lemunozm
+pallets/interest-accrual/* @lemunozm
 pallets/investments/* @mustermeiszer
 pallets/permissions/* @mustermeiszer
 pallets/restricted-tokens/* @mustermeiszer
 pallets/data-collector/* @lemunozm
-pallets/fees/* @lemunozm @mikiquantum
-pallets/transfer-allowlist/* @thea-leake @mustermeiszer
+pallets/fees/* @lemunozm
+pallets/transfer-allowlist/* @mustermeiszer
 
 ## Changes to specific libraries
 libs/mock-builder/* @lemunozm
@@ -38,9 +38,9 @@ libs/traits/src/changes.rs @lemunozm
 libs/traits/src/data.rs @lemunozm
 
 ## Changes to runtime
-runtime/common/* @branan @mikiquantum @mustermeiszer @NunoAlexandre @offerijns @lemunozm
-runtime/altair/* @branan @mikiquantum @mustermeiszer @NunoAlexandre @offerijns @wischli
-runtime/centrifuge/* @branan @mikiquantum @mustermeiszer @NunoAlexandre @offerijns @wischli
+runtime/common/* @mustermeiszer @NunoAlexandre @offerijns @lemunozm
+runtime/altair/* @mustermeiszer @NunoAlexandre @offerijns @wischli
+runtime/centrifuge/* @mustermeiszer @NunoAlexandre @offerijns @wischli
 
 ## Changes to integration tests
 runtime/integration-tests/* @mustermeiszer @NunoAlexandre @wischli @cdamian

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,15 +1,2 @@
-### Description
+# Description
 
-[Description of the issue or feature]
-
-### Research/based on
-
-[Which codebases, pallets or designs did you base your design on]
-
-### How will this affect the code base
-
-[Does it improve readability, performance? Will it introduce new complexity?]
-
-### What are foreseen obstacles or hurdles to overcome?
-
-[Are migrations needed, structural changes around testing etc?]

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,2 +1,15 @@
-# Description
+### Description
 
+[Description of the issue or feature]
+
+### Research/based on
+
+[Which codebases, pallets or designs did you base your design on]
+
+### How will this affect the code base
+
+[Does it improve readability, performance? Will it introduce new complexity?]
+
+### What are foreseen obstacles or hurdles to overcome?
+
+[Are migrations needed, structural changes around testing etc?]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,9 @@
 # Description
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+[description]
 
-Fixes # (issue)
+Fixes #(issue)
 
 ## Changes and Descriptions
 
 [List your changes here]
-
-# Checklist:
-
-- [ ] I have added Rust doc comments to structs, enums, traits and functions
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have performed a self-review of my code
-- [ ] I have added tests that prove my fix is effective or that my feature works

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,10 @@ Fixes #(issue)
 ## Changes and Descriptions
 
 [List your changes here]
+
+# Checklist:
+
+- [ ] I have added Rust doc comments to structs, enums, traits and functions
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have performed a self-review of my code
+- [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
## Changes and Descriptions

- Removed `*.toml` matching to avoid having all of us in all PRs.
- (opinionated) Removed more template sections. I think most of all, do not use those sections, and in a lot of cases, it does not apply to the issue/PR purpose, and it only puts another mind barrier to open new issues. I think open issues should be something fast/easy/kind to incentivize tracking our task.