### PR TITLE
centrifuge: Anemoy pool currency migration

### DIFF
--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -187,8 +187,8 @@ where
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct TrancheCurrency {
-	pub(crate) pool_id: PoolId,
-	pub(crate) tranche_id: TrancheId,
+	pub pool_id: PoolId,
+	pub tranche_id: TrancheId,
 }
 
 impl From<TrancheCurrency> for CurrencyId {

--- a/pallets/investments/src/lib.rs
+++ b/pallets/investments/src/lib.rs
@@ -224,7 +224,7 @@ pub mod pallet {
 		StorageMap<_, Blake2_128Concat, T::InvestmentId, OrderId, ValueQuery>;
 
 	#[pallet::storage]
-	pub(crate) type InvestOrders<T: Config> = StorageDoubleMap<
+	pub type InvestOrders<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		T::AccountId,
@@ -234,7 +234,7 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	pub(crate) type RedeemOrders<T: Config> = StorageDoubleMap<
+	pub type RedeemOrders<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		T::AccountId,
@@ -245,7 +245,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn acc_active_invest_order)]
-	pub(crate) type ActiveInvestOrders<T: Config> =
+	pub type ActiveInvestOrders<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::InvestmentId, TotalOrder<T::Amount>, ValueQuery>;
 
 	#[pallet::storage]

--- a/pallets/investments/src/lib.rs
+++ b/pallets/investments/src/lib.rs
@@ -250,7 +250,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn acc_active_redeem_order)]
-	pub(crate) type ActiveRedeemOrders<T: Config> =
+	pub type ActiveRedeemOrders<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::InvestmentId, TotalOrder<T::Amount>, ValueQuery>;
 
 	#[pallet::storage]

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -9,5 +9,80 @@
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
+use codec::{Decode, Encode};
 
-pub type UpgradeCentrifuge1021 = ();
+use crate::{PoolSystem, Runtime, Weight};
+
+pub type UpgradeCentrifuge1021 = anemoy_pool::Migration;
+
+/// Migrate the Anemoy Pool's currency from LpEthUSC to Circle's USDC,
+/// native on Polkadot's AssetHub.
+mod anemoy_pool {
+
+	use cfg_primitives::PoolId;
+	use cfg_types::tokens::CurrencyId;
+	use frame_support::traits::OnRuntimeUpgrade;
+	use pallet_pool_system::PoolDetailsOf;
+	#[cfg(feature = "try-runtime")]
+	use sp_std::vec::Vec;
+	#[cfg(feature = "try-runtime")]
+	use frame_support::ensure;
+
+	use super::*;
+
+	const ANEMOY_POOL_ID: PoolId = 4_139_607_887;
+	const LP_ETH_USDC: CurrencyId = CurrencyId::ForeignAsset(100_001);
+	const DOT_NATIVE_USDC: CurrencyId = CurrencyId::ForeignAsset(6);
+
+	pub struct Migration;
+
+	impl OnRuntimeUpgrade for Migration {
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+			let pool_details: PoolDetailsOf<Runtime> =
+				PoolSystem::pool(ANEMOY_POOL_ID).ok_or("Could not find Anemoy Pool")?;
+
+			ensure!(
+				pool_details.currency == LP_ETH_USDC,
+				"anemoy_pool::Migration: pre_upgrade failing as Anemoy's currency should be LpEthUSDC"
+			);
+
+			Ok(pool_details.encode())
+		}
+
+		fn on_runtime_upgrade() -> Weight {
+			// To be executed at 1021, reject higher spec_versions
+			if crate::VERSION.spec_version >= 1022 {
+				log::info!("anemoy_pool::Migration: NOT execution since VERSION.spec_version >= 1022");
+				return Weight::zero();
+			}
+
+			pallet_pool_system::Pool::<Runtime>::mutate(ANEMOY_POOL_ID, |details| {
+				let details = details.as_mut().unwrap();
+				details.currency = DOT_NATIVE_USDC;
+				log::info!("anemoy_pool::Migration: Finished mutating currency to USDC");
+			});
+
+			<Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, 1)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(old_state: Vec<u8>) -> Result<(), &'static str> {
+			let mut old_pool_details = PoolDetailsOf::<Runtime>::decode(&mut old_state.as_ref())
+				.map_err(|_| "Error decoding pre-upgrade state")?;
+
+			let pool_details: PoolDetailsOf<Runtime> =
+				PoolSystem::pool(ANEMOY_POOL_ID).ok_or("Could not find Anemoy Pool")?;
+
+			// Ensure the currency set to USDC is the only mutation performed
+			old_pool_details.currency = DOT_NATIVE_USDC;
+			ensure!(
+				old_pool_details == pool_details,
+				"Corrupted migration: Only the currency of the Anemoy pool should have changed"
+			);
+
+			log::info!("anemoy_pool::Migration: post_upgrade succeeded");
+			Ok(())
+		}
+	}
+}

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -75,11 +75,7 @@ mod anemoy_pool {
 			});
 
 			weight.saturating_add(
-				<Runtime as frame_system::Config>::DbWeight::get().reads(
-					pallet_pool_system::Pool::<Runtime>::iter_keys()
-						.count()
-						.saturating_mul(2) as u64,
-				),
+				<Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, 1),
 			)
 		}
 

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -123,8 +123,10 @@ mod anemoy_pool {
 				pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys().count(),
 				pallet_investments::ActiveRedeemOrders::<Runtime>::iter_keys().count(),
 				pallet_investments::InvestOrders::<Runtime>::iter_keys().count(),
-				pallet_investments::RedeemOrders::<Runtime>::iter_keys().count()
-			].iter().sum() as u64
+				pallet_investments::RedeemOrders::<Runtime>::iter_keys().count(),
+			]
+			.iter()
+			.sum() as u64,
 		);
 
 		(res, weight)

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -26,6 +26,7 @@ mod anemoy_pool {
 	use frame_support::traits::{fungibles::Inspect, OnRuntimeUpgrade};
 	#[cfg(feature = "try-runtime")]
 	use pallet_pool_system::PoolDetailsOf;
+	use sp_std::vec;
 	#[cfg(feature = "try-runtime")]
 	use sp_std::vec::Vec;
 
@@ -126,7 +127,7 @@ mod anemoy_pool {
 				pallet_investments::RedeemOrders::<Runtime>::iter_keys().count(),
 			]
 			.iter()
-			.sum() as u64,
+			.fold(0u64, |acc, x| acc.saturating_add(*x as u64)),
 		);
 
 		(res, weight)

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -109,7 +109,7 @@ mod anemoy_pool {
 				&<PoolSystem as PoolInspect<_, _>>::account_for(ANEMOY_POOL_ID),
 			) == 0 && pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys()
 				.filter(|investment| investment.pool_id == ANEMOY_POOL_ID)
-				.count() == 0 && pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys()
+				.count() == 0 && pallet_investments::ActiveRedeemOrders::<Runtime>::iter_keys()
 				.filter(|investment| investment.pool_id == ANEMOY_POOL_ID)
 				.count() == 0 && pallet_investments::InvestOrders::<Runtime>::iter_keys()
 				.filter(|(_, investment)| investment.pool_id == ANEMOY_POOL_ID)
@@ -118,21 +118,13 @@ mod anemoy_pool {
 				.count() == 0;
 
 		let weight = <Runtime as frame_system::Config>::DbWeight::get().reads(
-			1u64 // Anemoy pool account balance read
-				.saturating_add(
-					pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys().count() as u64,
-				)
-				.saturating_add(
-					pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys().count() as u64,
-				)
-				.saturating_add(
-					pallet_investments::InvestOrders::<Runtime>::iter_keys().count() as u64,
-				)
-				.saturating_add(
-					pallet_investments::RedeemOrders::<Runtime>::iter_keys().count() as u64,
-				)
-				// 2x, first for the sanity checks and now for calculating these weights
-				.saturating_mul(2),
+			vec![
+				1, // pool account balance read
+				pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys().count(),
+				pallet_investments::ActiveRedeemOrders::<Runtime>::iter_keys().count(),
+				pallet_investments::InvestOrders::<Runtime>::iter_keys().count(),
+				pallet_investments::RedeemOrders::<Runtime>::iter_keys().count()
+			].iter().sum() as u64
 		);
 
 		(res, weight)

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -16,7 +16,6 @@ pub type UpgradeCentrifuge1021 = anemoy_pool::Migration;
 /// Migrate the Anemoy Pool's currency from LpEthUSC to Circle's USDC,
 /// native on Polkadot's AssetHub.
 mod anemoy_pool {
-
 	use cfg_primitives::PoolId;
 	use cfg_traits::PoolInspect;
 	use cfg_types::tokens::CurrencyId;
@@ -31,11 +30,9 @@ mod anemoy_pool {
 	use sp_std::vec::Vec;
 
 	use super::*;
-	#[cfg(feature = "try-runtime")]
 	use crate::PoolSystem;
 
 	const ANEMOY_POOL_ID: PoolId = 4_139_607_887;
-	#[cfg(feature = "try-runtime")]
 	const LP_ETH_USDC: CurrencyId = CurrencyId::ForeignAsset(100_001);
 	const DOT_NATIVE_USDC: CurrencyId = CurrencyId::ForeignAsset(6);
 
@@ -107,10 +104,12 @@ mod anemoy_pool {
 
 	fn verify_sanity_checks() -> (bool, Weight) {
 		let res =
-			crate::Tokens::balance(LP_ETH_USDC, &PoolSystem::account_for(ANEMOY_POOL_ID)) == 0
-				&& pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys()
-					.filter(|investment| investment.pool_id == ANEMOY_POOL_ID)
-					.count() == 0 && pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys()
+			crate::Tokens::balance(
+				LP_ETH_USDC,
+				&<PoolSystem as PoolInspect<_, _>>::account_for(ANEMOY_POOL_ID),
+			) == 0 && pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys()
+				.filter(|investment| investment.pool_id == ANEMOY_POOL_ID)
+				.count() == 0 && pallet_investments::ActiveInvestOrders::<Runtime>::iter_keys()
 				.filter(|investment| investment.pool_id == ANEMOY_POOL_ID)
 				.count() == 0 && pallet_investments::InvestOrders::<Runtime>::iter_keys()
 				.filter(|(_, investment)| investment.pool_id == ANEMOY_POOL_ID)


### PR DESCRIPTION
# Description

We want to migrate the `currency` of the `Anemoy` pool from `LpEthUSDC` to (Polkadot-native) `USDC` on Centrifuge.

- Anemoy has pool id 4,139,607,887 (the only pool currently registered on Centrifuge)
- We will migrate the currency of that pool from `ForeignAsset(100,001)` (`LpEthUSDC`) to `ForeignAsset(6)`  (`Circle’s USDC native on Polkadot`)
- Both currencies have 6 decimals so no extra considerations in that regard

## To Do

- [x] You can just add a sanity check to the migration that the pool value is indeed 0 and there are no locked orders
  - [x] For all tranches within the Anemoy pool, verify that are no entries on pallet_investments' `InvestOrders` , `RedeemOrders` , `ActiveInvestOrders` and `ActiveRedeemOrders`.
  - [x] Check that pool value is `0`