### PR TITLE
ci: Publish Algol wasm to GCS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,10 @@ jobs:
         name: Publish to GCS
         run: |
           gsutil cp ./runtime/altair/target/srtool/release/wbuild/altair-runtime/altair_runtime.compact.compressed.wasm gs://centrifuge-artifact-releases/test-parachain/altair_runtime-$(git rev-parse --short HEAD).compact.compressed.wasm
+      - if: ${{ matrix.target == 'build-runtime-testnet' && matrix.package == 'altair-runtime' }}
+          name: Publish to GCS
+          run: |
+            gsutil cp ./runtime/altair/target/srtool/release/wbuild/altair-runtime/altair_runtime.compact.compressed.wasm gs://centrifuge-artifact-releases/parachain/algol-$(git rev-parse --short HEAD).compact.compressed.wasm
       - if: ${{ matrix.target == 'build-runtime' && matrix.package == 'centrifuge-runtime' }}
         name: Publish to GCS
         run: |


### PR DESCRIPTION
We cut a release for `Altair 1030 for Algol`, I realised after an `Unauthorised` runtime upgrade attempt, that we don't publish the `Algol` wasm runtime to GCS. 

So what I used for my attempted runtime upgrade was the output wasm of `build-runtime-fast` for Altair instead.

Here we do handle the `Publish to GCS` job for `target == 'build-runtime-testnet' && package == 'altair-runtime'`; in other words, for `Algol`. I also named the wasm stored on GCS `algol-{hash}` to avoid having multiple names to address it by and have it in different directories, etc.