### PR TITLE
Feat/order book add fulfill order partially

### DIFF
--- a/pallets/order-book/src/benchmarking.rs
+++ b/pallets/order-book/src/benchmarking.rs
@@ -61,7 +61,7 @@ benchmarks! {
 	fill_order_partial {
 		let (account_0, account_1, asset_0, asset_1) = set_up_users_currencies::<T>()?;
 
-		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 100 * CURRENCY_0)?;
+		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 10 * CURRENCY_0)?;
 
 	}:fill_order_partial(RawOrigin::Signed(account_1.clone()), order_id, 40 * CURRENCY_0)
 

--- a/pallets/order-book/src/benchmarking.rs
+++ b/pallets/order-book/src/benchmarking.rs
@@ -58,6 +58,13 @@ benchmarks! {
 
 	}:fill_order_full(RawOrigin::Signed(account_1.clone()), order_id)
 
+	fill_order_partial {
+		let (account_0, account_1, asset_0, asset_1) = set_up_users_currencies::<T>()?;
+
+		let order_id = Pallet::<T>::place_order(account_0.clone(), asset_0, asset_1, 100 * CURRENCY_0, T::SellRatio::saturating_from_integer(2).into(), 100 * CURRENCY_0)?;
+
+	}:fill_order_partial(RawOrigin::Signed(account_1.clone()), order_id, 40 * CURRENCY_0)
+
 	add_trading_pair {
 		let asset_0 = CurrencyId::ForeignAsset(1);
 		let asset_1 = CurrencyId::ForeignAsset(2);

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -515,98 +515,6 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Fill an existing order, based on the provided ratio.
-		#[pallet::call_index(7)]
-		#[pallet::weight(T::Weights::fill_order_partial())]
-		pub fn fill_order_partial(
-			origin: OriginFor<T>,
-			order_id: T::OrderIdNonce,
-			fulfillment_ratio: Perquintill,
-		) -> DispatchResult {
-			let account_id = ensure_signed(origin)?;
-			let order = <Orders<T>>::get(order_id)?;
-
-			ensure!(
-				!fulfillment_ratio.is_zero(),
-				Error::<T>::InvalidPartialOrderRatio
-			);
-
-			let partial_buy_amount = fulfillment_ratio.mul_floor(order.buy_amount);
-			let partial_sell_amount = fulfillment_ratio.mul_floor(order.max_sell_amount);
-			let remaining_buy_amount = order
-				.buy_amount
-				.checked_sub(&partial_buy_amount)
-				.ok_or(Error::<T>::RemainingBuyAmountError)?;
-			let partial_fulfillment = !remaining_buy_amount.is_zero();
-
-			if partial_fulfillment {
-				Self::update_order(
-					order.placing_account.clone(),
-					order_id,
-					remaining_buy_amount,
-					order.max_sell_rate,
-					remaining_buy_amount.min(order.min_fulfillment_amount),
-				)?;
-			} else {
-				T::TradeableAsset::release(
-					order.asset_out_id,
-					&order.placing_account,
-					partial_sell_amount,
-					false,
-				)?;
-
-				Self::remove_order(order.order_id)?;
-			}
-
-			ensure!(
-				partial_buy_amount >= order.min_fulfillment_amount,
-				Error::<T>::InsufficientOrderSize,
-			);
-
-			ensure!(
-				T::TradeableAsset::can_hold(order.asset_in_id, &account_id, partial_buy_amount),
-				Error::<T>::InsufficientAssetFunds,
-			);
-
-			T::TradeableAsset::transfer(
-				order.asset_in_id,
-				&account_id,
-				&order.placing_account,
-				partial_buy_amount,
-				false,
-			)?;
-
-			T::TradeableAsset::transfer(
-				order.asset_out_id,
-				&order.placing_account,
-				&account_id,
-				partial_sell_amount,
-				false,
-			)?;
-
-			T::FulfilledOrderHook::notify_status_change(
-				order_id,
-				Swap {
-					amount: partial_buy_amount,
-					currency_in: order.asset_in_id,
-					currency_out: order.asset_out_id,
-				},
-			)?;
-
-			Self::deposit_event(Event::OrderFulfillment {
-				order_id,
-				placing_account: order.placing_account,
-				fulfilling_account: account_id,
-				partial_fulfillment,
-				currency_in: order.asset_in_id,
-				currency_out: order.asset_out_id,
-				fulfillment_amount: partial_buy_amount,
-				sell_rate_limit: order.max_sell_rate,
-			});
-
-			Ok(())
-		}
-
 		/// Adds a valid trading pair.
 		#[pallet::call_index(4)]
 		#[pallet::weight(T::Weights::add_trading_pair())]
@@ -680,6 +588,98 @@ pub mod pallet {
 				asset_in,
 				asset_out,
 				min_order,
+			});
+
+			Ok(())
+		}
+
+		/// Fill an existing order, based on the provided ratio.
+		#[pallet::call_index(7)]
+		#[pallet::weight(T::Weights::fill_order_partial())]
+		pub fn fill_order_partial(
+			origin: OriginFor<T>,
+			order_id: T::OrderIdNonce,
+			fulfillment_ratio: Perquintill,
+		) -> DispatchResult {
+			let account_id = ensure_signed(origin)?;
+			let order = <Orders<T>>::get(order_id)?;
+
+			ensure!(
+				!fulfillment_ratio.is_zero(),
+				Error::<T>::InvalidPartialOrderRatio
+			);
+
+			let partial_buy_amount = fulfillment_ratio.mul_floor(order.buy_amount);
+			let partial_sell_amount = fulfillment_ratio.mul_floor(order.max_sell_amount);
+			let remaining_buy_amount = order
+				.buy_amount
+				.checked_sub(&partial_buy_amount)
+				.ok_or(Error::<T>::RemainingBuyAmountError)?;
+			let partial_fulfillment = !remaining_buy_amount.is_zero();
+
+			ensure!(
+				partial_buy_amount >= order.min_fulfillment_amount,
+				Error::<T>::InsufficientOrderSize,
+			);
+
+			ensure!(
+				T::TradeableAsset::can_hold(order.asset_in_id, &account_id, partial_buy_amount),
+				Error::<T>::InsufficientAssetFunds,
+			);
+
+			if partial_fulfillment {
+				Self::update_order(
+					order.placing_account.clone(),
+					order_id,
+					remaining_buy_amount,
+					order.max_sell_rate,
+					remaining_buy_amount.min(order.min_fulfillment_amount),
+				)?;
+			} else {
+				T::TradeableAsset::release(
+					order.asset_out_id,
+					&order.placing_account,
+					partial_sell_amount,
+					false,
+				)?;
+
+				Self::remove_order(order.order_id)?;
+			}
+
+			T::TradeableAsset::transfer(
+				order.asset_in_id,
+				&account_id,
+				&order.placing_account,
+				partial_buy_amount,
+				false,
+			)?;
+
+			T::TradeableAsset::transfer(
+				order.asset_out_id,
+				&order.placing_account,
+				&account_id,
+				partial_sell_amount,
+				false,
+			)?;
+
+			T::FulfilledOrderHook::notify_status_change(
+				order_id,
+				Swap {
+					amount: partial_buy_amount,
+					currency_in: order.asset_in_id,
+					currency_out: order.asset_out_id,
+				},
+			)?;
+
+			Self::deposit_event(Event::OrderFulfillment {
+				order_id,
+				placing_account: order.placing_account,
+				fulfilling_account: account_id,
+				partial_fulfillment,
+				currency_in: order.asset_in_id,
+				currency_out: order.asset_out_id,
+				fulfillment_amount: partial_buy_amount,
+				sell_rate_limit: order.max_sell_rate,
 			});
 
 			Ok(())

--- a/pallets/order-book/src/mock.rs
+++ b/pallets/order-book/src/mock.rs
@@ -154,7 +154,6 @@ impl orml_tokens::Config for Runtime {
 }
 
 parameter_types! {
-
 		pub const NativeToken: CurrencyId = CurrencyId::Native;
 }
 

--- a/pallets/order-book/src/tests.rs
+++ b/pallets/order-book/src/tests.rs
@@ -10,12 +10,18 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_primitives::conversion::convert_balance_decimals;
 use cfg_types::tokens::CurrencyId;
-use frame_support::{assert_err, assert_noop, assert_ok, dispatch::RawOrigin};
-use orml_traits::asset_registry::Inspect;
+use frame_support::{
+	assert_err, assert_noop, assert_ok,
+	dispatch::RawOrigin,
+	traits::fungibles::{Inspect, MutateHold},
+};
+use orml_tokens::Error::BalanceTooLow;
 use sp_arithmetic::Perquintill;
-use sp_runtime::{traits::Zero, DispatchError, FixedPointNumber, FixedU128};
+use sp_runtime::{
+	traits::{BadOrigin, Zero},
+	DispatchError, FixedPointNumber, FixedU128,
+};
 
 use super::*;
 use crate::mock::*;
@@ -383,9 +389,107 @@ fn fill_order_full_works() {
 	});
 }
 
-#[test]
-fn fill_order_partial_works() {
-	for fulfillment_ratio in 1..100 {
+mod fill_order_partial {
+	use super::*;
+
+	#[test]
+	fn fill_order_partial_works() {
+		for fulfillment_ratio in 1..100 {
+			new_test_ext().execute_with(|| {
+				let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
+				let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
+				let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
+
+				assert_ok!(OrderBook::place_order(
+					ACCOUNT_0,
+					DEV_AUSD_CURRENCY_ID,
+					DEV_USDT_CURRENCY_ID,
+					buy_amount,
+					sell_ratio,
+					min_fulfillment_amount,
+				));
+
+				let (order_id, order) = get_account_orders(ACCOUNT_0).unwrap()[0];
+
+				let fulfillment_ratio = Perquintill::from_percent(fulfillment_ratio);
+				let partial_buy_amount = fulfillment_ratio.mul_floor(buy_amount);
+
+				assert_ok!(OrderBook::fill_order_partial(
+					RuntimeOrigin::signed(ACCOUNT_1),
+					order_id,
+					partial_buy_amount,
+				));
+
+				assert_eq!(
+					AssetPairOrders::<Runtime>::get(DEV_AUSD_CURRENCY_ID, DEV_USDT_CURRENCY_ID),
+					vec![order_id]
+				);
+
+				let expected_sell_amount = OrderBook::convert_with_ratio(
+					order.asset_in_id,
+					order.asset_out_id,
+					order.max_sell_rate,
+					partial_buy_amount,
+				)
+				.unwrap();
+
+				let remaining_buy_amount = buy_amount - partial_buy_amount;
+
+				assert_eq!(
+					System::events()[2].event,
+					RuntimeEvent::OrmlTokens(orml_tokens::Event::Unreserved {
+						currency_id: DEV_USDT_CURRENCY_ID,
+						who: ACCOUNT_0,
+						amount: expected_sell_amount
+					})
+				);
+				assert_eq!(
+					System::events()[3].event,
+					RuntimeEvent::OrderBook(Event::OrderUpdated {
+						order_id,
+						account: order.placing_account,
+						buy_amount: remaining_buy_amount,
+						sell_rate_limit: order.max_sell_rate,
+						min_fulfillment_amount: order.min_fulfillment_amount,
+					})
+				);
+				assert_eq!(
+					System::events()[4].event,
+					RuntimeEvent::OrmlTokens(orml_tokens::Event::Transfer {
+						currency_id: DEV_AUSD_CURRENCY_ID,
+						to: ACCOUNT_0,
+						from: ACCOUNT_1,
+						amount: partial_buy_amount
+					})
+				);
+				assert_eq!(
+					System::events()[5].event,
+					RuntimeEvent::OrmlTokens(orml_tokens::Event::Transfer {
+						currency_id: DEV_USDT_CURRENCY_ID,
+						to: ACCOUNT_1,
+						from: ACCOUNT_0,
+						amount: expected_sell_amount
+					})
+				);
+				assert_eq!(
+					System::events()[6].event,
+					RuntimeEvent::OrderBook(Event::OrderFulfillment {
+						order_id,
+						placing_account: order.placing_account,
+						fulfilling_account: ACCOUNT_1,
+						partial_fulfillment: true,
+						fulfillment_amount: partial_buy_amount,
+						currency_in: order.asset_in_id,
+						currency_out: order.asset_out_id,
+						sell_rate_limit: order.max_sell_rate,
+					})
+				);
+			});
+		}
+	}
+
+	#[test]
+	fn fill_order_partial_with_full_amount_works() {
 		new_test_ext().execute_with(|| {
 			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
 			let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
@@ -402,81 +506,59 @@ fn fill_order_partial_works() {
 
 			let (order_id, order) = get_account_orders(ACCOUNT_0).unwrap()[0];
 
-			let fulfillment_ratio = Perquintill::from_percent(fulfillment_ratio);
-
 			assert_ok!(OrderBook::fill_order_partial(
 				RuntimeOrigin::signed(ACCOUNT_1),
 				order_id,
-				fulfillment_ratio,
+				buy_amount,
 			));
 
 			assert_eq!(
 				AssetPairOrders::<Runtime>::get(DEV_AUSD_CURRENCY_ID, DEV_USDT_CURRENCY_ID),
-				vec![order_id]
+				vec![]
 			);
 
-			let ausd_decimals = RegistryMock::metadata(&DEV_AUSD_CURRENCY_ID)
-				.unwrap()
-				.decimals;
-			let usdt_decimals = RegistryMock::metadata(&DEV_USDT_CURRENCY_ID)
-				.unwrap()
-				.decimals;
-
-			let max_sell_amount = convert_balance_decimals(
-				ausd_decimals,
-				usdt_decimals,
-				sell_ratio.checked_mul_int(buy_amount).unwrap(),
+			let max_sell_amount = OrderBook::convert_with_ratio(
+				order.asset_in_id,
+				order.asset_out_id,
+				order.max_sell_rate,
+				buy_amount,
 			)
 			.unwrap();
-
-			let expected_buy_amount = fulfillment_ratio.mul_floor(buy_amount);
-			let expected_sell_amount = fulfillment_ratio.mul_floor(max_sell_amount);
-			let remaining_buy_amount = buy_amount - expected_buy_amount;
 
 			assert_eq!(
 				System::events()[2].event,
 				RuntimeEvent::OrmlTokens(orml_tokens::Event::Unreserved {
 					currency_id: DEV_USDT_CURRENCY_ID,
 					who: ACCOUNT_0,
-					amount: expected_sell_amount
+					amount: max_sell_amount
 				})
 			);
 			assert_eq!(
 				System::events()[3].event,
-				RuntimeEvent::OrderBook(Event::OrderUpdated {
-					order_id,
-					account: order.placing_account,
-					buy_amount: remaining_buy_amount,
-					sell_rate_limit: order.max_sell_rate,
-					min_fulfillment_amount: order.min_fulfillment_amount,
+				RuntimeEvent::OrmlTokens(orml_tokens::Event::Transfer {
+					currency_id: DEV_AUSD_CURRENCY_ID,
+					to: ACCOUNT_0,
+					from: ACCOUNT_1,
+					amount: buy_amount
 				})
 			);
 			assert_eq!(
 				System::events()[4].event,
 				RuntimeEvent::OrmlTokens(orml_tokens::Event::Transfer {
-					currency_id: DEV_AUSD_CURRENCY_ID,
-					to: ACCOUNT_0,
-					from: ACCOUNT_1,
-					amount: expected_buy_amount
+					currency_id: DEV_USDT_CURRENCY_ID,
+					to: ACCOUNT_1,
+					from: ACCOUNT_0,
+					amount: max_sell_amount
 				})
 			);
 			assert_eq!(
 				System::events()[5].event,
-				RuntimeEvent::OrmlTokens(orml_tokens::Event::Transfer {
-					currency_id: DEV_USDT_CURRENCY_ID,
-					to: ACCOUNT_1,
-					from: ACCOUNT_0,
-					amount: expected_sell_amount
-				})
-			);
-			assert_eq!(
-				System::events()[6].event,
 				RuntimeEvent::OrderBook(Event::OrderFulfillment {
 					order_id,
 					placing_account: order.placing_account,
 					fulfilling_account: ACCOUNT_1,
-					partial_fulfillment: true,
-					fulfillment_amount: expected_buy_amount,
+					partial_fulfillment: false,
+					fulfillment_amount: buy_amount,
 					currency_in: order.asset_in_id,
 					currency_out: order.asset_out_id,
 					sell_rate_limit: order.max_sell_rate,
@@ -484,98 +566,146 @@ fn fill_order_partial_works() {
 			);
 		});
 	}
-}
 
-#[test]
-fn fill_order_partial_100_percent_works() {
-	new_test_ext().execute_with(|| {
-		let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
-		let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
-		let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
+	#[test]
+	fn fill_order_partial_bad_origin() {
+		new_test_ext().execute_with(|| {
+			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
+			let min_fulfillment_amount = 10 * CURRENCY_AUSD_DECIMALS;
+			let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
 
-		assert_ok!(OrderBook::place_order(
-			ACCOUNT_0,
-			DEV_AUSD_CURRENCY_ID,
-			DEV_USDT_CURRENCY_ID,
-			buy_amount,
-			sell_ratio,
-			min_fulfillment_amount,
-		));
+			assert_ok!(OrderBook::place_order(
+				ACCOUNT_0,
+				DEV_AUSD_CURRENCY_ID,
+				DEV_USDT_CURRENCY_ID,
+				buy_amount,
+				sell_ratio,
+				min_fulfillment_amount,
+			));
 
-		let (order_id, order) = get_account_orders(ACCOUNT_0).unwrap()[0];
+			let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 
-		let fulfillment_ratio = Perquintill::from_percent(100);
+			assert_noop!(
+				OrderBook::fill_order_partial(
+					RawOrigin::None.into(),
+					order_id,
+					min_fulfillment_amount,
+				),
+				BadOrigin
+			);
+		});
+	}
 
-		assert_ok!(OrderBook::fill_order_partial(
-			RuntimeOrigin::signed(ACCOUNT_1),
-			order_id,
-			fulfillment_ratio,
-		));
+	#[test]
+	fn fill_order_partial_invalid_order() {
+		new_test_ext().execute_with(|| {
+			assert_noop!(
+				OrderBook::fill_order_partial(
+					RuntimeOrigin::signed(ACCOUNT_1),
+					1234,
+					10 * CURRENCY_AUSD_DECIMALS,
+				),
+				Error::<Runtime>::OrderNotFound
+			);
+		});
+	}
 
-		assert_eq!(
-			AssetPairOrders::<Runtime>::get(DEV_AUSD_CURRENCY_ID, DEV_USDT_CURRENCY_ID),
-			vec![]
-		);
+	#[test]
+	fn fill_order_partial_insufficient_order_size() {
+		new_test_ext().execute_with(|| {
+			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
+			let min_fulfillment_amount = 10 * CURRENCY_AUSD_DECIMALS;
+			let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
 
-		let ausd_decimals = RegistryMock::metadata(&DEV_AUSD_CURRENCY_ID)
-			.unwrap()
-			.decimals;
-		let usdt_decimals = RegistryMock::metadata(&DEV_USDT_CURRENCY_ID)
-			.unwrap()
-			.decimals;
+			assert_ok!(OrderBook::place_order(
+				ACCOUNT_0,
+				DEV_AUSD_CURRENCY_ID,
+				DEV_USDT_CURRENCY_ID,
+				buy_amount,
+				sell_ratio,
+				min_fulfillment_amount,
+			));
 
-		let max_sell_amount = convert_balance_decimals(
-			ausd_decimals,
-			usdt_decimals,
-			sell_ratio.checked_mul_int(buy_amount).unwrap(),
-		)
-		.unwrap();
+			let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 
-		let expected_buy_amount = fulfillment_ratio.mul_floor(buy_amount);
-		let expected_sell_amount = fulfillment_ratio.mul_floor(max_sell_amount);
+			assert_noop!(
+				OrderBook::fill_order_partial(
+					RuntimeOrigin::signed(ACCOUNT_1),
+					order_id,
+					min_fulfillment_amount - 1 * CURRENCY_AUSD_DECIMALS,
+				),
+				Error::<Runtime>::InsufficientOrderSize
+			);
+		});
+	}
 
-		let _events = System::events();
+	#[test]
+	fn fill_order_partial_insufficient_asset_funds() {
+		new_test_ext().execute_with(|| {
+			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
+			let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
+			let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
 
-		assert_eq!(
-			System::events()[2].event,
-			RuntimeEvent::OrmlTokens(orml_tokens::Event::Unreserved {
-				currency_id: DEV_USDT_CURRENCY_ID,
-				who: ACCOUNT_0,
-				amount: expected_sell_amount
-			})
-		);
-		assert_eq!(
-			System::events()[3].event,
-			RuntimeEvent::OrmlTokens(orml_tokens::Event::Transfer {
-				currency_id: DEV_AUSD_CURRENCY_ID,
-				to: ACCOUNT_0,
-				from: ACCOUNT_1,
-				amount: expected_buy_amount
-			})
-		);
-		assert_eq!(
-			System::events()[4].event,
-			RuntimeEvent::OrmlTokens(orml_tokens::Event::Transfer {
-				currency_id: DEV_USDT_CURRENCY_ID,
-				to: ACCOUNT_1,
-				from: ACCOUNT_0,
-				amount: expected_sell_amount
-			})
-		);
-		assert_eq!(
-			System::events()[5].event,
-			RuntimeEvent::OrderBook(Event::OrderFulfillment {
-				order_id,
-				placing_account: order.placing_account,
-				fulfilling_account: ACCOUNT_1,
-				partial_fulfillment: false,
-				fulfillment_amount: expected_buy_amount,
-				currency_in: order.asset_in_id,
-				currency_out: order.asset_out_id,
-				sell_rate_limit: order.max_sell_rate,
-			})
-		);
-	});
+			assert_ok!(OrderBook::place_order(
+				ACCOUNT_0,
+				DEV_AUSD_CURRENCY_ID,
+				DEV_USDT_CURRENCY_ID,
+				buy_amount,
+				sell_ratio,
+				min_fulfillment_amount,
+			));
+
+			let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
+
+			let total_balance = OrmlTokens::balance(DEV_AUSD_CURRENCY_ID, &ACCOUNT_1);
+			assert_ok!(OrmlTokens::hold(
+				DEV_AUSD_CURRENCY_ID,
+				&ACCOUNT_1,
+				total_balance
+			));
+
+			// TODO(cdamian): No way of triggering `InsufficientAssetFunds` given that
+			// `T::TradeableAsset::can_hold` is always returning true?
+
+			assert_noop!(
+				OrderBook::fill_order_partial(
+					RuntimeOrigin::signed(ACCOUNT_1),
+					order_id,
+					buy_amount,
+				),
+				BalanceTooLow::<Runtime>,
+			);
+		});
+	}
+
+	#[test]
+	fn fill_order_partial_buy_amount_too_big() {
+		new_test_ext().execute_with(|| {
+			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
+			let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
+			let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
+
+			assert_ok!(OrderBook::place_order(
+				ACCOUNT_0,
+				DEV_AUSD_CURRENCY_ID,
+				DEV_USDT_CURRENCY_ID,
+				buy_amount,
+				sell_ratio,
+				min_fulfillment_amount,
+			));
+
+			let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
+
+			assert_noop!(
+				OrderBook::fill_order_partial(
+					RuntimeOrigin::signed(ACCOUNT_1),
+					order_id,
+					buy_amount + 1 * CURRENCY_AUSD_DECIMALS,
+				),
+				Error::<Runtime>::RemainingBuyAmountError
+			);
+		});
+	}
 }
 
 #[test]

--- a/pallets/order-book/src/weights.rs
+++ b/pallets/order-book/src/weights.rs
@@ -17,6 +17,7 @@ pub trait WeightInfo {
 	fn user_cancel_order() -> Weight;
 	fn user_update_order() -> Weight;
 	fn fill_order_full() -> Weight;
+	fn fill_order_partial() -> Weight;
 	fn add_trading_pair() -> Weight;
 	fn rm_trading_pair() -> Weight;
 	fn update_min_order() -> Weight;
@@ -36,6 +37,10 @@ impl WeightInfo for () {
 	}
 
 	fn fill_order_full() -> Weight {
+		Weight::zero()
+	}
+
+	fn fill_order_partial() -> Weight {
 		Weight::zero()
 	}
 

--- a/pallets/restricted-tokens/src/impl_fungibles.rs
+++ b/pallets/restricted-tokens/src/impl_fungibles.rs
@@ -151,12 +151,14 @@ impl<T: Config> InspectHold<T::AccountId> for Pallet<T> {
 		if asset == T::NativeToken::get() {
 			<Pallet<T> as fungible::InspectHold<T::AccountId>>::can_hold(who, amount)
 		} else {
+			let can_hold = <T::Fungibles as InspectHold<T::AccountId>>::can_hold(asset, who, amount);
+
 			T::PreFungiblesInspectHold::check(FungiblesInspectHoldEffects::CanHold(
 				asset,
 				who.clone(),
 				amount,
-				<T::Fungibles as InspectHold<T::AccountId>>::can_hold(asset, who, amount),
-			))
+				can_hold,
+			)) && can_hold
 		}
 	}
 }

--- a/pallets/restricted-tokens/src/impl_fungibles.rs
+++ b/pallets/restricted-tokens/src/impl_fungibles.rs
@@ -151,7 +151,8 @@ impl<T: Config> InspectHold<T::AccountId> for Pallet<T> {
 		if asset == T::NativeToken::get() {
 			<Pallet<T> as fungible::InspectHold<T::AccountId>>::can_hold(who, amount)
 		} else {
-			let can_hold = <T::Fungibles as InspectHold<T::AccountId>>::can_hold(asset, who, amount);
+			let can_hold =
+				<T::Fungibles as InspectHold<T::AccountId>>::can_hold(asset, who, amount);
 
 			T::PreFungiblesInspectHold::check(FungiblesInspectHoldEffects::CanHold(
 				asset,

--- a/runtime/altair/src/weights/pallet_order_book.rs
+++ b/runtime/altair/src/weights/pallet_order_book.rs
@@ -140,7 +140,6 @@ impl<T: frame_system::Config> pallet_order_book::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	// TODO(cdamian): This is copied from `fill_order_full`, don't merge until we get the real weight.
 	fn fill_order_partial() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1702`

--- a/runtime/altair/src/weights/pallet_order_book.rs
+++ b/runtime/altair/src/weights/pallet_order_book.rs
@@ -140,4 +140,14 @@ impl<T: frame_system::Config> pallet_order_book::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	// TODO(cdamian): This is copied from `fill_order_full`, don't merge until we get the real weight.
+	fn fill_order_partial() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1702`
+		//  Estimated: `8020828`
+		// Minimum execution time: 64_000 nanoseconds.
+		Weight::from_parts(64_000_000, 8020828)
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(7))
+	}
 }

--- a/runtime/centrifuge/src/weights/pallet_order_book.rs
+++ b/runtime/centrifuge/src/weights/pallet_order_book.rs
@@ -140,7 +140,6 @@ impl<T: frame_system::Config> pallet_order_book::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	// TODO(cdamian): This is copied from `fill_order_full`, don't merge until we get the real weight.
 	fn fill_order_partial() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1702`

--- a/runtime/centrifuge/src/weights/pallet_order_book.rs
+++ b/runtime/centrifuge/src/weights/pallet_order_book.rs
@@ -140,4 +140,14 @@ impl<T: frame_system::Config> pallet_order_book::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	// TODO(cdamian): This is copied from `fill_order_full`, don't merge until we get the real weight.
+	fn fill_order_partial() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1702`
+		//  Estimated: `8020828`
+		// Minimum execution time: 64_000 nanoseconds.
+		Weight::from_parts(64_000_000, 8020828)
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(7))
+	}
 }

--- a/runtime/development/src/weights/pallet_order_book.rs
+++ b/runtime/development/src/weights/pallet_order_book.rs
@@ -140,7 +140,6 @@ impl<T: frame_system::Config> pallet_order_book::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	// TODO(cdamian): This is copied from `fill_order_full`, don't merge until we get the real weight.
 	fn fill_order_partial() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1702`

--- a/runtime/development/src/weights/pallet_order_book.rs
+++ b/runtime/development/src/weights/pallet_order_book.rs
@@ -140,4 +140,14 @@ impl<T: frame_system::Config> pallet_order_book::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	// TODO(cdamian): This is copied from `fill_order_full`, don't merge until we get the real weight.
+	fn fill_order_partial() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1702`
+		//  Estimated: `28826`
+		// Minimum execution time: 64_000 nanoseconds.
+		Weight::from_parts(65_000_000, 28826)
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(7))
+	}
 }

--- a/runtime/integration-tests/src/evm/precompile.rs
+++ b/runtime/integration-tests/src/evm/precompile.rs
@@ -156,6 +156,7 @@ async fn axelar_precompile_execute() {
 
 	let command_id = H256::from_low_u64_be(5678);
 
+	#[allow(deprecated)]
 	let test_input = Contract {
 		constructor: None,
 		functions: BTreeMap::<String, Vec<Function>>::from([(


### PR DESCRIPTION
# Description

Added a new extrinsic in the `order-book` pallet that allows for a partial order fulfillment.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
