### PR TITLE
fix: remove spec_version check for Centrifuge 1023 migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "centrifuge-runtime"
-version = "0.10.22"
+version = "0.10.23"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "development-runtime"
-version = "0.10.31"
+version = "0.10.32"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -52,20 +52,15 @@ pub type UpgradeAltair1034 = (
 	// Sets currently unset safe XCM version to v2
 	xcm_v2_to_v3::SetSafeXcmVersion,
 	// Sets account codes for all precompiles
-	runtime_common::migrations::precompile_account_codes::Migration<
-		crate::Runtime,
-		{ crate::VERSION.spec_version },
-	>,
+	runtime_common::migrations::precompile_account_codes::Migration<crate::Runtime>,
 );
 
 /// The Upgrade set for Algol - it excludes the migrations already executed in
 /// the side releases that only landed on Algol (1028 to 1031) but not yet on
 /// Altair.
 #[cfg(feature = "testnet-runtime")]
-pub type UpgradeAltair1034 = (runtime_common::migrations::precompile_account_codes::Migration<
-	crate::Runtime,
-	{ crate::VERSION.spec_version },
->);
+pub type UpgradeAltair1034 =
+	(runtime_common::migrations::precompile_account_codes::Migration<crate::Runtime>);
 
 mod asset_registry {
 	use cfg_primitives::Balance;

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centrifuge-runtime"
-version = "0.10.22"
+version = "0.10.23"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -131,7 +131,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge"),
 	impl_name: create_runtime_str!("centrifuge"),
 	authoring_version: 1,
-	spec_version: 1022,
+	spec_version: 1023,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/common/src/migrations/precompile_account_codes.rs
+++ b/runtime/common/src/migrations/precompile_account_codes.rs
@@ -19,22 +19,11 @@ use sp_core::H160;
 
 use crate::evm::precompile::PRECOMPILE_CODE_STORAGE;
 
-pub struct Migration<T, const BEFORE_VERSION: u32>(sp_std::marker::PhantomData<T>);
+pub struct Migration<T>(sp_std::marker::PhantomData<T>);
 
-impl<T: pallet_evm::Config, const BEFORE_VERSION: u32> OnRuntimeUpgrade
-	for Migration<T, BEFORE_VERSION>
-{
+impl<T: pallet_evm::Config> OnRuntimeUpgrade for Migration<T> {
 	fn on_runtime_upgrade() -> Weight {
 		log::info!("precompile::AccountCodes: Inserting precompile account codes: on_runtime_upgrade: started");
-
-		let last_version = frame_system::LastRuntimeUpgrade::<T>::get()
-			.map(|v| v.spec_version.0)
-			.unwrap_or(<T::Version as frame_support::traits::Get<_>>::get().spec_version);
-
-		if last_version >= BEFORE_VERSION {
-			log::warn!("[precompile::AccountCodes: Current runtime version too high. Skipping migration. Migration can probably be removed.");
-			return Weight::zero();
-		}
 
 		if pallet_evm::AccountCodes::<T>::get(H160::from(crate::evm::precompile::ECRECOVER_ADDR))
 			.is_empty()

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "development-runtime"
-version = "0.10.31"
+version = "0.10.32"
 authors = ["Centrifuge <admin@centrifuge.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge-devel"),
 	impl_name: create_runtime_str!("centrifuge-devel"),
 	authoring_version: 1,
-	spec_version: 1031,
+	spec_version: 1032,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/development/src/migrations.rs
+++ b/runtime/development/src/migrations.rs
@@ -12,5 +12,5 @@
 
 pub type UpgradeDevelopment1031 = (
 	// Sets account codes for all precompiles
-	runtime_common::migrations::precompile_account_codes::Migration<crate::Runtime, 1031>,
+	runtime_common::migrations::precompile_account_codes::Migration<crate::Runtime>,
 );


### PR DESCRIPTION
# Description

Removes `spec_version` checks for Anemoy, USDC and EVM Precompile Accountcode migrations. 

Apparently, we cannot rely on the result of `try-runtime` which [succeeded for all these migrations](https://github.com/centrifuge/centrifuge-chain/pull/1580#issuecomment-1747015476). However, in practice neither Dev/Demo nor Catalyst ran the EVM Accountcode migrations (Anemoy & USDC migrations ran on Catalyst in a previous upgrade from 1020 to 1021). My understanding is that at the time of executing `on_runtime_upgrade()`, the spec_version has been bumped already and `LastRuntimeUpgrade` updated to the current `spec_version`. I could not find any way of reading the pre upgrade spec_version.

None of the migrations performs many reads or writes. Moreover, they were adjusted such that no written storage is mutated. Thus, they cannot do harm.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
