### PR TITLE
feat: add precompile migration to dev

### DIFF
--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -118,6 +118,7 @@ pub use crate::xcm::*;
 
 pub mod evm;
 pub mod liquidity_pools;
+mod migrations;
 mod weights;
 pub mod xcm;
 
@@ -1980,8 +1981,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	// We don't run migrations on the development runtime
-	(),
+	crate::migrations::UpgradeDevelopment1031,
 >;
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {

--- a/runtime/development/src/migrations.rs
+++ b/runtime/development/src/migrations.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+pub type UpgradeDevelopment1031 = (
+	// Sets account codes for all precompiles
+	runtime_common::migrations::precompile_account_codes::Migration<crate::Runtime, 1031>,
+);


### PR DESCRIPTION
# Description

* Adds precompile migration from #1580 to development runtime required for `Demo` environment

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
