### PR TITLE
fix: enable rocksdb for frontier backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,11 +3521,13 @@ source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-po
 dependencies = [
  "async-trait",
  "fp-storage",
+ "kvdb-rocksdb",
  "log",
  "parity-db",
  "parity-scale-codec 3.6.5",
  "parking_lot 0.12.1",
  "sc-client-db",
+ "smallvec",
  "sp-blockchain",
  "sp-core",
  "sp-database",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,7 +283,7 @@ url = "2.2.2"
 grandpa = { package = "sc-consensus-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", features = ["rocksdb"] }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
@@ -291,7 +291,7 @@ sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sc-network-sync = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
-sc-service = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", features = ["rocksdb"] }
 sc-sysinfo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
@@ -313,7 +313,7 @@ sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch 
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 
 # Cli specific
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", features = ["rocksdb"]}
 try-runtime-cli = { git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.43" }
 
 # Local dependencies
@@ -359,7 +359,7 @@ xcm = { git = "https://github.com/paritytech/polkadot", default-features = false
 
 # frontier
 fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.43" }
-fc-db = { git = "https://github.com/moonbeam-foundation/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.43" }
+fc-db = { git = "https://github.com/moonbeam-foundation/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.43", features = ["rocksdb"]}
 fc-mapping-sync = { git = "https://github.com/moonbeam-foundation/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.43" }
 fc-rpc = { git = "https://github.com/moonbeam-foundation/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.43" }
 fc-rpc-core = { git = "https://github.com/moonbeam-foundation/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.43" }
@@ -418,7 +418,6 @@ std = [
   "runtime-common/std",
   #"runtime-integration-tests/std",
   "sc-executor/std",
-  "sc-service/rocksdb",
   "serde/std",
   "serde/std",
   "sp-api/std",


### PR DESCRIPTION
# Description

Right now, our Substrate client supports `rocksdb, paritydb, auto` as database types. The frontier backend inherits the database type from that CLI. When [Frontier upgraded to Polkadot v0.9.42](https://github.com/paritytech/frontier/pull/1054), the `rocksdb` feature was added to the `fc-db` crate. Since we did not opt into that feature, our client is throwing when attempting to use `rocksdb` as db.

* Adds `rocksdb` feature to `sc-cli`, `sc-service`, `fc-db` and `frame-benchmarking-cli` crates
* Fixes issue of unsupported rocksdb for frontier backend
```
Error: Service(Other("Supported db sources: `auto` | `rocksdb` | `paritydb`"))
```

## How to test

```bash
cargo run -r \
  --chain="development" \
  --tmp \
  --parachain-id="2000" \
  --wasm-execution=compiled \
  --execution=wasm \
  --rpc-external \
  --rpc-cors all \
  --rpc-methods=Unsafe \
  --port=30366 \
  --rpc-port=9947 \
  --database=rocksdb \
  -- \
  --wasm-execution=compiled \
  --execution=wasm \
  --chain="./res/rococo-local.json"
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
