### PR TITLE
fix: lock of altair version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "altair-runtime"
-version = "0.10.31"
+version = "0.10.32"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",


### PR DESCRIPTION
# Description
Lock file was for some reason not updated in latest main. This fixes it and should fix the build

## Changes and Descriptions
* update lock file via local build

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
