### PR TITLE
Loans: Quantity with decimal support

### DIFF
--- a/pallets/loans/src/entities/pricing/external.rs
+++ b/pallets/loans/src/entities/pricing/external.rs
@@ -81,13 +81,6 @@ pub struct ExternalPricing<T: Config> {
 
 impl<T: Config> ExternalPricing<T> {
 	pub fn validate(&self) -> DispatchResult {
-		if let MaxBorrowAmount::Quantity(quantity) = self.max_borrow_amount {
-			ensure!(
-				quantity.frac().is_zero() && quantity >= T::Quantity::zero(),
-				Error::<T>::AmountNotNaturalNumber
-			)
-		}
-
 		Ok(())
 	}
 }
@@ -217,15 +210,10 @@ impl<T: Config> ExternalActivePricing<T> {
 	) -> DispatchResult {
 		self.outstanding_quantity = quantity_adj.ensure_add(self.outstanding_quantity)?;
 
-		let interest_adj = quantity_adj.try_map(|quantity| -> Result<_, DispatchError> {
-			ensure!(
-				quantity.frac().is_zero() && quantity >= T::Quantity::zero(),
-				Error::<T>::AmountNotNaturalNumber
-			);
-
-			Ok(quantity
+		let interest_adj = quantity_adj.try_map(|quantity| {
+			quantity
 				.ensure_mul_int(self.info.notional)?
-				.ensure_add(interest)?)
+				.ensure_add(interest)
 		})?;
 
 		self.interest.adjust_debt(interest_adj)?;

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -360,8 +360,6 @@ pub mod pallet {
 		NotLoanBorrower,
 		/// Emits when the max number of active loans was reached
 		MaxActiveLoansReached,
-		/// Emits when an amount used is not a natural number
-		AmountNotNaturalNumber,
 		/// The Change Id does not belong to a loan change
 		NoLoanChangeId,
 		/// The Change Id exists but it's not releated with the expected change

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -306,27 +306,6 @@ fn with_wrong_big_amount_external_pricing() {
 }
 
 #[test]
-fn with_wrong_quantity_amount_external_pricing() {
-	new_test_ext().execute_with(|| {
-		let loan_id = util::create_loan(util::base_external_loan());
-
-		// It's not multiple of PRICE_VALUE
-		let amount = ExternalAmount::new(Quantity::from_float(0.5), PRICE_VALUE);
-		config_mocks(amount.balance().unwrap());
-
-		assert_noop!(
-			Loans::borrow(
-				RuntimeOrigin::signed(BORROWER),
-				POOL_A,
-				loan_id,
-				PricingAmount::External(amount)
-			),
-			Error::<Runtime>::AmountNotNaturalNumber
-		);
-	});
-}
-
-#[test]
 fn with_incorrect_settlement_price_external_pricing() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_external_loan());

--- a/pallets/loans/src/tests/create_loan.rs
+++ b/pallets/loans/src/tests/create_loan.rs
@@ -152,28 +152,6 @@ fn with_wrong_interest_rate() {
 }
 
 #[test]
-fn with_no_natural_quantity() {
-	new_test_ext().execute_with(|| {
-		config_mocks(POOL_A);
-
-		let loan = LoanInfo {
-			pricing: Pricing::External(ExternalPricing {
-				max_borrow_amount: ExtMaxBorrowAmount::Quantity(
-					QUANTITY + Quantity::from_float(0.1),
-				),
-				..util::base_external_pricing()
-			}),
-			..util::base_external_loan()
-		};
-
-		assert_noop!(
-			Loans::create(RuntimeOrigin::signed(BORROWER), POOL_A, loan),
-			Error::<Runtime>::AmountNotNaturalNumber
-		);
-	});
-}
-
-#[test]
 fn with_unregister_price_id() {
 	new_test_ext().execute_with(|| {
 		config_mocks(POOL_A);

--- a/pallets/loans/src/tests/repay_loan.rs
+++ b/pallets/loans/src/tests/repay_loan.rs
@@ -589,31 +589,6 @@ fn external_pricing_goes_down() {
 }
 
 #[test]
-fn external_pricing_with_wrong_quantity() {
-	new_test_ext().execute_with(|| {
-		let loan_id = util::create_loan(util::base_external_loan());
-		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
-		util::borrow_loan(loan_id, PricingAmount::External(amount));
-
-		let amount = ExternalAmount::new(Quantity::from_float(0.5), PRICE_VALUE);
-		config_mocks(amount.balance().unwrap());
-		assert_noop!(
-			Loans::repay(
-				RuntimeOrigin::signed(BORROWER),
-				POOL_A,
-				loan_id,
-				RepaidPricingAmount {
-					principal: PricingAmount::External(amount),
-					interest: 0,
-					unscheduled: 0,
-				},
-			),
-			Error::<Runtime>::AmountNotNaturalNumber
-		);
-	});
-}
-
-#[test]
 fn with_unscheduled_repayment_internal() {
 	new_test_ext().execute_with(|| {
 		let loan_id = util::create_loan(util::base_internal_loan());


### PR DESCRIPTION
# Description

Remove the restriction for external pricing quantities where an integer number was mandatory.
