### PR TITLE
Loans: close with repays amount

### DIFF
--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -105,7 +105,7 @@ impl<T: Config> CreatedLoan<T> {
 			closed_at: frame_system::Pallet::<T>::current_block_number(),
 			info: self.info,
 			total_borrowed: Zero::zero(),
-			total_repaid: Zero::zero(),
+			total_repaid: Default::default(),
 		};
 
 		Ok((loan, self.borrower))
@@ -126,7 +126,7 @@ pub struct ClosedLoan<T: Config> {
 	total_borrowed: T::Balance,
 
 	/// Total repaid amount of this loan
-	total_repaid: T::Balance,
+	total_repaid: RepaidAmount<T::Balance>,
 }
 
 impl<T: Config> ClosedLoan<T> {
@@ -456,7 +456,7 @@ impl<T: Config> ActiveLoan<T> {
 				restrictions: self.restrictions,
 			},
 			total_borrowed: self.total_borrowed,
-			total_repaid: self.total_repaid.total()?,
+			total_repaid: self.total_repaid,
 		};
 
 		Ok((loan, self.borrower))

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -376,6 +376,11 @@ fn with_correct_settlement_price_external_pricing() {
 			PricingAmount::External(amount)
 		));
 
+		assert_eq!(
+			(QUANTITY / 3.into()).saturating_mul_int(PRICE_VALUE),
+			util::current_loan_pv(loan_id)
+		);
+
 		// Same
 		let amount = ExternalAmount::new(QUANTITY / 3.into(), PRICE_VALUE);
 		config_mocks(amount.balance().unwrap());
@@ -386,6 +391,11 @@ fn with_correct_settlement_price_external_pricing() {
 			loan_id,
 			PricingAmount::External(amount)
 		));
+
+		assert_eq!(
+			(QUANTITY / 3.into()).saturating_mul_int(PRICE_VALUE) * 2,
+			util::current_loan_pv(loan_id)
+		);
 
 		// Lower
 		let amount = ExternalAmount::new(
@@ -400,6 +410,11 @@ fn with_correct_settlement_price_external_pricing() {
 			loan_id,
 			PricingAmount::External(amount)
 		));
+
+		assert_eq!(
+			QUANTITY.saturating_mul_int(PRICE_VALUE),
+			util::current_loan_pv(loan_id)
+		);
 	});
 }
 

--- a/pallets/loans/src/tests/repay_loan.rs
+++ b/pallets/loans/src/tests/repay_loan.rs
@@ -730,6 +730,11 @@ fn with_correct_settlement_price_external_pricing() {
 			},
 		));
 
+		assert_eq!(
+			(QUANTITY / 3.into()).saturating_mul_int(PRICE_VALUE) * 2,
+			util::current_loan_pv(loan_id)
+		);
+
 		// Same
 		let amount = ExternalAmount::new(QUANTITY / 3.into(), PRICE_VALUE);
 		config_mocks_with_price(amount.balance().unwrap(), PRICE_VALUE);
@@ -743,6 +748,11 @@ fn with_correct_settlement_price_external_pricing() {
 				unscheduled: 0,
 			},
 		));
+
+		assert_eq!(
+			(QUANTITY / 3.into()).saturating_mul_int(PRICE_VALUE),
+			util::current_loan_pv(loan_id)
+		);
 
 		// Lower
 		let amount = ExternalAmount::new(
@@ -761,6 +771,7 @@ fn with_correct_settlement_price_external_pricing() {
 			},
 		));
 
+		assert_eq!(0, util::current_loan_pv(loan_id));
 		assert_eq!(0, util::current_loan_debt(loan_id));
 	});
 }


### PR DESCRIPTION
# Description

Minor loans changes.

## Changes and Descriptions

- `ClosedLoans` contains the split repaid amounts instead of the total.
- Extra: Add extra checks for present value in external pricing
