### PR TITLE
feat: safe XCM version migration + extend SafeCallFilter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
+ "xcm",
 ]
 
 [[package]]

--- a/libs/primitives/Cargo.toml
+++ b/libs/primitives/Cargo.toml
@@ -27,8 +27,11 @@ frame-support = { git = "https://github.com/paritytech/substrate", default-featu
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 
-# cumuluse primitives dependencies
+# cumulus primitives dependencies
 cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.38" }
+
+# XCM primitives dependencies
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.38" }
 
 [features]
 default = ["std"]
@@ -51,6 +54,7 @@ std = [
   "pallet-collective/std",
   "sp-consensus-aura/std",
   "cumulus-primitives-core/std",
+  "xcm/std",
 ]
 try-runtime = [
   "frame-support/try-runtime",

--- a/libs/primitives/src/lib.rs
+++ b/libs/primitives/src/lib.rs
@@ -269,6 +269,9 @@ pub mod constants {
 	/// Transaction pallet. As per:
 	/// <https://github.com/PureStake/moonbeam/blob/fb63014a5e487f17e31283776e4f6b0befd009a2/primitives/xcm/src/ethereum_xcm.rs#L167>
 	pub const TRANSACTION_RECOVERY_ID: u64 = 42;
+
+	/// The safe XCM version of pallet-xcm, same as on relay chain
+	pub const SAFE_XCM_VERSION: u32 = xcm::opaque::v2::VERSION;
 }
 
 /// Listing of parachains we integrate with.

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -901,18 +901,15 @@ mod xcm_v2_to_v3 {
 
 	impl OnRuntimeUpgrade for SetSafeXcmVersion {
 		fn on_runtime_upgrade() -> Weight {
-			if VERSION.spec_version > 1030 {
-				return Weight::zero();
-			}
-
-			// Unfortunately, SafeXcmVersion storage is not leaked to runtime
+			// Unfortunately, SafeXcmVersion storage is not leaked to runtime, so we can't
+			// do any pre- or post-upgrade checks
 			PolkadotXcm::force_default_xcm_version(
 				RuntimeOrigin::root(),
 				Some(cfg_primitives::SAFE_XCM_VERSION),
 			)
 			.unwrap_or_else(|_| log::error!("Failed to set safe XCM version on runtime upgrade, requires manual call via governance"));
 
-			RocksDbWeight::get().reads_writes(1, 1)
+			RocksDbWeight::get().writes(1)
 		}
 	}
 }

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -895,7 +895,7 @@ mod pool_system {
 
 mod xcm_v2_to_v3 {
 	use super::*;
-	use crate::{PolkadotXcm, RuntimeOrigin, VERSION};
+	use crate::{PolkadotXcm, RuntimeOrigin};
 
 	pub struct SetSafeXcmVersion;
 

--- a/runtime/altair/src/xcm.rs
+++ b/runtime/altair/src/xcm.rs
@@ -87,6 +87,9 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 			) | RuntimeCall::XcmpQueue(..)
 				| RuntimeCall::DmpQueue(..)
 				| RuntimeCall::Proxy(..)
+				| RuntimeCall::LiquidityPoolsGateway(
+					pallet_liquidity_pools_gateway::Call::process_msg { .. }
+				)
 		)
 	}
 }

--- a/runtime/altair/src/xcm.rs
+++ b/runtime/altair/src/xcm.rs
@@ -69,27 +69,17 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		matches!(
 			call,
-			RuntimeCall::System(
-				frame_system::Call::kill_prefix { .. } | frame_system::Call::set_heap_pages { .. },
-			) | RuntimeCall::Timestamp(..)
+			RuntimeCall::Timestamp(..)
 				| RuntimeCall::Balances(..)
-				| RuntimeCall::Session(pallet_session::Call::purge_keys { .. })
-				| RuntimeCall::Treasury(..)
 				| RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. })
-				| RuntimeCall::Vesting(..)
 				| RuntimeCall::PolkadotXcm(
 					pallet_xcm::Call::limited_reserve_transfer_assets { .. }
-				) | RuntimeCall::CollatorSelection(
-				pallet_collator_selection::Call::set_desired_candidates { .. }
-					| pallet_collator_selection::Call::set_candidacy_bond { .. }
-					| pallet_collator_selection::Call::register_as_candidate { .. }
-					| pallet_collator_selection::Call::leave_intent { .. },
-			) | RuntimeCall::XcmpQueue(..)
+				) | RuntimeCall::XcmpQueue(..)
 				| RuntimeCall::DmpQueue(..)
 				| RuntimeCall::Proxy(..)
 				| RuntimeCall::LiquidityPoolsGateway(
 					pallet_liquidity_pools_gateway::Call::process_msg { .. }
-				)
+				) | RuntimeCall::OrderBook(..)
 		)
 	}
 }

--- a/runtime/altair/src/xcm.rs
+++ b/runtime/altair/src/xcm.rs
@@ -79,7 +79,7 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 				| RuntimeCall::Proxy(..)
 				| RuntimeCall::LiquidityPoolsGateway(
 					pallet_liquidity_pools_gateway::Call::process_msg { .. }
-				) | RuntimeCall::OrderBook(..)
+				) // TODO: Enable later: | RuntimeCall::OrderBook(..)
 		)
 	}
 }

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -438,6 +438,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type AdminOrigin = EnsureRootOr<TwoThirdOfCouncil>;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
+	type BalanceRatio = Quantity;
 	type CurrencyId = CurrencyId;
 	type ForeignInvestment = Investments;
 	type GeneralCurrencyPrefix = cfg_primitives::liquidity_pools::GeneralCurrencyPrefix;
@@ -445,7 +446,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Permission = Permissions;
 	type PoolId = PoolId;
 	type PoolInspect = PoolSystem;
-	type Rate = Rate;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -457,7 +457,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 }
 
 type LiquidityPoolsMessage =
-	pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Rate>;
+	pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Quantity>;
 
 /// The FilteredOutboundQueue serves as a filter for outbound LP messages that
 /// we want to allow initially.
@@ -496,6 +496,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type LocalEVMOrigin = pallet_liquidity_pools_gateway::EnsureLocal;
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = LiquidityPoolsMessage;
+	type OriginRecovery = crate::LiquidityPoolsAxelarGateway;
 	type Router = liquidity_pools_gateway_routers::DomainRouter<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
@@ -507,7 +508,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 pub struct DummyInboundQueue;
 
 impl InboundQueue for DummyInboundQueue {
-	type Message = pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Rate>;
+	type Message = LiquidityPoolsMessage;
 	type Sender = DomainAddress;
 
 	fn submit(_: Self::Sender, _: Self::Message) -> DispatchResult {

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -607,18 +607,15 @@ mod xcm_v2_to_v3 {
 
 	impl OnRuntimeUpgrade for SetSafeXcmVersion {
 		fn on_runtime_upgrade() -> Weight {
-			if VERSION.spec_version != 1020 {
-				return Weight::zero();
-			}
-
-			// Unfortunately, SafeXcmVersion storage is not leaked to runtime
+			// Unfortunately, SafeXcmVersion storage is not leaked to runtime, so we can't
+			// do any pre- or post-upgrade checks
 			PolkadotXcm::force_default_xcm_version(
 				RuntimeOrigin::root(),
 				Some(cfg_primitives::SAFE_XCM_VERSION),
 			)
 			.unwrap_or_else(|_| log::error!("Failed to set safe XCM version on runtime upgrade, requires manual call via governance"));
 
-			RocksDbWeight::get().reads_writes(1, 1)
+			RocksDbWeight::get().writes(1)
 		}
 	}
 }

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -45,6 +45,8 @@ pub type UpgradeCentrifuge1020 = (
 	crate::XcmpQueue,
 	// Low weight, bumps uninitialized storage version from v0 to v1
 	pallet_xcm::migration::v1::MigrateToV1<crate::Runtime>,
+	// Sets currently unset safe XCM version to v2
+	xcm_v2_to_v3::SetSafeXcmVersion,
 );
 
 mod asset_registry {
@@ -595,4 +597,28 @@ pub fn get_centrifuge_assets() -> Vec<(
 			),
 		),
 	]
+}
+
+mod xcm_v2_to_v3 {
+	use super::*;
+	use crate::{PolkadotXcm, RuntimeOrigin, VERSION};
+
+	pub struct SetSafeXcmVersion;
+
+	impl OnRuntimeUpgrade for SetSafeXcmVersion {
+		fn on_runtime_upgrade() -> Weight {
+			if VERSION.spec_version != 1020 {
+				return Weight::zero();
+			}
+
+			// Unfortunately, SafeXcmVersion storage is not leaked to runtime
+			PolkadotXcm::force_default_xcm_version(
+				RuntimeOrigin::root(),
+				Some(cfg_primitives::SAFE_XCM_VERSION),
+			)
+			.unwrap_or_else(|_| log::error!("Failed to set safe XCM version on runtime upgrade, requires manual call via governance"));
+
+			RocksDbWeight::get().reads_writes(1, 1)
+		}
+	}
 }

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -601,7 +601,7 @@ pub fn get_centrifuge_assets() -> Vec<(
 
 mod xcm_v2_to_v3 {
 	use super::*;
-	use crate::{PolkadotXcm, RuntimeOrigin, VERSION};
+	use crate::{PolkadotXcm, RuntimeOrigin};
 
 	pub struct SetSafeXcmVersion;
 

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -81,7 +81,7 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 				| RuntimeCall::Proxy(..)
 				| RuntimeCall::LiquidityPoolsGateway(
 					pallet_liquidity_pools_gateway::Call::process_msg { .. }
-				) | RuntimeCall::OrderBook(..)
+				// TODO: Add OrderBook after it has been added to runtime
 		)
 	}
 }

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -71,27 +71,17 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		matches!(
 			call,
-			RuntimeCall::System(
-				frame_system::Call::kill_prefix { .. } | frame_system::Call::set_heap_pages { .. },
-			) | RuntimeCall::Timestamp(..)
+			RuntimeCall::Timestamp(..)
 				| RuntimeCall::Balances(..)
-				| RuntimeCall::Session(pallet_session::Call::purge_keys { .. })
-				| RuntimeCall::Treasury(..)
 				| RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. })
-				| RuntimeCall::Vesting(..)
 				| RuntimeCall::PolkadotXcm(
 					pallet_xcm::Call::limited_reserve_transfer_assets { .. }
-				) | RuntimeCall::CollatorSelection(
-				pallet_collator_selection::Call::set_desired_candidates { .. }
-					| pallet_collator_selection::Call::set_candidacy_bond { .. }
-					| pallet_collator_selection::Call::register_as_candidate { .. }
-					| pallet_collator_selection::Call::leave_intent { .. },
-			) | RuntimeCall::XcmpQueue(..)
+				) | RuntimeCall::XcmpQueue(..)
 				| RuntimeCall::DmpQueue(..)
 				| RuntimeCall::Proxy(..)
 				| RuntimeCall::LiquidityPoolsGateway(
 					pallet_liquidity_pools_gateway::Call::process_msg { .. }
-				)
+				) | RuntimeCall::OrderBook(..)
 		)
 	}
 }

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -88,8 +88,10 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 					| pallet_collator_selection::Call::leave_intent { .. },
 			) | RuntimeCall::XcmpQueue(..)
 				| RuntimeCall::DmpQueue(..)
-				| RuntimeCall::Proxy(..) /* TODO: Enable after merging 1523
-			                          * | RuntimeCall::pallet_liquidity_pools_gateway::process_msg */
+				| RuntimeCall::Proxy(..)
+				| RuntimeCall::LiquidityPoolsGateway(
+					pallet_liquidity_pools_gateway::Call::process_msg { .. }
+				)
 		)
 	}
 }

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -88,7 +88,8 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 					| pallet_collator_selection::Call::leave_intent { .. },
 			) | RuntimeCall::XcmpQueue(..)
 				| RuntimeCall::DmpQueue(..)
-				| RuntimeCall::Proxy(..)
+				| RuntimeCall::Proxy(..) /* TODO: Enable after merging 1523
+			                          * | RuntimeCall::pallet_liquidity_pools_gateway::process_msg */
 		)
 	}
 }

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -34,7 +34,7 @@ use orml_xcm_support::MultiNativeAsset;
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use runtime_common::{
-	xcm::{general_key, AccountIdToMultiLocation, FixedConversionRateProvider},
+	xcm::{general_key, AccountIdToMultiLocation, FixedConversionRateProvider, LpInstanceRelayer},
 	xcm_fees::{default_per_second, native_per_second},
 };
 use sp_core::ConstU32;
@@ -369,9 +369,8 @@ impl TryConvert<cfg_types::ParaId, EVMChainId> for ParaToEvm {
 /// `Transact`. There is an `OriginKind` which can biases the kind of local
 /// `Origin` it will become.
 pub type XcmOriginToTransactDispatchOrigin = (
-	// TODO: Activate once gateway is in here.
 	// A matcher that catches all Moonbeam relaying contracts to generate the right Origin
-	// LpGatewayInstance<ParaToEvm, Runtime>,
+	LpInstanceRelayer<ParaToEvm, Runtime>,
 	// Sovereign account converter; this attempts to derive an `AccountId` from the origin location
 	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
 	// foreign chains who want to have a local sovereign account on this chain which they control.

--- a/runtime/centrifuge/src/xcm.rs
+++ b/runtime/centrifuge/src/xcm.rs
@@ -81,7 +81,7 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 				| RuntimeCall::Proxy(..)
 				| RuntimeCall::LiquidityPoolsGateway(
 					pallet_liquidity_pools_gateway::Call::process_msg { .. }
-				// TODO: Add OrderBook after it has been added to runtime
+				) // TODO: Enable later: | RuntimeCall::OrderBook(..)
 		)
 	}
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -23,7 +23,9 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 use altair_runtime::constants::currency::{AIR, MILLI_AIR};
-use cfg_primitives::{currency_decimals, parachains, Balance, BlockNumber, CFG, MILLI_CFG};
+use cfg_primitives::{
+	currency_decimals, parachains, Balance, BlockNumber, CFG, MILLI_CFG, SAFE_XCM_VERSION,
+};
 use cfg_types::{
 	fee_keys::FeeKey,
 	tokens::{
@@ -51,9 +53,6 @@ pub type CentrifugeChainSpec =
 	sc_service::GenericChainSpec<centrifuge_runtime::GenesisConfig, Extensions>;
 pub type DevelopmentChainSpec =
 	sc_service::GenericChainSpec<development_runtime::GenesisConfig, Extensions>;
-
-/// The default XCM version to set in genesis config.
-const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 /// Helper function to generate a crypto pair from seed
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {


### PR DESCRIPTION
For both the Centrifuge as well as the Altair runtimes adds:

* Migration to set safe XCM version for Centrifuge and Altair chains to v2 (mirroring behaviour of relay and other parachains)
* `pallet_liquidity_pools_gateway::Call::process_msg` to `SafeCallFilter` which enables this to be executed by xcm `transact`