### PR TITLE
liquidityPools: Clean up orphan storage and events

### DIFF
--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -257,21 +257,11 @@ pub mod pallet {
 			domain: Domain,
 		},
 
-		/// The Router for a given domain was set
-		SetDomainRouter {
-			domain: Domain,
-			router: Router<CurrencyIdOf<T>>,
-		},
-
 		IncomingMessage {
 			sender: T::AccountId,
 			message: Vec<u8>,
 		},
 	}
-
-	#[pallet::storage]
-	pub(crate) type DomainRouter<T: Config> =
-		StorageMap<_, Blake2_128Concat, Domain, Router<CurrencyIdOf<T>>>;
 
 	#[pallet::error]
 	pub enum Error<T> {
@@ -333,22 +323,6 @@ pub mod pallet {
 	where
 		<T as frame_system::Config>::AccountId: From<[u8; 32]>,
 	{
-		/// Set a Domain's router
-		#[pallet::weight(< T as Config >::WeightInfo::set_domain_router())]
-		#[pallet::call_index(0)]
-		pub fn set_domain_router(
-			origin: OriginFor<T>,
-			domain: Domain,
-			router: Router<CurrencyIdOf<T>>,
-		) -> DispatchResult {
-			T::AdminOrigin::ensure_origin(origin.clone())?;
-
-			<DomainRouter<T>>::insert(domain.clone(), router.clone());
-			Self::deposit_event(Event::SetDomainRouter { domain, router });
-
-			Ok(())
-		}
-
 		/// Add a pool to a given domain
 		#[pallet::weight(< T as Config >::WeightInfo::add_pool())]
 		#[pallet::call_index(2)]

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, Convert},
 	FixedPointNumber, SaturatedConversion,
 };
-use sp_std::{convert::TryInto, vec, vec::Vec};
+use sp_std::{convert::TryInto, vec};
 use xcm::{
 	latest::NetworkId,
 	prelude::{AccountKey20, GlobalConsensus, PalletInstance, X3},
@@ -106,9 +106,6 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		/// The overarching event type.
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 
@@ -246,21 +243,6 @@ pub mod pallet {
 
 		#[pallet::constant]
 		type TreasuryAccount: Get<Self::AccountId>;
-	}
-
-	#[pallet::event]
-	#[pallet::generate_deposit(pub (super) fn deposit_event)]
-	pub enum Event<T: Config> {
-		/// A message was sent to a domain
-		MessageSent {
-			message: MessageOf<T>,
-			domain: Domain,
-		},
-
-		IncomingMessage {
-			sender: T::AccountId,
-			message: Vec<u8>,
-		},
 	}
 
 	#[pallet::error]

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1401,7 +1401,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Permission = Permissions;
 	type PoolId = PoolId;
 	type PoolInspect = PoolSystem;
-	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;
 	type TrancheCurrency = TrancheCurrency;
@@ -1796,7 +1795,7 @@ construct_runtime!(
 		BlockRewards: pallet_block_rewards::{Pallet, Call, Storage, Event<T>, Config<T>} = 105,
 		Keystore: pallet_keystore::{Pallet, Call, Storage, Event<T>} = 106,
 		PriceCollector: pallet_data_collector::{Pallet, Storage} = 107,
-		LiquidityPools: pallet_liquidity_pools::{Pallet, Call, Storage, Event<T>} = 108,
+		LiquidityPools: pallet_liquidity_pools::{Pallet, Call, Storage} = 108,
 		LiquidityPoolsGateway: pallet_liquidity_pools_gateway::{Pallet, Call, Storage, Event<T>, Origin } = 109,
 		LiquidityRewardsBase: pallet_rewards::<Instance2>::{Pallet, Storage, Event<T>, Config<T>} = 110,
 		LiquidityRewards: pallet_liquidity_rewards::{Pallet, Call, Storage, Event<T>} = 111,

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -448,7 +448,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Permission = Permissions;
 	type PoolId = PoolId;
 	type PoolInspect = PoolSystem;
-	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;
 	type TrancheCurrency = TrancheCurrency;
@@ -1961,7 +1960,7 @@ construct_runtime!(
 		BlockRewardsBase: pallet_rewards::<Instance1>::{Pallet, Storage, Event<T>, Config<T>} = 100,
 		BlockRewards: pallet_block_rewards::{Pallet, Call, Storage, Event<T>, Config<T>} = 101,
 		PriceCollector: pallet_data_collector::{Pallet, Storage} = 102,
-		LiquidityPools: pallet_liquidity_pools::{Pallet, Call, Storage, Event<T>} = 103,
+		LiquidityPools: pallet_liquidity_pools::{Pallet, Call, Storage} = 103,
 		LiquidityRewardsBase: pallet_rewards::<Instance2>::{Pallet, Storage, Event<T>, Config<T>} = 104,
 		LiquidityRewards: pallet_liquidity_rewards::{Pallet, Call, Storage, Event<T>} = 105,
 		GapRewardMechanism: pallet_rewards::mechanism::gap = 106,

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1561,7 +1561,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Permission = Permissions;
 	type PoolId = PoolId;
 	type PoolInspect = PoolSystem;
-	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;
 	type TrancheCurrency = TrancheCurrency;
@@ -1893,7 +1892,7 @@ construct_runtime!(
 		Investments: pallet_investments::{Pallet, Call, Storage, Event<T>} = 105,
 		LiquidityRewardsBase: pallet_rewards::<Instance1>::{Pallet, Storage, Event<T>, Config<T>} = 106,
 		LiquidityRewards: pallet_liquidity_rewards::{Pallet, Call, Storage, Event<T>} = 107,
-		LiquidityPools: pallet_liquidity_pools::{Pallet, Call, Storage, Event<T>} = 108,
+		LiquidityPools: pallet_liquidity_pools::{Pallet, Call, Storage} = 108,
 		PoolRegistry: pallet_pool_registry::{Pallet, Call, Storage, Event<T>} = 109,
 		BlockRewardsBase: pallet_rewards::<Instance2>::{Pallet, Storage, Event<T>, Config<T>} = 110,
 		BlockRewards: pallet_block_rewards::{Pallet, Call, Storage, Event<T>, Config<T>} = 111,


### PR DESCRIPTION
We forgot to remove these when we introduced the new gateway, deleting them here. No storage migrations needed.