### PR TITLE
ci: Disable taplo

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [fmt, taplo, clippy]
+        target: [fmt, clippy]
     runs-on: ${{ matrix.os }}
     env:
       RUST_TOOLCHAIN: "nightly-2022-11-14"
@@ -31,12 +31,6 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           default: true
-      - name: Install taplo
-        uses: actions-rs/install@v0.1
-        with:
-          crate: taplo-cli
-          version: 0.7.2
-          use-tool-cache: true
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c
       - name: Run lints
         run: ./ci/script.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "altair-runtime"
-version = "0.10.31"
+version = "0.10.32"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",


### PR DESCRIPTION
Taplo is suddenly failing to compile when installed on the CI but also locally. This is a commodity and we don't _need_ this job on the CI, particularly in a phase as we are in with lots of work to get in.

Removing the job for now.