### PR TITLE
fix: min fulfillment amount for partial fulfillment

### DIFF
--- a/libs/mocks/src/token_swaps.rs
+++ b/libs/mocks/src/token_swaps.rs
@@ -33,18 +33,16 @@ pub mod pallet {
 					T::CurrencyId,
 					T::Balance,
 					T::SellRatio,
-					T::Balance,
 				) -> Result<T::OrderId, DispatchError>
 				+ 'static,
 		) {
-			register_call!(move |(a, b, c, d, e, g)| f(a, b, c, d, e, g));
+			register_call!(move |(a, b, c, d, e)| f(a, b, c, d, e));
 		}
 
 		pub fn mock_update_order(
-			f: impl Fn(T::AccountId, T::OrderId, T::Balance, T::SellRatio, T::Balance) -> DispatchResult
-				+ 'static,
+			f: impl Fn(T::AccountId, T::OrderId, T::Balance, T::SellRatio) -> DispatchResult + 'static,
 		) {
-			register_call!(move |(a, b, c, d, e)| f(a, b, c, d, e));
+			register_call!(move |(a, b, c, d)| f(a, b, c, d));
 		}
 
 		pub fn mock_cancel_order(f: impl Fn(T::OrderId) -> DispatchResult + 'static) {
@@ -79,9 +77,8 @@ pub mod pallet {
 			c: Self::CurrencyId,
 			d: Self::Balance,
 			e: Self::SellRatio,
-			f: Self::Balance,
 		) -> Result<Self::OrderId, DispatchError> {
-			execute_call!((a, b, c, d, e, f))
+			execute_call!((a, b, c, d, e))
 		}
 
 		fn update_order(
@@ -89,9 +86,8 @@ pub mod pallet {
 			b: Self::OrderId,
 			c: Self::Balance,
 			d: Self::SellRatio,
-			e: Self::Balance,
 		) -> DispatchResult {
-			execute_call!((a, b, c, d, e))
+			execute_call!((a, b, c, d))
 		}
 
 		fn cancel_order(a: Self::OrderId) -> DispatchResult {

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -596,11 +596,32 @@ pub trait IdentityCurrencyConversion {
 }
 
 /// A trait for trying to convert between two types.
-// TODO: Remove usage for the one from Polkadot once we are on the same version
+// TODO: Remove usage for the one from sp_runtime::traits once we are on
+// the same Polkadot version
 pub trait TryConvert<A, B> {
 	type Error;
 
 	/// Attempt to make conversion. If returning [Result::Err], the inner must
 	/// always be `a`.
 	fn try_convert(a: A) -> Result<B, Self::Error>;
+}
+
+/// Converts a balance value into an asset balance.
+// TODO: Remove usage for the one from frame_support::traits::tokens once we are
+// on the same Polkadot version
+pub trait ConversionToAssetBalance<InBalance, AssetId, AssetBalance> {
+	type Error;
+	fn to_asset_balance(balance: InBalance, asset_id: AssetId)
+		-> Result<AssetBalance, Self::Error>;
+}
+
+/// Converts an asset balance value into balance.
+// TODO: Remove usage for the one from frame_support::traits::tokens once we are
+// on the same Polkadot version
+pub trait ConversionFromAssetBalance<AssetBalance, AssetId, OutBalance> {
+	type Error;
+	fn from_asset_balance(
+		balance: AssetBalance,
+		asset_id: AssetId,
+	) -> Result<OutBalance, Self::Error>;
 }

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -472,11 +472,15 @@ pub trait TokenSwaps<Account> {
 	/// `sell_rate_limit` defines the highest price acceptable for
 	/// `currency_in` currency when buying with `currency_out`. This
 	/// protects order placer if market changes unfavourably for swap order.
-	/// For example, with a `sell_rate_limit` of `3/2` one asset in should never
-	/// cost more than 1.5 units of asset out. Returns `Result` with `OrderId`
-	/// upon successful order creation.
+	/// For example, with a `sell_rate_limit` of `3/2`, one `asset_in`
+	/// should never cost more than 1.5 units of `asset_out`. Returns `Result`
+	/// with `OrderId` upon successful order creation.
 	///
-	/// Example usage with pallet_order_book impl:
+	/// NOTE: The minimum fulfillment amount is implicitly set by the
+	/// implementor.
+	///
+	/// Example usage with `pallet_order_book` impl:
+	/// ```rust
 	/// OrderBook::place_order(
 	///     {AccountId},
 	///     CurrencyId::ForeignAsset(0),
@@ -485,8 +489,9 @@ pub trait TokenSwaps<Account> {
 	///     Quantity::checked_from_rational(3u32, 2u32).unwrap(),
 	///     100 * FOREIGN_ASSET_0_DECIMALS
 	/// )
-	/// Would return Ok({OrderId})
-	/// and create the following order in storage:
+	/// ```
+	/// Would return `Ok({OrderId}` and create the following order in storage:
+	/// ```rust
 	/// Order {
 	///     order_id: {OrderId},
 	///     placing_account: {AccountId},
@@ -494,31 +499,31 @@ pub trait TokenSwaps<Account> {
 	///     asset_out_id: CurrencyId::ForeignAsset(1),
 	///     buy_amount: 100 * FOREIGN_ASSET_0_DECIMALS,
 	///     initial_buy_amount: 100 * FOREIGN_ASSET_0_DECIMALS,
-	///     sell_rate_limit: Quantity::checked_from_rational(3u32,
-	/// 2u32).unwrap(),     min_fulfillment_amount: 100 *
-	/// FOREIGN_ASSET_0_DECIMALS,     max_sell_amount: 150 *
-	/// FOREIGN_ASSET_1_DECIMALS }
+	///     sell_rate_limit: Quantity::checked_from_rational(3u32, 2u32).unwrap(),
+	///     max_sell_amount: 150 * FOREIGN_ASSET_1_DECIMALS,
+	///     min_fulfillment_amount: 10 * CFG * FOREIGN_ASSET_0_DECIMALS,
+	/// }
+	/// ```
 	fn place_order(
 		account: Account,
 		currency_in: Self::CurrencyId,
 		currency_out: Self::CurrencyId,
 		buy_amount: Self::Balance,
 		sell_rate_limit: Self::SellRatio,
-		min_fulfillment_amount: Self::Balance,
 	) -> Result<Self::OrderId, DispatchError>;
 
 	/// Update an existing active order.
-	/// As with create order `sell_rate_limit` defines the highest price
-	/// acceptable for `currency_in` currency when buying with `currency_out`.
-	/// Returns a Dispatch result.
+	/// As with creating an order, the `sell_rate_limit` defines the highest
+	/// price acceptable for `currency_in` currency when buying with
+	/// `currency_out`. Returns a Dispatch result.
 	///
-	/// This Can fail for various reasons
+	/// NOTE: The minimum fulfillment amount is implicitly set by the
+	/// implementor.
 	///
-	/// E.g. min_fulfillment_amount is lower and
-	///      the system has already fulfilled up to the previous
-	///      one.
+	/// This Can fail for various reasons.
 	///
-	/// Example usage with pallet_order_book impl:
+	/// Example usage with `pallet_order_book` impl:
+	/// ```rust
 	/// OrderBook::update_order(
 	///     {AccountId},
 	///     {OrderId},
@@ -526,8 +531,9 @@ pub trait TokenSwaps<Account> {
 	///     Quantity::checked_from_integer(2u32).unwrap(),
 	///     6 * FOREIGN_ASSET_0_DECIMALS
 	/// )
-	/// Would return Ok(())
-	/// and update the following order in storage:
+	/// ```
+	/// Would return `Ok(())` and update the following order in storage:
+	/// ```rust
 	/// Order {
 	///     order_id: {OrderId},
 	///     placing_account: {AccountId},
@@ -536,15 +542,15 @@ pub trait TokenSwaps<Account> {
 	///     buy_amount: 15 * FOREIGN_ASSET_0_DECIMALS,
 	///     initial_buy_amount: 100 * FOREIGN_ASSET_0_DECIMALS,
 	///     sell_rate_limit: Quantity::checked_from_integer(2u32).unwrap(),
-	///     min_fulfillment_amount: 6 * FOREIGN_ASSET_0_DECIMALS,
 	///     max_sell_amount: 30 * FOREIGN_ASSET_1_DECIMALS
+	///     min_fulfillment_amount: 10 * CFG * FOREIGN_ASSET_0_DECIMALS,
 	/// }
+	/// ```
 	fn update_order(
 		account: Account,
 		order_id: Self::OrderId,
 		buy_amount: Self::Balance,
 		sell_rate_limit: Self::SellRatio,
-		min_fulfillment_amount: Self::Balance,
 	) -> DispatchResult;
 
 	/// A sanity check that can be used for validating that a trading pair

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -480,7 +480,7 @@ pub trait TokenSwaps<Account> {
 	/// implementor.
 	///
 	/// Example usage with `pallet_order_book` impl:
-	/// ```rust
+	/// ```ignore
 	/// OrderBook::place_order(
 	///     {AccountId},
 	///     CurrencyId::ForeignAsset(0),
@@ -491,7 +491,7 @@ pub trait TokenSwaps<Account> {
 	/// )
 	/// ```
 	/// Would return `Ok({OrderId}` and create the following order in storage:
-	/// ```rust
+	/// ```ignore
 	/// Order {
 	///     order_id: {OrderId},
 	///     placing_account: {AccountId},
@@ -523,7 +523,7 @@ pub trait TokenSwaps<Account> {
 	/// This Can fail for various reasons.
 	///
 	/// Example usage with `pallet_order_book` impl:
-	/// ```rust
+	/// ```ignore
 	/// OrderBook::update_order(
 	///     {AccountId},
 	///     {OrderId},
@@ -533,7 +533,7 @@ pub trait TokenSwaps<Account> {
 	/// )
 	/// ```
 	/// Would return `Ok(())` and update the following order in storage:
-	/// ```rust
+	/// ```ignore
 	/// Order {
 	///     order_id: {OrderId},
 	///     placing_account: {AccountId},

--- a/pallets/foreign-investments/src/impls/mod.rs
+++ b/pallets/foreign-investments/src/impls/mod.rs
@@ -14,7 +14,8 @@
 
 use cfg_traits::{
 	investments::{ForeignInvestment, Investment, InvestmentCollector, TrancheCurrency},
-	IdentityCurrencyConversion, PoolInspect, StatusNotificationHook, TokenSwaps,
+	ConversionToAssetBalance, IdentityCurrencyConversion, PoolInspect, StatusNotificationHook,
+	TokenSwaps,
 };
 use cfg_types::investments::{
 	CollectedAmount, ExecutedForeignCollect, ExecutedForeignDecreaseInvest, Swap,
@@ -798,8 +799,11 @@ impl<T: Config> Pallet<T> {
 					swap.amount,
 					// The max accepted sell rate is independent of the asset type for now
 					T::DefaultTokenSellRatio::get(),
-					// The minimum fulfillment must be everything
-					swap.amount,
+					// Convert default min fulfillment amount from native to incoming currency
+					T::DecimalConverter::to_asset_balance(
+						T::DefaultMinSwapFulfillmentAmount::get(),
+						swap.currency_in,
+					)?,
 				)?;
 				ForeignInvestmentInfo::<T>::insert(
 					swap_order_id,
@@ -827,8 +831,11 @@ impl<T: Config> Pallet<T> {
 					swap.amount,
 					// The max accepted sell rate is independent of the asset type for now
 					T::DefaultTokenSellRatio::get(),
-					// The minimum fulfillment must be everything
-					swap.amount,
+					// Convert default min fulfillment amount from native to incoming currency
+					T::DecimalConverter::to_asset_balance(
+						T::DefaultMinSwapFulfillmentAmount::get(),
+						swap.currency_in,
+					)?,
 				)?;
 				TokenSwapOrderIds::<T>::insert(who, investment_id, swap_order_id);
 				ForeignInvestmentInfo::<T>::insert(

--- a/pallets/foreign-investments/src/impls/mod.rs
+++ b/pallets/foreign-investments/src/impls/mod.rs
@@ -14,8 +14,7 @@
 
 use cfg_traits::{
 	investments::{ForeignInvestment, Investment, InvestmentCollector, TrancheCurrency},
-	ConversionToAssetBalance, IdentityCurrencyConversion, PoolInspect, StatusNotificationHook,
-	TokenSwaps,
+	IdentityCurrencyConversion, PoolInspect, StatusNotificationHook, TokenSwaps,
 };
 use cfg_types::investments::{
 	CollectedAmount, ExecutedForeignCollect, ExecutedForeignDecreaseInvest, Swap,
@@ -799,11 +798,6 @@ impl<T: Config> Pallet<T> {
 					swap.amount,
 					// The max accepted sell rate is independent of the asset type for now
 					T::DefaultTokenSellRatio::get(),
-					// Convert default min fulfillment amount from native to incoming currency
-					T::DecimalConverter::to_asset_balance(
-						T::DefaultMinSwapFulfillmentAmount::get(),
-						swap.currency_in,
-					)?,
 				)?;
 				ForeignInvestmentInfo::<T>::insert(
 					swap_order_id,
@@ -832,10 +826,6 @@ impl<T: Config> Pallet<T> {
 					// The max accepted sell rate is independent of the asset type for now
 					T::DefaultTokenSellRatio::get(),
 					// Convert default min fulfillment amount from native to incoming currency
-					T::DecimalConverter::to_asset_balance(
-						T::DefaultMinSwapFulfillmentAmount::get(),
-						swap.currency_in,
-					)?,
 				)?;
 				TokenSwapOrderIds::<T>::insert(who, investment_id, swap_order_id);
 				ForeignInvestmentInfo::<T>::insert(

--- a/pallets/foreign-investments/src/impls/mod.rs
+++ b/pallets/foreign-investments/src/impls/mod.rs
@@ -825,7 +825,6 @@ impl<T: Config> Pallet<T> {
 					swap.amount,
 					// The max accepted sell rate is independent of the asset type for now
 					T::DefaultTokenSellRatio::get(),
-					// Convert default min fulfillment amount from native to incoming currency
 				)?;
 				TokenSwapOrderIds::<T>::insert(who, investment_id, swap_order_id);
 				ForeignInvestmentInfo::<T>::insert(

--- a/pallets/foreign-investments/src/lib.rs
+++ b/pallets/foreign-investments/src/lib.rs
@@ -173,15 +173,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type DefaultTokenSellRatio: Get<Self::BalanceRatio>;
 
-		/// The default minimum fulfillment amount for creating or updating swap
-		/// orders through `TokenSwaps.
-		///
-		/// NOTE: The amount is expected to be denominated in native currency.
-		/// When applying to a swap order, it will be re-denominated into the
-		/// target currency.
-		#[pallet::constant]
-		type DefaultMinSwapFulfillmentAmount: Get<Self::Balance>;
-
 		/// The token swap order identifying type
 		type TokenSwapOrderId: Parameter
 			+ Member
@@ -246,17 +237,6 @@ pub mod pallet {
 		type CurrencyConverter: cfg_traits::IdentityCurrencyConversion<
 			Balance = Self::Balance,
 			Currency = Self::CurrencyId,
-			Error = DispatchError,
-		>;
-
-		/// Type which provides a decimal conversion from native to a foreign
-		/// currency.
-		///
-		/// NOTE: Required for `DefaultMinSwapFulfillmentAmount`.
-		type DecimalConverter: cfg_traits::ConversionToAssetBalance<
-			Self::Balance,
-			Self::CurrencyId,
-			Self::Balance,
 			Error = DispatchError,
 		>;
 

--- a/pallets/foreign-investments/src/lib.rs
+++ b/pallets/foreign-investments/src/lib.rs
@@ -173,6 +173,15 @@ pub mod pallet {
 		#[pallet::constant]
 		type DefaultTokenSellRatio: Get<Self::BalanceRatio>;
 
+		/// The default minimum fulfillment amount for creating or updating swap
+		/// orders through `TokenSwaps.
+		///
+		/// NOTE: The amount is expected to be denominated in native currency.
+		/// When applying to a swap order, it will be re-denominated into the
+		/// target currency.
+		#[pallet::constant]
+		type DefaultMinSwapFulfillmentAmount: Get<Self::Balance>;
+
 		/// The token swap order identifying type
 		type TokenSwapOrderId: Parameter
 			+ Member
@@ -237,6 +246,17 @@ pub mod pallet {
 		type CurrencyConverter: cfg_traits::IdentityCurrencyConversion<
 			Balance = Self::Balance,
 			Currency = Self::CurrencyId,
+			Error = DispatchError,
+		>;
+
+		/// Type which provides a decimal conversion from native to a foreign
+		/// currency.
+		///
+		/// NOTE: Required for `DefaultMinSwapFulfillmentAmount`.
+		type DecimalConverter: cfg_traits::ConversionToAssetBalance<
+			Self::Balance,
+			Self::CurrencyId,
+			Self::Balance,
 			Error = DispatchError,
 		>;
 

--- a/pallets/foreign-investments/src/tests.rs
+++ b/pallets/foreign-investments/src/tests.rs
@@ -22,7 +22,7 @@ mod util {
 		MockInvestment::mock_investment_requires_collect(|_, _| false);
 		MockInvestment::mock_investment(|_, _| Ok(0));
 		MockInvestment::mock_update_investment(|_, _, _| Ok(()));
-		MockTokenSwaps::mock_place_order(move |_, _, _, _, _, _| Ok(order_id));
+		MockTokenSwaps::mock_place_order(move |_, _, _, _, _| Ok(order_id));
 		MockCurrencyConversion::mock_stable_to_stable(move |_, _, _| Ok(amount) /* 1:1 */);
 
 		ForeignInvestment::increase_foreign_investment(
@@ -37,7 +37,7 @@ mod util {
 		MockInvestment::mock_investment_requires_collect(|_, _| unimplemented!("no mock"));
 		MockInvestment::mock_investment(|_, _| unimplemented!("no mock"));
 		MockInvestment::mock_update_investment(|_, _, _| unimplemented!("no mock"));
-		MockTokenSwaps::mock_place_order(|_, _, _, _, _, _| unimplemented!("no mock"));
+		MockTokenSwaps::mock_place_order(|_, _, _, _, _| unimplemented!("no mock"));
 		MockCurrencyConversion::mock_stable_to_stable(|_, _, _| unimplemented!("no mock"));
 	}
 
@@ -92,17 +92,14 @@ mod increase_investment {
 				assert_eq!(amount, 0); // We still do not have the swap done.
 				Ok(())
 			});
-			MockTokenSwaps::mock_place_order(
-				|account_id, curr_in, curr_out, amount, limit, min| {
-					assert_eq!(account_id, USER);
-					assert_eq!(curr_in, POOL_CURR);
-					assert_eq!(curr_out, USER_CURR);
-					assert_eq!(amount, AMOUNT);
-					assert_eq!(limit, DefaultTokenSellRatio::get());
-					assert_eq!(min, AMOUNT);
-					Ok(ORDER_ID)
-				},
-			);
+			MockTokenSwaps::mock_place_order(|account_id, curr_in, curr_out, amount, limit| {
+				assert_eq!(account_id, USER);
+				assert_eq!(curr_in, POOL_CURR);
+				assert_eq!(curr_out, USER_CURR);
+				assert_eq!(amount, AMOUNT);
+				assert_eq!(limit, DefaultTokenSellRatio::get());
+				Ok(ORDER_ID)
+			});
 			MockCurrencyConversion::mock_stable_to_stable(|curr_in, curr_out, amount_out| {
 				assert_eq!(curr_in, POOL_CURR);
 				assert_eq!(curr_out, USER_CURR);
@@ -173,12 +170,11 @@ mod increase_investment {
 					amount: INITIAL_AMOUNT,
 				})
 			});
-			MockTokenSwaps::mock_update_order(|account_id, order_id, amount, limit, min| {
+			MockTokenSwaps::mock_update_order(|account_id, order_id, amount, limit| {
 				assert_eq!(account_id, USER);
 				assert_eq!(order_id, ORDER_ID);
 				assert_eq!(amount, INITIAL_AMOUNT + INCREASE_AMOUNT);
 				assert_eq!(limit, DefaultTokenSellRatio::get());
-				assert_eq!(min, INITIAL_AMOUNT + INCREASE_AMOUNT);
 				Ok(())
 			});
 			MockCurrencyConversion::mock_stable_to_stable(|curr_in, curr_out, amount_out| {
@@ -224,17 +220,14 @@ mod increase_investment {
 				assert_eq!(order_id, ORDER_ID);
 				false
 			});
-			MockTokenSwaps::mock_place_order(
-				|account_id, curr_in, curr_out, amount, limit, min| {
-					assert_eq!(account_id, USER);
-					assert_eq!(curr_in, POOL_CURR);
-					assert_eq!(curr_out, USER_CURR);
-					assert_eq!(amount, INCREASE_AMOUNT);
-					assert_eq!(limit, DefaultTokenSellRatio::get());
-					assert_eq!(min, INCREASE_AMOUNT);
-					Ok(ORDER_ID)
-				},
-			);
+			MockTokenSwaps::mock_place_order(|account_id, curr_in, curr_out, amount, limit| {
+				assert_eq!(account_id, USER);
+				assert_eq!(curr_in, POOL_CURR);
+				assert_eq!(curr_out, USER_CURR);
+				assert_eq!(amount, INCREASE_AMOUNT);
+				assert_eq!(limit, DefaultTokenSellRatio::get());
+				Ok(ORDER_ID)
+			});
 			MockInvestment::mock_update_investment(|_, _, amount| {
 				assert_eq!(amount, 0);
 				Ok(())

--- a/pallets/order-book/src/benchmarking.rs
+++ b/pallets/order-book/src/benchmarking.rs
@@ -12,6 +12,7 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
+use cfg_primitives::CFG;
 use cfg_traits::benchmarking::OrderBookBenchmarkHelper;
 use cfg_types::tokens::{CurrencyId, CustomMetadata};
 use frame_benchmarking::*;
@@ -21,8 +22,8 @@ use sp_runtime::FixedPointNumber;
 
 use super::*;
 
-const AMOUNT_IN: u128 = 1_000_000;
-const AMOUNT_OUT: u128 = 1_000_000_000_000;
+const AMOUNT_IN: u128 = 100 * CFG;
+const AMOUNT_OUT: u128 = 100_000_000 * CFG;
 const BUY_AMOUNT: u128 = 100 * AMOUNT_IN;
 const ASSET_IN: CurrencyId = CurrencyId::ForeignAsset(1);
 const ASSET_OUT: CurrencyId = CurrencyId::ForeignAsset(2);

--- a/pallets/order-book/src/benchmarking.rs
+++ b/pallets/order-book/src/benchmarking.rs
@@ -44,28 +44,28 @@ benchmarks! {
 	user_update_order {
 		let (account_out, _) = Pallet::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
 
-		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into(), BUY_AMOUNT)?;
+		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into())?;
 
 		}:user_update_order(RawOrigin::Signed(account_out.clone()), order_id, 10 * BUY_AMOUNT, T::SellRatio::saturating_from_integer(1))
 
 	user_cancel_order {
 		let (account_out, _) = Pallet::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
 
-		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into(), BUY_AMOUNT)?;
+		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into())?;
 
 	}:user_cancel_order(RawOrigin::Signed(account_out.clone()), order_id)
 
 	fill_order_full {
 		let (account_out, account_in) = Pallet::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
 
-		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into(), BUY_AMOUNT)?;
+		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into())?;
 
 	}:fill_order_full(RawOrigin::Signed(account_in.clone()), order_id)
 
 	fill_order_partial {
 		let (account_out, account_in) = Pallet::<T>::bench_setup_trading_pair(ASSET_IN, ASSET_OUT, 1000 * AMOUNT_IN, 1000 * AMOUNT_OUT, DECIMALS_IN, DECIMALS_OUT);
 
-		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into(), BUY_AMOUNT / 10)?;
+		let order_id = Pallet::<T>::place_order(account_out.clone(), ASSET_IN, ASSET_OUT, BUY_AMOUNT, T::SellRatio::saturating_from_integer(2).into())?;
 
 	}:fill_order_partial(RawOrigin::Signed(account_in.clone()), order_id, BUY_AMOUNT / 2)
 

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -40,7 +40,7 @@ pub mod pallet {
 	use core::fmt::Debug;
 
 	use cfg_primitives::conversion::convert_balance_decimals;
-	use cfg_traits::StatusNotificationHook;
+	use cfg_traits::{ConversionToAssetBalance, StatusNotificationHook};
 	use cfg_types::{investments::Swap, tokens::CustomMetadata};
 	use codec::{Decode, Encode, MaxEncodedLen};
 	use frame_support::{
@@ -150,6 +150,25 @@ pub mod pallet {
 		/// Size of order id bounded vec in storage
 		#[pallet::constant]
 		type OrderPairVecSize: Get<u32>;
+
+		/// The default minimum fulfillment amount for orders.
+		///
+		/// NOTE: The amount is expected to be denominated in native currency.
+		/// When applying to a swap order, it will be re-denominated into the
+		/// target currency.
+		#[pallet::constant]
+		type MinFulfillmentAmountNative: Get<Self::Balance>;
+
+		/// Type which provides a decimal conversion from native to another
+		/// currency.
+		///
+		/// NOTE: Required for `MinFulfillmentAmountNative`.
+		type DecimalConverter: cfg_traits::ConversionToAssetBalance<
+			Self::Balance,
+			Self::AssetCurrencyId,
+			Self::Balance,
+			Error = DispatchError,
+		>;
 
 		/// The hook which acts upon a (partially) fulfilled order
 		type FulfilledOrderHook: StatusNotificationHook<
@@ -374,6 +393,10 @@ pub mod pallet {
 			price: T::SellRatio,
 		) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
+			let min_fulfillment_amount = T::DecimalConverter::to_asset_balance(
+				T::MinFulfillmentAmountNative::get(),
+				asset_in,
+			)?;
 
 			Self::inner_place_order(
 				account_id,
@@ -381,7 +404,7 @@ pub mod pallet {
 				asset_out,
 				buy_amount,
 				price,
-				buy_amount,
+				min_fulfillment_amount,
 				|order| {
 					let min_amount = TradingPair::<T>::get(&asset_in, &asset_out)?;
 					Self::is_valid_order(
@@ -408,12 +431,18 @@ pub mod pallet {
 			price: T::SellRatio,
 		) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
+			let order = Orders::<T>::get(order_id)?;
+			let min_fulfillment_amount = T::DecimalConverter::to_asset_balance(
+				T::MinFulfillmentAmountNative::get(),
+				order.asset_in_id,
+			)?;
+
 			Self::inner_update_order(
 				account_id.clone(),
 				order_id,
 				buy_amount,
 				price,
-				buy_amount,
+				min_fulfillment_amount,
 				|order| {
 					ensure!(
 						account_id == order.placing_account,
@@ -588,7 +617,7 @@ pub mod pallet {
 			let partial_fulfillment = !remaining_buy_amount.is_zero();
 
 			if partial_fulfillment {
-				Self::update_order(
+				Self::update_order_with_fulfillment(
 					order.placing_account.clone(),
 					order.order_id,
 					remaining_buy_amount,
@@ -867,75 +896,14 @@ pub mod pallet {
 
 			Ok(order_id)
 		}
-	}
-
-	impl<T: Config> TokenSwaps<T::AccountId> for Pallet<T>
-	where
-		<T as frame_system::Config>::Hash: PartialEq<<T as frame_system::Config>::Hash>,
-	{
-		type Balance = T::Balance;
-		type CurrencyId = T::AssetCurrencyId;
-		type OrderDetails = Swap<T::Balance, T::AssetCurrencyId>;
-		type OrderId = T::OrderIdNonce;
-		type SellRatio = T::SellRatio;
-
-		/// Creates an order.
-		/// Verify funds available in, and reserve for  both chains fee currency
-		/// for storage fee, and amount of outgoing currency as determined by
-		/// the buy amount and price.
-		fn place_order(
-			account: T::AccountId,
-			currency_in: T::AssetCurrencyId,
-			currency_out: T::AssetCurrencyId,
-			buy_amount: T::Balance,
-			sell_rate_limit: T::SellRatio,
-			min_fulfillment_amount: T::Balance,
-		) -> Result<Self::OrderId, DispatchError> {
-			Self::inner_place_order(
-				account,
-				currency_in,
-				currency_out,
-				buy_amount,
-				sell_rate_limit,
-				min_fulfillment_amount,
-				|order| {
-					// We only check if the trading pair exists not if the minimum amount is
-					// reached.
-					let _min_amount = TradingPair::<T>::get(&currency_in, &currency_out)?;
-					Self::is_valid_order(
-						order.asset_in_id,
-						order.asset_out_id,
-						order.buy_amount,
-						order.max_sell_rate,
-						order.min_fulfillment_amount,
-						T::Balance::zero(),
-					)
-				},
-			)
-		}
-
-		/// Cancel an existing order.
-		/// Unreserve currency reserved for trade as well storage fee.
-		fn cancel_order(order: Self::OrderId) -> DispatchResult {
-			let order = <Orders<T>>::get(order)?;
-			let account_id = order.placing_account.clone();
-
-			Self::unreserve_order(&order)?;
-			Self::remove_order(order.order_id)?;
-			Self::deposit_event(Event::OrderCancelled {
-				account: account_id,
-				order_id: order.order_id,
-			});
-
-			Ok(())
-		}
 
 		/// Update an existing order.
+		///
 		/// Update outgoing asset currency reserved to match new amount or price
 		/// if either have changed.
-		fn update_order(
+		pub(crate) fn update_order_with_fulfillment(
 			account: T::AccountId,
-			order_id: Self::OrderId,
+			order_id: T::OrderIdNonce,
 			buy_amount: T::Balance,
 			sell_rate_limit: T::SellRatio,
 			min_fulfillment_amount: T::Balance,
@@ -962,8 +930,88 @@ pub mod pallet {
 				},
 			)
 		}
+	}
 
-		/// Check whether an order is active.
+	impl<T: Config> TokenSwaps<T::AccountId> for Pallet<T>
+	where
+		<T as frame_system::Config>::Hash: PartialEq<<T as frame_system::Config>::Hash>,
+	{
+		type Balance = T::Balance;
+		type CurrencyId = T::AssetCurrencyId;
+		type OrderDetails = Swap<T::Balance, T::AssetCurrencyId>;
+		type OrderId = T::OrderIdNonce;
+		type SellRatio = T::SellRatio;
+
+		fn place_order(
+			account: T::AccountId,
+			currency_in: T::AssetCurrencyId,
+			currency_out: T::AssetCurrencyId,
+			buy_amount: T::Balance,
+			sell_rate_limit: T::SellRatio,
+		) -> Result<Self::OrderId, DispatchError> {
+			let min_fulfillment_amount = T::DecimalConverter::to_asset_balance(
+				T::MinFulfillmentAmountNative::get(),
+				currency_in,
+			)?;
+
+			Self::inner_place_order(
+				account,
+				currency_in,
+				currency_out,
+				buy_amount,
+				sell_rate_limit,
+				min_fulfillment_amount,
+				|order| {
+					// We only check if the trading pair exists not if the minimum amount is
+					// reached.
+					let _min_amount = TradingPair::<T>::get(&currency_in, &currency_out)?;
+					Self::is_valid_order(
+						order.asset_in_id,
+						order.asset_out_id,
+						order.buy_amount,
+						order.max_sell_rate,
+						order.min_fulfillment_amount,
+						T::Balance::zero(),
+					)
+				},
+			)
+		}
+
+		fn cancel_order(order: Self::OrderId) -> DispatchResult {
+			let order = <Orders<T>>::get(order)?;
+			let account_id = order.placing_account.clone();
+
+			Self::unreserve_order(&order)?;
+			Self::remove_order(order.order_id)?;
+			Self::deposit_event(Event::OrderCancelled {
+				account: account_id,
+				order_id: order.order_id,
+			});
+
+			Ok(())
+		}
+
+		fn update_order(
+			account: T::AccountId,
+			order_id: Self::OrderId,
+			buy_amount: T::Balance,
+			sell_rate_limit: T::SellRatio,
+		) -> DispatchResult {
+			let order = Orders::<T>::get(order_id)?;
+			let min_fulfillment_amount = T::DecimalConverter::to_asset_balance(
+				T::MinFulfillmentAmountNative::get(),
+				order.asset_in_id,
+			)?;
+
+			Self::update_order_with_fulfillment(
+				account,
+				order_id,
+				buy_amount,
+				sell_rate_limit,
+				min_fulfillment_amount,
+			)
+		}
+
 		fn is_active(order: Self::OrderId) -> bool {
 			<Orders<T>>::contains_key(order)
 		}

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -381,8 +381,7 @@ pub mod pallet {
 	where
 		<T as frame_system::Config>::Hash: PartialEq<<T as frame_system::Config>::Hash>,
 	{
-		/// Create an order, with the minimum fulfillment amount set to the buy
-		/// amount, as the first iteration will not have partial fulfillment
+		/// Create an order with the default min fulfillment amount.
 		#[pallet::call_index(0)]
 		#[pallet::weight(T::Weights::create_order())]
 		pub fn create_order(

--- a/pallets/order-book/src/tests.rs
+++ b/pallets/order-book/src/tests.rs
@@ -177,7 +177,7 @@ fn create_order_works() {
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				min_fulfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
 		);
@@ -191,7 +191,7 @@ fn create_order_works() {
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				min_fulfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
 		);
@@ -230,7 +230,7 @@ fn user_update_order_works() {
 				buy_amount: 15 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 10 * CURRENCY_AUSD_DECIMALS,
 				max_sell_rate: FixedU128::checked_from_integer(2u32).unwrap(),
-				min_fulfillment_amount: 15 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				max_sell_amount: 30 * CURRENCY_USDT_DECIMALS
 			})
 		);
@@ -319,7 +319,7 @@ fn user_cancel_order_only_works_for_valid_account() {
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				min_fulfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
 		);
@@ -396,7 +396,6 @@ mod fill_order_partial {
 		for fulfillment_ratio in 1..100 {
 			new_test_ext().execute_with(|| {
 				let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
-				let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
 				let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
 
 				assert_ok!(OrderBook::place_order(
@@ -405,7 +404,6 @@ mod fill_order_partial {
 					DEV_USDT_CURRENCY_ID,
 					buy_amount,
 					sell_ratio,
-					min_fulfillment_amount,
 				));
 
 				let (order_id, order) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -491,7 +489,6 @@ mod fill_order_partial {
 	fn fill_order_partial_with_full_amount_works() {
 		new_test_ext().execute_with(|| {
 			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
-			let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
 			let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
 
 			assert_ok!(OrderBook::place_order(
@@ -500,7 +497,6 @@ mod fill_order_partial {
 				DEV_USDT_CURRENCY_ID,
 				buy_amount,
 				sell_ratio,
-				min_fulfillment_amount,
 			));
 
 			let (order_id, order) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -607,7 +603,6 @@ mod fill_order_partial {
 	fn fill_order_partial_insufficient_order_size() {
 		new_test_ext().execute_with(|| {
 			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
-			let min_fulfillment_amount = 10 * CURRENCY_AUSD_DECIMALS;
 			let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
 
 			assert_ok!(OrderBook::place_order(
@@ -616,7 +611,6 @@ mod fill_order_partial {
 				DEV_USDT_CURRENCY_ID,
 				buy_amount,
 				sell_ratio,
-				min_fulfillment_amount,
 			));
 
 			let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -625,7 +619,7 @@ mod fill_order_partial {
 				OrderBook::fill_order_partial(
 					RuntimeOrigin::signed(ACCOUNT_1),
 					order_id,
-					min_fulfillment_amount - 1 * CURRENCY_AUSD_DECIMALS,
+					MIN_AUSD_FULFILLMENT_AMOUNT - 1,
 				),
 				Error::<Runtime>::InsufficientOrderSize
 			);
@@ -636,7 +630,6 @@ mod fill_order_partial {
 	fn fill_order_partial_insufficient_asset_funds() {
 		new_test_ext().execute_with(|| {
 			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
-			let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
 			let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
 
 			assert_ok!(OrderBook::place_order(
@@ -645,7 +638,6 @@ mod fill_order_partial {
 				DEV_USDT_CURRENCY_ID,
 				buy_amount,
 				sell_ratio,
-				min_fulfillment_amount,
 			));
 
 			let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -672,7 +664,6 @@ mod fill_order_partial {
 	fn fill_order_partial_buy_amount_too_big() {
 		new_test_ext().execute_with(|| {
 			let buy_amount = 100 * CURRENCY_AUSD_DECIMALS;
-			let min_fulfillment_amount = 1 * CURRENCY_AUSD_DECIMALS;
 			let sell_ratio = FixedU128::checked_from_rational(3u32, 2u32).unwrap();
 
 			assert_ok!(OrderBook::place_order(
@@ -681,7 +672,6 @@ mod fill_order_partial {
 				DEV_USDT_CURRENCY_ID,
 				buy_amount,
 				sell_ratio,
-				min_fulfillment_amount,
 			));
 
 			let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
@@ -727,7 +717,6 @@ fn place_order_works() {
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			100 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_eq!(
@@ -740,7 +729,7 @@ fn place_order_works() {
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				min_fulfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
 		);
@@ -755,7 +744,7 @@ fn place_order_works() {
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				min_fulfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
 		);
@@ -781,7 +770,7 @@ fn place_order_works() {
 				currency_in: DEV_AUSD_CURRENCY_ID,
 				currency_out: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				min_fulfillment_amount: 100 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				sell_rate_limit: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			})
 		);
@@ -797,7 +786,6 @@ fn place_order_bases_max_sell_off_buy() {
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			10 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_eq!(
@@ -810,7 +798,7 @@ fn place_order_bases_max_sell_off_buy() {
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				initial_buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
 				max_sell_rate: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				min_fulfillment_amount: 10 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				max_sell_amount: 150 * CURRENCY_USDT_DECIMALS
 			})
 		);
@@ -823,7 +811,7 @@ fn place_order_bases_max_sell_off_buy() {
 				currency_in: DEV_AUSD_CURRENCY_ID,
 				currency_out: DEV_USDT_CURRENCY_ID,
 				buy_amount: 100 * CURRENCY_AUSD_DECIMALS,
-				min_fulfillment_amount: 10 * CURRENCY_AUSD_DECIMALS,
+				min_fulfillment_amount: MIN_AUSD_FULFILLMENT_AMOUNT,
 				sell_rate_limit: FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
 			})
 		);
@@ -839,7 +827,6 @@ fn ensure_nonce_updates_order_correctly() {
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			100 * CURRENCY_AUSD_DECIMALS
 		));
 		assert_ok!(OrderBook::place_order(
 			ACCOUNT_0,
@@ -847,7 +834,6 @@ fn ensure_nonce_updates_order_correctly() {
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			100 * CURRENCY_AUSD_DECIMALS
 		));
 		let [(order_id_0, _), (order_id_1, _)] = get_account_orders(ACCOUNT_0)
 			.unwrap()
@@ -866,7 +852,6 @@ fn place_order_requires_no_min_buy() {
 			DEV_USDT_CURRENCY_ID,
 			1 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			1 * CURRENCY_AUSD_DECIMALS,
 		),);
 	})
 }
@@ -897,26 +882,8 @@ fn place_order_requires_pair_with_defined_min() {
 				FOREIGN_CURRENCY_NO_MIN_ID,
 				10 * CURRENCY_AUSD_DECIMALS,
 				FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				1 * CURRENCY_AUSD_DECIMALS,
 			),
 			Error::<Runtime>::InvalidTradingPair
-		);
-	})
-}
-
-#[test]
-fn place_order_requires_non_zero_min_fulfillment() {
-	new_test_ext().execute_with(|| {
-		assert_err!(
-			OrderBook::place_order(
-				ACCOUNT_0,
-				DEV_AUSD_CURRENCY_ID,
-				DEV_USDT_CURRENCY_ID,
-				10 * CURRENCY_AUSD_DECIMALS,
-				FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				0
-			),
-			Error::<Runtime>::InvalidMinimumFulfillment
 		);
 	})
 }
@@ -929,9 +896,8 @@ fn place_order_min_fulfillment_cannot_be_less_than_buy() {
 				ACCOUNT_0,
 				DEV_AUSD_CURRENCY_ID,
 				DEV_USDT_CURRENCY_ID,
-				10 * CURRENCY_AUSD_DECIMALS,
+				MIN_AUSD_FULFILLMENT_AMOUNT - 1,
 				FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-				11 * CURRENCY_AUSD_DECIMALS
 			),
 			Error::<Runtime>::InvalidBuyAmount
 		);
@@ -948,7 +914,6 @@ fn place_order_requires_non_zero_price() {
 				DEV_USDT_CURRENCY_ID,
 				100 * CURRENCY_AUSD_DECIMALS,
 				FixedU128::zero(),
-				100 * CURRENCY_AUSD_DECIMALS
 			),
 			Error::<Runtime>::InvalidMaxPrice
 		);
@@ -964,7 +929,6 @@ fn cancel_order_works() {
 			DEV_USDT_CURRENCY_ID,
 			100 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			100 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_ok!(OrderBook::cancel_order(order_id));
@@ -1009,10 +973,9 @@ fn update_order_works_with_order_increase() {
 			DEV_USDT_CURRENCY_ID,
 			10 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
-		assert_ok!(OrderBook::update_order(
+		assert_ok!(OrderBook::update_order_with_fulfillment(
 			ACCOUNT_0,
 			order_id,
 			15 * CURRENCY_AUSD_DECIMALS,
@@ -1093,10 +1056,9 @@ fn update_order_updates_min_fulfillment() {
 			DEV_USDT_CURRENCY_ID,
 			10 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
-		assert_ok!(OrderBook::update_order(
+		assert_ok!(OrderBook::update_order_with_fulfillment(
 			ACCOUNT_0,
 			order_id,
 			10 * CURRENCY_AUSD_DECIMALS,
@@ -1159,10 +1121,9 @@ fn update_order_works_with_order_decrease() {
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
-		assert_ok!(OrderBook::update_order(
+		assert_ok!(OrderBook::update_order_with_fulfillment(
 			ACCOUNT_0,
 			order_id,
 			10 * CURRENCY_AUSD_DECIMALS,
@@ -1241,10 +1202,9 @@ fn update_order_requires_no_min_buy() {
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
-		assert_ok!(OrderBook::update_order(
+		assert_ok!(OrderBook::update_order_with_fulfillment(
 			ACCOUNT_0,
 			order_id,
 			1 * CURRENCY_AUSD_DECIMALS,
@@ -1263,7 +1223,6 @@ fn user_update_order_requires_min_buy() {
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_err!(
@@ -1287,11 +1246,10 @@ fn update_order_requires_non_zero_min_fulfillment() {
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_err!(
-			OrderBook::update_order(
+			OrderBook::update_order_with_fulfillment(
 				ACCOUNT_0,
 				order_id,
 				10 * CURRENCY_AUSD_DECIMALS,
@@ -1312,11 +1270,10 @@ fn update_order_min_fulfillment_cannot_be_less_than_buy() {
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_err!(
-			OrderBook::update_order(
+			OrderBook::update_order_with_fulfillment(
 				ACCOUNT_0,
 				order_id,
 				10 * CURRENCY_AUSD_DECIMALS,
@@ -1337,11 +1294,10 @@ fn update_order_requires_non_zero_price() {
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_err!(
-			OrderBook::update_order(
+			OrderBook::update_order_with_fulfillment(
 				ACCOUNT_0,
 				order_id,
 				10 * CURRENCY_AUSD_DECIMALS,
@@ -1362,7 +1318,6 @@ fn get_order_details_works() {
 			DEV_USDT_CURRENCY_ID,
 			15 * CURRENCY_AUSD_DECIMALS,
 			FixedU128::checked_from_rational(3u32, 2u32).unwrap(),
-			5 * CURRENCY_AUSD_DECIMALS
 		));
 		let (order_id, _) = get_account_orders(ACCOUNT_0).unwrap()[0];
 		assert_eq!(

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1390,6 +1390,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 
 parameter_types! {
 	pub DefaultTokenSellRatio: Ratio = Ratio::one();
+	pub DefaultMinSwapFulfillmentAmount: Balance = 10 * CFG;
 }
 
 impl pallet_foreign_investments::Config for Runtime {
@@ -1402,8 +1403,11 @@ impl pallet_foreign_investments::Config for Runtime {
 	type CurrencyConverter =
 		runtime_common::foreign_investments::IdentityPoolCurrencyConverter<OrmlAssetRegistry>;
 	type CurrencyId = CurrencyId;
+	type DecimalConverter =
+		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type DecreasedForeignInvestOrderHook =
 		pallet_liquidity_pools::hooks::DecreasedForeignInvestOrderHook<Runtime>;
+	type DefaultMinSwapFulfillmentAmount = DefaultMinSwapFulfillmentAmount;
 	type DefaultTokenSellRatio = DefaultTokenSellRatio;
 	type Investment = Investments;
 	type InvestmentId = TrancheCurrency;

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1390,7 +1390,6 @@ impl pallet_xcm_transactor::Config for Runtime {
 
 parameter_types! {
 	pub DefaultTokenSellRatio: Ratio = Ratio::one();
-	pub DefaultMinSwapFulfillmentAmount: Balance = 10 * CFG;
 }
 
 impl pallet_foreign_investments::Config for Runtime {
@@ -1403,11 +1402,8 @@ impl pallet_foreign_investments::Config for Runtime {
 	type CurrencyConverter =
 		runtime_common::foreign_investments::IdentityPoolCurrencyConverter<OrmlAssetRegistry>;
 	type CurrencyId = CurrencyId;
-	type DecimalConverter =
-		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type DecreasedForeignInvestOrderHook =
 		pallet_liquidity_pools::hooks::DecreasedForeignInvestOrderHook<Runtime>;
-	type DefaultMinSwapFulfillmentAmount = DefaultMinSwapFulfillmentAmount;
 	type DefaultTokenSellRatio = DefaultTokenSellRatio;
 	type Investment = Investments;
 	type InvestmentId = TrancheCurrency;
@@ -1779,6 +1775,7 @@ impl pallet_keystore::pallet::Config for Runtime {
 
 parameter_types! {
 	pub const OrderPairVecSize: u32 = 1_000_000u32;
+	pub MinFulfillmentAmountNative: Balance = 10 * CFG;
 }
 
 impl pallet_order_book::Config for Runtime {
@@ -1786,7 +1783,10 @@ impl pallet_order_book::Config for Runtime {
 	type AssetCurrencyId = CurrencyId;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
+	type DecimalConverter =
+		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type FulfilledOrderHook = pallet_foreign_investments::hooks::FulfilledSwapOrderHook<Runtime>;
+	type MinFulfillmentAmountNative = MinFulfillmentAmountNative;
 	type OrderIdNonce = u64;
 	type OrderPairVecSize = OrderPairVecSize;
 	type RuntimeEvent = RuntimeEvent;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -430,7 +430,6 @@ impl orml_asset_registry::Config for Runtime {
 
 parameter_types! {
 	pub DefaultTokenSellRatio: Ratio = Ratio::one();
-	pub DefaultMinSwapFulfillmentAmount: Balance = 10 * CFG;
 }
 
 impl pallet_foreign_investments::Config for Runtime {
@@ -443,11 +442,8 @@ impl pallet_foreign_investments::Config for Runtime {
 	type CurrencyConverter =
 		runtime_common::foreign_investments::IdentityPoolCurrencyConverter<OrmlAssetRegistry>;
 	type CurrencyId = CurrencyId;
-	type DecimalConverter =
-		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type DecreasedForeignInvestOrderHook =
 		pallet_liquidity_pools::hooks::DecreasedForeignInvestOrderHook<Runtime>;
-	type DefaultMinSwapFulfillmentAmount = DefaultMinSwapFulfillmentAmount;
 	type DefaultTokenSellRatio = DefaultTokenSellRatio;
 	type Investment = Investments;
 	type InvestmentId = TrancheCurrency;
@@ -1929,6 +1925,7 @@ impl pallet_uniques::Config for Runtime {
 
 parameter_types! {
 	pub const OrderPairVecSize: u32 = 1_000u32;
+	pub MinFulfillmentAmountNative: Balance = 10 * CFG;
 }
 
 impl pallet_order_book::Config for Runtime {
@@ -1936,7 +1933,10 @@ impl pallet_order_book::Config for Runtime {
 	type AssetCurrencyId = CurrencyId;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
+	type DecimalConverter =
+		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type FulfilledOrderHook = pallet_foreign_investments::hooks::FulfilledSwapOrderHook<Runtime>;
+	type MinFulfillmentAmountNative = MinFulfillmentAmountNative;
 	type OrderIdNonce = u64;
 	type OrderPairVecSize = OrderPairVecSize;
 	type RuntimeEvent = RuntimeEvent;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -430,6 +430,7 @@ impl orml_asset_registry::Config for Runtime {
 
 parameter_types! {
 	pub DefaultTokenSellRatio: Ratio = Ratio::one();
+	pub DefaultMinSwapFulfillmentAmount: Balance = 10 * CFG;
 }
 
 impl pallet_foreign_investments::Config for Runtime {
@@ -442,8 +443,11 @@ impl pallet_foreign_investments::Config for Runtime {
 	type CurrencyConverter =
 		runtime_common::foreign_investments::IdentityPoolCurrencyConverter<OrmlAssetRegistry>;
 	type CurrencyId = CurrencyId;
+	type DecimalConverter =
+		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type DecreasedForeignInvestOrderHook =
 		pallet_liquidity_pools::hooks::DecreasedForeignInvestOrderHook<Runtime>;
+	type DefaultMinSwapFulfillmentAmount = DefaultMinSwapFulfillmentAmount;
 	type DefaultTokenSellRatio = DefaultTokenSellRatio;
 	type Investment = Investments;
 	type InvestmentId = TrancheCurrency;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1546,6 +1546,7 @@ impl orml_asset_registry::Config for Runtime {
 
 parameter_types! {
 	pub DefaultTokenSellRatio: Ratio = Ratio::one();
+	pub DefaultMinSwapFulfillmentAmount: Balance = 10 * CFG;
 }
 
 impl pallet_foreign_investments::Config for Runtime {
@@ -1558,8 +1559,11 @@ impl pallet_foreign_investments::Config for Runtime {
 	type CurrencyConverter =
 		runtime_common::foreign_investments::IdentityPoolCurrencyConverter<OrmlAssetRegistry>;
 	type CurrencyId = CurrencyId;
+	type DecimalConverter =
+		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type DecreasedForeignInvestOrderHook =
 		pallet_liquidity_pools::hooks::DecreasedForeignInvestOrderHook<Runtime>;
+	type DefaultMinSwapFulfillmentAmount = DefaultMinSwapFulfillmentAmount;
 	type DefaultTokenSellRatio = DefaultTokenSellRatio;
 	type Investment = Investments;
 	type InvestmentId = TrancheCurrency;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1546,7 +1546,6 @@ impl orml_asset_registry::Config for Runtime {
 
 parameter_types! {
 	pub DefaultTokenSellRatio: Ratio = Ratio::one();
-	pub DefaultMinSwapFulfillmentAmount: Balance = 10 * CFG;
 }
 
 impl pallet_foreign_investments::Config for Runtime {
@@ -1559,11 +1558,8 @@ impl pallet_foreign_investments::Config for Runtime {
 	type CurrencyConverter =
 		runtime_common::foreign_investments::IdentityPoolCurrencyConverter<OrmlAssetRegistry>;
 	type CurrencyId = CurrencyId;
-	type DecimalConverter =
-		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type DecreasedForeignInvestOrderHook =
 		pallet_liquidity_pools::hooks::DecreasedForeignInvestOrderHook<Runtime>;
-	type DefaultMinSwapFulfillmentAmount = DefaultMinSwapFulfillmentAmount;
 	type DefaultTokenSellRatio = DefaultTokenSellRatio;
 	type Investment = Investments;
 	type InvestmentId = TrancheCurrency;
@@ -1854,6 +1850,7 @@ impl pallet_transfer_allowlist::Config for Runtime {
 
 parameter_types! {
 		pub const OrderPairVecSize: u32 = 1_000u32;
+		pub MinFulfillmentAmountNative: Balance = 10 * CFG;
 }
 
 impl pallet_order_book::Config for Runtime {
@@ -1861,7 +1858,10 @@ impl pallet_order_book::Config for Runtime {
 	type AssetCurrencyId = CurrencyId;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
+	type DecimalConverter =
+		runtime_common::foreign_investments::NativeBalanceDecimalConverter<OrmlAssetRegistry>;
 	type FulfilledOrderHook = pallet_foreign_investments::hooks::FulfilledSwapOrderHook<Runtime>;
+	type MinFulfillmentAmountNative = MinFulfillmentAmountNative;
 	type OrderIdNonce = u64;
 	type OrderPairVecSize = OrderPairVecSize;
 	type RuntimeEvent = RuntimeEvent;

--- a/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/foreign_investments.rs
+++ b/runtime/integration-tests/src/liquidity_pools/pallet/development/tests/liquidity_pools/foreign_investments.rs
@@ -41,9 +41,9 @@ use cfg_types::{
 	},
 };
 use development_runtime::{
-	Balances, DefaultMinSwapFulfillmentAmount, ForeignInvestments, Investments, LiquidityPools,
-	LocationToAccountId, OrmlAssetRegistry, Permissions, PoolSystem, Runtime as DevelopmentRuntime,
-	RuntimeOrigin, System, Tokens, TreasuryAccount,
+	Balances, ForeignInvestments, Investments, LiquidityPools, LocationToAccountId,
+	MinFulfillmentAmountNative, OrmlAssetRegistry, Permissions, PoolSystem,
+	Runtime as DevelopmentRuntime, RuntimeOrigin, System, Tokens, TreasuryAccount,
 };
 use frame_support::{
 	assert_noop, assert_ok,
@@ -3364,7 +3364,7 @@ mod mismatching_currencies {
 				invest_amount_foreign_denominated + invest_amount_foreign_denominated / 8;
 			dbg!(System::events());
 			dbg!(swap_amount);
-			dbg!(DefaultMinSwapFulfillmentAmount::get());
+			dbg!(MinFulfillmentAmountNative::get());
 			assert!(System::events().iter().any(|e| {
 				e.event
 					== pallet_order_book::Event::<DevelopmentRuntime>::OrderUpdated {
@@ -3951,7 +3951,7 @@ mod setup {
 
 	pub(crate) fn min_fulfillment_amount(currency_id: CurrencyId) -> Balance {
 		runtime_common::foreign_investments::NativeBalanceDecimalConverter::<OrmlAssetRegistry>::to_asset_balance(
-			DefaultMinSwapFulfillmentAmount::get(),
+			MinFulfillmentAmountNative::get(),
 			currency_id,
 		)
 		.expect("CurrencyId should be registered in AssetRegistry")


### PR DESCRIPTION
# Description

This PR mainly fixes issues for partial orderbook fulfillments of foreign investments as a successor of #1559. It also enables partial investments for orders created via extrinsics:

* Fixes issues for partial swap order fulfillments in `pallet-foreign-investments`
* Enables partial swaps for orders created through user extrinsics `pallet_order_book::create_order` and `pallet_order_book::user_update_order` which had the `min_fulfillment_amount` set to the `buy_amount` making partial fulfillments impossible
* Removes `min_fulfillment_amount` from `TokenSwaps` trait
  * IMO, it should solely be handled by the orderbook
* Adds `NativeBalanceDecimalConverter` which provides means of converting between native and asset balance (i.e. re-denomination)
* Adds `MinFulfillmentAmountNative` to `pallet_order_book::Config` which provides a global threshold which gets converted into the incoming asset precision via the also new `pallet_order_book::Config::DecimalConverter` type

## Integration tests

* Extends FI integration tests to check for correct `Executed*` dispatches
* Adds FI integration test for partial order fulfillment in edge case of having an order from pool to foreign as a result of decreasing an investment and collecting a redemption

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
