### PR TITLE
feat: enable full foreign collect flow via extrinsic

### DIFF
--- a/libs/traits/src/investments.rs
+++ b/libs/traits/src/investments.rs
@@ -297,7 +297,6 @@ pub trait ForeignInvestment<AccountId> {
 	type CurrencyId;
 	type Error: Debug;
 	type InvestmentId;
-	type CollectInvestResult;
 
 	/// Initiates the increment of a foreign investment amount in
 	/// `foreign_payment_currency` of who into the investment class
@@ -365,8 +364,7 @@ pub trait ForeignInvestment<AccountId> {
 		who: &AccountId,
 		investment_id: Self::InvestmentId,
 		foreign_currency: Self::CurrencyId,
-		pool_currency: Self::CurrencyId,
-	) -> Result<Self::CollectInvestResult, Self::Error>;
+	) -> Result<(), Self::Error>;
 
 	/// Collect the results of a user's foreign redeem orders for the given
 	/// investment. If any amounts are not fulfilled they are directly

--- a/libs/types/src/investments.rs
+++ b/libs/types/src/investments.rs
@@ -185,7 +185,7 @@ pub struct Swap<
 	pub currency_in: Currency,
 	/// The outgoing currency, i.e. the one which should be replaced.
 	pub currency_out: Currency,
-	/// The amount of outgoing currency which shall be exchanged.
+	/// The amount of incoming currency which shall be bought.
 	pub amount: Balance,
 }
 

--- a/libs/types/src/investments.rs
+++ b/libs/types/src/investments.rs
@@ -237,30 +237,29 @@ pub struct ExecutedForeignDecreaseInvest<Balance, Currency> {
 	pub amount_remaining: Balance,
 }
 
-/// A representation of an executed collected investment.
+/// A representation of an executed collected foreign investment or redemption.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, Default, TypeInfo, MaxEncodedLen)]
 
-pub struct ExecutedForeignCollectInvest<Balance> {
-	/// The amount that was actually collected
-	pub amount_currency_payout: Balance,
-	/// The amount of tranche tokens received for the investment made
-	pub amount_tranche_tokens_payout: Balance,
-	/// The unprocessed plus processed but not yet collected investment amount
-	/// denominated in foreign currency
-	pub amount_remaining_invest: Balance,
-}
-
-/// A representation of an executed collected redemption.
-#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, Default, TypeInfo, MaxEncodedLen)]
-
-pub struct ExecutedForeignCollectRedeem<Balance, Currency> {
-	/// The foreign currency in which the payout takes place
+pub struct ExecutedForeignCollect<Balance, Currency> {
+	/// The foreign currency in which ...
+	/// * If investment: the payment took place
+	/// * If redemption: the payout takes place
 	pub currency: Currency,
-	/// The amount of `currency` being paid out to the investor
+
+	/// The amount of `currency`...
+	/// * If investment: that was collected
+	/// * If redemption: paid out to the investor
 	pub amount_currency_payout: Balance,
-	/// How many tranche tokens were actually redeemed
+
+	/// The amount of tranche tokens...
+	/// * If investment: received for the investment made
+	/// * If redemption: which were actually redeemed
 	pub amount_tranche_tokens_payout: Balance,
-	/// The unprocessed plus processed but not yet collected redemption amount
-	/// of tranche tokens
-	pub amount_remaining_redeem: Balance,
+
+	/// The unprocessed ...
+	/// * If investment: investment amount of `currency` (denominated in foreign
+	///   currency)
+	/// * If redemption: redemption amount of tranche tokens (denominated in
+	///   pool currency)
+	pub amount_remaining: Balance,
 }

--- a/pallets/foreign-investments/src/errors.rs
+++ b/pallets/foreign-investments/src/errors.rs
@@ -32,6 +32,12 @@ pub enum InvestError {
 	CollectTransition,
 	/// The investment needs to be collected before it can be updated further.
 	CollectRequired,
+	/// The provided currency does not match the one stored when the first
+	/// investment increase was triggered.
+	///
+	/// NOTE: As long as the `InvestmentState` has not been cleared, the
+	/// payment currency cannot change from the initially provided one.
+	InvalidPaymentCurrency,
 }
 
 #[derive(Encode, Decode, TypeInfo, PalletError)]
@@ -41,13 +47,6 @@ pub enum RedeemError {
 	IncreaseTransition,
 	/// Failed to collect the redemption.
 	CollectTransition,
-	/// Failed to retrieve the foreign payout currency for a collected
-	/// redemption.
-	///
-	/// NOTE: This error can only occur, if a user tries to collect before
-	/// having increased their redemption as this would store the payout
-	/// currency.
-	CollectPayoutCurrencyNotFound,
 	/// The desired decreasing amount exceeds the max amount.
 	DecreaseAmountOverflow,
 	/// Failed to transition the state as a result of a decrease.
@@ -56,6 +55,12 @@ pub enum RedeemError {
 	FulfillSwapOrderTransition,
 	/// The redemption needs to be collected before it can be updated further.
 	CollectRequired,
+	/// The provided currency does not match the one stored when the first
+	/// redemption increase was triggered.
+	///
+	/// NOTE: As long as the `RedemptionState` has not been cleared, the
+	/// payout currency cannot change from the initially provided one.
+	InvalidPayoutCurrency,
 }
 
 impl<T: Config> From<InvestError> for Error<T> {

--- a/pallets/foreign-investments/src/impls/mod.rs
+++ b/pallets/foreign-investments/src/impls/mod.rs
@@ -56,7 +56,7 @@ impl<T: Config> ForeignInvestment<T::AccountId> for Pallet<T> {
 		);
 
 		// NOTE: For the MVP, we simply overwrite any existing payment currency. In a
-		// later version, we might want to store a `BoundedVec` instead.
+		// later version, we might want to store a `StorageDoubleMap` instead.
 		InvestmentPaymentCurrency::<T>::insert(who, investment_id, foreign_currency);
 
 		let amount_pool_denominated =
@@ -328,9 +328,6 @@ impl<T: Config> Pallet<T> {
 		match state {
 			InvestState::NoState => {
 				InvestmentState::<T>::remove(who, investment_id);
-				#[cfg(feature = "std")] {
-					println!("Clearing InvestState");
-				}
 				InvestmentPaymentCurrency::<T>::remove(who, investment_id);
 
 				Ok((InvestState::NoState, None, Zero::zero()))

--- a/pallets/foreign-investments/src/impls/mod.rs
+++ b/pallets/foreign-investments/src/impls/mod.rs
@@ -1194,7 +1194,7 @@ impl<T: Config> Pallet<T> {
 			},
 			ExecutedForeignCollect {
 				currency: foreign_payout_currency,
-				amount_currency_payout: amount_currency_payout,
+				amount_currency_payout,
 				amount_tranche_tokens_payout: collected.amount_collected,
 				amount_remaining: amount_remaining_invest_foreign_denominated,
 			},

--- a/pallets/foreign-investments/src/lib.rs
+++ b/pallets/foreign-investments/src/lib.rs
@@ -375,6 +375,7 @@ pub mod pallet {
 		Blake2_128Concat,
 		T::InvestmentId,
 		T::CurrencyId,
+		ResultQuery<Error<T>::InvestmentPaymentCurrencyNotFound>,
 	>;
 
 	/// Maps an investor and their investment id to the foreign payout currency
@@ -390,6 +391,7 @@ pub mod pallet {
 		Blake2_128Concat,
 		T::InvestmentId,
 		T::CurrencyId,
+		ResultQuery<Error<T>::RedemptionPayoutCurrencyNotFound>,
 	>;
 
 	#[pallet::event]
@@ -417,15 +419,23 @@ pub mod pallet {
 
 	#[pallet::error]
 	pub enum Error<T> {
+		/// Failed to retrieve the foreign payment currency for a collected
+		/// investment.
+		///
+		/// NOTE: This error can only occur, if a user tries to collect before
+		/// having increased their investment as this would store the payment
+		/// currency.
+		InvestmentPaymentCurrencyNotFound,
+		/// Failed to retrieve the foreign payout currency for a collected
+		/// redemption.
+		///
+		/// NOTE: This error can only occur, if a user tries to collect before
+		/// having increased their redemption as this would store the payout
+		/// currency.
+		RedemptionPayoutCurrencyNotFound,
 		/// Failed to retrieve the `TokenSwapReason` from the given
 		/// `TokenSwapOrderId`.
 		InvestmentInfoNotFound,
-		/// The provided currency does not match the one provided when the first
-		/// redemption increase was triggered.
-		///
-		/// NOTE: As long as the `RedemptionState` has not been cleared, the
-		/// payout currency cannot change from the initially provided one.
-		InvalidRedemptionPayoutCurrency,
 		/// Failed to retrieve the `TokenSwapReason` from the given
 		/// `TokenSwapOrderId`.
 		TokenSwapReasonNotFound,
@@ -439,10 +449,5 @@ pub mod pallet {
 		RedeemError(RedeemError),
 		/// Failed to retrieve the pool for the given pool id.
 		PoolNotFound,
-		/// Failed to retrieve the payment currency when collecting an
-		/// investment.
-		///
-		/// NOTE: The payment currency is mutated upon increasing an investment.
-		InvestmentPaymentCurrencyNotFound,
 	}
 }

--- a/pallets/foreign-investments/src/lib.rs
+++ b/pallets/foreign-investments/src/lib.rs
@@ -68,7 +68,7 @@ pub mod pallet {
 		PoolInspect, StatusNotificationHook, TokenSwaps,
 	};
 	use cfg_types::investments::{
-		CollectedAmount, ExecutedForeignCollectRedeem, ExecutedForeignDecreaseInvest,
+		CollectedAmount, ExecutedForeignCollect, ExecutedForeignDecreaseInvest,
 	};
 	use errors::{InvestError, RedeemError};
 	use frame_support::{dispatch::HasCompact, pallet_prelude::*};
@@ -211,7 +211,18 @@ pub mod pallet {
 				Self::InvestmentId,
 				(),
 			>,
-			Status = ExecutedForeignCollectRedeem<Self::Balance, Self::CurrencyId>,
+			Status = ExecutedForeignCollect<Self::Balance, Self::CurrencyId>,
+			Error = DispatchError,
+		>;
+
+		/// The hook type which acts upon a finalized redemption collection.
+		type CollectedForeignInvestmentHook: StatusNotificationHook<
+			Id = cfg_types::investments::ForeignInvestmentInfo<
+				Self::AccountId,
+				Self::InvestmentId,
+				(),
+			>,
+			Status = ExecutedForeignCollect<Self::Balance, Self::CurrencyId>,
 			Error = DispatchError,
 		>;
 
@@ -318,7 +329,7 @@ pub mod pallet {
 	/// NOTE: The lifetime of this storage starts with receiving a notification
 	/// of an executed investment via the `CollectedInvestmentHook`. It ends
 	/// with transferring the collected tranche tokens by executing
-	/// `transfer_collected_investment` which is part of
+	/// `notify_executed_collect_invest` which is part of
 	/// `collect_foreign_investment`.
 	#[pallet::storage]
 	pub type CollectedInvestment<T: Config> = StorageDoubleMap<
@@ -351,12 +362,26 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
+	/// Maps an investor and their investment id to the foreign payment currency
+	/// provided on the initial investment increment.
+	///
+	/// The lifetime is synchronized with the one of
+	/// `InvestmentState`.
+	#[pallet::storage]
+	pub type InvestmentPaymentCurrency<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,
+		Blake2_128Concat,
+		T::InvestmentId,
+		T::CurrencyId,
+	>;
+
 	/// Maps an investor and their investment id to the foreign payout currency
 	/// requested on the initial redemption increment.
 	///
-	/// TODO(future): The lifetime of this storage is currently defensively
-	/// indefinite. It should most likely mirror the one of `RedemptionState`
-	/// though right now it
+	/// The lifetime is synchronized with the one of
+	/// `RedemptionState`.
 	#[pallet::storage]
 	pub type RedemptionPayoutCurrency<T: Config> = StorageDoubleMap<
 		_,
@@ -412,17 +437,12 @@ pub mod pallet {
 		InvestError(InvestError),
 		/// Failed to transition the `RedeemState.`
 		RedeemError(RedeemError),
+		/// Failed to retrieve the pool for the given pool id.
+		PoolNotFound,
+		/// Failed to retrieve the payment currency when collecting an
+		/// investment.
+		///
+		/// NOTE: The payment currency is mutated upon increasing an investment.
+		InvestmentPaymentCurrencyNotFound,
 	}
-
-	// 	impl<T> From<InvestError> for Error<T> {
-	// 		fn from(error: InvestError) -> Self {
-	// 			Error::<T>::InvestError(error)
-	// 		}
-	// 	}
-
-	// 	impl<T> From<RedeemError> for Error<T> {
-	// 		fn from(error: RedeemError) -> Self {
-	// 			Error::<T>::RedeemError(error)
-	// 		}
-	// 	}
 }

--- a/pallets/liquidity-pools/src/hooks.rs
+++ b/pallets/liquidity-pools/src/hooks.rs
@@ -114,7 +114,6 @@ where
 }
 
 /// The hook struct which acts upon a finalized investment collection.
-
 pub struct CollectedForeignInvestmentHook<T>(PhantomData<T>);
 
 impl<T: Config> StatusNotificationHook for CollectedForeignInvestmentHook<T>

--- a/pallets/liquidity-pools/src/hooks.rs
+++ b/pallets/liquidity-pools/src/hooks.rs
@@ -151,7 +151,7 @@ where
 			pool_id: investment_id.of_pool(),
 			tranche_id: investment_id.of_tranche(),
 			investor: investor.into(),
-			currency: currency,
+			currency,
 			currency_payout: status.amount_currency_payout,
 			tranche_tokens_payout: status.amount_tranche_tokens_payout,
 			remaining_invest_amount: status.amount_remaining,

--- a/pallets/liquidity-pools/src/inbound.rs
+++ b/pallets/liquidity-pools/src/inbound.rs
@@ -137,7 +137,10 @@ where
 		amount: <T as Config>::Balance,
 	) -> DispatchResult {
 		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
-		let payment_currency = Self::try_get_payment_currency(invest_id.clone(), currency_index)?;
+		// NOTE: Even though we can assume this currency to have been used as payment,
+		// the trading pair needs to be registered for the opposite direction in case a
+		// swap from pool to foreign results from updating the `InvestState`
+		let payout_currency = Self::try_get_payout_currency(invest_id.clone(), currency_index)?;
 		let pool_currency =
 			T::PoolInspect::currency_for(pool_id).ok_or(Error::<T>::PoolNotFound)?;
 
@@ -145,7 +148,7 @@ where
 			&investor,
 			invest_id,
 			amount,
-			payment_currency,
+			payout_currency,
 			pool_currency,
 		)?;
 
@@ -305,11 +308,11 @@ where
 		currency_index: GeneralCurrencyIndexOf<T>,
 	) -> DispatchResult {
 		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
-		let payout_currency = Self::try_get_payout_currency(invest_id.clone(), currency_index)?;
+		let payment_currency = Self::try_get_payment_currency(invest_id.clone(), currency_index)?;
 
 		// NOTE: Dispatch of `ExecutedCollectInvest` is handled by
 		// `ExecutedCollectInvestHook`
-		T::ForeignInvestment::collect_foreign_investment(&investor, invest_id, payout_currency)?;
+		T::ForeignInvestment::collect_foreign_investment(&investor, invest_id, payment_currency)?;
 
 		Ok(())
 	}

--- a/pallets/liquidity-pools/src/inbound.rs
+++ b/pallets/liquidity-pools/src/inbound.rs
@@ -309,11 +309,7 @@ where
 
 		// NOTE: Dispatch of `ExecutedCollectInvest` is handled by
 		// `ExecutedCollectInvestHook`
-		T::ForeignInvestment::collect_foreign_investment(
-			&investor,
-			invest_id.clone(),
-			payout_currency,
-		)?;
+		T::ForeignInvestment::collect_foreign_investment(&investor, invest_id, payout_currency)?;
 
 		Ok(())
 	}

--- a/pallets/liquidity-pools/src/inbound.rs
+++ b/pallets/liquidity-pools/src/inbound.rs
@@ -16,7 +16,6 @@ use cfg_traits::{
 };
 use cfg_types::{
 	domain_address::{Domain, DomainAddress},
-	investments::ExecutedForeignCollectInvest,
 	permissions::{PermissionScope, PoolRole, Role},
 };
 use frame_support::{
@@ -195,7 +194,6 @@ where
 
 		// Transfer tranche tokens from `DomainLocator` account of
 		// origination domain
-		// TODO(@review): Should this rather be part of `increase_foreign_redemption`?
 		T::Tokens::transfer(
 			invest_id.clone().into(),
 			&Domain::convert(sending_domain.domain()),
@@ -305,44 +303,17 @@ where
 		tranche_id: T::TrancheId,
 		investor: T::AccountId,
 		currency_index: GeneralCurrencyIndexOf<T>,
-		destination: DomainAddress,
 	) -> DispatchResult {
 		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
-		let currency_index_u128 = currency_index.index;
 		let payout_currency = Self::try_get_payout_currency(invest_id.clone(), currency_index)?;
-		let pool_currency =
-			T::PoolInspect::currency_for(pool_id).ok_or(Error::<T>::PoolNotFound)?;
 
-		let ExecutedForeignCollectInvest::<T::Balance> {
-			amount_currency_payout,
-			amount_tranche_tokens_payout,
-			amount_remaining_invest,
-		} = T::ForeignInvestment::collect_foreign_investment(
+		// NOTE: Dispatch of `ExecutedCollectInvest` is handled by
+		// `ExecutedCollectInvestHook`
+		T::ForeignInvestment::collect_foreign_investment(
 			&investor,
 			invest_id.clone(),
 			payout_currency,
-			pool_currency,
 		)?;
-
-		T::Tokens::transfer(
-			invest_id.into(),
-			&investor,
-			&Domain::convert(destination.domain()),
-			amount_tranche_tokens_payout,
-			false,
-		)?;
-
-		let message: MessageOf<T> = Message::ExecutedCollectInvest {
-			pool_id,
-			tranche_id,
-			investor: investor.into(),
-			currency: currency_index_u128,
-			currency_payout: amount_currency_payout,
-			tranche_tokens_payout: amount_tranche_tokens_payout,
-			remaining_invest_amount: amount_remaining_invest,
-		};
-
-		T::OutboundQueue::submit(T::TreasuryAccount::get(), destination.domain(), message)?;
 
 		Ok(())
 	}

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -44,7 +44,6 @@ use core::convert::TryFrom;
 use cfg_traits::liquidity_pools::{InboundQueue, OutboundQueue};
 use cfg_types::{
 	domain_address::{Domain, DomainAddress},
-	investments::ExecutedForeignCollectInvest,
 	tokens::GeneralCurrencyIndex,
 };
 use cfg_utils::vec_to_fixed_array;
@@ -227,7 +226,6 @@ pub mod pallet {
 			CurrencyId = CurrencyIdOf<Self>,
 			Error = DispatchError,
 			InvestmentId = <Self as Config>::TrancheCurrency,
-			CollectInvestResult = ExecutedForeignCollectInvest<Self::Balance>,
 		>;
 
 		/// The source of truth for the transferability of assets via the
@@ -679,7 +677,7 @@ pub mod pallet {
 		/// pool on the domain derived from the given currency.
 		#[pallet::call_index(9)]
 		#[pallet::weight(10_000 + T::DbWeight::get().writes(1).ref_time())]
-		pub fn allow_pool_currency(
+		pub fn allow_investment_currency(
 			origin: OriginFor<T>,
 			pool_id: T::PoolId,
 			tranche_id: T::TrancheId,
@@ -799,8 +797,6 @@ pub mod pallet {
 				},
 			)
 		}
-
-		// TODO(@future): pub fn update_tranche_investment_limit
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -1025,7 +1021,6 @@ pub mod pallet {
 					tranche_id,
 					T::DomainAccountToAccountId::convert((sender.domain(), investor)),
 					currency.into(),
-					sender,
 				),
 				Message::CollectRedeem {
 					pool_id,

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -688,11 +688,18 @@ pub mod pallet {
 			// See spec: https://centrifuge.hackmd.io/SERpps-URlG4hkOyyS94-w?view#fn-add_pool_currency
 			let who = ensure_signed(origin)?;
 
-			// Ensure currency matches the currency of the pool
+			// Ensure currency is allowed as payment and payout currency for pool
 			let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
+			// Required for increasing and collecting investments
 			ensure!(
-				T::ForeignInvestment::accepted_payment_currency(invest_id, currency_id),
+				T::ForeignInvestment::accepted_payment_currency(invest_id.clone(), currency_id),
 				Error::<T>::InvalidPaymentCurrency
+			);
+			// Required for decreasing investments as well as increasing, decreasing and
+			// collecting redemptions
+			ensure!(
+				T::ForeignInvestment::accepted_payout_currency(invest_id, currency_id),
+				Error::<T>::InvalidPayoutCurrency
 			);
 
 			// Ensure the currency is enabled as pool_currency

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -913,13 +913,18 @@ pub mod pallet {
 		/// Ensures that currency id can be derived from the
 		/// GeneralCurrencyIndex and that the former is an accepted payout
 		/// currency for the given investment id.
-		///
-		/// NOTE: Exactly the same as try_get_payment_currency for now.
 		pub fn try_get_payout_currency(
 			invest_id: <T as pallet::Config>::TrancheCurrency,
 			currency_index: GeneralCurrencyIndexOf<T>,
 		) -> Result<CurrencyIdOf<T>, DispatchError> {
-			Self::try_get_payment_currency(invest_id, currency_index)
+			let currency = Self::try_get_currency_id(currency_index)?;
+
+			ensure!(
+				T::ForeignInvestment::accepted_payout_currency(invest_id, currency),
+				Error::<T>::InvalidPaymentCurrency
+			);
+
+			Ok(currency)
 		}
 	}
 

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -1006,7 +1006,7 @@ mod tests {
 	}
 
 	#[test]
-	fn allow_pool_currency() {
+	fn allow_investment_currency() {
 		test_encode_decode_identity(
 			LiquidityPoolsMessage::AllowInvestmentCurrency {
 				currency: TOKEN_ID,
@@ -1017,7 +1017,7 @@ mod tests {
 	}
 
 	#[test]
-	fn allow_pool_currency_zero() {
+	fn allow_investment_currency_zero() {
 		test_encode_decode_identity(
 			LiquidityPoolsMessage::AllowInvestmentCurrency {
 				currency: 0,

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1394,6 +1394,8 @@ parameter_types! {
 
 impl pallet_foreign_investments::Config for Runtime {
 	type Balance = Balance;
+	type CollectedForeignInvestmentHook =
+		pallet_liquidity_pools::hooks::CollectedForeignInvestmentHook<Runtime>;
 	type CollectedForeignRedemptionHook =
 		pallet_liquidity_pools::hooks::CollectedForeignRedemptionHook<Runtime>;
 	type CurrencyConverter =

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -434,6 +434,8 @@ parameter_types! {
 
 impl pallet_foreign_investments::Config for Runtime {
 	type Balance = Balance;
+	type CollectedForeignInvestmentHook =
+		pallet_liquidity_pools::hooks::CollectedForeignInvestmentHook<Runtime>;
 	type CollectedForeignRedemptionHook =
 		pallet_liquidity_pools::hooks::CollectedForeignRedemptionHook<Runtime>;
 	type CurrencyConverter =

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1550,6 +1550,8 @@ parameter_types! {
 
 impl pallet_foreign_investments::Config for Runtime {
 	type Balance = Balance;
+	type CollectedForeignInvestmentHook =
+		pallet_liquidity_pools::hooks::CollectedForeignInvestmentHook<Runtime>;
 	type CollectedForeignRedemptionHook =
 		pallet_liquidity_pools::hooks::CollectedForeignRedemptionHook<Runtime>;
 	type CurrencyConverter =

--- a/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/add_allow_upgrade.rs
+++ b/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/add_allow_upgrade.rs
@@ -37,7 +37,7 @@ use cfg_types::{
 	},
 };
 use development_runtime::{
-	LiquidityPools, LocationToAccountId, OrmlAssetRegistry, OrmlTokens, Permissions,
+	LiquidityPools, LocationToAccountId, OrderBook, OrmlAssetRegistry, OrmlTokens, Permissions,
 	Runtime as DevelopmentRuntime, RuntimeOrigin, System, TreasuryAccount, XTokens, XcmTransactor,
 };
 use frame_support::{assert_noop, assert_ok, traits::fungibles::Mutate};
@@ -509,7 +509,7 @@ fn allow_pool_should_fail() {
 		// Create pool
 		create_currency_pool(pool_id, currency_id, 10_000 * dollar(12));
 
-		// Should fail if asset is not pool currency
+		// Should fail if asset is not payment currency
 		assert!(currency_id != ausd_currency_id);
 		assert_noop!(
 			LiquidityPools::allow_investment_currency(
@@ -519,6 +519,25 @@ fn allow_pool_should_fail() {
 				ausd_currency_id,
 			),
 			pallet_liquidity_pools::Error::<DevelopmentRuntime>::InvalidPaymentCurrency
+		);
+
+		// Allow as payment but not payout currency
+		assert_ok!(OrderBook::add_trading_pair(
+			RuntimeOrigin::root(),
+			currency_id,
+			ausd_currency_id,
+			Default::default()
+		));
+		// Should fail if asset is not payout currency
+		enable_liquidity_pool_transferability(ausd_currency_id);
+		assert_noop!(
+			LiquidityPools::allow_investment_currency(
+				RuntimeOrigin::signed(BOB.into()),
+				pool_id,
+				default_tranche_id(pool_id),
+				ausd_currency_id,
+			),
+			pallet_liquidity_pools::Error::<DevelopmentRuntime>::InvalidPayoutCurrency
 		);
 
 		// Should fail if currency is not liquidityPools transferable

--- a/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/add_allow_upgrade.rs
+++ b/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/add_allow_upgrade.rs
@@ -426,7 +426,7 @@ fn add_currency_should_fail() {
 }
 
 #[test]
-fn allow_pool_currency() {
+fn allow_investment_currency() {
 	TestNet::reset();
 	Development::execute_with(|| {
 		setup_pre_requirements();
@@ -461,7 +461,7 @@ fn allow_pool_currency() {
 			})
 		));
 
-		assert_ok!(LiquidityPools::allow_pool_currency(
+		assert_ok!(LiquidityPools::allow_investment_currency(
 			RuntimeOrigin::signed(BOB.into()),
 			pool_id,
 			default_tranche_id(pool_id),
@@ -482,7 +482,7 @@ fn allow_pool_should_fail() {
 		setup_pre_requirements();
 		// Should fail if pool does not exist
 		assert_noop!(
-			LiquidityPools::allow_pool_currency(
+			LiquidityPools::allow_investment_currency(
 				RuntimeOrigin::signed(BOB.into()),
 				pool_id,
 				// Tranche id is arbitrary in this case as pool does not exist
@@ -512,7 +512,7 @@ fn allow_pool_should_fail() {
 		// Should fail if asset is not pool currency
 		assert!(currency_id != ausd_currency_id);
 		assert_noop!(
-			LiquidityPools::allow_pool_currency(
+			LiquidityPools::allow_investment_currency(
 				RuntimeOrigin::signed(BOB.into()),
 				pool_id,
 				default_tranche_id(pool_id),
@@ -540,7 +540,7 @@ fn allow_pool_should_fail() {
 			}),
 		));
 		assert_noop!(
-			LiquidityPools::allow_pool_currency(
+			LiquidityPools::allow_investment_currency(
 				RuntimeOrigin::signed(BOB.into()),
 				pool_id,
 				default_tranche_id(pool_id),
@@ -568,7 +568,7 @@ fn allow_pool_should_fail() {
 			}),
 		));
 		assert_noop!(
-			LiquidityPools::allow_pool_currency(
+			LiquidityPools::allow_investment_currency(
 				RuntimeOrigin::signed(BOB.into()),
 				pool_id,
 				default_tranche_id(pool_id),
@@ -592,7 +592,7 @@ fn allow_pool_should_fail() {
 			None,
 		));
 		assert_noop!(
-			LiquidityPools::allow_pool_currency(
+			LiquidityPools::allow_investment_currency(
 				RuntimeOrigin::signed(BOB.into()),
 				pool_id,
 				default_tranche_id(pool_id),
@@ -618,7 +618,7 @@ fn allow_pool_should_fail() {
 		create_currency_pool(pool_id + 1, CurrencyId::AUSD, 10_000 * dollar(12));
 		// Should fail if currency is not foreign asset
 		assert_noop!(
-			LiquidityPools::allow_pool_currency(
+			LiquidityPools::allow_investment_currency(
 				RuntimeOrigin::signed(BOB.into()),
 				pool_id + 1,
 				// Tranche id is arbitrary in this case, so we don't need to check for the exact

--- a/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/foreign_investments.rs
+++ b/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/foreign_investments.rs
@@ -1500,12 +1500,12 @@ mod mismatching_currencies {
 			let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 			let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 			let pool_currency_decimals = currency_decimals::AUSD;
-			let invest_amount_pool_denominated: u128 = 6_000_000_000_000_000;
+			let invest_amount_pool_denominated: u128 = 6 * dollar(18);
 			let sending_domain_locator = Domain::convert(DEFAULT_DOMAIN_ADDRESS_MOONBEAM.domain());
 			create_currency_pool(pool_id, pool_currency, pool_currency_decimals.into());
 			let invest_amount_foreign_denominated: u128 =
 				enable_usdt_trading(pool_currency, invest_amount_pool_denominated, true, || {});
-			
+
 			do_initial_increase_investment(
 				pool_id,
 				invest_amount_pool_denominated,
@@ -1584,7 +1584,7 @@ mod mismatching_currencies {
 			let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 			let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 			let pool_currency_decimals = currency_decimals::AUSD;
-			let invest_amount_pool_denominated: u128 = 6_000_000_000_000_000;
+			let invest_amount_pool_denominated: u128 = 6 * dollar(18);
 			create_currency_pool(pool_id, pool_currency, pool_currency_decimals.into());
 			do_initial_increase_investment(
 				pool_id,
@@ -1753,7 +1753,7 @@ mod mismatching_currencies {
 			let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 			let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 			let pool_currency_decimals = currency_decimals::AUSD;
-			let invest_amount_pool_denominated: u128 = 10_000_000_000_000_000;
+			let invest_amount_pool_denominated: u128 = 10 * dollar(18);
 			create_currency_pool(pool_id, pool_currency, pool_currency_decimals.into());
 			let invest_amount_foreign_denominated: u128 =
 				enable_usdt_trading(pool_currency, invest_amount_pool_denominated, true, || {});
@@ -1905,7 +1905,7 @@ mod mismatching_currencies {
 			let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 			let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 			let pool_currency_decimals = currency_decimals::AUSD;
-			let invest_amount_pool_denominated: u128 = 10_000_000_000_000_000;
+			let invest_amount_pool_denominated: u128 = 10 * dollar(18);
 			let swap_order_id = 1;
 			create_currency_pool(pool_id, pool_currency, pool_currency_decimals.into());
 			let invest_amount_foreign_denominated: u128 =
@@ -2140,7 +2140,7 @@ mod mismatching_currencies {
 			let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 			let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 			let pool_currency_decimals = currency_decimals::AUSD;
-			let invest_amount_pool_denominated: u128 = 10_000_000_000_000_000;
+			let invest_amount_pool_denominated: u128 = 10 * dollar(18);
 			let swap_order_id = 1;
 			create_currency_pool(pool_id, pool_currency, pool_currency_decimals.into());
 			let invest_amount_foreign_denominated: u128 =
@@ -2429,7 +2429,7 @@ mod mismatching_currencies {
 			let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 			let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 			let pool_currency_decimals = currency_decimals::AUSD;
-			let invest_amount_pool_denominated: u128 = 10_000_000_000_000_000;
+			let invest_amount_pool_denominated: u128 = 10 * dollar(18);
 			let swap_order_id = 1;
 			create_currency_pool(pool_id, pool_currency, pool_currency_decimals.into());
 			let invest_amount_foreign_denominated: u128 =
@@ -2526,7 +2526,7 @@ mod mismatching_currencies {
 			let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 			let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 			let pool_currency_decimals = currency_decimals::AUSD;
-			let redeem_amount_pool_denominated: u128 = 10_000_000_000_000_000;
+			let redeem_amount_pool_denominated: u128 = 10 * dollar(18);
 			let swap_order_id = 1;
 			create_currency_pool(pool_id, pool_currency, pool_currency_decimals.into());
 			let pool_account =

--- a/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/foreign_investments.rs
+++ b/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/foreign_investments.rs
@@ -1505,6 +1505,7 @@ mod mismatching_currencies {
 			create_currency_pool(pool_id, pool_currency, pool_currency_decimals.into());
 			let invest_amount_foreign_denominated: u128 =
 				enable_usdt_trading(pool_currency, invest_amount_pool_denominated, true, || {});
+			
 			do_initial_increase_investment(
 				pool_id,
 				invest_amount_pool_denominated,


### PR DESCRIPTION
# Description

## Collect

* Adds `InvestmentPaymentCurrency` storage for the `foreign payment currency` upon receiving the first IncreaseInvestOrder message (similar to redemptions)
  * `InvestmentPaymentCurrency` will be cleared if the `InvestState` is cleared, i.e. if neither an unprocessed swap nor investment is happening in case of reaching `NoState` or `SwapIntoForeignDone`
  * `InvestmentPaymentCurrency` will be overwritten upon receiving `IncreaseInvestOrder` or `CollectInvestOrder` to be less restrictive to investors
  * We will read from that storage after the investment was collected through `pallet_investments::collect_invest_for` such that the dispatch of `ExecutedCollectInvest` happens automatically
* This enables us to not have to add a `collect_foreign_investment_for` extrinsic.
* For collecting redemptions, this flow is already implemented. However, there is an async gap in between collecting the redemption (into `pool `currency) and fully fulfilling the swap order (to `foreign` currency).
  * When that swap is fulfilled, the dispatch of `ExecutedCollectRedeem` happens automatically
* Of course, triggering collections through LP messages from EVM domains is also supported. The flows would be the same as for `pallet_investments::collect_{invest, redeem}_for`.

## Misc

* Renames `allow_pool_currency` extrinsic to `allow_investment_currency`
* Slightly reduces `foreign_investments` integration test boilerplate

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
