### PR TITLE
Fees API Improvement

### DIFF
--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -435,6 +435,13 @@ pub mod fees {
 			fee: Fee<Self::Balance, Self::FeeKey>,
 		) -> DispatchResult;
 	}
+
+	/// Trait to pay fees
+	/// This trait can be used by pallet to just pay fees without worring about
+	/// the value or where the fee goes.
+	pub trait PayFee<AccountId> {
+		fn pay_for(who: &AccountId) -> DispatchResult;
+	}
 }
 
 /// Trait to determine whether a sending account and currency have a

--- a/libs/traits/src/lib.rs
+++ b/libs/traits/src/lib.rs
@@ -440,7 +440,7 @@ pub mod fees {
 	/// This trait can be used by pallet to just pay fees without worring about
 	/// the value or where the fee goes.
 	pub trait PayFee<AccountId> {
-		fn pay_for(who: &AccountId) -> DispatchResult;
+		fn pay(who: &AccountId) -> DispatchResult;
 	}
 }
 

--- a/libs/types/src/fee_keys.rs
+++ b/libs/types/src/fee_keys.rs
@@ -54,3 +54,5 @@ impl Default for FeeKey {
 		FeeKey::AnchorsCommit
 	}
 }
+
+pub type Fee = cfg_traits::fees::Fee<cfg_primitives::Balance, FeeKey>;

--- a/runtime/common/src/fees.rs
+++ b/runtime/common/src/fees.rs
@@ -1,9 +1,13 @@
 use cfg_primitives::{
 	constants::{CENTI_CFG, TREASURY_FEE_RATIO},
 	types::Balance,
+	AccountId,
 };
+use cfg_traits::fees::{Fee, Fees, PayFee};
+use cfg_types::fee_keys::FeeKey;
 use frame_support::{
-	traits::{Currency, Imbalance, OnUnbalanced},
+	dispatch::DispatchResult,
+	traits::{Currency, Get, Imbalance, OnUnbalanced},
 	weights::{
 		constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients,
 		WeightToFeePolynomial,
@@ -79,6 +83,39 @@ impl WeightToFeePolynomial for WeightToFee {
 			coeff_frac: Perbill::from_rational(p % q, q),
 			coeff_integer: p / q,
 		})
+	}
+}
+
+pub struct FeeToTreasury<F, V>(sp_std::marker::PhantomData<(F, V)>);
+impl<
+		F: Fees<AccountId = AccountId, Balance = Balance, FeeKey = FeeKey>,
+		V: Get<Fee<Balance, FeeKey>>,
+	> PayFee<AccountId> for FeeToTreasury<F, V>
+{
+	fn pay_for(who: &AccountId) -> DispatchResult {
+		F::fee_to_treasury(who, V::get())
+	}
+}
+
+pub struct FeeToAuthor<F, V>(sp_std::marker::PhantomData<(F, V)>);
+impl<
+		F: Fees<AccountId = AccountId, Balance = Balance, FeeKey = FeeKey>,
+		V: Get<Fee<Balance, FeeKey>>,
+	> PayFee<AccountId> for FeeToAuthor<F, V>
+{
+	fn pay_for(who: &AccountId) -> DispatchResult {
+		F::fee_to_author(who, V::get())
+	}
+}
+
+pub struct FeeToBurn<F, V>(sp_std::marker::PhantomData<(F, V)>);
+impl<
+		F: Fees<AccountId = AccountId, Balance = Balance, FeeKey = FeeKey>,
+		V: Get<Fee<Balance, FeeKey>>,
+	> PayFee<AccountId> for FeeToBurn<F, V>
+{
+	fn pay_for(who: &AccountId) -> DispatchResult {
+		F::fee_to_burn(who, V::get())
 	}
 }
 

--- a/runtime/common/src/fees.rs
+++ b/runtime/common/src/fees.rs
@@ -92,7 +92,7 @@ impl<
 		V: Get<Fee<Balance, FeeKey>>,
 	> PayFee<AccountId> for FeeToTreasury<F, V>
 {
-	fn pay_for(who: &AccountId) -> DispatchResult {
+	fn pay(who: &AccountId) -> DispatchResult {
 		F::fee_to_treasury(who, V::get())
 	}
 }
@@ -103,7 +103,7 @@ impl<
 		V: Get<Fee<Balance, FeeKey>>,
 	> PayFee<AccountId> for FeeToAuthor<F, V>
 {
-	fn pay_for(who: &AccountId) -> DispatchResult {
+	fn pay(who: &AccountId) -> DispatchResult {
 		F::fee_to_author(who, V::get())
 	}
 }
@@ -114,7 +114,7 @@ impl<
 		V: Get<Fee<Balance, FeeKey>>,
 	> PayFee<AccountId> for FeeToBurn<F, V>
 {
-	fn pay_for(who: &AccountId) -> DispatchResult {
+	fn pay(who: &AccountId) -> DispatchResult {
 		F::fee_to_burn(who, V::get())
 	}
 }


### PR DESCRIPTION
# Description

## Problem

The current API provided by the traits around `pallet_fees` to handle fees has two negative points:
1. In order to use it in a pallet you need to use at least 2 associated types in the `Config` trait. i.e:
  ```rust
  /// Entity used to pay fees
  type Fees: Fees<AccountId = Self::AccountId>;

  /// Key used to get the fee value.
  type ActionAFeeKey: Get<<Self::Fees as Fees>::FeeKey>;
  ```
2. The knowledge of how to consume that fee is in the pallet when the pallet should not be aware of it. This should be a runtime concern.
  ```rust
  /// Inside the pallet we decide when we should not do that
  T::Fees::fee_to_treasury(&who, Fee::Key(T::ActionAFeeKey))?;
  // or
  T::Fees::fee_to_author(&who, Fee::Balance(T::ActionAFeeValue))?;
  ```
  
## Solution

We can fix these 2 points by coding the whole fee action in different types (see PR code) under a new trait `PayFee`.

Pallet:
```rust
// In Config trait:
type ActionAPayFee: PayFee<T::Account>;

// When use it:
T::ActionAPayFee::pay_for(&who)?;
```

Runtime:
```rust
parameter_types! {
    pub const ActionAFee: Fee = Fee::Balance(10 * CFG);
}

impl pallet_example::Config for Runtime {
    // We set in one line:
    //   - How the fee is handled
    //   - The value of the fee
    type ActionAPayFee = FeeToTreasury<Fees, ActionAFee>;
    // ...
}
```