### PR TITLE
Loans: Remove portfolio entry when removing a loan +  portfolio UT

### DIFF
--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -947,6 +947,10 @@ pub mod pallet {
 					.position(|(id, _)| *id == loan_id)
 					.ok_or(Error::<T>::LoanNotActiveOrNotFound)?;
 
+				PortfolioValuation::<T>::try_mutate(pool_id, |portfolio| {
+					portfolio.remove_elem(loan_id)
+				})?;
+
 				Ok((
 					active_loans.swap_remove(index).1,
 					active_loans.len().ensure_into()?,


### PR DESCRIPTION
# Description

Optional addition: I think it could be beneficial to leave the portfolio values representing the exact loans found in `ActiveLoans`. Anyways, the storage is reset for each NAV computation, but having during some time different elements in the portfolio and active loans could lead to errors.

PROS: Data more structured.
CONS: 1 read/write DB for `close_loan()` action.

## Changes and Descriptions

- add `portfolio.remove_elem()`
- add Unitary tests to the portfolio module.
