### PR TITLE
fix: identifying algol chain correctly

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -56,6 +56,7 @@ impl IdentifyChain for dyn sc_service::ChainSpec {
 		} else if self.id().starts_with("altair")
 			|| self.id().starts_with("charcoal")
 			|| self.id().starts_with("antares")
+			|| self.id().starts_with("algol")
 		{
 			ChainIdentity::Altair
 		} else {


### PR DESCRIPTION
# Description

Identifycation of path based specs is based in the `id` string. We did not adapt our matching case for `algol` and it is wrongly identified as `Development` then, making the start-up fail.