### PR TITLE
LiquidityPools: Add `restriction_set` field to `AddTranche` message

### DIFF
--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -426,10 +426,10 @@ pub mod pallet {
 					decimals: metadata.decimals.saturated_into(),
 					token_name,
 					token_symbol,
-					// NOTE: This value is for now intentionally hardcoded to 1 since that's the only available option.
-					// We will design a dynamic approach going forward where this value can be set on a per-tranche-token
-					// basis on storage.
-					restriction_set: 1
+					// NOTE: This value is for now intentionally hardcoded to 1 since that's the
+					// only available option. We will design a dynamic approach going forward where
+					// this value can be set on a per-tranche-token basis on storage.
+					restriction_set: 1,
 				},
 			)?;
 

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -426,6 +426,10 @@ pub mod pallet {
 					decimals: metadata.decimals.saturated_into(),
 					token_name,
 					token_symbol,
+					// NOTE: This value is for now intentionally hardcoded to 1 since that's the only available option.
+					// We will design a dynamic approach going forward where this value can be set on a per-tranche-token
+					// basis on storage.
+					restriction_set: 1
 				},
 			)?;
 

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -71,6 +71,9 @@ where
 		token_name: [u8; TOKEN_NAME_SIZE],
 		token_symbol: [u8; TOKEN_SYMBOL_SIZE],
 		decimals: u8,
+		/// The RestrictionManager implementation to be used for this tranche token on the domain it
+		/// will be added and subsequently deployed in.
+		restriction_set: u8,
 	},
 	/// Update the price of a tranche token on the target domain.
 	///
@@ -436,6 +439,7 @@ impl<
 				token_name,
 				token_symbol,
 				decimals,
+				restriction_set,
 			} => encoded_message(
 				self.call_type(),
 				vec![
@@ -444,6 +448,7 @@ impl<
 					token_name.encode(),
 					token_symbol.encode(),
 					decimals.encode(),
+					restriction_set.encode(),
 				],
 			),
 			Message::UpdateTrancheTokenPrice {
@@ -749,6 +754,7 @@ impl<
 				token_name: decode::<TOKEN_NAME_SIZE, _, _>(input)?,
 				token_symbol: decode::<TOKEN_SYMBOL_SIZE, _, _>(input)?,
 				decimals: decode::<1, _, _>(input)?,
+				restriction_set: decode::<1, _, _>(input)?,
 			}),
 			5 => Ok(Self::UpdateTrancheTokenPrice {
 				pool_id: decode_be_bytes::<8, _, _>(input)?,
@@ -1017,8 +1023,9 @@ mod tests {
 				token_name: vec_to_fixed_array("Some Name".to_string().into_bytes()),
 				token_symbol: vec_to_fixed_array("SYMBOL".to_string().into_bytes()),
 				decimals: 15,
+				restriction_set: 1,
 			},
-			"040000000000000001811acd5b3f17c06841c7e41e9e04cb1b536f6d65204e616d65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000053594d424f4c00000000000000000000000000000000000000000000000000000f",
+			"040000000000000001811acd5b3f17c06841c7e41e9e04cb1b536f6d65204e616d65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000053594d424f4c00000000000000000000000000000000000000000000000000000f01",
 		)
 	}
 

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -71,8 +71,8 @@ where
 		token_name: [u8; TOKEN_NAME_SIZE],
 		token_symbol: [u8; TOKEN_SYMBOL_SIZE],
 		decimals: u8,
-		/// The RestrictionManager implementation to be used for this tranche token on the domain it
-		/// will be added and subsequently deployed in.
+		/// The RestrictionManager implementation to be used for this tranche
+		/// token on the domain it will be added and subsequently deployed in.
 		restriction_set: u8,
 	},
 	/// Update the price of a tranche token on the target domain.


### PR DESCRIPTION
# Description

When adding a tranche token to a LP-compatible domain, we now need to specify which implementation of the `RestrictionManager` we want to use on a per-tranche-token basis. For that, we add this new field that serves as an identifier that will be picked up on the destination accordingly.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
