### PR TITLE
lp: Add `compute_at` to `UpdateTrancheTokenPrice`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,8 +169,8 @@ fc-mapping-sync = { git = "https://github.com/PureStake/frontier", default-featu
 fc-rpc = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 fc-rpc-core = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 fp-consensus = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
-fp-rpc = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 fp-evm = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
+fp-rpc = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 fp-storage = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 pallet-evm = { git = "https://github.com/PureStake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.38" }
 

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -453,7 +453,7 @@ pub mod pallet {
 			// TODO(future): Once we diverge from 1-to-1 conversions for foreign and pool
 			// currencies, this price must be first converted into the currency_id and then
 			// re-denominated to 18 decimals (i.e. `Ratio` precision)
-			let price_value  = T::TrancheTokenPrice::get(pool_id, tranche_id)
+			let price_value = T::TrancheTokenPrice::get(pool_id, tranche_id)
 				.ok_or(Error::<T>::MissingTranchePrice)?;
 
 			// Check that the registered asset location matches the destination

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -193,6 +193,7 @@ pub mod pallet {
 			BalanceRatio = Self::BalanceRatio,
 			PoolId = Self::PoolId,
 			TrancheId = Self::TrancheId,
+			Moment = Seconds,
 		>;
 
 		/// The source of truth for investment permissions.
@@ -452,9 +453,8 @@ pub mod pallet {
 			// TODO(future): Once we diverge from 1-to-1 conversions for foreign and pool
 			// currencies, this price must be first converted into the currency_id and then
 			// re-denominated to 18 decimals (i.e. `Ratio` precision)
-			let price = T::TrancheTokenPrice::get(pool_id, tranche_id)
-				.ok_or(Error::<T>::MissingTranchePrice)?
-				.price;
+			let price_value  = T::TrancheTokenPrice::get(pool_id, tranche_id)
+				.ok_or(Error::<T>::MissingTranchePrice)?;
 
 			// Check that the registered asset location matches the destination
 			match Self::try_get_wrapped_token(&currency_id)? {
@@ -474,7 +474,8 @@ pub mod pallet {
 					pool_id,
 					tranche_id,
 					currency,
-					price,
+					price: price_value.price,
+					computed_at: price_value.last_updated,
 				},
 			)?;
 

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -80,6 +80,8 @@ where
 		tranche_id: TrancheId,
 		currency: u128,
 		price: Ratio,
+		/// The timestamp at which the price was computed
+		computed_at: Seconds,
 	},
 	/// Whitelist an address for the specified pair of pool and tranche token on
 	/// the target domain.
@@ -449,6 +451,7 @@ impl<
 				tranche_id,
 				currency,
 				price,
+				computed_at,
 			} => encoded_message(
 				self.call_type(),
 				vec![
@@ -456,6 +459,7 @@ impl<
 					tranche_id.encode(),
 					encode_be(currency),
 					encode_be(price),
+					computed_at.to_be_bytes().to_vec(),
 				],
 			),
 			Message::UpdateMember {
@@ -751,6 +755,7 @@ impl<
 				tranche_id: decode::<16, _, _>(input)?,
 				currency: decode_be_bytes::<16, _, _>(input)?,
 				price: decode_be_bytes::<16, _, _>(input)?,
+				computed_at: decode_be_bytes::<8, _, _>(input)?,
 			}),
 			6 => Ok(Self::UpdateMember {
 				pool_id: decode_be_bytes::<8, _, _>(input)?,
@@ -1025,8 +1030,9 @@ mod tests {
 				tranche_id: default_tranche_id(),
 				currency: TOKEN_ID,
 				price: Ratio::one(),
+				computed_at: 1698131924,
 			},
-			"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b0000000000000000000000000eb5ec7b00000000000000000de0b6b3a7640000",
+			"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b0000000000000000000000000eb5ec7b00000000000000000de0b6b3a76400000000000065376fd4",
 		)
 	}
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -8,9 +8,9 @@ homepage = "https://centrifuge.io/"
 repository = "https://github.com/centrifuge/centrifuge-chain"
 
 [dependencies]
+hex-literal = { version = "0.3.4", default-features = false }
 serde = { version = "1.0.119" }
 smallvec = "1.6.1"
-hex-literal = { version = "0.3.4", default-features = false }
 
 # Substrate dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -21,36 +21,36 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", optional
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 pallet-collective = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 pallet-democracy = { git = "https://github.com/paritytech//substrate", rev = "bcff60a227d455d95b4712b6cb356ce56b1ff672" }
 pallet-preimage = { git = "https://github.com/paritytech//substrate", rev = "bcff60a227d455d95b4712b6cb356ce56b1ff672" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
 
 ## Substrate-Primitives
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 #sp-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
+fp-self-contained = { git = "https://github.com/PureStake/frontier", branch = "moonbeam-polkadot-v0.9.38" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-consensus-slots = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
-fp-self-contained = { git = "https://github.com/PureStake/frontier", branch = "moonbeam-polkadot-v0.9.38" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 
 ## Substrate-Client
 node-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 #sc-consensus-uncles = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 sc-service = { git = "https://github.com/paritytech/substrate", features = ["rocksdb", "test-helpers"], branch = "polkadot-v0.9.38" }
@@ -68,8 +68,8 @@ rococo-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rel
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.38" }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.38" }
 cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.38" }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.38" }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.38" }
 cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.38" }
 
@@ -120,8 +120,8 @@ pallet-order-book = { path = "../../pallets/order-book" }
 pallet-permissions = { path = "../../pallets/permissions" }
 pallet-pool-registry = { path = "../../pallets/pool-registry" }
 pallet-pool-system = { path = "../../pallets/pool-system" }
-pallet-rewards = { path = "../../pallets/rewards" }
 pallet-restricted-tokens = { path = "../../pallets/restricted-tokens" }
+pallet-rewards = { path = "../../pallets/rewards" }
 
 pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 pallet-xcm-transactor = { git = "https://github.com/PureStake/moonbeam", default-features = false, rev = "00b3e3d97806e889b02e1bcb4b69e65433dd805d" }


### PR DESCRIPTION
After a discussion within the `MultiChain` team, we agreed that we need to include the timestamp at which a tranche token price was calculated in the `UpdateTrancheToken` message.

Given that we add this new field at the end of the message, no migrations or special handing is necessary since this will make this messages backwards and forwards compatible.