### PR TITLE
feat: encode source address correctly in gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "development-runtime"
-version = "0.10.24"
+version = "0.10.26"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "development-runtime"
-version = "0.10.26"
+version = "0.10.27"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.3.4",
  "liquidity-pools-gateway-routers",
  "log",
  "moonbeam-relay-encoder",
@@ -605,6 +605,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-traits",
  "cfg-types",
+ "cfg-utils",
  "ethabi 18.0.0",
  "fp-evm",
  "frame-benchmarking",
@@ -1079,7 +1080,7 @@ dependencies = [
  "frame-system",
  "futures",
  "getrandom 0.2.10",
- "hex-literal",
+ "hex-literal 0.3.4",
  "jsonrpsee",
  "log",
  "pallet-anchors",
@@ -1161,7 +1162,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.3.4",
  "liquidity-pools-gateway-routers",
  "log",
  "moonbeam-relay-encoder",
@@ -1360,7 +1361,7 @@ dependencies = [
  "cfg-utils",
  "frame-support",
  "hex",
- "hex-literal",
+ "hex-literal 0.3.4",
  "orml-asset-registry",
  "parity-scale-codec 3.6.4",
  "scale-info",
@@ -1378,6 +1379,7 @@ version = "2.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "hex",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec 3.6.4",
@@ -2709,7 +2711,7 @@ dependencies = [
  "frame-try-runtime",
  "getrandom 0.2.10",
  "hex",
- "hex-literal",
+ "hex-literal 0.3.4",
  "liquidity-pools-gateway-routers",
  "moonbeam-relay-encoder",
  "orml-asset-registry",
@@ -4461,6 +4463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5048,7 +5056,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.3.4",
  "kusama-runtime-constants",
  "log",
  "pallet-authority-discovery",
@@ -7679,9 +7687,12 @@ dependencies = [
  "cfg-mocks",
  "cfg-traits",
  "cfg-types",
+ "cfg-utils",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex",
+ "hex-literal 0.4.1",
  "pallet-balances",
  "parity-scale-codec 3.6.4",
  "rand 0.8.5",
@@ -9654,7 +9665,7 @@ version = "0.9.38"
 source = "git+https://github.com/paritytech//polkadot?rev=097ffd245c42aeff28cf80f8a3568e1bee2e7da7#097ffd245c42aeff28cf80f8a3568e1bee2e7da7"
 dependencies = [
  "bitvec 1.0.1",
- "hex-literal",
+ "hex-literal 0.3.4",
  "parity-scale-codec 3.6.4",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -9720,7 +9731,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.3.4",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -9924,7 +9935,7 @@ dependencies = [
  "frame-support",
  "frame-system-rpc-runtime-api",
  "futures",
- "hex-literal",
+ "hex-literal 0.3.4",
  "kusama-runtime",
  "kvdb",
  "kvdb-rocksdb",
@@ -10817,7 +10828,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.3.4",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -10978,7 +10989,7 @@ dependencies = [
  "fp-self-contained",
  "frame-support",
  "frame-system",
- "hex-literal",
+ "hex-literal 0.3.4",
  "log",
  "orml-asset-registry",
  "orml-oracle",
@@ -15410,7 +15421,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
+ "hex-literal 0.3.4",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",

--- a/libs/mocks/src/liquidity_pools.rs
+++ b/libs/mocks/src/liquidity_pools.rs
@@ -1,7 +1,7 @@
 use cfg_traits::liquidity_pools::Codec;
-use codec::{Error, Input};
+use codec::{Decode, Error, Input};
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, codec::Encode, Decode)]
 pub enum MessageMock {
 	First,
 	Second,

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -12,6 +12,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
+hex = { version = "0.4.3", default_features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
@@ -33,6 +34,7 @@ std = [
   "codec/std",
   "scale-info/std",
   "sp-consensus-aura/std",
+  "hex/std"
 ]
 
 runtime-benchmarks = [

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -12,9 +12,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
-hex = { version = "0.4.3", default_features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+hex = { version = "0.4.3", default_features = false }
 pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
@@ -34,7 +34,7 @@ std = [
   "codec/std",
   "scale-info/std",
   "sp-consensus-aura/std",
-  "hex/std"
+  "hex/std",
 ]
 
 runtime-benchmarks = [

--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -78,9 +78,70 @@ where
 	pallet_timestamp::Pallet::<T>::set_timestamp(timestamp);
 }
 
+pub fn decode_var_source<const EXPECTED_SOURCE_ADDRESS_SIZE: usize>(
+	source_address: &[u8],
+) -> Option<[u8; EXPECTED_SOURCE_ADDRESS_SIZE]> {
+	const HEX_PREFIX: &str = "0x";
+
+	let mut address = [0u8; EXPECTED_SOURCE_ADDRESS_SIZE];
+
+	if source_address.len() == EXPECTED_SOURCE_ADDRESS_SIZE {
+		address.copy_from_slice(source_address);
+		return Some(address);
+	}
+
+	let try_bytes = match sp_std::str::from_utf8(source_address) {
+		Ok(res) => res.as_bytes(),
+		Err(_) => source_address
+	};
+
+	// Attempt to hex decode source address.
+	let bytes = match hex::decode(try_bytes) {
+		Ok(res) => Some(res),
+		Err(_) => {
+			// Strip 0x prefix.
+			let res = try_bytes.strip_prefix(HEX_PREFIX.as_bytes())?;
+
+			hex::decode(res).ok()
+		}
+	}?;
+
+	if bytes.len() == EXPECTED_SOURCE_ADDRESS_SIZE {
+		address.copy_from_slice(bytes.as_slice());
+		Some(address)
+	} else {
+		None
+	}
+}
+
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	mod get_source_address_bytes {
+		const EXPECTED: usize = 20;
+		use super::*;
+
+		#[test]
+		fn get_source_address_bytes_works() {
+			let hash = [1u8; 20];
+
+			decode_var_source::<EXPECTED>(&hash).expect("address bytes from H160 works");
+
+			let str = String::from(
+				"d47ed02acbbb66ee8a3fe0275bd98add0aa607c3",
+			);
+
+			decode_var_source::<EXPECTED>(str.as_bytes()).expect("address bytes from un-prefixed hex works");
+
+			let str = String::from(
+				"0xd47ed02acbbb66ee8a3fe0275bd98add0aa607c3",
+			);
+
+			decode_var_source::<EXPECTED>(str.as_bytes()).expect("address bytes from prefixed hex works");
+		}
+	}
 
 	mod vec_to_fixed_array {
 		use super::*;

--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -92,7 +92,7 @@ pub fn decode_var_source<const EXPECTED_SOURCE_ADDRESS_SIZE: usize>(
 
 	let try_bytes = match sp_std::str::from_utf8(source_address) {
 		Ok(res) => res.as_bytes(),
-		Err(_) => source_address
+		Err(_) => source_address,
 	};
 
 	// Attempt to hex decode source address.
@@ -114,7 +114,6 @@ pub fn decode_var_source<const EXPECTED_SOURCE_ADDRESS_SIZE: usize>(
 	}
 }
 
-
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -129,17 +128,15 @@ mod tests {
 
 			decode_var_source::<EXPECTED>(&hash).expect("address bytes from H160 works");
 
-			let str = String::from(
-				"d47ed02acbbb66ee8a3fe0275bd98add0aa607c3",
-			);
+			let str = String::from("d47ed02acbbb66ee8a3fe0275bd98add0aa607c3");
 
-			decode_var_source::<EXPECTED>(str.as_bytes()).expect("address bytes from un-prefixed hex works");
+			decode_var_source::<EXPECTED>(str.as_bytes())
+				.expect("address bytes from un-prefixed hex works");
 
-			let str = String::from(
-				"0xd47ed02acbbb66ee8a3fe0275bd98add0aa607c3",
-			);
+			let str = String::from("0xd47ed02acbbb66ee8a3fe0275bd98add0aa607c3");
 
-			decode_var_source::<EXPECTED>(str.as_bytes()).expect("address bytes from prefixed hex works");
+			decode_var_source::<EXPECTED>(str.as_bytes())
+				.expect("address bytes from prefixed hex works");
 		}
 	}
 

--- a/pallets/liquidity-pools-gateway/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/Cargo.toml
@@ -12,9 +12,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
-hex = {version = "0.4.3", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+hex = { version = "0.4.3", default-features = false }
 scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
@@ -32,9 +32,9 @@ cfg-utils = { path = "../../libs/utils", default-features = false }
 
 [dev-dependencies]
 cfg-mocks = { path = "../../libs/mocks", features = ["runtime-benchmarks", "std"] }
+hex-literal = "0.4.1"
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
-hex-literal = "0.4.1"
 
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 rand = "0.8.5"
@@ -52,7 +52,8 @@ std = [
   "sp-core/std",
   "sp-runtime/std",
   "scale-info/std",
-  "cfg-utils/std"
+  "cfg-utils/std",
+  "hex/std",
 ]
 try-runtime = [
   "cfg-traits/try-runtime",
@@ -60,7 +61,7 @@ try-runtime = [
   "frame-support/try-runtime",
   "frame-system/try-runtime",
   "sp-runtime/try-runtime",
-  "cfg-utils/try-runtime"
+  "cfg-utils/try-runtime",
 ]
 runtime-benchmarks = [
   "frame-benchmarking/runtime-benchmarks",
@@ -69,5 +70,5 @@ runtime-benchmarks = [
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
-  "cfg-utils/runtime-benchmarks"
+  "cfg-utils/runtime-benchmarks",
 ]

--- a/pallets/liquidity-pools-gateway/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/Cargo.toml
@@ -12,6 +12,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
+hex = {version = "0.4.3", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
@@ -27,11 +28,13 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 # Our custom pallets
 cfg-traits = { path = "../../libs/traits", default-features = false }
 cfg-types = { path = "../../libs/types", default-features = false }
+cfg-utils = { path = "../../libs/utils", default-features = false }
 
 [dev-dependencies]
 cfg-mocks = { path = "../../libs/mocks", features = ["runtime-benchmarks", "std"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
+hex-literal = "0.4.1"
 
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 rand = "0.8.5"
@@ -49,6 +52,7 @@ std = [
   "sp-core/std",
   "sp-runtime/std",
   "scale-info/std",
+  "cfg-utils/std"
 ]
 try-runtime = [
   "cfg-traits/try-runtime",
@@ -56,6 +60,7 @@ try-runtime = [
   "frame-support/try-runtime",
   "frame-system/try-runtime",
   "sp-runtime/try-runtime",
+  "cfg-utils/try-runtime"
 ]
 runtime-benchmarks = [
   "frame-benchmarking/runtime-benchmarks",
@@ -64,4 +69,5 @@ runtime-benchmarks = [
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
+  "cfg-utils/runtime-benchmarks"
 ]

--- a/pallets/liquidity-pools-gateway/axelar-gateway-precompile/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/axelar-gateway-precompile/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hex = { version = "0.4.3", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+hex = { version = "0.4.3", default-features = false }
 scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
@@ -24,8 +24,8 @@ pallet-evm = { git = "https://github.com/PureStake/frontier", default-features =
 precompile-utils = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
 
 cfg-traits = { path = "../../../libs/traits", default-features = false }
-cfg-utils = { path = "../../../libs/utils", default-features = false }
 cfg-types = { path = "../../../libs/types", default-features = false }
+cfg-utils = { path = "../../../libs/utils", default-features = false }
 pallet-liquidity-pools-gateway = { path = "../../liquidity-pools-gateway", default-features = false }
 
 [features]

--- a/pallets/liquidity-pools-gateway/axelar-gateway-precompile/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/axelar-gateway-precompile/Cargo.toml
@@ -24,6 +24,7 @@ pallet-evm = { git = "https://github.com/PureStake/frontier", default-features =
 precompile-utils = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }
 
 cfg-traits = { path = "../../../libs/traits", default-features = false }
+cfg-utils = { path = "../../../libs/utils", default-features = false }
 cfg-types = { path = "../../../libs/types", default-features = false }
 pallet-liquidity-pools-gateway = { path = "../../liquidity-pools-gateway", default-features = false }
 
@@ -44,6 +45,7 @@ std = [
   "pallet-liquidity-pools-gateway/std",
   "cfg-types/std",
   "cfg-traits/std",
+  "cfg-utils/std",
   "ethabi/std",
   "frame-benchmarking/std",
 ]
@@ -51,6 +53,7 @@ runtime-benchmarks = [
   "frame-benchmarking/runtime-benchmarks",
   "cfg-types/runtime-benchmarks",
   "cfg-traits/runtime-benchmarks",
+  "cfg-utils/runtime-benchmarks",
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
@@ -63,6 +66,7 @@ try-runtime = [
   "pallet-liquidity-pools-gateway/try-runtime",
   "cfg-types/try-runtime",
   "cfg-traits/try-runtime",
+  "cfg-utils/try-runtime",
   "pallet-evm/try-runtime",
   "sp-runtime/try-runtime",
 ]

--- a/pallets/liquidity-pools-gateway/axelar-gateway-precompile/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/axelar-gateway-precompile/src/lib.rs
@@ -276,9 +276,10 @@ where
 		})?;
 
 		let source_address_bytes =
-			cfg_utils::decode_var_source::<EXPECTED_SOURCE_ADDRESS_SIZE>(source_address.as_bytes()).ok_or(PrecompileFailure::Error {
-				exit_status: ExitError::Other("invalid source address".into()),
-			})?;
+			cfg_utils::decode_var_source::<EXPECTED_SOURCE_ADDRESS_SIZE>(source_address.as_bytes())
+				.ok_or(PrecompileFailure::Error {
+					exit_status: ExitError::Other("invalid source address".into()),
+				})?;
 
 		let domain_address = domain_converter
 			.try_convert(source_address_bytes.as_slice())

--- a/pallets/liquidity-pools-gateway/routers/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/routers/Cargo.toml
@@ -11,10 +11,10 @@ version = "0.0.1"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-hex = { version = "0.4.3", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+hex = { version = "0.4.3", default-features = false }
 scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -388,9 +388,9 @@ pub mod pallet {
 						Error::<T>::from(MalformedSourceAddress),
 						|source_address| {
 							// NOTE: Axelar simply provides the hexadecimal string of an EVM
-							// address as the `sourceAddress` argument.       Solidity does on the
-							// other side recognize the hex-encoding and encode the hex bytes to
-							//       utf-8 bytes.
+							//       address as the `sourceAddress` argument. Solidity does on the
+							//       other side recognize the hex-encoding and encode the hex bytes
+							//       to utf-8 bytes.
 							//
 							//       Hence, we are reverting this process here.
 							let source_address =

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -352,17 +352,23 @@ pub mod pallet {
 							})
 						})?;
 
-					let source_address =
-						Pallet::<T>::try_range(slice_ref, length_source_address, |source_address| {
-							// NOTE: Axelar simply provides the hexadecimal string of an EVM  address as the `sourceAddress` argument.
-							//       Solidity does on the other side recognize the hex-encoding and encode the hex bytes to
+					let source_address = Pallet::<T>::try_range(
+						slice_ref,
+						length_source_address,
+						|source_address| {
+							// NOTE: Axelar simply provides the hexadecimal string of an EVM
+							// address as the `sourceAddress` argument.       Solidity does on the
+							// other side recognize the hex-encoding and encode the hex bytes to
 							//       utf-8 bytes.
 							//
 							//       Hence, we are reverting this process here.
-							let source_address = cfg_utils::decode_var_source::<BYTES_ACCOUNT_20>(source_address).ok_or(Error::<T>::MessageDecodingFailed)?;
+							let source_address =
+								cfg_utils::decode_var_source::<BYTES_ACCOUNT_20>(source_address)
+									.ok_or(Error::<T>::MessageDecodingFailed)?;
 
 							Ok(source_address.to_vec())
-						})?;
+						},
+					)?;
 
 					let origin_msg = Pallet::<T>::try_range(slice_ref, slice_ref.len(), |msg| {
 						BoundedVec::try_from(msg.to_vec()).map_err(|_| {

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -40,7 +40,7 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	const BYTES_U32: usize = 4;
-
+	const BYTES_ACCOUNT_20: usize = 20;
 	use super::*;
 
 	#[pallet::pallet]
@@ -353,8 +353,15 @@ pub mod pallet {
 						})?;
 
 					let source_address =
-						Pallet::<T>::try_range(slice_ref, length_source_address, |source_chain| {
-							Ok(source_chain.to_vec())
+						Pallet::<T>::try_range(slice_ref, length_source_address, |source_address| {
+							// NOTE: Axelar simply provides the hexadecimal string of an EVM  address as the `sourceAddress` argument.
+							//       Solidity does on the other side recognize the hex-encoding and encode the hex bytes to
+							//       utf-8 bytes.
+							//
+							//       Hence, we are reverting this process here.
+							let source_address = cfg_utils::decode_var_source::<BYTES_ACCOUNT_20>(source_address).ok_or(Error::<T>::MessageDecodingFailed)?;
+
+							Ok(source_address.to_vec())
 						})?;
 
 					let origin_msg = Pallet::<T>::try_range(slice_ref, slice_ref.len(), |msg| {

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -18,8 +18,8 @@ pub type Balance = u128;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 
-pub const LENGTH_SOURCE_CHAIN: usize = 8;
-pub const SOURCE_CHAIN: [u8; LENGTH_SOURCE_CHAIN] = *b"ethereum";
+pub const LENGTH_SOURCE_CHAIN: usize = 10;
+pub const SOURCE_CHAIN: [u8; LENGTH_SOURCE_CHAIN] = *b"ethereum-2";
 pub const SOURCE_CHAIN_EVM_ID: u64 = 1;
 
 pub const LENGTH_SOURCE_ADDRESS: usize = 20;

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1416,7 +1416,8 @@ parameter_types! {
 	pub Sender: AccountId = GatewayAccountProvider::<Runtime, LocationToAccountId>::get_gateway_account();
 }
 
-/// A
+/// A stumb inbound queue that does not yet hit the LP logic (before FI we do
+/// not want that) but stores an Event.
 pub struct StumbInboundQueue;
 impl InboundQueue for StumbInboundQueue {
 	type Message = pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Quantity>;

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "development-runtime"
-version = "0.10.26"
+version = "0.10.27"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "development-runtime"
-version = "0.10.24"
+version = "0.10.26"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -138,7 +138,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge-devel"),
 	impl_name: create_runtime_str!("centrifuge-devel"),
 	authoring_version: 1,
-	spec_version: 1026,
+	spec_version: 1027,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -138,7 +138,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge-devel"),
 	impl_name: create_runtime_str!("centrifuge-devel"),
 	authoring_version: 1,
-	spec_version: 1024,
+	spec_version: 1026,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/development/src/liquidity_pools.rs
+++ b/runtime/development/src/liquidity_pools.rs
@@ -11,13 +11,46 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::{AccountId, Balance, PoolId, TrancheId};
-use cfg_types::{domain_address::Domain, fixed_point::Quantity};
-use frame_support::parameter_types;
+use cfg_traits::liquidity_pools::InboundQueue;
+use cfg_types::{
+	domain_address::{Domain, DomainAddress},
+	fixed_point::Quantity,
+};
+use frame_support::{dispatch::DispatchResult, parameter_types};
 use frame_system::EnsureRoot;
 use runtime_common::gateway::GatewayAccountProvider;
 
 use super::{Runtime, RuntimeEvent, RuntimeOrigin};
 use crate::LocationToAccountId;
+
+/// A stumb inbound queue that does not yet hit the LP logic (before FI we do
+/// not want that) but stores an Event.
+pub struct StumbInboundQueue;
+impl InboundQueue for StumbInboundQueue {
+	type Message = pallet_liquidity_pools::Message<Domain, PoolId, TrancheId, Balance, Quantity>;
+	type Sender = DomainAddress;
+
+	fn submit(sender: Self::Sender, message: Self::Message) -> DispatchResult {
+		let event = {
+			let event =
+				pallet_liquidity_pools::Event::<Runtime>::IncomingMessage { sender, message };
+
+			// Mirror deposit_event logic here as it is private
+			let event = <<Runtime as pallet_liquidity_pools::Config>::RuntimeEvent as From<
+				pallet_liquidity_pools::Event<Runtime>,
+			>>::from(event);
+
+			<<Runtime as pallet_liquidity_pools::Config>::RuntimeEvent as Into<
+				<Runtime as frame_system::Config>::RuntimeEvent,
+			>>::into(event)
+		};
+
+		// Triggering only the event for error resolution
+		crate::System::deposit_event(event);
+
+		Ok(())
+	}
+}
 
 parameter_types! {
 	pub const MaxIncomingMessageSize: u32 = 1024;

--- a/runtime/development/src/xcm.rs
+++ b/runtime/development/src/xcm.rs
@@ -333,7 +333,7 @@ pub type XcmRouter = (
 
 const MOONBASE_ALPHA_PARA_ID: u32 = 1000;
 /// https://chainlist.org/chain/1287
-const MOONBASE_ALPHA_EVM_ID: u64 = 1282;
+const MOONBASE_ALPHA_EVM_ID: u64 = 1287;
 
 /// A constant way of mapping parachain IDs to EVM-chain IDs
 pub struct ParaToEvm;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,5 +3,5 @@ imports_granularity = "Crate"
 reorder_impl_items = true
 reorder_imports = true
 group_imports = "StdExternalCrate"
-reorder_modules = true 
+reorder_modules = true
 wrap_comments = true


### PR DESCRIPTION
# Description
The address that we are receiving from EVM chains is a `utf-8(hex(address))` encoded byte bloob. This was an issue before because we expected it to be just an `[u8; 20]`.

## Changes and Descriptions
* update parsing of account from Axelar
* utility function for both precompile and gateway

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
