### PR TITLE
LiquidityRewards: support for centrifuge runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "pallet-interest-accrual",
  "pallet-investments",
  "pallet-keystore",
+ "pallet-liquidity-rewards",
  "pallet-loans",
  "pallet-membership",
  "pallet-migration-manager",

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -116,6 +116,7 @@ pallet-fees = { path = "../../pallets/fees", default-features = false }
 pallet-interest-accrual = { path = "../../pallets/interest-accrual", default-features = false }
 pallet-investments = { path = "../../pallets/investments", default-features = false }
 pallet-keystore = { path = "../../pallets/keystore", default-features = false }
+pallet-liquidity-rewards = { path = "../../pallets/liquidity-rewards", default-features = false }
 pallet-loans = { path = "../../pallets/loans", default-features = false }
 pallet-migration-manager = { path = "../../pallets/migration", default-features = false }
 pallet-nft = { path = "../../pallets/nft", default-features = false }
@@ -190,6 +191,7 @@ std = [
   "pallet-identity/std",
   "pallet-interest-accrual/std",
   "pallet-investments/std",
+  "pallet-liquidity-rewards/std",
   "pallet-loans/std",
   "pallet-keystore/std",
   "pallet-migration-manager/std",
@@ -271,6 +273,7 @@ runtime-benchmarks = [
   "pallet-identity/runtime-benchmarks",
   "pallet-interest-accrual/runtime-benchmarks",
   "pallet-investments/runtime-benchmarks",
+  "pallet-liquidity-rewards/runtime-benchmarks",
   "pallet-loans/runtime-benchmarks",
   "pallet-keystore/runtime-benchmarks",
   "pallet-migration-manager/runtime-benchmarks",
@@ -343,6 +346,7 @@ try-runtime = [
   "pallet-identity/try-runtime",
   "pallet-interest-accrual/try-runtime",
   "pallet-investments/try-runtime",
+  "pallet-liquidity-rewards/try-runtime",
   "pallet-loans/try-runtime",
   "pallet-keystore/try-runtime",
   "pallet-migration-manager/try-runtime",

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -20,6 +20,12 @@ pub type UpgradeCentrifuge1020 = (
 	runtime_common::migrations::nuke::Migration<crate::Loans, RocksDbWeight, 1>,
 	runtime_common::migrations::nuke::Migration<crate::InterestAccrual, RocksDbWeight, 0>,
 	asset_registry::RegisterLpEthUSDC,
+	pallet_rewards::migrations::new_instance::FundExistentialDeposit<
+		crate::Runtime,
+		pallet_rewards::Instance2,
+		crate::NativeToken,
+		crate::ExistentialDeposit,
+	>,
 );
 
 mod asset_registry {

--- a/runtime/centrifuge/src/weights/mod.rs
+++ b/runtime/centrifuge/src/weights/mod.rs
@@ -25,6 +25,7 @@ pub mod pallet_fees;
 pub mod pallet_identity;
 pub mod pallet_interest_accrual;
 pub mod pallet_keystore;
+pub mod pallet_liquidity_rewards;
 pub mod pallet_loans;
 pub mod pallet_migration_manager;
 pub mod pallet_multisig;

--- a/runtime/centrifuge/src/weights/pallet_liquidity_rewards.rs
+++ b/runtime/centrifuge/src/weights/pallet_liquidity_rewards.rs
@@ -1,0 +1,37 @@
+//! File pending to be auto-generated
+
+use frame_support::weights::Weight;
+pub struct WeightInfo<T>(sp_std::marker::PhantomData<T>);
+impl<T: frame_system::Config> pallet_liquidity_rewards::WeightInfo for WeightInfo<T> {
+	fn on_initialize(_: u32, _: u32, _: u32) -> Weight {
+		Weight::zero()
+	}
+
+	fn stake() -> Weight {
+		Weight::zero()
+	}
+
+	fn unstake() -> Weight {
+		Weight::zero()
+	}
+
+	fn claim_reward() -> Weight {
+		Weight::zero()
+	}
+
+	fn set_distributed_reward() -> Weight {
+		Weight::zero()
+	}
+
+	fn set_epoch_duration() -> Weight {
+		Weight::zero()
+	}
+
+	fn set_group_weight() -> Weight {
+		Weight::zero()
+	}
+
+	fn set_currency_group() -> Weight {
+		Weight::zero()
+	}
+}

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -663,6 +663,7 @@ fn centrifuge_genesis(
 		},
 		ethereum: Default::default(),
 		evm: Default::default(),
+		liquidity_rewards_base: Default::default(),
 	}
 }
 


### PR DESCRIPTION
## Changes and Descriptions

- Liquidity reward pallets to centrifuge runtime.
- Added a migration to fund the distributed reward account with ED.
