### PR TITLE
Fix: Transfer debt

### DIFF
--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -401,14 +401,13 @@ impl<T: Config> ChangeGuard for Pallet<T> {
 	type PoolId = T::PoolId;
 
 	fn note(pool_id: Self::PoolId, change: Self::Change) -> Result<Self::ChangeId, DispatchError> {
+		// NOTE: Essentially, this key-generation allows to override previously
+		//       submitted changes, if they are identical.
+		let change_id: Self::ChangeId = T::Hashing::hash(&change.encode());
 		let noted_change = NotedPoolChange {
 			submitted_time: T::Time::now(),
 			change,
 		};
-
-		// NOTE: Essentially, this key-generation allows to override previously
-		//       submitted changes, if they are identical.
-		let change_id: Self::ChangeId = T::Hashing::hash(&change.encode());
 		NotedChange::<T>::insert(pool_id, change_id, noted_change.clone());
 
 		Self::deposit_event(Event::ProposedChange {

--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -406,7 +406,9 @@ impl<T: Config> ChangeGuard for Pallet<T> {
 			change,
 		};
 
-		let change_id: Self::ChangeId = T::Hashing::hash(&noted_change.encode());
+		// NOTE: Essentially, this key-generation allows to override previously
+		//       submitted changes, if they are identical.
+		let change_id: Self::ChangeId = T::Hashing::hash(&change.encode());
 		NotedChange::<T>::insert(pool_id, change_id, noted_change.clone());
 
 		Self::deposit_event(Event::ProposedChange {

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -2449,12 +2449,14 @@ mod changes {
 			let change = PoolChangeProposal::new([Requirement::DelayTime(2)]);
 			let change_id_3 = PoolSystem::note(DEFAULT_POOL_ID, change).unwrap();
 
-			// Same change but different moment;
+			// Same change but different moment so overwrites
 			util::advance_secs(1);
 			let change = PoolChangeProposal::new([Requirement::DelayTime(2)]);
 			let change_id_4 = PoolSystem::note(DEFAULT_POOL_ID, change).unwrap();
 
-			let ids = [change_id_1, change_id_2, change_id_3, change_id_4];
+			assert_eq!(change_id_4, change_id_3);
+
+			let ids = [change_id_1, change_id_2, change_id_3];
 			assert_eq!(BTreeSet::from(ids.clone()).len(), ids.len());
 		});
 	}

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -293,7 +293,7 @@ pub mod changes {
 					},
 				},
 				LoansChange::<T>::Policy(_) => vec![week, blocked],
-				LoansChange::<T>::TransferDebt(_, _, _, _) => vec![epoch, blocked],
+				LoansChange::<T>::TransferDebt(_, _, _, _) => vec![],
 			};
 
 			PoolChangeProposal::new(requirements)


### PR DESCRIPTION
# Description
Issuers need to have the possibility to transfer debt between loans without restrictions. In the future we might add restrictions back, but based on a per pool setup, so investors know for each pool what to expect.

Fixes issues that our issuers are having.

Furthermore, this change allows to deterministically derive a `ChangeId` for a given proposed change, as we exclude the time of submission from the hash. This means, that equal changes will overwrite past onces, but that is fine as it just means we are extending the time of execution for that change.

## Changes and Descriptions
* `ChangeId` now `Blake256(Change)`
* `Change::TransferDebt` has no restrictions

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
