### PR TITLE
CI Testing in debug

### DIFF
--- a/ci/run-check.sh
+++ b/ci/run-check.sh
@@ -10,15 +10,15 @@ cargo --version
 
 case $TARGET in
   cargo-build)
-    cargo build --release "$@"
+    cargo build "$@"
     ;;
 
   test-general)
-    cargo test --workspace --release --features runtime-benchmarks,try-runtime --exclude runtime-integration-tests
+    cargo test --workspace --features runtime-benchmarks,try-runtime --exclude runtime-integration-tests
     ;;
 
   test-integration)
-    cargo test --release --package runtime-integration-tests --features fast-runtime
+    cargo test --package runtime-integration-tests --features fast-runtime
     ;;
 
   lint-fmt)

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -28,7 +28,7 @@ and another one to verify how it works in a more real environment as a parachain
 The following command will run the unit and integration tests:
 
 ```bash
-cargo +nightly test --workspace --release --features runtime-benchmarks,try-runtime
+cargo test --workspace --features runtime-benchmarks,try-runtime
 ```
 
 ### Environment tests
@@ -84,7 +84,7 @@ You can play with it from the parachain client, make transfers, inspect events, 
 ## Linting
 
 ### Source code
-Lint the source code with `cargo +nightly fmt`. This excludes certain paths (defined in `rustfmt.toml`) that we want to stay as close as possible to `paritytech/substrate` to simplify upgrading to new releases.
+Lint the source code with `cargo fmt`. This excludes certain paths (defined in `rustfmt.toml`) that we want to stay as close as possible to `paritytech/substrate` to simplify upgrading to new releases.
 
 ### Cargo.toml files
 1. Install [taplo](https://github.com/tamasfe/taplo) with `cargo install taplo-cli`.


### PR DESCRIPTION
# Description

CI workflows in debug instead of release.

Note: In the original PR modifying this, the workflow of checking benchmarks was also computed in debug to reuse artifacts (see [here](https://github.com/centrifuge/centrifuge-chain/pull/1273/files#diff-1f813070c7581975ad731d80bf757a5c032827b98b4f4bee9133eefa34015618R67)). Maybe it's still required here, but it's still not added. Let's see how it behaves.

