### PR TITLE
feat: orderbook bench helper

### DIFF
--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -23,6 +23,7 @@ pub mod pallet {
 		type Balance;
 		type BalanceRatio;
 		type CurrencyId;
+		type TrancheCurrency;
 	}
 
 	#[pallet::pallet]
@@ -66,12 +67,18 @@ pub mod pallet {
 			register_call!(move |(a, b, c)| f(a, b, c));
 		}
 
-		pub fn mock_benchmark_create_pool(f: impl Fn(T::PoolId, &T::AccountId) + 'static) {
+		pub fn mock_bench_create_pool(f: impl Fn(T::PoolId, &T::AccountId) + 'static) {
 			register_call!(move |(a, b)| f(a, b));
 		}
 
-		pub fn mock_benchmark_give_ausd(f: impl Fn(&T::AccountId, T::Balance) + 'static) {
-			register_call!(move |(a, b)| f(a, b));
+		pub fn mock_bench_investor_setup(
+			f: impl Fn(T::PoolId, T::AccountId, T::Balance) + 'static,
+		) {
+			register_call!(move |(a, b, c)| f(a, b, c));
+		}
+
+		pub fn mock_bench_default_investment_id(f: impl Fn(T::TrancheCurrency) + 'static) {
+			register_call!(f);
 		}
 	}
 
@@ -133,8 +140,18 @@ pub mod pallet {
 			execute_call!((a, b))
 		}
 
-		fn bench_mint_pool_currency_into(a: &Self::AccountId, b: Self::Balance) {
-			execute_call!((a, b))
+		fn bench_investor_setup(a: Self::PoolId, b: Self::AccountId, c: Self::Balance) {
+			execute_call!((a, b, c))
+		}
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	impl<T: Config> cfg_traits::benchmarking::InvestmentIdBenchmarkHelper for Pallet<T> {
+		type InvestmentId = T::TrancheCurrency;
+		type PoolId = T::PoolId;
+
+		fn bench_default_investment_id(a: Self::PoolId) -> Self::InvestmentId {
+			execute_call!(a)
 		}
 	}
 }

--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -129,11 +129,11 @@ pub mod pallet {
 		type Balance = T::Balance;
 		type PoolId = T::PoolId;
 
-		fn bench_create_ausd_pool(a: Self::PoolId, b: &Self::AccountId) {
+		fn bench_create_pool(a: Self::PoolId, b: &Self::AccountId) {
 			execute_call!((a, b))
 		}
 
-		fn bench_mint_ausd_into(a: &Self::AccountId, b: Self::Balance) {
+		fn bench_mint_pool_currency_into(a: &Self::AccountId, b: Self::Balance) {
 			execute_call!((a, b))
 		}
 	}

--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -124,16 +124,16 @@ pub mod pallet {
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	impl<T: Config> cfg_traits::PoolBenchmarkHelper for Pallet<T> {
+	impl<T: Config> cfg_traits::benchmarking::PoolBenchmarkHelper for Pallet<T> {
 		type AccountId = T::AccountId;
 		type Balance = T::Balance;
 		type PoolId = T::PoolId;
 
-		fn benchmark_create_pool(a: Self::PoolId, b: &Self::AccountId) {
+		fn bench_create_ausd_pool(a: Self::PoolId, b: &Self::AccountId) {
 			execute_call!((a, b))
 		}
 
-		fn benchmark_give_ausd(a: &Self::AccountId, b: Self::Balance) {
+		fn bench_mint_ausd_into(a: &Self::AccountId, b: Self::Balance) {
 			execute_call!((a, b))
 		}
 	}

--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -77,7 +77,9 @@ pub mod pallet {
 			register_call!(move |(a, b, c)| f(a, b, c));
 		}
 
-		pub fn mock_bench_default_investment_id(f: impl Fn(T::TrancheCurrency) + 'static) {
+		pub fn mock_bench_default_investment_id(
+			f: impl Fn(T::PoolId) -> T::TrancheCurrency + 'static + 'static,
+		) {
 			register_call!(f);
 		}
 	}

--- a/libs/traits/src/benchmarking.rs
+++ b/libs/traits/src/benchmarking.rs
@@ -28,6 +28,7 @@ pub trait OrderBookBenchmarkHelper {
 	type AccountId;
 	type Balance;
 	type CurrencyId;
+	type OrderIdNonce;
 
 	/// Adds the corresponding trading pair, creates trader accounts and mints
 	/// appropriate amounts of balance into these
@@ -39,4 +40,7 @@ pub trait OrderBookBenchmarkHelper {
 		decimals_in: u32,
 		decimals_out: u32,
 	) -> (Self::AccountId, Self::AccountId);
+
+	/// Fulfills the given swap order from the trader account
+	fn bench_fill_order_full(trader: Self::AccountId, order_id: Self::OrderIdNonce);
 }

--- a/libs/traits/src/benchmarking.rs
+++ b/libs/traits/src/benchmarking.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+/// Benchmark utility to create pools
+pub trait PoolBenchmarkHelper {
+	type PoolId;
+	type AccountId;
+	type Balance;
+
+	/// Create a benchmark AUSD pool giving the id and the admin.
+	fn bench_create_ausd_pool(pool_id: Self::PoolId, admin: &Self::AccountId);
+
+	/// Give AUSD to the account
+	fn bench_mint_ausd_into(account: &Self::AccountId, balance: Self::Balance);
+}
+
+/// Benchmark utility for adding currency trading pairs
+pub trait OrderBookBenchmarkHelper {
+	type AccountId;
+	type Balance;
+	type CurrencyId;
+
+	/// Adds the corresponding trading pair, creates trader accounts and mints
+	/// appropriate amounts of balance into these
+	fn bench_setup_trading_pair(
+		asset_in: Self::CurrencyId,
+		asset_out: Self::CurrencyId,
+		amount_in: Self::Balance,
+		amount_out: Self::Balance,
+		decimals_in: u32,
+		decimals_out: u32,
+	) -> (Self::AccountId, Self::AccountId);
+}

--- a/libs/traits/src/benchmarking.rs
+++ b/libs/traits/src/benchmarking.rs
@@ -19,8 +19,22 @@ pub trait PoolBenchmarkHelper {
 	/// Create a pool for the given the pool id and the admin.
 	fn bench_create_pool(pool_id: Self::PoolId, admin: &Self::AccountId);
 
-	/// Give pool currency to the account
-	fn bench_mint_pool_currency_into(account: &Self::AccountId, balance: Self::Balance);
+	/// Prepare user to be able to invest, i.e. fund with pool currency and give
+	/// permissions.
+	fn bench_investor_setup(
+		pool_id: Self::PoolId,
+		account: Self::AccountId,
+		balance: Self::Balance,
+	);
+}
+
+/// Benchmark utility to expose investment identifiers
+pub trait InvestmentIdBenchmarkHelper {
+	type PoolId;
+	type InvestmentId;
+
+	/// Return the default investment id for the given pool.
+	fn bench_default_investment_id(pool_id: Self::PoolId) -> Self::InvestmentId;
 }
 
 /// Benchmark utility for adding currency trading pairs
@@ -43,27 +57,4 @@ pub trait OrderBookBenchmarkHelper {
 
 	/// Fulfills the given swap order from the trader account
 	fn bench_fill_order_full(trader: Self::AccountId, order_id: Self::OrderIdNonce);
-}
-
-/// Benchmark utility for updating/collecting foreign investments and
-/// redemptions.
-
-pub trait ForeignInvestmentsBenchmarkHelper {
-	type AccountId;
-	type AssetRegistry;
-	type Balance;
-	type CurrencyId;
-	type InvestmentId;
-
-	fn bench_foreign_investment_setup();
-
-	fn bench_increase_foreign_investment(
-		investor: Self::AccountId,
-		investment_id: Self::InvestmentId,
-		foreign_currency: Self::CurrencyId,
-		pool_currency: Self::CurrencyId,
-		amount_foreign_denominated: Self::Balance,
-	);
-
-	fn bench_enable_lp_transferability(currency: Self::CurrencyId);
 }

--- a/libs/traits/src/benchmarking.rs
+++ b/libs/traits/src/benchmarking.rs
@@ -16,11 +16,11 @@ pub trait PoolBenchmarkHelper {
 	type AccountId;
 	type Balance;
 
-	/// Create a benchmark AUSD pool giving the id and the admin.
-	fn bench_create_ausd_pool(pool_id: Self::PoolId, admin: &Self::AccountId);
+	/// Create a pool for the given the pool id and the admin.
+	fn bench_create_pool(pool_id: Self::PoolId, admin: &Self::AccountId);
 
-	/// Give AUSD to the account
-	fn bench_mint_ausd_into(account: &Self::AccountId, balance: Self::Balance);
+	/// Give pool currency to the account
+	fn bench_mint_pool_currency_into(account: &Self::AccountId, balance: Self::Balance);
 }
 
 /// Benchmark utility for adding currency trading pairs
@@ -43,4 +43,27 @@ pub trait OrderBookBenchmarkHelper {
 
 	/// Fulfills the given swap order from the trader account
 	fn bench_fill_order_full(trader: Self::AccountId, order_id: Self::OrderIdNonce);
+}
+
+/// Benchmark utility for updating/collecting foreign investments and
+/// redemptions.
+
+pub trait ForeignInvestmentsBenchmarkHelper {
+	type AccountId;
+	type AssetRegistry;
+	type Balance;
+	type CurrencyId;
+	type InvestmentId;
+
+	fn bench_foreign_investment_setup();
+
+	fn bench_increase_foreign_investment(
+		investor: Self::AccountId,
+		investment_id: Self::InvestmentId,
+		foreign_currency: Self::CurrencyId,
+		pool_currency: Self::CurrencyId,
+		amount_foreign_denominated: Self::Balance,
+	);
+
+	fn bench_enable_lp_transferability(currency: Self::CurrencyId);
 }

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -132,8 +132,10 @@ pub trait PoolInspect<AccountId, CurrencyId> {
 	type TrancheId;
 	type Moment;
 
-	/// check if the pool exists
+	/// Check if the pool exists
 	fn pool_exists(pool_id: Self::PoolId) -> bool;
+
+	/// Check if the tranche exists for the given pool
 	fn tranche_exists(pool_id: Self::PoolId, tranche_id: Self::TrancheId) -> bool;
 
 	/// Get the account used for the given `pool_id`.

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -49,6 +49,10 @@ pub mod liquidity_pools;
 /// Traits related to rewards.
 pub mod rewards;
 
+#[cfg(feature = "runtime-benchmarks")]
+/// Traits related to benchmarking tooling.
+pub mod benchmarking;
+
 /// A trait used for loosely coupling the claim pallet with a reward mechanism.
 ///
 /// ## Overview
@@ -255,20 +259,6 @@ pub trait PoolWriteOffPolicyMutate<PoolId> {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn worst_case_policy() -> Self::Policy;
-}
-
-/// Utility to benchmark pools easily
-#[cfg(feature = "runtime-benchmarks")]
-pub trait PoolBenchmarkHelper {
-	type PoolId;
-	type AccountId;
-	type Balance;
-
-	/// Create a benchmark pool giving the id and the admin.
-	fn benchmark_create_pool(pool_id: Self::PoolId, admin: &Self::AccountId);
-
-	/// Give AUSD to the account
-	fn benchmark_give_ausd(account: &Self::AccountId, balance: Self::Balance);
 }
 
 /// A trait that can be used to retrieve the current price for a currency

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -108,7 +108,7 @@ where
 		let pool_id = Default::default();
 
 		let pool_admin = account("pool_admin", 0, 0);
-		T::Pool::bench_create_ausd_pool(pool_id, &pool_admin);
+		T::Pool::bench_create_pool(pool_id, &pool_admin);
 
 		let loan_admin = account("loan_admin", 0, 0);
 		T::Permissions::add(
@@ -119,7 +119,7 @@ where
 		.unwrap();
 
 		let borrower = account::<T::AccountId>("borrower", 0, 0);
-		T::Pool::bench_mint_ausd_into(&borrower, (FUNDS * CFG).into());
+		T::Pool::bench_mint_pool_currency_into(&borrower, (FUNDS * CFG).into());
 		T::NonFungible::create_collection(&COLLECION_ID.into(), &borrower, &borrower).unwrap();
 		T::Permissions::add(
 			PermissionScope::Pool(pool_id),

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -13,10 +13,11 @@
 
 use cfg_primitives::CFG;
 use cfg_traits::{
+	benchmarking::PoolBenchmarkHelper,
 	changes::ChangeGuard,
 	data::DataRegistry,
 	interest::{CompoundingSchedule, InterestAccrual, InterestRate},
-	Permissions, PoolBenchmarkHelper, PoolWriteOffPolicyMutate,
+	Permissions, PoolWriteOffPolicyMutate,
 };
 use cfg_types::{
 	adjustments::Adjustment,
@@ -107,7 +108,7 @@ where
 		let pool_id = Default::default();
 
 		let pool_admin = account("pool_admin", 0, 0);
-		T::Pool::benchmark_create_pool(pool_id, &pool_admin);
+		T::Pool::bench_create_ausd_pool(pool_id, &pool_admin);
 
 		let loan_admin = account("loan_admin", 0, 0);
 		T::Permissions::add(
@@ -118,7 +119,7 @@ where
 		.unwrap();
 
 		let borrower = account::<T::AccountId>("borrower", 0, 0);
-		T::Pool::benchmark_give_ausd(&borrower, (FUNDS * CFG).into());
+		T::Pool::bench_mint_ausd_into(&borrower, (FUNDS * CFG).into());
 		T::NonFungible::create_collection(&COLLECION_ID.into(), &borrower, &borrower).unwrap();
 		T::Permissions::add(
 			PermissionScope::Pool(pool_id),

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -78,8 +78,8 @@ fn config_mocks() {
 	MockPools::mock_account_for(|_| 0);
 	MockPools::mock_withdraw(|_, _, _| Ok(()));
 	MockPools::mock_deposit(|_, _, _| Ok(()));
-	MockPools::mock_benchmark_create_pool(|_, _| {});
-	MockPools::mock_benchmark_give_ausd(|_, _| {});
+	MockPools::mock_bench_create_pool(|_, _| {});
+	MockPools::mock_bench_investor_setup(|_, _, _| {});
 	MockPrices::mock_feed_value(|_, _, _| Ok(()));
 	MockPrices::mock_register_id(|_, _| Ok(()));
 	MockPrices::mock_collection(|_| MockDataCollection::new(|_| Ok(Default::default())));
@@ -119,7 +119,7 @@ where
 		.unwrap();
 
 		let borrower = account::<T::AccountId>("borrower", 0, 0);
-		T::Pool::bench_mint_pool_currency_into(&borrower, (FUNDS * CFG).into());
+		T::Pool::bench_investor_setup(pool_id, borrower.clone(), (FUNDS * CFG).into());
 		T::NonFungible::create_collection(&COLLECION_ID.into(), &borrower, &borrower).unwrap();
 		T::Permissions::add(
 			PermissionScope::Pool(pool_id),

--- a/pallets/loans/src/tests/mock.rs
+++ b/pallets/loans/src/tests/mock.rs
@@ -17,7 +17,7 @@ use cfg_mocks::{
 	pallet_mock_change_guard, pallet_mock_data, pallet_mock_permissions, pallet_mock_pools,
 };
 use cfg_primitives::Moment;
-use cfg_types::permissions::PermissionScope;
+use cfg_types::{permissions::PermissionScope, tokens::TrancheCurrency};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::traits::{
 	tokens::nonfungibles::{Create, Mutate},
@@ -199,6 +199,7 @@ impl pallet_mock_pools::Config for Runtime {
 	type BalanceRatio = Quantity;
 	type CurrencyId = CurrencyId;
 	type PoolId = PoolId;
+	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 }
 

--- a/pallets/order-book/src/benchmarking.rs
+++ b/pallets/order-book/src/benchmarking.rs
@@ -63,11 +63,11 @@ benchmarks! {
 	}:fill_order_full(RawOrigin::Signed(account_in.clone()), order_id)
 
 	fill_order_partial {
-		let (account_0, account_1, asset_0, asset_1) = set_up_users_currencies::<T>()?;
+		let (account_out, account_in) = Pallet::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
 
-		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 10 * CURRENCY_0)?;
+		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into(), BUY_AMOUNT / 10)?;
 
-	}:fill_order_partial(RawOrigin::Signed(account_1.clone()), order_id, 40 * CURRENCY_0)
+	}:fill_order_partial(RawOrigin::Signed(account_in.clone()), order_id, BUY_AMOUNT / 2)
 
 	add_trading_pair {
 		}:add_trading_pair(RawOrigin::Root, ASSET_IN, ASSET_OUT, BUY_AMOUNT)

--- a/pallets/order-book/src/benchmarking.rs
+++ b/pallets/order-book/src/benchmarking.rs
@@ -86,6 +86,7 @@ where
 	type AccountId = T::AccountId;
 	type Balance = T::Balance;
 	type CurrencyId = T::AssetCurrencyId;
+	type OrderIdNonce = T::OrderIdNonce;
 
 	fn bench_setup_trading_pair(
 		asset_in: Self::CurrencyId,
@@ -113,6 +114,13 @@ where
 		TradingPair::<T>::insert(asset_in, asset_out, Self::Balance::one());
 
 		(account_out, account_in)
+	}
+
+	fn bench_fill_order_full(trader: Self::AccountId, order_id: Self::OrderIdNonce) {
+		assert_ok!(Pallet::<T>::fill_order_full(
+			RawOrigin::Signed(trader.clone()).into(),
+			order_id
+		));
 	}
 }
 

--- a/pallets/order-book/src/benchmarking.rs
+++ b/pallets/order-book/src/benchmarking.rs
@@ -12,18 +12,23 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
+use cfg_traits::benchmarking::OrderBookBenchmarkHelper;
 use cfg_types::tokens::{CurrencyId, CustomMetadata};
 use frame_benchmarking::*;
-use frame_support::traits::fungibles::Mutate as FungiblesMutate;
+use frame_support::{assert_ok, traits::fungibles::Mutate as FungiblesMutate};
 use frame_system::RawOrigin;
 use orml_traits::asset_registry::{Inspect, Mutate};
-use sp_runtime::FixedPointNumber;
+use sp_runtime::{traits::One, FixedPointNumber};
 
-// use pallet_pool_system::benchmarking::prepare_asset_registry;
 use super::*;
 
-const CURRENCY_0: u128 = 1_000_000;
-const CURRENCY_1: u128 = 1_000_000_000_000;
+const AMOUNT_IN: u128 = 1_000_000;
+const AMOUNT_OUT: u128 = 1_000_000_000_000;
+const BUY_AMOUNT: u128 = 100 * AMOUNT_IN;
+const ASSET_IN: CurrencyId = CurrencyId::ForeignAsset(1);
+const ASSET_OUT: CurrencyId = CurrencyId::ForeignAsset(2);
+const DECIMALS_IN: u32 = 12;
+const DECIMALS_OUT: u32 = 6;
 
 benchmarks! {
 	where_clause {
@@ -33,110 +38,129 @@ benchmarks! {
 	}
 
 	create_order {
-		let (account_0, _, asset_0, asset_1) = set_up_users_currencies::<T>()?;
-		}:create_order(RawOrigin::Signed(account_0.clone()), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2))
+		let (account_out, _) = Helper::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
+		}:create_order(RawOrigin::Signed(account_out.clone()), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2))
 
 
 	user_update_order {
-		let (account_0, _, asset_0, asset_1) = set_up_users_currencies::<T>()?;
+		let (account_out, _) = Helper::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
 
-		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 100 * CURRENCY_0)?;
+		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into(), BUY_AMOUNT)?;
 
-		}:user_update_order(RawOrigin::Signed(account_0.clone()), order_id, 150 * CURRENCY_0, T::SellRatio::saturating_from_integer(1))
+		}:user_update_order(RawOrigin::Signed(account_out.clone()), order_id, 10 * BUY_AMOUNT, T::SellRatio::saturating_from_integer(1))
 
 	user_cancel_order {
-		let (account_0, _, asset_0, asset_1) = set_up_users_currencies::<T>()?;
+		let (account_out, _) = Helper::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
 
-		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 100 * CURRENCY_0)?;
+		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into(), BUY_AMOUNT)?;
 
-	}:user_cancel_order(RawOrigin::Signed(account_0.clone()), order_id)
+	}:user_cancel_order(RawOrigin::Signed(account_out.clone()), order_id)
 
 	fill_order_full {
-		let (account_0, account_1, asset_0, asset_1) = set_up_users_currencies::<T>()?;
+		let (account_out, account_in) = Helper::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
 
-		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 100 * CURRENCY_0)?;
+		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into(), BUY_AMOUNT)?;
 
-	}:fill_order_full(RawOrigin::Signed(account_1.clone()), order_id)
+	}:fill_order_full(RawOrigin::Signed(account_in.clone()), order_id)
 
 	add_trading_pair {
-		let asset_0 = CurrencyId::ForeignAsset(1);
-		let asset_1 = CurrencyId::ForeignAsset(2);
-		}:add_trading_pair(RawOrigin::Root, asset_0, asset_1, 100 * CURRENCY_0)
+		}:add_trading_pair(RawOrigin::Root, ASSET_IN, ASSET_OUT, BUY_AMOUNT)
 
 	rm_trading_pair {
-		let (account_0, _, asset_0, asset_1) = set_up_users_currencies::<T>()?;
-		}:rm_trading_pair(RawOrigin::Root, asset_0, asset_1)
+		let (account_out, _) = Helper::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
+		}:rm_trading_pair(RawOrigin::Root, ASSET_IN, ASSET_OUT)
 
 	update_min_order {
-		let (account_0, _, asset_0, asset_1) = set_up_users_currencies::<T>()?;
-		}:update_min_order(RawOrigin::Root, asset_0, asset_1, 1 * CURRENCY_0)
-
-
+		let (account_out, _) = Helper::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
+		}:update_min_order(RawOrigin::Root, ASSET_IN, ASSET_OUT, AMOUNT_IN)
 }
 
-fn set_up_users_currencies<T: Config<AssetCurrencyId = CurrencyId, Balance = u128>>() -> Result<
-	(
-		T::AccountId,
-		T::AccountId,
-		T::AssetCurrencyId,
-		T::AssetCurrencyId,
-	),
-	&'static str,
->
-where
-	<T as pallet::Config>::AssetRegistry: orml_traits::asset_registry::Mutate,
-{
-	let account_0: T::AccountId = account::<T::AccountId>("Account0", 1, 0);
-	let account_1: T::AccountId = account::<T::AccountId>("Account1", 2, 0);
-	let asset_0 = CurrencyId::ForeignAsset(1);
-	let asset_1 = CurrencyId::ForeignAsset(2);
-	prepare_asset_registry::<T>();
-	T::TradeableAsset::mint_into(asset_0, &account_0, 1_000 * CURRENCY_0)?;
-	T::TradeableAsset::mint_into(asset_1, &account_0, 1_000 * CURRENCY_1)?;
-	T::TradeableAsset::mint_into(asset_0, &account_1, 1_000 * CURRENCY_0)?;
-	T::TradeableAsset::mint_into(asset_1, &account_1, 1_000 * CURRENCY_1)?;
-	TradingPair::<T>::insert(asset_0, asset_1, 1 * CURRENCY_0);
-	Ok((account_0, account_1, asset_0, asset_1))
-}
 impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Runtime,);
 
-pub fn prepare_asset_registry<T: Config>()
+struct Helper<T>(sp_std::marker::PhantomData<T>);
+impl<T: Config> OrderBookBenchmarkHelper for Helper<T>
 where
-	T::AssetRegistry: Mutate<AssetId = CurrencyId, Balance = u128, CustomMetadata = CustomMetadata>,
+	T::AssetRegistry:
+		Mutate<AssetId = T::AssetCurrencyId, Balance = T::Balance, CustomMetadata = CustomMetadata>,
 {
-	match T::AssetRegistry::metadata(&CurrencyId::ForeignAsset(1)) {
-		Some(_) => (),
-		None => {
-			T::AssetRegistry::register_asset(
-				Some(CurrencyId::ForeignAsset(1)),
-				orml_asset_registry::AssetMetadata {
-					decimals: 12,
-					name: "MOCK TOKEN".as_bytes().to_vec(),
-					symbol: "MOCK".as_bytes().to_vec(),
-					existential_deposit: 0,
-					location: None,
-					additional: CustomMetadata::default(),
-				},
-			)
-			.expect("Registering Pool asset must work");
-		}
-	}
+	type AccountId = T::AccountId;
+	type Balance = T::Balance;
+	type CurrencyId = T::AssetCurrencyId;
 
-	match T::AssetRegistry::metadata(&CurrencyId::ForeignAsset(2)) {
-		Some(_) => (),
-		None => {
-			T::AssetRegistry::register_asset(
-				Some(CurrencyId::ForeignAsset(2)),
-				orml_asset_registry::AssetMetadata {
-					decimals: 6,
-					name: "MOCK TOKEN 1".as_bytes().to_vec(),
-					symbol: "MOCK1".as_bytes().to_vec(),
-					existential_deposit: 0,
-					location: None,
-					additional: CustomMetadata::default(),
-				},
-			)
-			.expect("Registering Pool asset must work");
+	fn bench_setup_trading_pair(
+		asset_in: Self::CurrencyId,
+		asset_out: Self::CurrencyId,
+		amount_in: Self::Balance,
+		amount_out: Self::Balance,
+		decimals_in: u32,
+		decimals_out: u32,
+	) -> (Self::AccountId, Self::AccountId) {
+		let account_out: Self::AccountId = account::<Self::AccountId>("account_out", 1, 0);
+		let account_in: Self::AccountId = account::<Self::AccountId>("account_in", 2, 0);
+		Self::register_trading_assets(asset_in.into(), asset_out.into(), decimals_in, decimals_out);
+
+		assert_ok!(T::TradeableAsset::mint_into(
+			asset_out,
+			&account_out,
+			amount_out
+		));
+		assert_ok!(T::TradeableAsset::mint_into(
+			asset_in,
+			&account_in,
+			amount_in,
+		));
+
+		TradingPair::<T>::insert(asset_in, asset_out, Self::Balance::one());
+
+		(account_out, account_in)
+	}
+}
+
+impl<T: Config> Helper<T>
+where
+	T::AssetRegistry:
+		Mutate<AssetId = T::AssetCurrencyId, Balance = T::Balance, CustomMetadata = CustomMetadata>,
+{
+	pub fn register_trading_assets(
+		asset_in: T::AssetCurrencyId,
+		asset_out: T::AssetCurrencyId,
+		decimals_in: u32,
+		decimals_out: u32,
+	) {
+		match T::AssetRegistry::metadata(&asset_in) {
+			Some(_) => (),
+			None => {
+				T::AssetRegistry::register_asset(
+					Some(asset_in),
+					orml_asset_registry::AssetMetadata {
+						decimals: decimals_in,
+						name: "ASSET IN".as_bytes().to_vec(),
+						symbol: "INC".as_bytes().to_vec(),
+						existential_deposit: T::Balance::zero(),
+						location: None,
+						additional: CustomMetadata::default(),
+					},
+				)
+				.expect("Registering Pool asset must work");
+			}
+		}
+
+		match T::AssetRegistry::metadata(&asset_out) {
+			Some(_) => (),
+			None => {
+				T::AssetRegistry::register_asset(
+					Some(asset_out),
+					orml_asset_registry::AssetMetadata {
+						decimals: decimals_out,
+						name: "ASSET OUT".as_bytes().to_vec(),
+						symbol: "OUT".as_bytes().to_vec(),
+						existential_deposit: T::Balance::zero(),
+						location: None,
+						additional: CustomMetadata::default(),
+					},
+				)
+				.expect("Registering Pool asset must work");
+			}
 		}
 	}
 }

--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -456,7 +456,7 @@ mod benchmarks_utils {
 
 	use super::*;
 
-	const AUSD_CURRENCY_ID: CurrencyId = CurrencyId::ForeignAsset(1);
+	const POOL_CURRENCY: CurrencyId = CurrencyId::ForeignAsset(1);
 
 	impl<T: Config<CurrencyId = CurrencyId>> PoolBenchmarkHelper for Pallet<T>
 	where
@@ -467,16 +467,16 @@ mod benchmarks_utils {
 		type Balance = T::Balance;
 		type PoolId = T::PoolId;
 
-		fn bench_create_ausd_pool(pool_id: T::PoolId, admin: &T::AccountId) {
+		fn bench_create_pool(pool_id: T::PoolId, admin: &T::AccountId) {
 			const FUNDS: u32 = u32::max_value();
 
-			if T::AssetRegistry::metadata(&AUSD_CURRENCY_ID).is_none() {
+			if T::AssetRegistry::metadata(&POOL_CURRENCY).is_none() {
 				T::AssetRegistry::register_asset(
-					Some(AUSD_CURRENCY_ID),
+					Some(POOL_CURRENCY),
 					orml_asset_registry::AssetMetadata {
 						decimals: 12,
-						name: "MOCK AUSD".as_bytes().to_vec(),
-						symbol: "MOCKAUSD".as_bytes().to_vec(),
+						name: "MOCK POOL CURRENCY".as_bytes().to_vec(),
+						symbol: "MOCKPCUR".as_bytes().to_vec(),
 						existential_deposit: Zero::zero(),
 						location: None,
 						additional: CustomMetadata {
@@ -515,7 +515,7 @@ mod benchmarks_utils {
 						},
 					},
 				],
-				AUSD_CURRENCY_ID,
+				POOL_CURRENCY,
 				FUNDS.into(),
 			)
 			.unwrap();
@@ -535,7 +535,7 @@ mod benchmarks_utils {
 			)
 			.unwrap();
 
-			T::Tokens::mint_into(AUSD_CURRENCY_ID, &investor, FUNDS.into()).unwrap();
+			T::Tokens::mint_into(POOL_CURRENCY, &investor, FUNDS.into()).unwrap();
 			T::Investments::update_investment(
 				&investor,
 				T::TrancheCurrency::generate(pool_id.into(), tranche),
@@ -553,8 +553,8 @@ mod benchmarks_utils {
 			Pallet::<T>::close_epoch(RawOrigin::Signed(admin.clone()).into(), pool_id).unwrap();
 		}
 
-		fn bench_mint_ausd_into(account: &T::AccountId, balance: T::Balance) {
-			T::Tokens::mint_into(AUSD_CURRENCY_ID, account, balance).unwrap();
+		fn bench_mint_pool_currency_into(account: &T::AccountId, balance: T::Balance) {
+			T::Tokens::mint_into(POOL_CURRENCY, account, balance).unwrap();
 			T::Currency::make_free_balance_be(account, balance);
 		}
 	}

--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -444,7 +444,7 @@ impl<T: Config> ChangeGuard for Pallet<T> {
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarks_utils {
-	use cfg_traits::{investments::Investment, PoolBenchmarkHelper};
+	use cfg_traits::{benchmarking::PoolBenchmarkHelper, investments::Investment};
 	use cfg_types::{
 		pools::TrancheMetadata,
 		tokens::{CurrencyId, CustomMetadata},
@@ -467,7 +467,7 @@ mod benchmarks_utils {
 		type Balance = T::Balance;
 		type PoolId = T::PoolId;
 
-		fn benchmark_create_pool(pool_id: T::PoolId, admin: &T::AccountId) {
+		fn bench_create_ausd_pool(pool_id: T::PoolId, admin: &T::AccountId) {
 			const FUNDS: u32 = u32::max_value();
 
 			if T::AssetRegistry::metadata(&AUSD_CURRENCY_ID).is_none() {
@@ -553,7 +553,7 @@ mod benchmarks_utils {
 			Pallet::<T>::close_epoch(RawOrigin::Signed(admin.clone()).into(), pool_id).unwrap();
 		}
 
-		fn benchmark_give_ausd(account: &T::AccountId, balance: T::Balance) {
+		fn bench_mint_ausd_into(account: &T::AccountId, balance: T::Balance) {
 			T::Tokens::mint_into(AUSD_CURRENCY_ID, account, balance).unwrap();
 			T::Currency::make_free_balance_be(account, balance);
 		}

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -2665,6 +2665,6 @@ fn benchmark_pool() {
 	use cfg_traits::benchmarking::PoolBenchmarkHelper;
 
 	new_test_ext().execute_with(|| {
-		PoolSystem::benchmark_create_pool(0, &0);
+		PoolSystem::bench_create_pool(0, &0);
 	});
 }

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -2662,7 +2662,7 @@ mod changes {
 #[test]
 #[cfg(feature = "runtime-benchmarks")]
 fn benchmark_pool() {
-	use cfg_traits::PoolBenchmarkHelper;
+	use cfg_traits::benchmarking::PoolBenchmarkHelper;
 
 	new_test_ext().execute_with(|| {
 		PoolSystem::benchmark_create_pool(0, &0);


### PR DESCRIPTION
Adds an benchmark helper to the `pallet-order-book` which exposes the necessary setup to register a trading pair for arbitrary currencies. 

It is inspired by the the existing `PoolBenchmarkHelper` which was moved to a new `benchmarking` module of `cfg_traits`.

Required for benchmarking LPs, especially foreign investments