### PR TITLE
Hotfix/algol 1031

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -262,7 +262,10 @@ parameter_types! {
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
+	#[cfg(not(feature = "testnet-runtime"))]
 	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+	#[cfg(feature = "testnet-runtime")]
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::AnyRelayNumber;
 	type DmpMessageHandler = DmpQueue;
 	type OnSystemEvent = ();
 	type OutboundXcmpMessageSource = XcmpQueue;


### PR DESCRIPTION
## Description

* Adds `AnyRelayNumber` for Algol, i.e.`testnet-runtime` feature
* Substitutes the WASM of Algol 1031 with above adjustment into the chain spec 
  * This substitution overwrites the current WASM until the spec version is bumped
  * Necessary to be able to point Algol to another relaychain with a lower block number than the current stalled one

```json
  "codeSubstitutes": {
    "209843": "$bytes_to_hex(WASM_FILE_ALTAIR_WITH_TESTNET_FEAT)"
    },
```

### Context 

Algol is stalled because the relay chain validators were offline for too long such that finalization is halted. One approach top fix this is to create a new relay and point Algol to that one. See [here](https://substrate.stackexchange.com/questions/6421/para-header-not-found-after-moving-to-another-relay-chain) for details.

### How was the WASM hex created?

1. Build WASM
```
cargo b --release -F testnet-runtime
```

2. WASM file to bytes to hex
```rust
    let mut file = match File::open(ALTAIR_WASM_FILE) {
        Ok(file) => file,
        Err(e) => {
            eprintln!("Error opening file: {}", e);
            std::process::exit(1);
        }
    };

    let mut wasm_bytes = Vec::new();
    if let Err(e) = file.read_to_end(&mut wasm_bytes) {
        eprintln!("Error reading file: {}", e);
        std::process::exit(1);
    }

    // Convert the Vec<u8> to a hexadecimal string
    let hex_string = hex::encode(&wasm_bytes);
```