### PR TITLE
Add Liquidity Pools related pallets to centrifuge runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,7 @@ dependencies = [
 name = "centrifuge-runtime"
 version = "0.10.20"
 dependencies = [
+ "axelar-gateway-precompile",
  "cfg-primitives",
  "cfg-traits",
  "cfg-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,9 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex-literal 0.3.4",
+ "liquidity-pools-gateway-routers",
  "log",
+ "moonbeam-relay-encoder",
  "orml-asset-registry",
  "orml-oracle",
  "orml-tokens",
@@ -1184,6 +1186,7 @@ dependencies = [
  "pallet-democracy",
  "pallet-elections-phragmen",
  "pallet-ethereum",
+ "pallet-ethereum-transaction",
  "pallet-evm",
  "pallet-evm-chain-id",
  "pallet-evm-precompile-dispatch",
@@ -1192,6 +1195,8 @@ dependencies = [
  "pallet-interest-accrual",
  "pallet-investments",
  "pallet-keystore",
+ "pallet-liquidity-pools",
+ "pallet-liquidity-pools-gateway",
  "pallet-liquidity-rewards",
  "pallet-loans",
  "pallet-membership",
@@ -1216,6 +1221,7 @@ dependencies = [
  "pallet-utility",
  "pallet-vesting",
  "pallet-xcm",
+ "pallet-xcm-transactor",
  "parachain-info",
  "parity-scale-codec 3.6.4",
  "polkadot-parachain",
@@ -1240,6 +1246,7 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
+ "xcm-primitives",
 ]
 
 [[package]]

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -73,7 +73,7 @@ mod asset_registry {
 	use cfg_types::{tokens as v1, tokens::CustomMetadata};
 	use frame_support::{pallet_prelude::OptionQuery, storage_alias, Twox64Concat};
 	use orml_traits::asset_registry::AssetMetadata;
-	use sp_std::{marker::PhantomData, vec::Vec};
+	use sp_std::marker::PhantomData;
 
 	use super::*;
 	use crate::VERSION;
@@ -250,12 +250,11 @@ mod asset_registry {
 			log::info!("Found {} LocationToAssetId keys ", loc_count);
 			log::info!("Found {} Metadata keys ", meta_count);
 
-			let assets_to_migrate;
-			if is_altair {
-				assets_to_migrate = get_altair_assets();
+			let assets_to_migrate = if is_altair {
+				get_altair_assets()
 			} else {
-				assets_to_migrate = get_algol_assets();
-			}
+				get_algol_assets()
+			};
 
 			assets_to_migrate
 				.iter()
@@ -428,122 +427,115 @@ pub fn get_algol_assets() -> Vec<(
 
 	vec![
 		(
-			CurrencyId::Tranche(3151673055, polka_jr.into()),
+			CurrencyId::Tranche(3151673055, polka_jr),
 			orml_asset_registry::AssetMetadata {
 				decimals: 6,
 				name: b"Polka Pool Junior".to_vec(),
 				symbol: b"PP1J".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
 					permissioned: true,
 					pool_currency: false,
 					transferability: CrossChainTransferability::LiquidityPools,
-				}
-				.into(),
+				},
 			},
 		),
 		(
-			CurrencyId::Tranche(3151673055, polka_mezz_1.into()),
+			CurrencyId::Tranche(3151673055, polka_mezz_1),
 			orml_asset_registry::AssetMetadata {
 				decimals: 6,
 				name: b"Polka Pool Mezz 1".to_vec(),
 				symbol: b"PP1M1".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
 					permissioned: true,
 					pool_currency: false,
 					transferability: CrossChainTransferability::LiquidityPools,
-				}
-				.into(),
+				},
 			},
 		),
 		(
-			CurrencyId::Tranche(3151673055, polka_mezz_2.into()),
+			CurrencyId::Tranche(3151673055, polka_mezz_2),
 			orml_asset_registry::AssetMetadata {
 				decimals: 6,
 				name: b"Polka Pool Mezz 2".to_vec(),
 				symbol: b"PP1M2".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
 					permissioned: true,
 					pool_currency: false,
 					transferability: CrossChainTransferability::LiquidityPools,
-				}
-				.into(),
+				},
 			},
 		),
 		(
-			CurrencyId::Tranche(3151673055, polka_mezz_3.into()),
+			CurrencyId::Tranche(3151673055, polka_mezz_3),
 			orml_asset_registry::AssetMetadata {
 				decimals: 6,
 				name: b"Polka Pool Mezz 3".to_vec(),
 				symbol: b"PP1M3".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
 					permissioned: true,
 					pool_currency: false,
 					transferability: CrossChainTransferability::LiquidityPools,
-				}
-				.into(),
+				},
 			},
 		),
 		(
-			CurrencyId::Tranche(3151673055, polka_senior.into()),
+			CurrencyId::Tranche(3151673055, polka_senior),
 			orml_asset_registry::AssetMetadata {
 				decimals: 6,
 				name: b"Polka Pool Senior".to_vec(),
 				symbol: b"PP1S".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
 					permissioned: true,
 					pool_currency: false,
 					transferability: CrossChainTransferability::LiquidityPools,
-				}
-				.into(),
+				},
 			},
 		),
 		(
-			CurrencyId::Tranche(3581766799, just_jr.into()),
+			CurrencyId::Tranche(3581766799, just_jr),
 			orml_asset_registry::AssetMetadata {
 				decimals: 6,
 				name: b"Just Logistics Series 3 Junior".to_vec(),
 				symbol: b"JL3JR".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
 					permissioned: true,
 					pool_currency: false,
 					transferability: CrossChainTransferability::LiquidityPools,
-				}
-				.into(),
+				},
 			},
 		),
 		(
-			CurrencyId::Tranche(3581766799, just_sr.into()),
+			CurrencyId::Tranche(3581766799, just_sr),
 			orml_asset_registry::AssetMetadata {
 				decimals: 6,
 				name: b"Just Logistics Series 3 Senior".to_vec(),
 				symbol: b"JL3SR".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
 					permissioned: true,
 					pool_currency: false,
 					transferability: CrossChainTransferability::LiquidityPools,
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -552,7 +544,7 @@ pub fn get_algol_assets() -> Vec<(
 				decimals: 6,
 				name: b"Tether USD".to_vec(),
 				symbol: b"USDT".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984)),
@@ -564,8 +556,7 @@ pub fn get_algol_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -574,7 +565,7 @@ pub fn get_algol_assets() -> Vec<(
 				decimals: 6,
 				name: b"LP Ethereum Wrapped USDC".to_vec(),
 				symbol: b"LpEthUSDC".to_vec(),
-				existential_deposit: 1_000u128.into(),
+				existential_deposit: 1_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					0,
 					Junctions::X3(
@@ -591,8 +582,7 @@ pub fn get_algol_assets() -> Vec<(
 					permissioned: false,
 					pool_currency: true,
 					transferability: CrossChainTransferability::LiquidityPools,
-				}
-				.into(),
+				},
 			},
 		),
 	]
@@ -618,7 +608,7 @@ pub fn get_altair_assets() -> Vec<(
 				decimals: 18,
 				name: b"Altair".to_vec(),
 				symbol: b"AIR".to_vec(),
-				existential_deposit: 1_000_000_000_000u128.into(),
+				existential_deposit: 1_000_000_000_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					0,
 					Junctions::X1(GeneralKey {
@@ -633,8 +623,7 @@ pub fn get_altair_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -643,7 +632,7 @@ pub fn get_altair_assets() -> Vec<(
 				decimals: 6,
 				name: b"Tether USDT".to_vec(),
 				symbol: b"USDT".to_vec(),
-				existential_deposit: 10_000u128.into(),
+				existential_deposit: 10_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984)),
@@ -655,8 +644,7 @@ pub fn get_altair_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -665,7 +653,7 @@ pub fn get_altair_assets() -> Vec<(
 				decimals: 12,
 				name: b"Acala Dollar".to_vec(),
 				symbol: b"aUSD".to_vec(),
-				existential_deposit: 10_000_000_000u128.into(),
+				existential_deposit: 10_000_000_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::X2(
@@ -683,8 +671,7 @@ pub fn get_altair_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -693,7 +680,7 @@ pub fn get_altair_assets() -> Vec<(
 				decimals: 12,
 				name: b"Kusama".to_vec(),
 				symbol: b"KSM".to_vec(),
-				existential_deposit: 10_000_000_000u128.into(),
+				existential_deposit: 10_000_000_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::Here,
@@ -705,20 +692,20 @@ pub fn get_altair_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 	]
 }
 
 // Returns the count of all keys sharing the same storage prefix
+#[allow(dead_code)]
 pub fn count_storage_keys(prefix: &[u8]) -> u32 {
 	let mut count = 0;
 	let mut next_key = prefix.to_vec();
 	loop {
 		match sp_io::storage::next_key(&next_key) {
-			Some(key) if !key.starts_with(&prefix) => break count,
+			Some(key) if !key.starts_with(prefix) => break count,
 			Some(key) => {
 				next_key = key;
 				count += 1;

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -101,10 +101,10 @@ pallet-evm-chain-id = { git = "https://github.com/PureStake/frontier", default-f
 pallet-evm-precompile-dispatch = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 
 # Our pallets and modules
-liquidity-pools-gateway-routers = { path = "../../pallets/liquidity-pools-gateway/routers", default-features = false }
 cfg-primitives = { path = "../../libs/primitives", default-features = false }
 cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-types = { path = "../../libs/types", default-features = false }
+liquidity-pools-gateway-routers = { path = "../../pallets/liquidity-pools-gateway/routers", default-features = false }
 pallet-anchors = { path = "../../pallets/anchors", default-features = false }
 pallet-block-rewards = { path = "../../pallets/block-rewards", default-features = false }
 pallet-bridge = { path = "../../pallets/bridge", default-features = false }
@@ -132,8 +132,8 @@ pallet-rewards = { path = "../../pallets/rewards", default-features = false }
 runtime-common = { path = "../common", default-features = false }
 
 # LiquidityPools 3rd-party dependencies
-pallet-xcm-transactor = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
 moonbeam-relay-encoder = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
+pallet-xcm-transactor = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
 xcm-primitives = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
 
 # bridge pallets

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -101,6 +101,7 @@ pallet-evm-chain-id = { git = "https://github.com/PureStake/frontier", default-f
 pallet-evm-precompile-dispatch = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 
 # Our pallets and modules
+axelar-gateway-precompile = { path = "../../pallets/liquidity-pools-gateway/axelar-gateway-precompile", default-features = false }
 cfg-primitives = { path = "../../libs/primitives", default-features = false }
 cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-types = { path = "../../libs/types", default-features = false }
@@ -253,6 +254,7 @@ std = [
   "xcm-executor/std",
   "xcm-primitives/std",
   "xcm/std",
+  "axelar-gateway-precompile/std",
 ]
 
 runtime-benchmarks = [
@@ -323,6 +325,7 @@ runtime-benchmarks = [
   "xcm-primitives/runtime-benchmarks",
   "pallet-claims/runtime-benchmarks",
   "pallet-rewards/runtime-benchmarks",
+  "axelar-gateway-precompile/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -401,6 +404,7 @@ try-runtime = [
   "polkadot-runtime-common/try-runtime",
   "runtime-common/try-runtime",
   "sp-runtime/try-runtime",
+  "axelar-gateway-precompile/try-runtime",
 ]
 
 # A feature that should be enabled when the runtime should be build for on-chain

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -55,7 +55,7 @@ sp-version = { git = "https://github.com/paritytech/substrate", default-features
 # frame dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.38" }
 frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, features = ["tuples-96"], branch = "polkadot-v0.9.38" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.38" }
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
@@ -101,6 +101,7 @@ pallet-evm-chain-id = { git = "https://github.com/PureStake/frontier", default-f
 pallet-evm-precompile-dispatch = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 
 # Our pallets and modules
+liquidity-pools-gateway-routers = { path = "../../pallets/liquidity-pools-gateway/routers", default-features = false }
 cfg-primitives = { path = "../../libs/primitives", default-features = false }
 cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-types = { path = "../../libs/types", default-features = false }
@@ -112,10 +113,13 @@ pallet-collator-allowlist = { path = "../../pallets/collator-allowlist", default
 pallet-crowdloan-claim = { path = "../../pallets/crowdloan-claim", default-features = false }
 pallet-crowdloan-reward = { path = "../../pallets/crowdloan-reward", default-features = false }
 pallet-data-collector = { path = "../../pallets/data-collector", default-features = false }
+pallet-ethereum-transaction = { path = "../../pallets/ethereum-transaction", default-features = false }
 pallet-fees = { path = "../../pallets/fees", default-features = false }
 pallet-interest-accrual = { path = "../../pallets/interest-accrual", default-features = false }
 pallet-investments = { path = "../../pallets/investments", default-features = false }
 pallet-keystore = { path = "../../pallets/keystore", default-features = false }
+pallet-liquidity-pools = { path = "../../pallets/liquidity-pools", default-features = false }
+pallet-liquidity-pools-gateway = { path = "../../pallets/liquidity-pools-gateway", default-features = false }
 pallet-liquidity-rewards = { path = "../../pallets/liquidity-rewards", default-features = false }
 pallet-loans = { path = "../../pallets/loans", default-features = false }
 pallet-migration-manager = { path = "../../pallets/migration", default-features = false }
@@ -126,6 +130,11 @@ pallet-pool-system = { path = "../../pallets/pool-system", default-features = fa
 pallet-restricted-tokens = { path = "../../pallets/restricted-tokens", default-features = false }
 pallet-rewards = { path = "../../pallets/rewards", default-features = false }
 runtime-common = { path = "../common", default-features = false }
+
+# LiquidityPools 3rd-party dependencies
+pallet-xcm-transactor = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
+moonbeam-relay-encoder = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
+xcm-primitives = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
 
 # bridge pallets
 chainbridge = { git = "https://github.com/centrifuge/chainbridge-substrate.git", default-features = false, branch = "polkadot-v0.9.38" }
@@ -160,6 +169,8 @@ std = [
   "frame-system-rpc-runtime-api/std",
   "frame-system/std",
   "frame-try-runtime/std",
+  "liquidity-pools-gateway-routers/std",
+  "moonbeam-relay-encoder/std",
   "orml-asset-registry/std",
   "orml-tokens/std",
   "orml-traits/std",
@@ -184,6 +195,7 @@ std = [
   "pallet-democracy/std",
   "pallet-elections-phragmen/std",
   "pallet-ethereum/std",
+  "pallet-ethereum-transaction/std",
   "pallet-evm/std",
   "pallet-evm-precompile-dispatch/std",
   "pallet-evm-chain-id/std",
@@ -191,6 +203,8 @@ std = [
   "pallet-identity/std",
   "pallet-interest-accrual/std",
   "pallet-investments/std",
+  "pallet-liquidity-pools/std",
+  "pallet-liquidity-pools-gateway/std",
   "pallet-liquidity-rewards/std",
   "pallet-loans/std",
   "pallet-keystore/std",
@@ -216,6 +230,7 @@ std = [
   "pallet-utility/std",
   "pallet-vesting/std",
   "pallet-xcm/std",
+  "pallet-xcm-transactor/std",
   "parachain-info/std",
   "polkadot-parachain/std",
   "polkadot-runtime-common/std",
@@ -236,6 +251,7 @@ std = [
   "sp-version/std",
   "xcm-builder/std",
   "xcm-executor/std",
+  "xcm-primitives/std",
   "xcm/std",
 ]
 
@@ -252,6 +268,7 @@ runtime-benchmarks = [
   "frame-system-benchmarking/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
   "hex-literal",
+  "liquidity-pools-gateway-routers/runtime-benchmarks",
   "orml-asset-registry/runtime-benchmarks",
   "orml-tokens/runtime-benchmarks",
   "orml-xtokens/runtime-benchmarks",
@@ -268,11 +285,14 @@ runtime-benchmarks = [
   "pallet-democracy/runtime-benchmarks",
   "pallet-elections-phragmen/runtime-benchmarks",
   "pallet-ethereum/runtime-benchmarks",
+  "pallet-ethereum-transaction/runtime-benchmarks",
   "pallet-evm/runtime-benchmarks",
   "pallet-fees/runtime-benchmarks",
   "pallet-identity/runtime-benchmarks",
   "pallet-interest-accrual/runtime-benchmarks",
   "pallet-investments/runtime-benchmarks",
+  "pallet-liquidity-pools/runtime-benchmarks",
+  "pallet-liquidity-pools-gateway/runtime-benchmarks",
   "pallet-liquidity-rewards/runtime-benchmarks",
   "pallet-loans/runtime-benchmarks",
   "pallet-keystore/runtime-benchmarks",
@@ -293,12 +313,14 @@ runtime-benchmarks = [
   "pallet-utility/runtime-benchmarks",
   "pallet-vesting/runtime-benchmarks",
   "pallet-xcm/runtime-benchmarks",
+  "pallet-xcm-transactor/runtime-benchmarks",
   "polkadot-parachain/runtime-benchmarks",
   "polkadot-runtime-common/runtime-benchmarks",
   "runtime-common/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
   "xcm-builder/runtime-benchmarks",
   "xcm-executor/runtime-benchmarks",
+  "xcm-primitives/runtime-benchmarks",
   "pallet-claims/runtime-benchmarks",
   "pallet-rewards/runtime-benchmarks",
 ]
@@ -318,6 +340,7 @@ try-runtime = [
   "frame-support/try-runtime",
   "frame-system/try-runtime",
   "frame-try-runtime",
+  "liquidity-pools-gateway-routers/try-runtime",
   "orml-asset-registry/try-runtime",
   "orml-tokens/try-runtime",
   "orml-xcm/try-runtime",
@@ -340,12 +363,15 @@ try-runtime = [
   "pallet-democracy/try-runtime",
   "pallet-elections-phragmen/try-runtime",
   "pallet-ethereum/try-runtime",
+  "pallet-ethereum-transaction/try-runtime",
   "pallet-evm/try-runtime",
   "pallet-evm-chain-id/try-runtime",
   "pallet-fees/try-runtime",
   "pallet-identity/try-runtime",
   "pallet-interest-accrual/try-runtime",
   "pallet-investments/try-runtime",
+  "pallet-liquidity-pools/try-runtime",
+  "pallet-liquidity-pools-gateway/try-runtime",
   "pallet-liquidity-rewards/try-runtime",
   "pallet-loans/try-runtime",
   "pallet-keystore/try-runtime",
@@ -370,6 +396,7 @@ try-runtime = [
   "pallet-utility/try-runtime",
   "pallet-vesting/try-runtime",
   "pallet-xcm/try-runtime",
+  "pallet-xcm-transactor/try-runtime",
   "parachain-info/try-runtime",
   "polkadot-runtime-common/try-runtime",
   "runtime-common/try-runtime",

--- a/runtime/centrifuge/src/evm.rs
+++ b/runtime/centrifuge/src/evm.rs
@@ -10,8 +10,9 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_primitives::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO};
+use cfg_primitives::{AccountId, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO};
 use frame_support::{parameter_types, traits::FindAuthor, weights::Weight, ConsensusEngineId};
+use frame_system::EnsureRoot;
 use pallet_evm::{EnsureAddressRoot, EnsureAddressTruncated};
 use runtime_common::{
 	account_conversion::AccountConverter,
@@ -86,5 +87,10 @@ impl pallet_ethereum::Config for crate::Runtime {
 }
 
 impl pallet_ethereum_transaction::Config for crate::Runtime {
+	type RuntimeEvent = crate::RuntimeEvent;
+}
+
+impl axelar_gateway_precompile::Config for crate::Runtime {
+	type AdminOrigin = EnsureRoot<AccountId>;
 	type RuntimeEvent = crate::RuntimeEvent;
 }

--- a/runtime/centrifuge/src/evm.rs
+++ b/runtime/centrifuge/src/evm.rs
@@ -84,3 +84,7 @@ impl pallet_ethereum::Config for crate::Runtime {
 	type RuntimeEvent = crate::RuntimeEvent;
 	type StateRoot = pallet_ethereum::IntermediateStateRoot<Self>;
 }
+
+impl pallet_ethereum_transaction::Config for crate::Runtime {
+	type RuntimeEvent = crate::RuntimeEvent;
+}

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -23,8 +23,9 @@
 use ::xcm::latest::{MultiAsset, MultiLocation};
 pub use cfg_primitives::{constants::*, types::*};
 use cfg_traits::{
-	liquidity_pools::InboundQueue, OrderManager, Permissions as PermissionsT, PoolNAV,
-	PoolUpdateGuard, PreConditions, TrancheCurrency as _,
+	liquidity_pools::{InboundQueue, OutboundQueue},
+	OrderManager, Permissions as PermissionsT, PoolNAV, PoolUpdateGuard, PreConditions,
+	TrancheCurrency as _,
 };
 use cfg_types::{
 	consts::pools::{MaxTrancheNameLengthBytes, MaxTrancheSymbolLengthBytes},
@@ -2050,7 +2051,6 @@ mod __runtime_api_use {
 
 #[cfg(not(feature = "disable-runtime-api"))]
 use __runtime_api_use::*;
-use cfg_traits::liquidity_pools::OutboundQueue;
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -19,8 +19,6 @@
 // Allow things like `1 * CFG`
 #![allow(clippy::identity_op)]
 
-// TODO(cdamian): Use V3?
-use ::xcm::latest::{MultiAsset, MultiLocation};
 pub use cfg_primitives::{constants::*, types::*};
 use cfg_traits::{
 	liquidity_pools::{InboundQueue, OutboundQueue},
@@ -104,7 +102,7 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use xcm_executor::XcmExecutor;
 
-use crate::xcm::{XcmConfig, XcmOriginToTransactDispatchOrigin};
+use crate::xcm::{MultiAsset, MultiLocation, XcmConfig, XcmOriginToTransactDispatchOrigin};
 
 pub mod evm;
 mod migrations;
@@ -431,6 +429,7 @@ impl orml_asset_registry::Config for Runtime {
 }
 
 parameter_types! {
+	// To be used if we want to register a particular asset in the chain spec, when running the chain locally.
 	pub LiquidityPoolsPalletIndex: PalletIndex = <LiquidityPools as PalletInfoAccess>::index() as u8;
 }
 
@@ -1282,9 +1281,8 @@ impl pallet_collator_selection::Config for Runtime {
 pub type XcmWeigher = xcm_builder::FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 
 parameter_types! {
-	// TODO(cdamian): is this correct?
-	// 1 DOT should be enough to cover for fees opening/accepting hrmp channels
-	pub MaxHrmpRelayFee: MultiAsset = (MultiLocation::parent(), 1_000_000_000_000u128).into();
+	// 1 DOT, which has 10 decimals, should be enough to cover for fees opening/accepting hrmp channels.
+	pub MaxHrmpRelayFee: MultiAsset = (MultiLocation::parent(), 10_000_000_000u128).into();
 }
 
 impl pallet_xcm_transactor::Config for Runtime {
@@ -1295,7 +1293,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type CurrencyId = CurrencyId;
 	type CurrencyIdToMultiLocation = xcm::CurrencyIdConvert;
 	type DerivativeAddressRegistrationOrigin = EnsureRootOr<HalfOfCouncil>;
-	type HrmpEncoder = moonbeam_relay_encoder::westend::WestendEncoder;
+	type HrmpEncoder = moonbeam_relay_encoder::polkadot::PolkadotEncoder;
 	type HrmpManipulatorOrigin = EnsureRootOr<HalfOfCouncil>;
 	type MaxHrmpFee = xcm_builder::Case<MaxHrmpRelayFee>;
 	type ReserveProvider = xcm_primitives::AbsoluteAndRelativeReserve<SelfLocation>;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1294,14 +1294,14 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type CurrencyId = CurrencyId;
 	type CurrencyIdToMultiLocation = xcm::CurrencyIdConvert;
-	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
+	type DerivativeAddressRegistrationOrigin = EnsureRootOr<HalfOfCouncil>;
 	type HrmpEncoder = moonbeam_relay_encoder::westend::WestendEncoder;
 	type HrmpManipulatorOrigin = EnsureRootOr<HalfOfCouncil>;
 	type MaxHrmpFee = xcm_builder::Case<MaxHrmpRelayFee>;
 	type ReserveProvider = xcm_primitives::AbsoluteAndRelativeReserve<SelfLocation>;
 	type RuntimeEvent = RuntimeEvent;
 	type SelfLocation = SelfLocation;
-	type SovereignAccountDispatcherOrigin = EnsureRoot<AccountId>;
+	type SovereignAccountDispatcherOrigin = EnsureRootOr<HalfOfCouncil>;
 	type Transactor = xcm_transactor::NullTransactor;
 	type UniversalLocation = UniversalLocation;
 	type Weigher = XcmWeigher;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1970,6 +1970,7 @@ construct_runtime!(
 		BaseFee: pallet_base_fee::{Pallet, Call, Config<T>, Storage, Event} = 162,
 		Ethereum: pallet_ethereum::{Pallet, Config, Call, Storage, Event, Origin} = 163,
 		EthereumTransaction: pallet_ethereum_transaction::{Pallet, Storage, Event<T>} = 164,
+		LiquidityPoolsAxelarGateway: axelar_gateway_precompile::{Pallet, Call, Storage, Event<T>} = 165,
 
 		// Synced pallets across all runtimes - Range: 180-240
 		// WHY: * integrations like fireblocks will need to know the index in the enum

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -441,7 +441,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type CurrencyId = CurrencyId;
 	type ForeignInvestment = Investments;
 	type GeneralCurrencyPrefix = cfg_primitives::liquidity_pools::GeneralCurrencyPrefix;
-	type OutboundQueue = WrapperOutboundQueue;
+	type OutboundQueue = FilteredOutboundQueue;
 	type Permission = Permissions;
 	type PoolId = PoolId;
 	type PoolInspect = PoolSystem;
@@ -459,11 +459,11 @@ impl pallet_liquidity_pools::Config for Runtime {
 type LiquidityPoolsMessage =
 	pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Rate>;
 
-/// The WrapperOutboundQueue serves as a filter for outbound LP messages that we
-/// want to allow initially.
-pub struct WrapperOutboundQueue;
+/// The FilteredOutboundQueue serves as a filter for outbound LP messages that
+/// we want to allow initially.
+pub struct FilteredOutboundQueue;
 
-impl OutboundQueue for WrapperOutboundQueue {
+impl OutboundQueue for FilteredOutboundQueue {
 	type Destination = Domain;
 	type Message = LiquidityPoolsMessage;
 	type Sender = AccountId;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -511,7 +511,7 @@ impl InboundQueue for DummyInboundQueue {
 	type Sender = DomainAddress;
 
 	fn submit(_: Self::Sender, _: Self::Message) -> DispatchResult {
-		Err(DispatchError::Other("not supported yet"))
+		Err(DispatchError::Other("InboundQueue not supported yet"))
 	}
 }
 

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -123,7 +123,7 @@ mod asset_registry {
 			.map_err(|_| "Error decoding pre-upgrade state")?;
 
 			for (asset_id, old_metadata) in old_state {
-				let new_metadata = OrmlAssetRegistry::metadata(asset_id)
+				let new_metadata = crate::OrmlAssetRegistry::metadata(asset_id)
 					.ok_or_else(|| "New state lost the metadata of an asset")?;
 
 				match asset_id {

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -24,7 +24,7 @@ use frame_support::{
 use sp_std::{vec, vec::Vec};
 use xcm::{v3::prelude::*, VersionedMultiLocation};
 
-use crate::{LiquidityPoolsPalletIndex, OrmlAssetRegistry, RocksDbWeight, Runtime};
+use crate::{LiquidityPoolsPalletIndex, RocksDbWeight, Runtime};
 
 pub type UpgradeCentrifuge1020 = (
 	asset_registry::CrossChainTransferabilityMigration,
@@ -234,12 +234,11 @@ mod asset_registry {
 			log::info!("Found {} LocationToAssetId keys ", loc_count);
 			log::info!("Found {} Metadata keys ", meta_count);
 
-			let assets_to_migrate;
-			if is_centrifuge {
-				assets_to_migrate = get_centrifuge_assets();
+			let assets_to_migrate = if is_centrifuge {
+				get_centrifuge_assets()
 			} else {
-				assets_to_migrate = get_catalyst_assets();
-			}
+				get_catalyst_assets()
+			};
 
 			assets_to_migrate
 				.iter()
@@ -336,12 +335,13 @@ mod asset_registry {
 	}
 }
 /// Returns the count of all keys sharing the same storage prefix
+#[allow(dead_code)]
 pub fn count_storage_keys(prefix: &[u8]) -> u32 {
 	let mut count = 0;
 	let mut next_key = prefix.to_vec();
 	loop {
 		match sp_io::storage::next_key(&next_key) {
-			Some(key) if !key.starts_with(&prefix) => break count,
+			Some(key) if !key.starts_with(prefix) => break count,
 			Some(key) => {
 				next_key = key;
 				count += 1;
@@ -380,7 +380,7 @@ pub fn get_catalyst_assets() -> Vec<(
 				decimals: 6,
 				name: b"Wormhole USDC".to_vec(),
 				symbol: b"USDC".to_vec(),
-				existential_deposit: 10_000u128.into(),
+				existential_deposit: 10_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::X2(
@@ -398,8 +398,7 @@ pub fn get_catalyst_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -408,7 +407,7 @@ pub fn get_catalyst_assets() -> Vec<(
 				decimals: 6,
 				name: b"Rococo USDT".to_vec(),
 				symbol: b"USDR".to_vec(),
-				existential_deposit: 100u128.into(),
+				existential_deposit: 100u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984)),
@@ -420,17 +419,16 @@ pub fn get_catalyst_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
-			CurrencyId::Tranche(3041110957, tranche_id.into()),
+			CurrencyId::Tranche(3041110957, tranche_id),
 			orml_asset_registry::AssetMetadata {
 				decimals: 6,
 				name: b"New Pool Junior".to_vec(),
 				symbol: b"NPJUN".to_vec(),
-				existential_deposit: 0u128.into(),
+				existential_deposit: 0u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
@@ -439,8 +437,7 @@ pub fn get_catalyst_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 	]
@@ -460,7 +457,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 				decimals: 18,
 				name: b"Centrifuge".to_vec(),
 				symbol: b"CFG".to_vec(),
-				existential_deposit: 1_000_000_000_000u128.into(),
+				existential_deposit: 1_000_000_000_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					0,
 					Junctions::X1(GeneralKey {
@@ -475,8 +472,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -485,7 +481,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 				decimals: 6,
 				name: b"Tether USDT".to_vec(),
 				symbol: b"USDT".to_vec(),
-				existential_deposit: 10_000u128.into(),
+				existential_deposit: 10_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984)),
@@ -497,8 +493,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -507,7 +502,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 				decimals: 6,
 				name: b"Axelar USDC".to_vec(),
 				symbol: b"xcUSDC".to_vec(),
-				existential_deposit: 10_000u128.into(),
+				existential_deposit: 10_000u128,
 				location: None,
 				additional: CustomMetadata {
 					mintable: false,
@@ -516,8 +511,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -526,7 +520,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 				decimals: 12,
 				name: b"Acala Dollar".to_vec(),
 				symbol: b"aUSD".to_vec(),
-				existential_deposit: 10_000_000_000u128.into(),
+				existential_deposit: 10_000_000_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::X2(
@@ -544,8 +538,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -554,7 +547,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 				decimals: 18,
 				name: b"Glimmer".to_vec(),
 				symbol: b"GLMR".to_vec(),
-				existential_deposit: 1_000_000_000_000_000u128.into(),
+				existential_deposit: 1_000_000_000_000_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::X2(Parachain(2004), PalletInstance(10)),
@@ -566,8 +559,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		(
@@ -576,7 +568,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 				decimals: 10,
 				name: b"DOT".to_vec(),
 				symbol: b"DOT".to_vec(),
-				existential_deposit: 100_000u128.into(),
+				existential_deposit: 100_000u128,
 				location: Some(VersionedMultiLocation::V3(MultiLocation::new(
 					1,
 					Junctions::Here,
@@ -588,8 +580,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 					transferability: CrossChainTransferability::Xcm(XcmMetadata {
 						fee_per_second: None,
 					}),
-				}
-				.into(),
+				},
 			},
 		),
 		// Adding LP USDC here

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -34,6 +34,7 @@ use runtime_common::{
 };
 use sp_core::ConstU32;
 use sp_runtime::traits::{Convert, Zero};
+pub use xcm::v3::{MultiAsset, MultiLocation};
 use xcm::{prelude::*, v3::Weight as XcmWeight};
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,

--- a/runtime/common/src/evm/precompile.rs
+++ b/runtime/common/src/evm/precompile.rs
@@ -59,9 +59,10 @@ impl<R> CentrifugePrecompiles<R> {
 
 impl<R> PrecompileSet for CentrifugePrecompiles<R>
 where
-	R: pallet_evm::Config,
+	R: pallet_evm::Config + axelar_gateway_precompile::Config + frame_system::Config,
 	R::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
 	<R::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<R::AccountId>>,
+	axelar_gateway_precompile::Pallet<R>: Precompile,
 {
 	fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
 		match handle.code_address().0 {
@@ -77,6 +78,9 @@ where
 			SHA3FIPS256_ADDR => Some(Sha3FIPS256::execute(handle)),
 			DISPATCH_ADDR => Some(Dispatch::<R>::execute(handle)),
 			ECRECOVERPUBLICKEY_ADDR => Some(ECRecoverPublicKey::execute(handle)),
+			LP_AXELAR_GATEWAY => {
+				Some(<axelar_gateway_precompile::Pallet<R> as Precompile>::execute(handle))
+			}
 			_ => None,
 		}
 	}
@@ -91,6 +95,7 @@ where
 				| BN128PAIRING_ADDR
 				| BLAKE2F_ADDR | SHA3FIPS256_ADDR
 				| DISPATCH_ADDR | ECRECOVERPUBLICKEY_ADDR
+				| LP_AXELAR_GATEWAY
 		)
 	}
 }


### PR DESCRIPTION
# Description

Adding the Liquidity Pools pallets to the centrifuge runtime.

## Changes and Descriptions

- [x] Add Liquidity Pool Gateway Pallet to runtime
    - [x] Dummy Liquidity Pool `InboundQueue` that triggers event with info (Runtime struct)
      - NOTE - No event being triggered at the moment
    - [x] Include Liquidity Pools to runtime
        - NOT use LPs as InboundQueue
    - [x] Wrapper `OutboundQueue` that LPs consumes
        - Only allow (`AddCurrency`, `UpdateMember`, `AddPool`, `AddTranche`, `UpdateTrancheTokenPrice`)
        - Uses gateway as real outbound 

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
