### PR TITLE
fix: foreign investments bench

### DIFF
--- a/pallets/foreign-investments/src/impls/benchmark_utils.rs
+++ b/pallets/foreign-investments/src/impls/benchmark_utils.rs
@@ -11,6 +11,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+use cfg_primitives::CFG;
 use cfg_traits::{
 	benchmarking::{
 		BenchForeignInvestmentSetupInfo, ForeignInvestmentBenchmarkHelper,
@@ -33,7 +34,7 @@ pub const CURRENCY_POOL: CurrencyId = CurrencyId::ForeignAsset(1);
 pub const CURRENCY_FOREIGN: CurrencyId = CurrencyId::ForeignAsset(2);
 pub const DECIMALS_POOL: u32 = 12;
 pub const DECIMALS_FOREIGN: u32 = 6;
-pub const INVEST_AMOUNT_POOL_DENOMINATED: u128 = 1_000_000_000_000;
+pub const INVEST_AMOUNT_POOL_DENOMINATED: u128 = 100_000_000 * CFG;
 pub const INVEST_AMOUNT_FOREIGN_DENOMINATED: u128 = INVEST_AMOUNT_POOL_DENOMINATED / 1_000_000;
 
 impl<T: Config> ForeignInvestmentBenchmarkHelper for Pallet<T>


### PR DESCRIPTION
# Description

Fixes benchmarking CI after merging #1570 unwantedly before the entire CI finished (benches were still progressing, suppose those are optional which I was not aware of). Sorry about the inconvenience!

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
