### PR TITLE
altair: feature-gate migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "altair-runtime"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -37,7 +37,7 @@ pub type UpgradeAltair1030 = (
 	>,
 );
 
-/// The Upgrade set for Algol - it exludes the migrations already executed in
+/// The Upgrade set for Algol - it excludes the migrations already executed in
 /// the side releases that only landed on Algol (1028 & 1029) but not yet on
 /// Altair.
 #[cfg(feature = "testnet-runtime")]

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -19,12 +19,29 @@ use sp_std::vec::Vec;
 
 use crate::Runtime;
 
-// NOTE: Do not remove before Altair release, even if we might bump spec version
-// as this is most likely related to Algol
+/// The migration set for Altair 1030 @ Kusama. It includes all the migrations
+/// that have to be applied on that chain, which includes migrations that have
+/// already been executed on Algol (1028 & 1029).
+#[cfg(not(feature = "testnet-runtime"))]
 pub type UpgradeAltair1030 = (
 	asset_registry::CrossChainTransferabilityMigration,
 	orml_tokens_migration::CurrencyIdRefactorMigration,
 	pool_system::MigrateAUSDPools,
+	runtime_common::migrations::nuke::Migration<crate::Loans, crate::RocksDbWeight, 1>,
+	runtime_common::migrations::nuke::Migration<crate::InterestAccrual, crate::RocksDbWeight, 0>,
+	pallet_rewards::migrations::new_instance::FundExistentialDeposit<
+		crate::Runtime,
+		pallet_rewards::Instance2,
+		crate::NativeToken,
+		crate::ExistentialDeposit,
+	>,
+);
+
+/// The Upgrade set for Algol - it exludes the migrations already executed in
+/// the side releases that only landed on Algol (1028 & 1029) but not yet on
+/// Altair.
+#[cfg(feature = "testnet-runtime")]
+pub type UpgradeAltair1030 = (
 	runtime_common::migrations::nuke::Migration<crate::Loans, crate::RocksDbWeight, 1>,
 	runtime_common::migrations::nuke::Migration<crate::InterestAccrual, crate::RocksDbWeight, 0>,
 	pallet_rewards::migrations::new_instance::FundExistentialDeposit<


### PR DESCRIPTION
### Context

> This will run on Algol then?
>
>@NunoAlexandre IIRC you already tested that another run does not harm, right?
>
> https://github.com/centrifuge/centrifuge-chain/pull/1502#discussion_r1299732775


Currently, `Algol` is at `1029` going for `2030` while Altair is still at `1027` _maybe_ going to `2030`. This causes the migrations for each runtime to differ since the migration set meant for Altair 1028 was already executed on `Algol` but not yet on Altair.

Instead of relying on version checks to avoid migrations from re-runing and hopefully not break, here we feature gate the migration set to have a dedicated one for `Altair` (**not** `testnet-runtime`) which contains all the migrations applicable since `Altair 2017`, and one for `Algol` with only the migrations applicable since `Algol 1029`.