### PR TITLE
MockBuilder: fix doc link

### DIFF
--- a/libs/mock-builder/src/lib.rs
+++ b/libs/mock-builder/src/lib.rs
@@ -122,8 +122,10 @@
 //! }
 //! ```
 //!
-//! Take a look to the [pallet tests](`tests/pallet.rs`) to have a user view of
-//! how to use a *mock pallet*. It supports any kind of trait, with reference
+//! Take a look to the [pallet
+//! tests](https://github.com/foss3/runtime-pallet-library/blob/main/mock-builder/tests/pallet.rs)
+//! to have a user view of how to use a *mock pallet*.
+//! It supports any kind of trait, with reference
 //! parameters and generics at trait level and method level.
 //!
 //! ## Mock pallet creation


### PR DESCRIPTION
# Description

Fix the link issue.

Because the test code can not be attached from rust docs, I've linked directly to the file in `foss3` repo.

Done also in `foss3` copy of `mock-builder`
