### PR TITLE
Rewards: Add deposit for reward account for Altair. Enable liquidity rewards for all chains based on Altair

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1249,7 +1249,6 @@ impl pallet_block_rewards::Config for Runtime {
 
 // Liquidity rewards
 
-#[cfg(feature = "testnet-runtime")]
 parameter_types! {
 	#[derive(scale_info::TypeInfo)]
 	pub const MaxCurrencyMovements: u32 = 50;
@@ -1259,7 +1258,6 @@ parameter_types! {
 	pub const InitialEpochDuration: Moment = SECONDS_PER_MINUTE * 1000; // 1 min in milliseconds
 }
 
-#[cfg(feature = "testnet-runtime")]
 impl pallet_rewards::mechanism::gap::Config for Runtime {
 	type Balance = Balance;
 	type DistributionId = u32;
@@ -1268,7 +1266,6 @@ impl pallet_rewards::mechanism::gap::Config for Runtime {
 	type Rate = FixedI128;
 }
 
-#[cfg(feature = "testnet-runtime")]
 impl pallet_liquidity_rewards::Config for Runtime {
 	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type Balance = Balance;
@@ -1284,7 +1281,6 @@ impl pallet_liquidity_rewards::Config for Runtime {
 	type WeightInfo = weights::pallet_liquidity_rewards::WeightInfo<Runtime>;
 }
 
-#[cfg(feature = "testnet-runtime")]
 impl pallet_rewards::Config<pallet_rewards::Instance2> for Runtime {
 	type Currency = Tokens;
 	type CurrencyId = CurrencyId;
@@ -1795,11 +1791,8 @@ construct_runtime!(
 		PriceCollector: pallet_data_collector::{Pallet, Storage} = 107,
 		LiquidityPools: pallet_liquidity_pools::{Pallet, Call, Storage, Event<T>} = 108,
 		LiquidityPoolsGateway: pallet_liquidity_pools_gateway::{Pallet, Call, Storage, Event<T>, Origin } = 109,
-		#[cfg(feature = "testnet-runtime")]
 		LiquidityRewardsBase: pallet_rewards::<Instance2>::{Pallet, Storage, Event<T>, Config<T>} = 110,
-		#[cfg(feature = "testnet-runtime")]
 		LiquidityRewards: pallet_liquidity_rewards::{Pallet, Call, Storage, Event<T>} = 111,
-		#[cfg(feature = "testnet-runtime")]
 		GapRewardMechanism: pallet_rewards::mechanism::gap = 112,
 
 		// XCM

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -25,6 +25,12 @@ pub type UpgradeAltair1028 = (
 	pool_system::MigrateAUSDPools,
 	runtime_common::migrations::nuke::Migration<crate::Loans, crate::RocksDbWeight, 1>,
 	runtime_common::migrations::nuke::Migration<crate::InterestAccrual, crate::RocksDbWeight, 0>,
+	pallet_rewards::migrations::new_instance::FundExistentialDeposit<
+		crate::Runtime,
+		pallet_rewards::Instance2,
+		crate::NativeToken,
+		crate::ExistentialDeposit,
+	>,
 );
 
 const DEPRECATED_AUSD_CURRENCY_ID: CurrencyId = CurrencyId::AUSD;

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -768,7 +768,6 @@ fn altair_genesis(
 		},
 		ethereum: Default::default(),
 		evm: Default::default(),
-		#[cfg(feature = "testnet-runtime")]
 		liquidity_rewards_base: Default::default(),
 	}
 }


### PR DESCRIPTION
# Description

This PR adds:
- A migration to fund the distributed reward account with `ED`.
- Enable liquidity rewards for all chains based on `altair`. After this [slack conversation](https://kflabs.slack.com/archives/C04H9H7EVEE/p1692286840844139) resolution