### PR TITLE
OrderBook: Use ratio instead of rate

### DIFF
--- a/pallets/order-book/src/benchmarking.rs
+++ b/pallets/order-book/src/benchmarking.rs
@@ -12,10 +12,7 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
-use cfg_types::{
-	fixed_point::Rate,
-	tokens::{CurrencyId, CustomMetadata},
-};
+use cfg_types::tokens::{CurrencyId, CustomMetadata};
 use frame_benchmarking::*;
 use frame_support::traits::fungibles::Mutate as FungiblesMutate;
 use frame_system::RawOrigin;
@@ -31,33 +28,33 @@ const CURRENCY_1: u128 = 1_000_000_000_000;
 benchmarks! {
 	where_clause {
 		where
-			T: Config<AssetCurrencyId = CurrencyId, Balance = u128, SellRatio = Rate>,
+			T: Config<AssetCurrencyId = CurrencyId, Balance = u128>,
 			<T as pallet::Config>::AssetRegistry: orml_traits::asset_registry::Mutate,
 	}
 
 	create_order {
 		let (account_0, _, asset_0, asset_1) = set_up_users_currencies::<T>()?;
-		}:create_order(RawOrigin::Signed(account_0.clone()), asset_0, asset_1, 100 * CURRENCY_0, Rate::checked_from_integer(2u32).unwrap())
+		}:create_order(RawOrigin::Signed(account_0.clone()), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2))
 
 
 	user_update_order {
 		let (account_0, _, asset_0, asset_1) = set_up_users_currencies::<T>()?;
 
-		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, Rate::checked_from_integer(2u32).unwrap().into(), 100 * CURRENCY_0)?;
+		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 100 * CURRENCY_0)?;
 
-		}:user_update_order(RawOrigin::Signed(account_0.clone()), order_id, 150 * CURRENCY_0, Rate::checked_from_integer(1u32).unwrap())
+		}:user_update_order(RawOrigin::Signed(account_0.clone()), order_id, 150 * CURRENCY_0, T::SellRatio::saturating_from_integer(1))
 
 	user_cancel_order {
 		let (account_0, _, asset_0, asset_1) = set_up_users_currencies::<T>()?;
 
-		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, Rate::checked_from_integer(2u32).unwrap().into(), 100 * CURRENCY_0)?;
+		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 100 * CURRENCY_0)?;
 
 	}:user_cancel_order(RawOrigin::Signed(account_0.clone()), order_id)
 
 	fill_order_full {
 		let (account_0, account_1, asset_0, asset_1) = set_up_users_currencies::<T>()?;
 
-		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, Rate::checked_from_integer(2u32).unwrap().into(), 100 * CURRENCY_0)?;
+		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 100 * CURRENCY_0)?;
 
 	}:fill_order_full(RawOrigin::Signed(account_1.clone()), order_id)
 

--- a/pallets/order-book/src/mock.rs
+++ b/pallets/order-book/src/mock.rs
@@ -23,6 +23,7 @@ use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	FixedU128,
 };
 
 use crate as order_book;
@@ -201,7 +202,7 @@ impl order_book::Config for Runtime {
 	type OrderIdNonce = u64;
 	type OrderPairVecSize = OrderPairVecSize;
 	type RuntimeEvent = RuntimeEvent;
-	type SellRatio = cfg_types::fixed_point::Rate;
+	type SellRatio = FixedU128;
 	type TradeableAsset = Tokens;
 	type Weights = ();
 }

--- a/pallets/order-book/src/tests.rs
+++ b/pallets/order-book/src/tests.rs
@@ -10,9 +10,9 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_types::{fixed_point::Rate, tokens::CurrencyId};
+use cfg_types::tokens::CurrencyId;
 use frame_support::{assert_err, assert_noop, assert_ok, dispatch::RawOrigin};
-use sp_runtime::{traits::Zero, DispatchError, FixedPointNumber};
+use sp_runtime::{traits::Zero, DispatchError, FixedPointNumber, FixedU128};
 
 use super::*;
 use crate::mock::*;
@@ -144,7 +144,7 @@ fn create_order_works() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3, 2).unwrap()
+			FixedU128::checked_from_rational(3, 2).unwrap()
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_eq!(
@@ -156,7 +156,7 @@ fn create_order_works() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				min_fullfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
@@ -170,7 +170,7 @@ fn create_order_works() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				min_fullfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
@@ -190,14 +190,14 @@ fn user_update_order_works() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			10 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3, 2).unwrap()
+			FixedU128::checked_from_rational(3, 2).unwrap()
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_ok!(OrderBook::user_update_order(
 			RuntimeOrigin::signed(ACCOUNT_0),
 			order_id,
 			15 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_integer(2u32).unwrap(),
+			FixedU128::checked_from_integer(2u32).unwrap(),
 		));
 
 		assert_eq!(
@@ -209,7 +209,7 @@ fn user_update_order_works() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 15 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_integer(2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_integer(2u32).unwrap(),
 				min_fullfillment_amount: 15 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 30 * CURRENCY_USDT_DECIMALS
 			})
@@ -225,7 +225,7 @@ fn user_update_order_only_works_for_valid_account() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			10 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3, 2).unwrap()
+			FixedU128::checked_from_rational(3, 2).unwrap()
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_err!(
@@ -233,7 +233,7 @@ fn user_update_order_only_works_for_valid_account() {
 				RuntimeOrigin::signed(ACCOUNT_1),
 				order_id,
 				15 * CURRENCY_AUSD_DECIMALS,
-				Rate::checked_from_integer(2u32).unwrap(),
+				FixedU128::checked_from_integer(2u32).unwrap(),
 			),
 			Error::<Runtime>::Unauthorised
 		);
@@ -248,7 +248,7 @@ fn user_cancel_order_works() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap()
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap()
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_ok!(OrderBook::user_cancel_order(
@@ -280,7 +280,7 @@ fn user_cancel_order_only_works_for_valid_account() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap()
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap()
 		));
 
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -298,7 +298,7 @@ fn user_cancel_order_only_works_for_valid_account() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				min_fullfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
@@ -314,7 +314,7 @@ fn fill_order_full_works() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap()
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap()
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		// verify fulfill runs
@@ -376,7 +376,7 @@ fn fill_order_full_checks_asset_in_for_fulfiller() {
 			CurrencyId::Native,
 			DEV_AUSD_CURRENCY_ID,
 			400 * CURRENCY_NATIVE_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap()
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap()
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		// verify fulfill runs
@@ -396,7 +396,7 @@ fn place_order_works() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			100 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -409,7 +409,7 @@ fn place_order_works() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				min_fullfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
@@ -424,7 +424,7 @@ fn place_order_works() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				min_fullfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
@@ -452,7 +452,7 @@ fn place_order_works() {
 				currency_out: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				min_fullfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				sell_rate_limit: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				sell_rate_limit: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			})
 		);
 	})
@@ -466,7 +466,7 @@ fn place_order_bases_max_sell_off_buy() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			10 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -479,7 +479,7 @@ fn place_order_bases_max_sell_off_buy() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				min_fullfillment_amount: 10 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
@@ -494,7 +494,7 @@ fn place_order_bases_max_sell_off_buy() {
 				currency_out: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				min_fullfillment_amount: 10 * CURRENCY_AUSD_DECIMALS,
-				sell_rate_limit: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				sell_rate_limit: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			})
 		);
 	})
@@ -508,7 +508,7 @@ fn ensure_nonce_updates_order_correctly() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			100 * CURRENCY_AUSD_DECIMALS
 		));
 		assert_ok!(OrderBook::place_order(
@@ -516,7 +516,7 @@ fn ensure_nonce_updates_order_correctly() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			100 * CURRENCY_AUSD_DECIMALS
 		));
 		let [(order_id_0, _), (order_id_1, _)] = get_account_orders(ACCOUNT_0)
@@ -535,7 +535,7 @@ fn place_order_requires_no_min_buy() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			1 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			1 * CURRENCY_AUSD_DECIMALS,
 		),);
 	})
@@ -550,7 +550,7 @@ fn create_order_requires_min_buy() {
 				DEV_AUSD_CURRENCY_ID,
 				DEV_USDT_CURRENCY_ID,
 				1 * CURRENCY_AUSD_DECIMALS,
-				Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			),
 			Error::<Runtime>::InsufficientOrderSize
 		);
@@ -566,7 +566,7 @@ fn place_order_requires_pair_with_defined_min() {
 				DEV_AUSD_CURRENCY_ID,
 				FOREIGN_CURRENCY_NO_MIN_ID,
 				10 * CURRENCY_AUSD_DECIMALS,
-				Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				1 * CURRENCY_AUSD_DECIMALS,
 			),
 			Error::<Runtime>::InvalidTradingPair
@@ -583,7 +583,7 @@ fn place_order_requires_non_zero_min_fulfillment() {
 				DEV_AUSD_CURRENCY_ID,
 				DEV_USDT_CURRENCY_ID,
 				10 * CURRENCY_AUSD_DECIMALS,
-				Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				0
 			),
 			Error::<Runtime>::InvalidMinimumFulfillment
@@ -600,7 +600,7 @@ fn place_order_min_fulfillment_cannot_be_less_than_buy() {
 				DEV_AUSD_CURRENCY_ID,
 				DEV_USDT_CURRENCY_ID,
 				10 * CURRENCY_AUSD_DECIMALS,
-				Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				11 * CURRENCY_AUSD_DECIMALS
 			),
 			Error::<Runtime>::InvalidBuyAmount
@@ -617,7 +617,7 @@ fn place_order_requires_non_zero_price() {
 				DEV_AUSD_CURRENCY_ID,
 				DEV_USDT_CURRENCY_ID,
 				100 * CURRENCY_AUSD_DECIMALS,
-				Rate::zero(),
+				FixedU128::zero(),
 				100 * CURRENCY_AUSD_DECIMALS
 			),
 			Error::<Runtime>::InvalidMaxPrice
@@ -633,7 +633,7 @@ fn cancel_order_works() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			100 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -678,7 +678,7 @@ fn update_order_works_with_order_increase() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			10 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -686,7 +686,7 @@ fn update_order_works_with_order_increase() {
 			ACCOUNT_0,
 			order_id,
 			15 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_integer(2u32).unwrap(),
+			FixedU128::checked_from_integer(2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		assert_eq!(
@@ -698,7 +698,7 @@ fn update_order_works_with_order_increase() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 15 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_integer(2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_integer(2u32).unwrap(),
 				min_fullfillment_amount: 5 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 30 * CURRENCY_USDT_DECIMALS
 			})
@@ -713,7 +713,7 @@ fn update_order_works_with_order_increase() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 15 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_integer(2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_integer(2u32).unwrap(),
 				min_fullfillment_amount: 5 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 30 * CURRENCY_USDT_DECIMALS
 			})
@@ -746,7 +746,7 @@ fn update_order_works_with_order_increase() {
 				account: ACCOUNT_0,
 				buy_amount: 15 * CURRENCY_AUSD_DECIMALS,
 				min_fullfillment_amount: 5 * CURRENCY_AUSD_DECIMALS,
-				sell_rate_limit: Rate::checked_from_integer(2u32).unwrap()
+				sell_rate_limit: FixedU128::checked_from_integer(2u32).unwrap()
 			})
 		);
 	})
@@ -762,7 +762,7 @@ fn update_order_updates_min_fulfillment() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			10 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -770,7 +770,7 @@ fn update_order_updates_min_fulfillment() {
 			ACCOUNT_0,
 			order_id,
 			10 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			6 * CURRENCY_AUSD_DECIMALS
 		));
 		assert_eq!(
@@ -783,7 +783,7 @@ fn update_order_updates_min_fulfillment() {
 				buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 
-				max_sell_rate: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				min_fullfillment_amount: 6 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 15 * CURRENCY_USDT_DECIMALS
 			})
@@ -799,7 +799,7 @@ fn update_order_updates_min_fulfillment() {
 				buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 
-				max_sell_rate: Rate::checked_from_rational(3u32, 2u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 				min_fullfillment_amount: 6 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 15 * CURRENCY_USDT_DECIMALS
 			})
@@ -814,7 +814,7 @@ fn update_order_updates_min_fulfillment() {
 				account: ACCOUNT_0,
 				buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 				min_fullfillment_amount: 6 * CURRENCY_AUSD_DECIMALS,
-				sell_rate_limit: Rate::checked_from_rational(3u32, 2u32).unwrap()
+				sell_rate_limit: FixedU128::checked_from_rational(3u32, 2u32).unwrap()
 			})
 		);
 	})
@@ -828,7 +828,7 @@ fn update_order_works_with_order_decrease() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -836,7 +836,7 @@ fn update_order_works_with_order_decrease() {
 			ACCOUNT_0,
 			order_id,
 			10 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_integer(1u32).unwrap(),
+			FixedU128::checked_from_integer(1u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		assert_eq!(
@@ -848,7 +848,7 @@ fn update_order_works_with_order_decrease() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 15 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_integer(1u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_integer(1u32).unwrap(),
 				min_fullfillment_amount: 5 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 10 * CURRENCY_USDT_DECIMALS
 			})
@@ -863,7 +863,7 @@ fn update_order_works_with_order_decrease() {
 				asset_out_id: DEV_USDT_CURRENCY_ID,
 				buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 15 * CURRENCY_AUSD_DECIMALS,
-				max_sell_rate: Rate::checked_from_integer(1u32).unwrap(),
+				max_sell_rate: FixedU128::checked_from_integer(1u32).unwrap(),
 				min_fullfillment_amount: 5 * CURRENCY_AUSD_DECIMALS,
 				max_sell_amount: 10 * CURRENCY_USDT_DECIMALS
 			})
@@ -896,7 +896,7 @@ fn update_order_works_with_order_decrease() {
 				account: ACCOUNT_0,
 				buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 				min_fullfillment_amount: 5 * CURRENCY_AUSD_DECIMALS,
-				sell_rate_limit: Rate::checked_from_integer(1u32).unwrap()
+				sell_rate_limit: FixedU128::checked_from_integer(1u32).unwrap()
 			})
 		);
 	})
@@ -910,7 +910,7 @@ fn update_order_requires_no_min_buy() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -918,7 +918,7 @@ fn update_order_requires_no_min_buy() {
 			ACCOUNT_0,
 			order_id,
 			1 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_integer(1u32).unwrap(),
+			FixedU128::checked_from_integer(1u32).unwrap(),
 			1 * CURRENCY_AUSD_DECIMALS
 		),);
 	})
@@ -932,7 +932,7 @@ fn user_update_order_requires_min_buy() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -941,7 +941,7 @@ fn user_update_order_requires_min_buy() {
 				RuntimeOrigin::signed(ACCOUNT_0),
 				order_id,
 				1 * CURRENCY_AUSD_DECIMALS,
-				Rate::checked_from_integer(1u32).unwrap(),
+				FixedU128::checked_from_integer(1u32).unwrap(),
 			),
 			Error::<Runtime>::InsufficientOrderSize
 		);
@@ -956,7 +956,7 @@ fn update_order_requires_non_zero_min_fulfillment() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -965,7 +965,7 @@ fn update_order_requires_non_zero_min_fulfillment() {
 				ACCOUNT_0,
 				order_id,
 				10 * CURRENCY_AUSD_DECIMALS,
-				Rate::checked_from_integer(1u32).unwrap(),
+				FixedU128::checked_from_integer(1u32).unwrap(),
 				0
 			),
 			Error::<Runtime>::InvalidMinimumFulfillment
@@ -981,7 +981,7 @@ fn update_order_min_fulfillment_cannot_be_less_than_buy() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -990,7 +990,7 @@ fn update_order_min_fulfillment_cannot_be_less_than_buy() {
 				ACCOUNT_0,
 				order_id,
 				10 * CURRENCY_AUSD_DECIMALS,
-				Rate::checked_from_integer(1u32).unwrap(),
+				FixedU128::checked_from_integer(1u32).unwrap(),
 				15 * CURRENCY_AUSD_DECIMALS,
 			),
 			Error::<Runtime>::InvalidBuyAmount
@@ -1006,7 +1006,7 @@ fn update_order_requires_non_zero_price() {
 			DEV_AUSD_CURRENCY_ID,
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
-			Rate::checked_from_rational(3u32, 2u32).unwrap(),
+			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -1015,7 +1015,7 @@ fn update_order_requires_non_zero_price() {
 				ACCOUNT_0,
 				order_id,
 				10 * CURRENCY_AUSD_DECIMALS,
-				Rate::zero(),
+				FixedU128::zero(),
 				15 * CURRENCY_AUSD_DECIMALS,
 			),
 			Error::<Runtime>::InvalidMaxPrice

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -30,7 +30,7 @@ use cfg_traits::{
 use cfg_types::{
 	consts::pools::*,
 	fee_keys::FeeKey,
-	fixed_point::{Quantity, Rate},
+	fixed_point::{Quantity, Rate, Ratio},
 	ids::PRICE_ORACLE_PALLET_ID,
 	locations::Location,
 	oracles::OracleKey,
@@ -1827,7 +1827,7 @@ impl pallet_order_book::Config for Runtime {
 	type OrderIdNonce = u64;
 	type OrderPairVecSize = OrderPairVecSize;
 	type RuntimeEvent = RuntimeEvent;
-	type SellRatio = Rate;
+	type SellRatio = Ratio;
 	type TradeableAsset = Tokens;
 	type Weights = weights::pallet_order_book::WeightInfo<Runtime>;
 }


### PR DESCRIPTION
# Description

Ideally, `order-book` should use an 18-decimal fixed point number too.

## Changes and Descriptions
- Change type in dev runtime.
- Remove dependency from `Rate` type in tests/benchs.