### PR TITLE
ci: Fix build.yaml syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           gsutil cp ./runtime/altair/target/srtool/release/wbuild/altair-runtime/altair_runtime.compact.compressed.wasm gs://centrifuge-artifact-releases/test-parachain/altair_runtime-$(git rev-parse --short HEAD).compact.compressed.wasm
       - if: ${{ matrix.target == 'build-runtime-testnet' && matrix.package == 'altair-runtime' }}
-          name: Publish to GCS
-          run: |
-            gsutil cp ./runtime/altair/target/srtool/release/wbuild/altair-runtime/altair_runtime.compact.compressed.wasm gs://centrifuge-artifact-releases/parachain/algol-$(git rev-parse --short HEAD).compact.compressed.wasm
+        name: Publish to GCS
+        run: |
+          gsutil cp ./runtime/altair/target/srtool/release/wbuild/altair-runtime/altair_runtime.compact.compressed.wasm gs://centrifuge-artifact-releases/parachain/algol-$(git rev-parse --short HEAD).compact.compressed.wasm
       - if: ${{ matrix.target == 'build-runtime' && matrix.package == 'centrifuge-runtime' }}
         name: Publish to GCS
         run: |


### PR DESCRIPTION
Syntax fixup for https://github.com/centrifuge/centrifuge-chain/actions/runs/5947693754/workflow#L76.


✅  Installed and ran [actionlint](https://github.com/rhysd/actionlint/tree/main) locally to make sure this issue is resolved