### PR TITLE
routers: Drop LP contract call from Axelar message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "development-runtime"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",

--- a/pallets/liquidity-pools-gateway/routers/src/routers/axelar_evm.rs
+++ b/pallets/liquidity-pools-gateway/routers/src/routers/axelar_evm.rs
@@ -15,10 +15,7 @@ use ethabi::{Contract, Function, Param, ParamType, Token};
 use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_system::pallet_prelude::OriginFor;
 use scale_info::{
-	prelude::{
-		format,
-		string::{String, ToString},
-	},
+	prelude::{format, string::String},
 	TypeInfo,
 };
 use sp_core::{bounded::BoundedVec, ConstU32, H160};
@@ -78,7 +75,7 @@ where
 
 /// Encodes the provided message into the format required for submitting it
 /// to the Axelar contract which in turn calls the LiquidityPools
-/// contract with the serialized LP message a payload.
+/// contract with the serialized LP message as `payload`.
 ///
 /// Axelar contract call:
 /// <https://github.com/axelarnetwork/axelar-cgp-solidity/blob/v4.3.2/contracts/AxelarGateway.sol#L78>

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "development-runtime"
-version = "0.10.23"
+version = "0.10.24"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -138,7 +138,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge-devel"),
 	impl_name: create_runtime_str!("centrifuge-devel"),
 	authoring_version: 1,
-	spec_version: 1023,
+	spec_version: 1024,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
# Description

Dropping the explicit call to the LP contract since our testing revealed that it is unnecessary.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
