### PR TITLE
Upgrade1020 LP follow-ups

### DIFF
--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -438,6 +438,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type AdminOrigin = EnsureRootOr<TwoThirdOfCouncil>;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
+	type BalanceRatio = Quantity;
 	type CurrencyId = CurrencyId;
 	type ForeignInvestment = Investments;
 	type GeneralCurrencyPrefix = cfg_primitives::liquidity_pools::GeneralCurrencyPrefix;
@@ -445,7 +446,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Permission = Permissions;
 	type PoolId = PoolId;
 	type PoolInspect = PoolSystem;
-	type Rate = Rate;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -457,7 +457,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 }
 
 type LiquidityPoolsMessage =
-	pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Rate>;
+	pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Quantity>;
 
 /// The FilteredOutboundQueue serves as a filter for outbound LP messages that
 /// we want to allow initially.
@@ -496,6 +496,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type LocalEVMOrigin = pallet_liquidity_pools_gateway::EnsureLocal;
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = LiquidityPoolsMessage;
+	type OriginRecovery = crate::LiquidityPoolsAxelarGateway;
 	type Router = liquidity_pools_gateway_routers::DomainRouter<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
@@ -507,7 +508,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 pub struct DummyInboundQueue;
 
 impl InboundQueue for DummyInboundQueue {
-	type Message = pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Rate>;
+	type Message = LiquidityPoolsMessage;
 	type Sender = DomainAddress;
 
 	fn submit(_: Self::Sender, _: Self::Message) -> DispatchResult {

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -34,7 +34,7 @@ use orml_xcm_support::MultiNativeAsset;
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use runtime_common::{
-	xcm::{general_key, AccountIdToMultiLocation, FixedConversionRateProvider},
+	xcm::{general_key, AccountIdToMultiLocation, FixedConversionRateProvider, LpInstanceRelayer},
 	xcm_fees::{default_per_second, native_per_second},
 };
 use sp_core::ConstU32;
@@ -377,7 +377,7 @@ impl TryConvert<cfg_types::ParaId, EVMChainId> for ParaToEvm {
 /// `Origin` it will become.
 pub type XcmOriginToTransactDispatchOrigin = (
 	// A matcher that catches all Moonbeam relaying contracts to generate the right Origin
-	LpGatewayInstance<ParaToEvm, Runtime>,
+	LpInstanceRelayer<ParaToEvm, Runtime>,
 	// Sovereign account converter; this attempts to derive an `AccountId` from the origin location
 	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
 	// foreign chains who want to have a local sovereign account on this chain which they control.

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -376,9 +376,8 @@ impl TryConvert<cfg_types::ParaId, EVMChainId> for ParaToEvm {
 /// `Transact`. There is an `OriginKind` which can biases the kind of local
 /// `Origin` it will become.
 pub type XcmOriginToTransactDispatchOrigin = (
-	// TODO: Activate once gateway is in here.
 	// A matcher that catches all Moonbeam relaying contracts to generate the right Origin
-	// LpGatewayInstance<ParaToEvm, Runtime>,
+	LpGatewayInstance<ParaToEvm, Runtime>,
 	// Sovereign account converter; this attempts to derive an `AccountId` from the origin location
 	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
 	// foreign chains who want to have a local sovereign account on this chain which they control.


### PR DESCRIPTION
# Description

The changes in this PR are some of the follow-ups needed after adding the LP related pallets, specifically:
- enable the LP gateway XCM origin converter
- use `Quantity` instead of `Rate` in the LP pallet config

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
