### PR TITLE
lp-gateway: Emit more events when processing an incoming message

### DIFF
--- a/runtime/integration-tests/src/liquidity_pools/pallet/development/setup.rs
+++ b/runtime/integration-tests/src/liquidity_pools/pallet/development/setup.rs
@@ -25,7 +25,7 @@ pub const TEST_DOMAIN: Domain = Domain::EVM(1284);
 
 /// A PARA ID used for a sibling parachain emulating Moonbeam.
 /// It must be one that doesn't collide with any other in use.
-pub const PARA_ID_MOONBEAM: u32 = 2023;
+pub const PARA_ID_MOONBEAM: u32 = 1000;
 
 pub struct ExtBuilder {
 	balances: Vec<(AccountId, CurrencyId, Balance)>,

--- a/runtime/integration-tests/src/liquidity_pools/pallet/development/test_net.rs
+++ b/runtime/integration-tests/src/liquidity_pools/pallet/development/test_net.rs
@@ -62,7 +62,7 @@ decl_test_network! {
 			// Be sure to use `parachains::polkadot::centrifuge::ID`
 			(2031, Development),
 			// Be sure to use `PARA_ID_MOONBEAM`
-			(2023, Moonbeam),
+			(1000, Moonbeam),
 		],
 	}
 }


### PR DESCRIPTION
# Description

Added more events in LP gateway `process_msg` to allow for better debugging of incoming XCM transaction.

# Checklist:

- [ ] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
