### PR TITLE
Use latest settlement price by default

### DIFF
--- a/pallets/loans/docs/types.md
+++ b/pallets/loans/docs/types.md
@@ -30,6 +30,7 @@ RepaymentSchedule *----> InterestPayments
 enum BorrowRestrictions {
     NoWrittenOff
     FullOnce
+    OraclePriceRequired
 }
 
 enum RepayRestrictions {

--- a/pallets/loans/docs/types.md
+++ b/pallets/loans/docs/types.md
@@ -166,6 +166,7 @@ package pricing {
             info: ExternalPricing
             outstanding_quantity: Rate,
             interest: ActiveInterestRate
+            latest_settlement_price: Option<Balance>
         }
 
         ExternalActivePricing *-r-> ActiveInterestRate

--- a/pallets/loans/docs/types.md
+++ b/pallets/loans/docs/types.md
@@ -166,7 +166,7 @@ package pricing {
             info: ExternalPricing
             outstanding_quantity: Rate,
             interest: ActiveInterestRate
-            latest_settlement_price: Option<Balance>
+            latest_settlement_price: Balance,
         }
 
         ExternalActivePricing *-r-> ActiveInterestRate

--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -192,7 +192,6 @@ impl<T: Config> ActiveLoan<T> {
 		Ok(ActiveLoan {
 			schedule: info.schedule,
 			collateral: info.collateral,
-			restrictions: info.restrictions,
 			borrower,
 			write_off_percentage: T::Rate::zero(),
 			origination_date: now,
@@ -206,9 +205,11 @@ impl<T: Config> ActiveLoan<T> {
 						info.interest_rate,
 						pool_id,
 						initial_amount.external()?,
+						info.restrictions.borrows == BorrowRestrictions::OraclePriceRequired,
 					)?)
 				}
 			},
+			restrictions: info.restrictions,
 			total_borrowed: T::Balance::zero(),
 			total_repaid: RepaidAmount::default(),
 			repayments_on_schedule_until: now,

--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -304,6 +304,12 @@ impl<T: Config> ActiveLoan<T> {
 				BorrowRestrictions::FullOnce => {
 					self.total_borrowed.is_zero() && amount.balance()? == max_borrow_amount
 				}
+				BorrowRestrictions::OraclePriceRequired => {
+					match &self.pricing {
+						ActivePricing::Internal(_) => true,
+						ActivePricing::External(inner) => inner.last_updated(pool_id).is_ok(),
+					}
+				}
 			},
 			Error::<T>::from(BorrowLoanError::Restriction)
 		);

--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -327,6 +327,9 @@ impl<T: Config> ActiveLoan<T> {
 				inner.adjust(Adjustment::Increase(amount.balance()?))?
 			}
 			ActivePricing::External(inner) => {
+				let settlement_price = amount.external()?.settlement_price;
+				inner.update_latest_settlement_price(settlement_price)?;
+
 				let quantity = amount.external()?.quantity;
 				inner.adjust(Adjustment::Increase(quantity), Zero::zero())?
 			}
@@ -402,7 +405,10 @@ impl<T: Config> ActiveLoan<T> {
 			}
 			ActivePricing::External(inner) => {
 				let quantity = amount.principal.external()?.quantity;
-				inner.adjust(Adjustment::Decrease(quantity), amount.interest)?
+				inner.adjust(Adjustment::Decrease(quantity), amount.interest)?;
+
+				let settlement_price = amount.principal.external()?.settlement_price;
+				inner.update_latest_settlement_price(settlement_price)?
 			}
 		}
 

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -471,7 +471,7 @@ pub mod pallet {
 				Some(created_loan) => {
 					Self::ensure_loan_borrower(&who, created_loan.borrower())?;
 
-					let mut active_loan = created_loan.activate(pool_id)?;
+					let mut active_loan = created_loan.activate(pool_id, amount.clone())?;
 					active_loan.borrow(&amount, pool_id)?;
 
 					Self::insert_active_loan(pool_id, loan_id, active_loan)?

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -272,6 +272,8 @@ fn with_unregister_price_id() {
 		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
 		config_mocks(amount.balance().unwrap());
 
+		// TODO: test for loan with OraclePriceRequired borrow restriction
+
 		assert_ok!(Loans::borrow(
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -333,10 +333,10 @@ fn with_unregister_price_id_and_oracle_not_required() {
 		);
 
 		// Suddenty, the oracle set a value
-		MockPrices::mock_get(|_, _| Ok((PRICE_VALUE, BLOCK_TIME.as_secs())));
+		MockPrices::mock_get(|_, _| Ok((PRICE_VALUE * 8, BLOCK_TIME.as_secs())));
 
 		assert_eq!(
-			(QUANTITY).saturating_mul_int(PRICE_VALUE),
+			(QUANTITY).saturating_mul_int(PRICE_VALUE * 8),
 			util::current_loan_pv(loan_id)
 		);
 	});

--- a/pallets/loans/src/tests/mock.rs
+++ b/pallets/loans/src/tests/mock.rs
@@ -30,7 +30,7 @@ use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
-	FixedU128,
+	DispatchError, FixedU128,
 };
 
 use crate::{pallet as pallet_loans, ChangeOf};
@@ -73,6 +73,8 @@ pub const NOTIONAL: Balance = 1000;
 pub const QUANTITY: Quantity = Quantity::from_rational(12, 1);
 pub const CHANGE_ID: ChangeId = H256::repeat_byte(0x42);
 pub const MAX_PRICE_VARIATION: Rate = Rate::from_rational(1, 100);
+
+pub const PRICE_ID_NO_FOUND: DispatchError = DispatchError::Other("Price ID not found");
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/pallets/loans/src/types/mod.rs
+++ b/pallets/loans/src/types/mod.rs
@@ -172,6 +172,10 @@ pub enum BorrowRestrictions {
 
 	/// You only can borrow the full loan value once.
 	FullOnce,
+
+	/// The externally priced loan can only be borrowed
+	/// once an oracle price exists.
+	OraclePriceRequired,
 }
 
 /// Specify how offer a loan can be repaid


### PR DESCRIPTION
# Description

Adds behaviour that external assets can use latest settlement price instead of the oracle price, if no price has been fed. Also adds a borrow restriction that blocks this behaviour.

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
