### PR TITLE
Investments: simplify constraints and remove InvestmentProperties trait

### DIFF
--- a/libs/test-utils/src/mocks/accountant.rs
+++ b/libs/test-utils/src/mocks/accountant.rs
@@ -12,12 +12,7 @@
 
 /// Exposes a struct $name that implements the `trait Accountant`. The struct
 /// expects one generic parameter that implements the fungibles traits
-/// `Inspect`, `Mutate` and `Transfer`. Furthermore, there exists a struct
-/// `GenesisConfig` that implements `trait GenesisBuild` that can be used
-/// like any other `GenesisConfig` to initialize state in the
-/// `TestExternalities`.
-///
-/// Also exports a `struct InvestmentInfo` to be used in the `GenesisConfig`
+/// `Inspect`, `Mutate` and `Transfer`.
 ///
 /// * E.g.: `MockAccountant<Tokens:
 ///   frame_support::traits::tokens::fungibles::{Inspect, Mutate, Transfer}>`
@@ -54,7 +49,7 @@
 ///
 /// // Using the `GenesisConfig`
 /// use accountant_mock::InvestmentInfo;
-/// let storage = GenesisBuild::build_storage(&accountant_mock::GenesisConfig {
+/// let storage = GenesisBuild::init(&accountant_mock::Genesis {
 ///             infos: vec![
 ///             (
 ///                 InvestmentId::Tranche(0, [0;16]),
@@ -79,30 +74,26 @@ macro_rules! impl_mock_accountant {
 
 			use super::*;
 
-			#[derive(Default, serde::Serialize, serde::Deserialize)]
-			pub struct GenesisConfig {
+			pub type InvestmentInfo =
+				cfg_types::investments::InvestmentInfo<$account_id, $currency_id, $investment_id>;
+
+			#[derive(Default)]
+			pub struct Genesis {
 				pub infos: Vec<($investment_id, InvestmentInfo)>,
-			}
-
-			impl frame_support::traits::GenesisBuild<()> for GenesisConfig {
-				fn build(&self) {
-					__private_STATE.with(|s| {
-						let mut state = s.borrow_mut();
-
-						for (id, info) in &self.infos {
-							state.add(id.clone(), info.clone())
-						}
-					})
-				}
 			}
 
 			pub struct $name<Tokens>(sp_std::marker::PhantomData<Tokens>);
 
-			#[derive(Clone, serde::Serialize, serde::Deserialize)]
-			pub struct InvestmentInfo {
-				pub owner: $account_id,
-				pub id: $investment_id,
-				pub payment_currency: $currency_id,
+			impl<Tokens> $name<Tokens> {
+				pub fn init(genesis: Genesis) {
+					__private_STATE.with(|s| {
+						let mut state = s.borrow_mut();
+
+						for (id, info) in &genesis.infos {
+							state.add(id.clone(), info.clone())
+						}
+					})
+				}
 			}
 
 			impl<Tokens> cfg_traits::investments::InvestmentAccountant<$account_id> for $name<Tokens>
@@ -187,23 +178,6 @@ macro_rules! impl_mock_accountant {
 				}
 			}
 
-			impl cfg_traits::investments::InvestmentProperties<$account_id> for InvestmentInfo {
-				type Currency = $currency_id;
-				type Id = $investment_id;
-
-				fn owner(&self) -> $account_id {
-					self.owner
-				}
-
-				fn id(&self) -> Self::Id {
-					self.id
-				}
-
-				fn payment_currency(&self) -> Self::Currency {
-					self.payment_currency
-				}
-			}
-
 			mod __private {
 				use super::*;
 
@@ -235,7 +209,7 @@ macro_rules! impl_mock_accountant {
 
 					pub fn add(&mut self, investment_id: $investment_id, info: InvestmentInfo) {
 						// NOTE: We deliberately update the info here as add() is only called
-						//       upon GenesisConfig.build(). We assume, if we are running in the
+						//       upon init(). We assume, if we are running in the
 						//       same thread this means a new initialization is wanted.
 						for (curr_id, curr_info) in &mut self.infos {
 							if *curr_id == investment_id {

--- a/libs/traits/src/investments.rs
+++ b/libs/traits/src/investments.rs
@@ -186,7 +186,7 @@ pub trait OrderManager {
 pub trait InvestmentAccountant<AccountId> {
 	type Error;
 	type InvestmentId;
-	type InvestmentInfo: InvestmentProperties<AccountId, Id = Self::InvestmentId>;
+	type InvestmentInfo;
 	type Amount;
 
 	/// Information about an asset. Must allow to derive
@@ -217,55 +217,6 @@ pub trait InvestmentAccountant<AccountId> {
 		id: Self::InvestmentId,
 		amount: Self::Amount,
 	) -> Result<(), Self::Error>;
-}
-
-/// A trait that allows to retrieve information
-/// about an investment class.
-pub trait InvestmentProperties<AccountId> {
-	/// The overarching Currency that payments
-	/// for this class are made in
-	type Currency;
-	/// Who the investment class can be identified
-	type Id;
-
-	/// Returns the owner of the investment class
-	fn owner(&self) -> AccountId;
-
-	/// Returns the id of the investment class
-	fn id(&self) -> Self::Id;
-
-	/// Returns the currency in which the investment class
-	/// can be bought.
-	fn payment_currency(&self) -> Self::Currency;
-
-	/// Returns the account a payment for the investment class
-	/// must be made to.
-	///
-	/// Defaults to owner.
-	fn payment_account(&self) -> AccountId {
-		self.owner()
-	}
-}
-
-impl<AccountId, T: InvestmentProperties<AccountId>> InvestmentProperties<AccountId> for &T {
-	type Currency = T::Currency;
-	type Id = T::Id;
-
-	fn owner(&self) -> AccountId {
-		(*self).owner()
-	}
-
-	fn id(&self) -> Self::Id {
-		(*self).id()
-	}
-
-	fn payment_currency(&self) -> Self::Currency {
-		(*self).payment_currency()
-	}
-
-	fn payment_account(&self) -> AccountId {
-		(*self).payment_account()
-	}
 }
 
 /// Trait to handle Investment Portfolios for accounts

--- a/libs/types/src/investments.rs
+++ b/libs/types/src/investments.rs
@@ -11,7 +11,6 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::OrderId;
-use cfg_traits::investments::InvestmentProperties;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{dispatch::fmt::Debug, RuntimeDebug};
 use scale_info::TypeInfo;
@@ -33,29 +32,6 @@ pub struct InvestmentInfo<AccountId, Currency, InvestmentId> {
 	pub owner: AccountId,
 	pub id: InvestmentId,
 	pub payment_currency: Currency,
-}
-
-impl<AccountId, Currency, InvestmentId> InvestmentProperties<AccountId>
-	for InvestmentInfo<AccountId, Currency, InvestmentId>
-where
-	AccountId: Clone,
-	Currency: Clone,
-	InvestmentId: Clone,
-{
-	type Currency = Currency;
-	type Id = InvestmentId;
-
-	fn owner(&self) -> AccountId {
-		self.owner.clone()
-	}
-
-	fn id(&self) -> Self::Id {
-		self.id.clone()
-	}
-
-	fn payment_currency(&self) -> Self::Currency {
-		self.payment_currency.clone()
-	}
 }
 
 /// The outstanding collections for an account

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -13,7 +13,7 @@
 
 use cfg_traits::{
 	benchmarking::{InvestmentIdBenchmarkHelper, PoolBenchmarkHelper},
-	investments::{Investment, InvestmentAccountant, InvestmentProperties, OrderManager},
+	investments::{Investment, InvestmentAccountant, OrderManager},
 };
 use cfg_types::orders::FulfillmentWithPrice;
 use frame_benchmarking::{account, impl_benchmark_test_suite, v2::*, whitelisted_caller};
@@ -58,7 +58,7 @@ mod benchmarks {
 	fn update_invest_order() {
 		let caller: T::AccountId = whitelisted_caller();
 		let investment_id = Helper::<T>::get_investment_id();
-		let currency_id = T::Accountant::info(investment_id)?.payment_currency();
+		let currency_id = T::Accountant::info(investment_id)?.payment_currency;
 
 		T::Tokens::mint_into(currency_id, &caller, 1u32.into())?;
 
@@ -82,9 +82,7 @@ mod benchmarks {
 	fn collect_investments(n: Linear<1, 10>) {
 		let caller: T::AccountId = whitelisted_caller();
 		let investment_id = Helper::<T>::get_investment_id();
-		let currency_id = T::Accountant::info(investment_id)
-			.unwrap()
-			.payment_currency();
+		let currency_id = T::Accountant::info(investment_id)?.payment_currency;
 
 		T::Tokens::mint_into(currency_id, &caller, 1u32.into())?;
 

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -26,8 +26,6 @@ use crate::{Call, Config, CurrencyOf, Pallet};
 struct Helper<T>(sp_std::marker::PhantomData<T>);
 impl<T: Config> Helper<T>
 where
-	<T::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
-		InvestmentProperties<T::AccountId, Currency = CurrencyOf<T>>,
 	T::Accountant: PoolBenchmarkHelper<AccountId = T::AccountId>
 		+ InvestmentIdBenchmarkHelper<
 			InvestmentId = T::InvestmentId,
@@ -46,8 +44,6 @@ where
 
 #[benchmarks(
 	where
-		<T::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
-			InvestmentProperties<T::AccountId, Currency = CurrencyOf<T>>,
 		T::Accountant: PoolBenchmarkHelper<AccountId = T::AccountId>
 			+ InvestmentIdBenchmarkHelper<
 				InvestmentId = T::InvestmentId,
@@ -74,7 +70,7 @@ mod benchmarks {
 	fn update_redeem_order() {
 		let caller: T::AccountId = whitelisted_caller();
 		let investment_id = Helper::<T>::get_investment_id();
-		let currency_id: CurrencyOf<T> = T::Accountant::info(investment_id)?.id().into();
+		let currency_id: CurrencyOf<T> = investment_id.into();
 
 		T::Tokens::mint_into(currency_id, &caller, 1u32.into())?;
 
@@ -112,7 +108,7 @@ mod benchmarks {
 	fn collect_redemptions(n: Linear<1, 10>) {
 		let caller: T::AccountId = whitelisted_caller();
 		let investment_id = Helper::<T>::get_investment_id();
-		let currency_id: CurrencyOf<T> = T::Accountant::info(investment_id)?.id().into();
+		let currency_id: CurrencyOf<T> = investment_id.into();
 
 		T::Tokens::mint_into(currency_id, &caller, 1u32.into())?;
 

--- a/pallets/investments/src/mock.rs
+++ b/pallets/investments/src/mock.rs
@@ -162,6 +162,7 @@ impl pallet_investments::Config for MockRuntime {
 	type CollectedInvestmentHook = NoopCollectHook;
 	type CollectedRedemptionHook = NoopCollectHook;
 	type InvestmentId = InvestmentId;
+	type InvestmentInfo = accountant_mock::InvestmentInfo;
 	type MaxOutstandingCollects = MaxOutstandingCollect;
 	type PreConditions = Always;
 	type RuntimeEvent = RuntimeEvent;

--- a/pallets/investments/src/mock.rs
+++ b/pallets/investments/src/mock.rs
@@ -18,7 +18,7 @@ use cfg_primitives::*;
 use cfg_traits::{investments::OrderManager, PreConditions};
 use cfg_types::{
 	fixed_point::Rate,
-	investments::InvestmentAccount,
+	investments::{InvestmentAccount, InvestmentInfo},
 	orders::{FulfillmentWithPrice, TotalOrder},
 	tokens::CurrencyId,
 };
@@ -162,7 +162,6 @@ impl pallet_investments::Config for MockRuntime {
 	type CollectedInvestmentHook = NoopCollectHook;
 	type CollectedRedemptionHook = NoopCollectHook;
 	type InvestmentId = InvestmentId;
-	type InvestmentInfo = accountant_mock::InvestmentInfo;
 	type MaxOutstandingCollects = MaxOutstandingCollect;
 	type PreConditions = Always;
 	type RuntimeEvent = RuntimeEvent;
@@ -295,8 +294,7 @@ impl TestExternalitiesBuilder {
 		.assimilate_storage(&mut storage)
 		.unwrap();
 
-		use accountant_mock::InvestmentInfo;
-		accountant_mock::GenesisConfig {
+		MockAccountant::<OrmlTokens>::init(accountant_mock::Genesis {
 			infos: vec![
 				(
 					INVESTMENT_0_0,
@@ -315,9 +313,7 @@ impl TestExternalitiesBuilder {
 					},
 				),
 			],
-		}
-		.assimilate_storage(&mut storage)
-		.unwrap();
+		});
 
 		let mut externalities = TestExternalities::new(storage);
 		externalities.execute_with(|| {

--- a/pallets/pool-registry/src/benchmarking.rs
+++ b/pallets/pool-registry/src/benchmarking.rs
@@ -13,7 +13,7 @@
 
 //! Module provides benchmarking for Loan Pallet
 use cfg_primitives::{Moment, PoolEpochId};
-use cfg_traits::investments::{InvestmentAccountant, InvestmentProperties, TrancheCurrency as _};
+use cfg_traits::investments::TrancheCurrency as _;
 use cfg_types::{
 	pools::TrancheMetadata,
 	tokens::{CurrencyId, TrancheCurrency},
@@ -70,8 +70,6 @@ benchmarks! {
 			  MaxTranches = <T as Config>::MaxTranches>,
 		T: pallet_timestamp::Config<Moment = Moment>,
 		<T as pallet_investments::Config>::Tokens: Inspect<T::AccountId, AssetId = CurrencyId, Balance = u128>,
-		<<T as pallet_investments::Config>::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
-			InvestmentProperties<T::AccountId, Currency = CurrencyId>,
 		<<T as frame_system::Config>::Lookup as sp_runtime::traits::StaticLookup>::Source:
 			From<<T as frame_system::Config>::AccountId>,
 		<T as pallet_pool_system::Config>::Permission: Permissions<T::AccountId, Ok = ()>,

--- a/pallets/pool-system/src/benchmarking.rs
+++ b/pallets/pool-system/src/benchmarking.rs
@@ -13,10 +13,7 @@
 
 //! Module provides benchmarking for Loan Pallet
 use cfg_primitives::PoolEpochId;
-use cfg_traits::{
-	investments::{InvestmentAccountant, InvestmentProperties, TrancheCurrency as _},
-	UpdateState,
-};
+use cfg_traits::{investments::TrancheCurrency as _, UpdateState};
 use cfg_types::{
 	pools::TrancheMetadata,
 	tokens::{CurrencyId, CustomMetadata, TrancheCurrency},
@@ -53,8 +50,6 @@ benchmarks! {
 			  EpochId = PoolEpochId>
 			+ pallet_investments::Config<InvestmentId = TrancheCurrency, Amount = u128>,
 		<T as pallet_investments::Config>::Tokens: Inspect<T::AccountId, AssetId = CurrencyId, Balance = u128>,
-		<<T as pallet_investments::Config>::Accountant as InvestmentAccountant<T::AccountId>>::InvestmentInfo:
-			InvestmentProperties<T::AccountId, Currency = CurrencyId>,
 		T::AccountId: EncodeLike<<T as frame_system::Config>::AccountId>,
 		<<T as frame_system::Config>::Lookup as sp_runtime::traits::StaticLookup>::Source:
 			From<<T as frame_system::Config>::AccountId>,


### PR DESCRIPTION
# Description

Some simplifications regarding investment info/properties. [Slack conversation](https://kflabs.slack.com/archives/C04GJQAM9P0/p1695383388075129)

## Changes and Descriptions

- Removed the `InvestmentProperties` trait. Now, the type `InvestmentInfo` is used directly (which I think simplifies some parts)
- Removed the need for the `where` bound everywhere the investment pallets is used to determine the correct `InvestmentInfo` (this simplifies things for future integration tests)
