### PR TITLE
Add nuke migration for loans & interest-accrual

### DIFF
--- a/pallets/interest-accrual/src/lib.rs
+++ b/pallets/interest-accrual/src/lib.rs
@@ -167,20 +167,6 @@ pub struct RateDetails<Rate> {
 	pub reference_count: u32,
 }
 
-#[derive(Encode, Decode, TypeInfo, PartialEq, Eq, MaxEncodedLen, RuntimeDebug)]
-#[repr(u32)]
-pub enum Release {
-	V0,
-	V1,
-	V2,
-}
-
-impl Default for Release {
-	fn default() -> Self {
-		Self::V2
-	}
-}
-
 #[frame_support::pallet]
 pub mod pallet {
 	use frame_support::pallet_prelude::*;
@@ -188,8 +174,11 @@ pub mod pallet {
 	use super::*;
 	use crate::weights::WeightInfo;
 
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
+
 	#[pallet::pallet]
 	#[pallet::generate_store(pub (super) trait Store)]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
@@ -234,10 +223,6 @@ pub mod pallet {
 	#[pallet::getter(fn last_updated)]
 	pub(super) type LastUpdated<T: Config> = StorageValue<_, Moment, ValueQuery>;
 
-	#[pallet::storage]
-	#[pallet::getter(fn storage_version)]
-	pub(super) type StorageVersion<T: Config> = StorageValue<_, Release, ValueQuery>;
-
 	#[pallet::event]
 	pub enum Event<T: Config> {}
 
@@ -253,23 +238,6 @@ pub mod pallet {
 		InvalidRate,
 		/// Emits when adding a new rate would exceed the storage limits
 		TooManyRates,
-	}
-
-	#[pallet::genesis_config]
-	pub struct GenesisConfig<T: Config>(core::marker::PhantomData<T>);
-
-	#[cfg(feature = "std")]
-	impl<T: Config> Default for GenesisConfig<T> {
-		fn default() -> Self {
-			Self(core::marker::PhantomData)
-		}
-	}
-
-	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
-		fn build(&self) {
-			StorageVersion::<T>::put(Release::V2);
-		}
 	}
 
 	#[pallet::hooks]

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1735,7 +1735,7 @@ construct_runtime!(
 		NftSales: pallet_nft_sales::{Pallet, Call, Storage, Event<T>} = 98,
 		PoolSystem: pallet_pool_system::{Pallet, Call, Storage, Event<T>} = 99,
 		Loans: pallet_loans::{Pallet, Call, Storage, Event<T>} = 100,
-		InterestAccrual: pallet_interest_accrual::{Pallet, Storage, Event<T>, Config<T>} = 101,
+		InterestAccrual: pallet_interest_accrual::{Pallet, Storage, Event<T>} = 101,
 		Investments: pallet_investments::{Pallet, Call, Storage, Event<T>} = 102,
 		PoolRegistry: pallet_pool_registry::{Pallet, Call, Storage, Event<T>} = 103,
 		BlockRewardsBase: pallet_rewards::<Instance1>::{Pallet, Storage, Event<T>, Config<T>} = 104,

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -23,6 +23,8 @@ pub type UpgradeAltair1028 = (
 	asset_registry::CrossChainTransferabilityMigration,
 	orml_tokens_migration::CurrencyIdRefactorMigration,
 	pool_system::MigrateAUSDPools,
+	runtime_common::migrations::nuke::Migration<crate::Loans, crate::RocksDbWeight, 1>,
+	runtime_common::migrations::nuke::Migration<crate::InterestAccrual, crate::RocksDbWeight, 0>,
 );
 
 const DEPRECATED_AUSD_CURRENCY_ID: CurrencyId = CurrencyId::AUSD;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1801,7 +1801,7 @@ construct_runtime!(
 		PoolSystem: pallet_pool_system::{Pallet, Call, Storage, Event<T>} = 181,
 		Permissions: pallet_permissions::{Pallet, Call, Storage, Event<T>} = 182,
 		Investments: pallet_investments::{Pallet, Call, Storage, Event<T>} = 183,
-		InterestAccrual: pallet_interest_accrual::{Pallet, Storage, Event<T>, Config<T>} = 184,
+		InterestAccrual: pallet_interest_accrual::{Pallet, Storage, Event<T>} = 184,
 		Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 185,
 		Keystore: pallet_keystore::{Pallet, Call, Storage, Event<T>} = 186,
 		Loans: pallet_loans::{Pallet, Call, Storage, Event<T>} = 187,

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -15,7 +15,11 @@ use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 
 use crate::Runtime;
 
-pub type UpgradeCentrifuge1020 = (asset_registry::CrossChainTransferabilityMigration,);
+pub type UpgradeCentrifuge1020 = (
+	asset_registry::CrossChainTransferabilityMigration,
+	runtime_common::migrations::nuke::Migration<crate::Loans, crate::RocksDbWeight, 1>,
+	runtime_common::migrations::nuke::Migration<crate::InterestAccrual, crate::RocksDbWeight, 0>,
+);
 
 mod asset_registry {
 	use cfg_types::{tokens as v1, tokens::CustomMetadata};

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1912,7 +1912,7 @@ construct_runtime!(
 		Tokens: pallet_restricted_tokens::{Pallet, Call, Event<T>} = 99,
 		NftSales: pallet_nft_sales::{Pallet, Call, Storage, Event<T>} = 100,
 		Bridge: pallet_bridge::{Pallet, Call, Storage, Config<T>, Event<T>} = 101,
-		InterestAccrual: pallet_interest_accrual::{Pallet, Storage, Event<T>, Config<T>} = 102,
+		InterestAccrual: pallet_interest_accrual::{Pallet, Storage, Event<T>} = 102,
 		Nfts: pallet_nft::{Pallet, Call, Event<T>} = 103,
 		Keystore: pallet_keystore::{Pallet, Call, Storage, Event<T>} = 104,
 		Investments: pallet_investments::{Pallet, Call, Storage, Event<T>} = 105,

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -641,7 +641,6 @@ fn centrifuge_genesis(
 			threshold: 1,
 		},
 		treasury: Default::default(),
-		interest_accrual: Default::default(),
 		block_rewards: centrifuge_runtime::BlockRewardsConfig {
 			collators: initial_authorities
 				.iter()
@@ -766,7 +765,6 @@ fn altair_genesis(
 		democracy: Default::default(),
 		parachain_system: Default::default(),
 		treasury: Default::default(),
-		interest_accrual: Default::default(),
 		base_fee: Default::default(),
 		evm_chain_id: development_runtime::EVMChainIdConfig {
 			chain_id: chain_id.into(),
@@ -915,7 +913,6 @@ fn development_genesis(
 		democracy: Default::default(),
 		parachain_system: Default::default(),
 		treasury: Default::default(),
-		interest_accrual: Default::default(),
 		block_rewards: development_runtime::BlockRewardsConfig {
 			collators: initial_authorities
 				.iter()


### PR DESCRIPTION
# Description

Fixes #1461

## Changes and Descriptions

- Nuke migration for `pallet-loans`
  - Tested in `altair` and `centrifuge`, and currently, there is nothing there. **Should we then add the migration?** I think it makes sense to remove anything anyone can add these days there until the next release.
- Nuke migration for `interest-accrual`
  - I removed the old `StorageVersion` storage in order to use the new one.
  - Found some rates that we can delete.

## Tests

### `altair`
Comand: 
```sh
RUST_LOG=runtime=trace,try-runtime::cli=trace,executor=trace cargo run --release --features try-runtime try-runtime --runtime target/release/wbuild/altair-runtime/altair_runtime.wasm --chain centrifuge on-runtime-upgrade live --uri wss://fullnode.altair.centrifuge.io:443
```
Output:
```
2023-08-17 16:38:24.490  INFO main runtime_common::migrations::nuke: Nuke-Loans: nuking pallet...
2023-08-17 16:38:24.490  INFO main runtime_common::migrations::nuke: Nuke-Loans: storage cleared successful
2023-08-17 16:38:24.490  INFO main runtime_common::migrations::nuke: Nuke-Loans: iteration result. backend: 1 unique: 1 loops: 1
2023-08-17 16:38:24.490  INFO main runtime_common::migrations::nuke: Nuke-InterestAccrual: nuking pallet...
2023-08-17 16:38:24.490  INFO main runtime_common::migrations::nuke: Nuke-InterestAccrual: storage cleared successful
2023-08-17 16:38:24.490  INFO main runtime_common::migrations::nuke: Nuke-InterestAccrual: iteration result. backend: 3 unique: 3 loops: 3
```

### `centrifuge`
Command:
```sh
RUST_LOG=runtime=trace,try-runtime::cli=trace,executor=trace cargo run --release --features try-runtime try-runtime --runtime target/release/wbuild/centrifuge-runtime/centrifuge_runtime.wasm --chain centrifuge on-runtime-upgrade live --uri wss://fullnode.centrifuge.io:443
```
Output:
```
2023-08-17 12:57:55.948  INFO main runtime_common::migrations::nuke: Nuke-Loans: nuking pallet...
2023-08-17 12:57:55.948  INFO main runtime_common::migrations::nuke: Nuke-Loans: storage cleared successful
2023-08-17 12:57:55.948  INFO main runtime_common::migrations::nuke: Nuke-Loans: iteration result. backend: 1 unique: 1 loops: 1
2023-08-17 12:57:55.948  INFO main runtime_common::migrations::nuke: Nuke-InterestAccrual: nuking pallet...
2023-08-17 12:57:55.948  INFO main runtime_common::migrations::nuke: Nuke-InterestAccrual: storage cleared successful
2023-08-17 12:57:55.948  INFO main runtime_common::migrations::nuke: Nuke-InterestAccrual: iteration result. backend: 2 unique: 2 loops: 2
```