### PR TITLE
Investments: benchmarks

### DIFF
--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -43,7 +43,7 @@ pub mod pallet {
 			register_call!(f);
 		}
 
-		pub fn tranche_exists(f: impl Fn(T::PoolId, T::TrancheId) -> bool + 'static) {
+		pub fn mock_tranche_exists(f: impl Fn(T::PoolId, T::TrancheId) -> bool + 'static) {
 			register_call!(move |(a, b)| f(a, b));
 		}
 

--- a/libs/test-utils/src/mocks/accountant.rs
+++ b/libs/test-utils/src/mocks/accountant.rs
@@ -166,6 +166,27 @@ macro_rules! impl_mock_accountant {
 				}
 			}
 
+			#[cfg(feature = "runtime-benchmarks")]
+			impl<Tokens> cfg_traits::benchmarking::PoolBenchmarkHelper for $name<Tokens> {
+				type AccountId = $account_id;
+				type Balance = $balance;
+				type PoolId = ();
+
+				fn bench_create_pool(_: Self::PoolId, _: &Self::AccountId) {}
+
+				fn bench_investor_setup(_: Self::PoolId, _: Self::AccountId, _: Self::Balance) {}
+			}
+
+			#[cfg(feature = "runtime-benchmarks")]
+			impl<Tokens> cfg_traits::benchmarking::InvestmentIdBenchmarkHelper for $name<Tokens> {
+				type InvestmentId = $investment_id;
+				type PoolId = ();
+
+				fn bench_default_investment_id(_: Self::PoolId) -> Self::InvestmentId {
+					Self::InvestmentId::default()
+				}
+			}
+
 			impl cfg_traits::investments::InvestmentProperties<$account_id> for InvestmentInfo {
 				type Currency = $currency_id;
 				type Id = $investment_id;

--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -183,18 +183,7 @@ where
 /// enables us to use the `TrancheCurrency` type separately where solely this
 /// enum variant would be relevant. Most notably, in the `struct Tranche`.
 #[derive(
-	Clone,
-	Copy,
-	Default,
-	PartialOrd,
-	Ord,
-	PartialEq,
-	Eq,
-	Debug,
-	Encode,
-	Decode,
-	TypeInfo,
-	MaxEncodedLen,
+	Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct TrancheCurrency {

--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -183,7 +183,18 @@ where
 /// enables us to use the `TrancheCurrency` type separately where solely this
 /// enum variant would be relevant. Most notably, in the `struct Tranche`.
 #[derive(
-	Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
+	Clone,
+	Copy,
+	Default,
+	PartialOrd,
+	Ord,
+	PartialEq,
+	Eq,
+	Debug,
+	Encode,
+	Decode,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct TrancheCurrency {

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
 // This file is part of Centrifuge chain project.
 
 // Centrifuge is free software: you can redistribute it and/or modify
@@ -10,3 +10,63 @@
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
+
+use cfg_traits::investments::{InvestmentAccountant, InvestmentProperties};
+use cfg_types::tokens::CurrencyId;
+use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
+use frame_support::traits::fungibles::Mutate;
+use frame_system::RawOrigin;
+
+use crate::{Call, Config, CurrencyOf, Pallet};
+
+benchmarks! {
+	where_clause {
+	where
+		<T::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
+			InvestmentProperties<T::AccountId, Currency = CurrencyOf<T>>,
+		T::InvestmentId: Default + Into<CurrencyOf<T>>,
+	}
+
+	update_invest_order {
+		let caller: T::AccountId = whitelisted_caller();
+		let investment_id = T::InvestmentId::default();
+		let currency_id = T::Accountant::info(investment_id).unwrap().payment_currency();
+		dbg!(investment_id, &caller);
+		T::Tokens::mint_into(currency_id, &caller, 10u32.into()).unwrap();
+
+
+	}: _(RawOrigin::Signed(caller), T::InvestmentId::default(), 1u32.into())
+}
+
+impl_benchmark_test_suite!(
+	Pallet,
+	crate::mock::TestExternalitiesBuilder::build(),
+	crate::mock::MockRuntime
+);
+
+/*
+use cfg_types::tokens::CurrencyId;
+use frame_benchmarking::v2::*;
+use frame_system::RawOrigin;
+
+use crate::{Call, Config, Pallet};
+
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn update_invest_order() {
+		let caller: T::AccountId = whitelisted_caller();
+
+		#[extrinsic_call]
+		update_invest_order(
+			RawOrigin::Signed(caller),
+			T::InvestmentId::from(1.into()),
+			1.into(),
+		);
+
+		//assert_eq!(Something::<T>::get(), Some(value));
+	}
+}
+*/

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -36,8 +36,7 @@ where
 		>,
 	<T::Accountant as PoolBenchmarkHelper>::PoolId: Default + Copy,
 {
-	fn get_investment_id() -> T::InvestmentId
-where {
+	fn get_investment_id() -> T::InvestmentId {
 		let pool_id = Default::default();
 		let pool_admin = account("pool_admin", 0, 0);
 

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -28,7 +28,6 @@ impl<T: Config> Helper<T>
 where
 	<T::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
 		InvestmentProperties<T::AccountId, Currency = CurrencyOf<T>>,
-	T::InvestmentId: Default + Into<CurrencyOf<T>>,
 	T::Accountant: PoolBenchmarkHelper<AccountId = T::AccountId>
 		+ InvestmentIdBenchmarkHelper<
 			InvestmentId = T::InvestmentId,
@@ -49,7 +48,6 @@ where
 	where
 		<T::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
 			InvestmentProperties<T::AccountId, Currency = CurrencyOf<T>>,
-		T::InvestmentId: Default + Into<CurrencyOf<T>>,
 		T::Accountant: PoolBenchmarkHelper<AccountId = T::AccountId>
 			+ InvestmentIdBenchmarkHelper<
 				InvestmentId = T::InvestmentId,

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -11,6 +11,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+/*
 use cfg_traits::investments::{InvestmentAccountant, InvestmentProperties};
 use cfg_types::tokens::CurrencyId;
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
@@ -43,30 +44,46 @@ impl_benchmark_test_suite!(
 	crate::mock::TestExternalitiesBuilder::build(),
 	crate::mock::MockRuntime
 );
+*/
 
-/*
+use cfg_traits::investments::{InvestmentAccountant, InvestmentProperties};
 use cfg_types::tokens::CurrencyId;
-use frame_benchmarking::v2::*;
+use frame_benchmarking::{account, impl_benchmark_test_suite, v2::*, whitelisted_caller};
+use frame_support::traits::fungibles::Mutate;
 use frame_system::RawOrigin;
 
-use crate::{Call, Config, Pallet};
+use crate::{Call, Config, CurrencyOf, Pallet};
 
-#[benchmarks]
+#[benchmarks(
+	where
+		<T::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
+			InvestmentProperties<T::AccountId, Currency = CurrencyOf<T>>,
+		T::InvestmentId: Default + Into<CurrencyOf<T>>,
+)]
 mod benchmarks {
 	use super::*;
 
 	#[benchmark]
 	fn update_invest_order() {
 		let caller: T::AccountId = whitelisted_caller();
+		let investment_id = T::InvestmentId::default();
+		let currency_id = T::Accountant::info(investment_id)
+			.unwrap()
+			.payment_currency();
+
+		T::Tokens::mint_into(currency_id, &caller, 10u32.into()).unwrap();
 
 		#[extrinsic_call]
 		update_invest_order(
 			RawOrigin::Signed(caller),
-			T::InvestmentId::from(1.into()),
-			1.into(),
+			T::InvestmentId::default(),
+			1u32.into(),
 		);
-
-		//assert_eq!(Something::<T>::get(), Some(value));
 	}
+
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::TestExternalitiesBuilder::build(),
+		crate::mock::MockRuntime
+	);
 }
-*/

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -11,46 +11,12 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-/*
 use cfg_traits::investments::{InvestmentAccountant, InvestmentProperties};
-use cfg_types::tokens::CurrencyId;
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
-use frame_support::traits::fungibles::Mutate;
-use frame_system::RawOrigin;
-
-use crate::{Call, Config, CurrencyOf, Pallet};
-
-benchmarks! {
-	where_clause {
-	where
-		<T::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
-			InvestmentProperties<T::AccountId, Currency = CurrencyOf<T>>,
-		T::InvestmentId: Default + Into<CurrencyOf<T>>,
-	}
-
-	update_invest_order {
-		let caller: T::AccountId = whitelisted_caller();
-		let investment_id = T::InvestmentId::default();
-		let currency_id = T::Accountant::info(investment_id).unwrap().payment_currency();
-		dbg!(investment_id, &caller);
-		T::Tokens::mint_into(currency_id, &caller, 10u32.into()).unwrap();
-
-
-	}: _(RawOrigin::Signed(caller), T::InvestmentId::default(), 1u32.into())
-}
-
-impl_benchmark_test_suite!(
-	Pallet,
-	crate::mock::TestExternalitiesBuilder::build(),
-	crate::mock::MockRuntime
-);
-*/
-
-use cfg_traits::investments::{InvestmentAccountant, InvestmentProperties};
-use cfg_types::tokens::CurrencyId;
+use cfg_types::{investments::InvestmentAccount, tokens::CurrencyId};
 use frame_benchmarking::{account, impl_benchmark_test_suite, v2::*, whitelisted_caller};
 use frame_support::traits::fungibles::Mutate;
 use frame_system::RawOrigin;
+use sp_runtime::traits::AccountIdConversion;
 
 use crate::{Call, Config, CurrencyOf, Pallet};
 
@@ -71,14 +37,22 @@ mod benchmarks {
 			.unwrap()
 			.payment_currency();
 
-		T::Tokens::mint_into(currency_id, &caller, 10u32.into()).unwrap();
+		T::Tokens::mint_into(currency_id, &caller, 1u32.into()).unwrap();
 
 		#[extrinsic_call]
-		update_invest_order(
-			RawOrigin::Signed(caller),
-			T::InvestmentId::default(),
-			1u32.into(),
-		);
+		update_invest_order(RawOrigin::Signed(caller), investment_id, 1u32.into());
+	}
+
+	#[benchmark]
+	fn update_redeem_order() {
+		let caller: T::AccountId = whitelisted_caller();
+		let investment_id = T::InvestmentId::default();
+		let currency_id: CurrencyOf<T> = T::Accountant::info(investment_id).unwrap().id().into();
+
+		T::Tokens::mint_into(currency_id, &caller, 1u32.into()).unwrap();
+
+		#[extrinsic_call]
+		update_redeem_order(RawOrigin::Signed(caller), investment_id, 1u32.into());
 	}
 
 	impl_benchmark_test_suite!(

--- a/pallets/investments/src/lib.rs
+++ b/pallets/investments/src/lib.rs
@@ -46,7 +46,7 @@ use sp_std::{
 	vec::Vec,
 };
 pub mod weights;
-use weights::WeightInfo;
+pub use weights::WeightInfo;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;

--- a/pallets/investments/src/lib.rs
+++ b/pallets/investments/src/lib.rs
@@ -933,14 +933,7 @@ where
 			&mut total_order.amount,
 		)?;
 
-		dbg!(transfer_amount);
-		dbg!(info.payment_currency());
-		dbg!(send, recv, who);
-
-		dbg!(
-			T::Tokens::transfer(info.payment_currency(), send, recv, transfer_amount, false)
-				.map(|_| ()),
-		)
+		T::Tokens::transfer(info.payment_currency(), send, recv, transfer_amount, false).map(|_| ())
 	}
 
 	pub(crate) fn do_update_redeem_order(

--- a/pallets/investments/src/lib.rs
+++ b/pallets/investments/src/lib.rs
@@ -933,7 +933,14 @@ where
 			&mut total_order.amount,
 		)?;
 
-		T::Tokens::transfer(info.payment_currency(), send, recv, transfer_amount, false).map(|_| ())
+		dbg!(transfer_amount);
+		dbg!(info.payment_currency());
+		dbg!(send, recv, who);
+
+		dbg!(
+			T::Tokens::transfer(info.payment_currency(), send, recv, transfer_amount, false)
+				.map(|_| ()),
+		)
 	}
 
 	pub(crate) fn do_update_redeem_order(

--- a/pallets/investments/src/lib.rs
+++ b/pallets/investments/src/lib.rs
@@ -46,6 +46,7 @@ use sp_std::{
 	vec::Vec,
 };
 pub mod weights;
+use weights::WeightInfo;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
@@ -162,7 +163,8 @@ pub mod pallet {
 
 		/// The bound on how many fulfilled orders we cache until
 		/// the user needs to collect them.
-		type MaxOutstandingCollects: Get<u64>;
+		#[pallet::constant]
+		type MaxOutstandingCollects: Get<u32>;
 
 		/// Something that can handle payments and transfers of
 		/// currencies
@@ -423,7 +425,7 @@ pub mod pallet {
 		/// amount is less than the current order, the balance
 		/// will be transferred from the pool to the calling
 		/// account.
-		#[pallet::weight(5_000_000_000)]
+		#[pallet::weight(T::WeightInfo::update_invest_order())]
 		#[pallet::call_index(0)]
 		pub fn update_invest_order(
 			origin: OriginFor<T>,
@@ -443,7 +445,7 @@ pub mod pallet {
 		/// amount is less than the current order, the balance
 		/// will be transferred from the pool to the calling
 		/// account.
-		#[pallet::weight(5_000_000_000)]
+		#[pallet::weight(T::WeightInfo::update_redeem_order())]
 		#[pallet::call_index(1)]
 		pub fn update_redeem_order(
 			origin: OriginFor<T>,
@@ -458,7 +460,7 @@ pub mod pallet {
 		/// Collect the results of a user's invest orders for the given
 		/// investment. If any amounts are not fulfilled they are directly
 		/// appended to the next active order for this investment.
-		#[pallet::weight(5_000_000_000)]
+		#[pallet::weight(T::WeightInfo::collect_investments(T::MaxOutstandingCollects::get()))]
 		#[pallet::call_index(2)]
 		pub fn collect_investments(
 			origin: OriginFor<T>,
@@ -472,7 +474,7 @@ pub mod pallet {
 		/// Collect the results of a user's redeem orders for the given
 		/// investment. If any amounts are not fulfilled they are directly
 		/// appended to the next active order for this investment.
-		#[pallet::weight(5_000_000_000)]
+		#[pallet::weight(T::WeightInfo::collect_redemptions(T::MaxOutstandingCollects::get()))]
 		#[pallet::call_index(3)]
 		pub fn collect_redemptions(
 			origin: OriginFor<T>,
@@ -486,7 +488,7 @@ pub mod pallet {
 		/// Collect the results of another users invest orders for the given
 		/// investment. If any amounts are not fulfilled they are directly
 		/// appended to the next active order for this investment.
-		#[pallet::weight(5_000_000_000)]
+		#[pallet::weight(T::WeightInfo::collect_investments(T::MaxOutstandingCollects::get()))]
 		#[pallet::call_index(4)]
 		pub fn collect_investments_for(
 			origin: OriginFor<T>,
@@ -501,7 +503,7 @@ pub mod pallet {
 		/// Collect the results of another users redeem orders for the given
 		/// investment. If any amounts are not fulfilled they are directly
 		/// appended to the next active order for this investment.
-		#[pallet::weight(5_000_000_000)]
+		#[pallet::weight(T::WeightInfo::collect_redemptions(T::MaxOutstandingCollects::get()))]
 		#[pallet::call_index(5)]
 		pub fn collect_redemptions_for(
 			origin: OriginFor<T>,
@@ -687,7 +689,7 @@ where
 				let last_processed_order_id = min(
 					order
 						.submitted_at()
-						.saturating_add(T::MaxOutstandingCollects::get()),
+						.saturating_add(T::MaxOutstandingCollects::get().into()),
 					cur_order_id,
 				);
 
@@ -814,7 +816,7 @@ where
 				let last_processed_order_id = min(
 					order
 						.submitted_at()
-						.saturating_add(T::MaxOutstandingCollects::get()),
+						.saturating_add(T::MaxOutstandingCollects::get().into()),
 					cur_order_id,
 				);
 

--- a/pallets/investments/src/mock.rs
+++ b/pallets/investments/src/mock.rs
@@ -203,6 +203,15 @@ pub enum InvestmentId {
 	},
 }
 
+impl Default for InvestmentId {
+	fn default() -> Self {
+		Self::PoolTranche {
+			pool_id: Default::default(),
+			tranche_id: Default::default(),
+		}
+	}
+}
+
 impl From<InvestmentId> for CurrencyId {
 	fn from(val: InvestmentId) -> Self {
 		match val {
@@ -366,7 +375,7 @@ pub(crate) fn invest_x_per_investor(amount: Balance) -> DispatchResult {
 }
 
 /// Redeem amount into INVESTMENT_0_0
-///  
+///
 /// User accounts are the default TrancheHolder{A,B,C}
 pub(crate) fn redeem_x_per_investor(amount: Balance) -> DispatchResult {
 	Investments::update_redeem_order(

--- a/pallets/investments/src/mock.rs
+++ b/pallets/investments/src/mock.rs
@@ -152,7 +152,7 @@ impl cfg_traits::StatusNotificationHook for NoopCollectHook {
 }
 
 parameter_types! {
-	pub const MaxOutstandingCollect: u64 = 10;
+	pub const MaxOutstandingCollect: u32 = 10;
 }
 
 impl pallet_investments::Config for MockRuntime {

--- a/pallets/investments/src/tests.rs
+++ b/pallets/investments/src/tests.rs
@@ -2859,7 +2859,7 @@ fn collecting_over_max_works() {
 				InvestOrders::<MockRuntime>::get(InvestorA::get(), INVESTMENT_0_0),
 				Some(Order::new(
 					5368709120000000000,
-					MaxOutstandingCollect::get()
+					MaxOutstandingCollect::get().into()
 				)),
 			);
 			assert_ok!(collect_both(
@@ -2914,7 +2914,7 @@ fn collecting_over_max_works() {
 				RedeemOrders::<MockRuntime>::get(TrancheHolderA::get(), INVESTMENT_0_0),
 				Some(Order::new(
 					5368709120000000000,
-					MaxOutstandingCollect::get()
+					MaxOutstandingCollect::get().into()
 				)),
 			);
 			assert_ok!(collect_both(

--- a/pallets/investments/src/weights.rs
+++ b/pallets/investments/src/weights.rs
@@ -11,6 +11,29 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-pub trait WeightInfo {}
+use frame_support::weights::Weight;
 
-impl WeightInfo for () {}
+pub trait WeightInfo {
+	fn update_invest_order() -> Weight;
+	fn update_redeem_order() -> Weight;
+	fn collect_investments(n: u32) -> Weight;
+	fn collect_redemptions(n: u32) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn update_invest_order() -> Weight {
+		Weight::zero()
+	}
+
+	fn update_redeem_order() -> Weight {
+		Weight::zero()
+	}
+
+	fn collect_investments(_: u32) -> Weight {
+		Weight::zero()
+	}
+
+	fn collect_redemptions(_: u32) -> Weight {
+		Weight::zero()
+	}
+}

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1745,7 +1745,7 @@ impl<
 			),
 		};
 
-		if is_tranche_investor {
+		if is_tranche_investor || cfg!(feature = "runtime-benchmarks") {
 			Ok(())
 		} else {
 			// TODO: We should adapt the permissions pallets interface to return an error

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -2457,6 +2457,7 @@ impl_runtime_apis! {
 			list_benchmark!(list, extra, pallet_restricted_tokens, Tokens);
 			list_benchmark!(list, extra, pallet_keystore, Keystore);
 			list_benchmark!(list, extra, pallet_order_book, OrderBook);
+			list_benchmark!(list, extra, pallet_investments, Investments);
 
 			let storage_info = AllPalletsWithSystem::storage_info();
 
@@ -2528,6 +2529,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_restricted_tokens, Tokens);
 			add_benchmark!(params, batches, pallet_keystore, Keystore);
 			add_benchmark!(params, batches, pallet_order_book, OrderBook);
+			add_benchmark!(params, batches, pallet_investments, Investments);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1704,7 +1704,7 @@ impl pallet_investments::Config for Runtime {
 	type PreConditions = IsTrancheInvestor<Permissions, Timestamp>;
 	type RuntimeEvent = RuntimeEvent;
 	type Tokens = Tokens;
-	type WeightInfo = ();
+	type WeightInfo = weights::pallet_investments::WeightInfo<Runtime>;
 }
 
 /// Checks whether the given `who` has the role

--- a/runtime/altair/src/weights/mod.rs
+++ b/runtime/altair/src/weights/mod.rs
@@ -22,6 +22,7 @@ pub mod pallet_democracy;
 pub mod pallet_fees;
 pub mod pallet_identity;
 pub mod pallet_interest_accrual;
+pub mod pallet_investments;
 pub mod pallet_keystore;
 pub mod pallet_liquidity_rewards;
 pub mod pallet_loans;

--- a/runtime/altair/src/weights/pallet_investments.rs
+++ b/runtime/altair/src/weights/pallet_investments.rs
@@ -1,6 +1,6 @@
 //! TEMP: This file will be regenerated!
 
-use frame_support::{traits::Get, weights::Weight};
+use frame_support::weights::Weight;
 use sp_std::marker::PhantomData;
 
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtime/altair/src/weights/pallet_investments.rs
+++ b/runtime/altair/src/weights/pallet_investments.rs
@@ -1,0 +1,23 @@
+//! TEMP: This file will be regenerated!
+
+use frame_support::{traits::Get, weights::Weight};
+use sp_std::marker::PhantomData;
+
+pub struct WeightInfo<T>(PhantomData<T>);
+impl<T: frame_system::Config> pallet_investments::WeightInfo for WeightInfo<T> {
+	fn update_invest_order() -> Weight {
+		Weight::zero()
+	}
+
+	fn update_redeem_order() -> Weight {
+		Weight::zero()
+	}
+
+	fn collect_investments(_: u32) -> Weight {
+		Weight::zero()
+	}
+
+	fn collect_redemptions(_: u32) -> Weight {
+		Weight::zero()
+	}
+}

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1746,7 +1746,7 @@ impl<
 			),
 		};
 
-		if is_tranche_investor {
+		if is_tranche_investor || cfg!(feature = "runtime-benchmarks") {
 			Ok(())
 		} else {
 			// TODO: We should adapt the permissions pallets interface to return an error

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1772,11 +1772,7 @@ impl pallet_investments::Config for Runtime {
 	type PreConditions = IsTrancheInvestor<Permissions, Timestamp>;
 	type RuntimeEvent = RuntimeEvent;
 	type Tokens = Tokens;
-	// TODO: Fix benchmarks
-	//
-	// NOTE: Fixed weights are really high and
-	//       cover worst case, but are inefficient.
-	type WeightInfo = ();
+	type WeightInfo = weights::pallet_investments::WeightInfo<Runtime>;
 }
 
 parameter_types! {

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -2527,6 +2527,7 @@ impl_runtime_apis! {
 			list_benchmark!(list, extra, pallet_collator_selection, CollatorSelection);
 			list_benchmark!(list, extra, cumulus_pallet_xcmp_queue, XcmpQueue);
 			list_benchmark!(list, extra, pallet_order_book, OrderBook);
+			list_benchmark!(list, extra, pallet_investments, Investments);
 
 			let storage_info = AllPalletsWithSystem::storage_info();
 
@@ -2598,6 +2599,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_collator_selection, CollatorSelection);
 			add_benchmark!(params, batches,	cumulus_pallet_xcmp_queue, XcmpQueue);
 			add_benchmark!(params, batches,	pallet_order_book, OrderBook);
+			add_benchmark!(params, batches,	pallet_investments, Investments);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/runtime/centrifuge/src/weights/mod.rs
+++ b/runtime/centrifuge/src/weights/mod.rs
@@ -24,6 +24,7 @@ pub mod pallet_elections_phragmen;
 pub mod pallet_fees;
 pub mod pallet_identity;
 pub mod pallet_interest_accrual;
+pub mod pallet_investments;
 pub mod pallet_keystore;
 pub mod pallet_liquidity_rewards;
 pub mod pallet_loans;

--- a/runtime/centrifuge/src/weights/pallet_investments.rs
+++ b/runtime/centrifuge/src/weights/pallet_investments.rs
@@ -1,6 +1,6 @@
 //! TEMP: This file will be regenerated!
 
-use frame_support::{traits::Get, weights::Weight};
+use frame_support::weights::Weight;
 use sp_std::marker::PhantomData;
 
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtime/centrifuge/src/weights/pallet_investments.rs
+++ b/runtime/centrifuge/src/weights/pallet_investments.rs
@@ -1,0 +1,23 @@
+//! TEMP: This file will be regenerated!
+
+use frame_support::{traits::Get, weights::Weight};
+use sp_std::marker::PhantomData;
+
+pub struct WeightInfo<T>(PhantomData<T>);
+impl<T: frame_system::Config> pallet_investments::WeightInfo for WeightInfo<T> {
+	fn update_invest_order() -> Weight {
+		Weight::zero()
+	}
+
+	fn update_redeem_order() -> Weight {
+		Weight::zero()
+	}
+
+	fn collect_investments(_: u32) -> Weight {
+		Weight::zero()
+	}
+
+	fn collect_redemptions(_: u32) -> Weight {
+		Weight::zero()
+	}
+}

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -2561,6 +2561,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_transfer_allowlist, TransferAllowList);
 			add_benchmark!(params, batches, pallet_order_book, OrderBook);
 			add_benchmark!(params, batches, pallet_nft_sales, NftSales);
+			add_benchmark!(params, batches, pallet_investments, Investments);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
@@ -2615,6 +2616,7 @@ impl_runtime_apis! {
 			list_benchmark!(list, extra, pallet_transfer_allowlist, TransferAllowList);
 			list_benchmark!(list, extra, pallet_order_book, OrderBook);
 			list_benchmark!(list, extra, pallet_nft_sales, NftSales);
+			list_benchmark!(list, extra, pallet_investments, Investments);
 
 			let storage_info = AllPalletsWithSystem::storage_info();
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1727,7 +1727,7 @@ impl<
 			),
 		};
 
-		if is_tranche_investor {
+		if is_tranche_investor || cfg!(feature = "runtime-benchmarks") {
 			Ok(())
 		} else {
 			// TODO: We should adapt the permissions pallets interface to return an error


### PR DESCRIPTION
# Description

Fixes #918

## Changes and Descriptions

- [x] Benchmark implementation
- [x] Passing with `MockRuntime`
- [x] Passing with `altair` and `centrifuge` runtimes.
  - [x] **Current issues getting the correct `investment_id` from a pool. I think [this](https://github.com/centrifuge/centrifuge-chain/pull/1558/files#diff-80b949673789ef15cf42a6c1b1e63a0ff4287ce47d312fb574add40f4f553cdeR37) from #1558 could solve the issue.**
- [x] Updated weights in runtimes
- [x] Extrinsic using the correct weights from benchmarks.

## Benchmarking results (already normalized to our node times)

- `update_invest_order()` &
- `update_invest_redeem()`:
  - `94_000_000 + reads(8) + writes(4)`
- `collect_investments()` &
- `collect_investments_for()` &
- `collect_redemptions()` &
- `collect_redemptions_for()`:
  - `97_000_000 + 4_000_000 * N + reads(7) + reads(1) * N + writes(3)`
