### PR TITLE
fix: docker-compose

### DIFF
--- a/docker/docker-compose-local-chain.yml
+++ b/docker/docker-compose-local-chain.yml
@@ -3,6 +3,7 @@ services:
   cc_alice:
     profiles:
       - default
+    user: root
     container_name: cc-alice
     image: "centrifugeio/centrifuge-chain:${CC_DOCKER_TAG:-test-main-latest}"
     platform: "linux/x86_64"
@@ -11,7 +12,7 @@ services:
       - "9946:9933"
     volumes:
       - type: bind
-        source: ./res/rococo-local.json
+        source: ../res/rococo-local.json
         target: /chainspec.json
         read_only: true
     command: >
@@ -26,7 +27,7 @@ services:
       --rpc-cors all
       --rpc-methods=Unsafe
       --log="main,info,xcm=trace,xcm-executor=trace"
-      --database=auto
+      --database=rocksdb
       -- 
       --wasm-execution=compiled 
       --execution=wasm
@@ -45,7 +46,7 @@ services:
       - "9946:9944"
     volumes:
       - type: bind
-        source: ./res/rococo-local.json
+        source: ../res/rococo-local.json
         target: /chainspec.json
         read_only: true
     command: >

--- a/docker/docker-compose-local-relay.yml
+++ b/docker/docker-compose-local-relay.yml
@@ -11,7 +11,7 @@ services:
       - "9944:9933"
     volumes:
       - type: bind
-        source: ./res/rococo-local.json
+        source: ../res/rococo-local.json
         target: /chainspec.json
         read_only: true
     command: >
@@ -37,7 +37,7 @@ services:
       - "9945:9933"
     volumes:
       - type: bind
-        source: ./res/rococo-local.json
+        source: ../res/rococo-local.json
         target: /chainspec.json
         read_only: true
     command: >

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -21,22 +21,22 @@ install-toolchain)
 
 start-relay-chain)
   echo "Starting local relay chain with Alice and Bob..."
-  docker-compose -f ./docker-compose-local-relay.yml up --remove-orphans -d
+  docker-compose -f ./docker/docker-compose-local-relay.yml up --remove-orphans -d
   ;;
 
 stop-relay-chain)
   echo "Stopping relay chain..."
-  docker-compose -f ./docker-compose-local-relay.yml down
+  docker-compose -f ./docker/docker-compose-local-relay.yml down
   ;;
 
 start-parachain-docker)
   echo "Starting local parachain with Alice..."
-  docker-compose -f ./docker-compose-local-chain.yml --profile=$cc_docker_profile up -d
+  docker-compose -f ./docker/docker-compose-local-chain.yml --profile=$cc_docker_profile up -d
   ;;
 
 stop-parachain-docker)
   echo "Stopping local parachain with Alice..."
-  docker-compose -f ./docker-compose-local-chain.yml --profile=$cc_docker_profile down
+  docker-compose -f ./docker/docker-compose-local-chain.yml --profile=$cc_docker_profile down
   ;;
 
 start-parachain)
@@ -64,7 +64,7 @@ start-parachain)
     --rpc-cors all \
     --rpc-methods=Unsafe \
     --log="main,info" \
-    --database=auto
+    --database=rocksdb
   ;;
 
 onboard-parachain)


### PR DESCRIPTION
# Description

* Fixes `docker-compose` files and usage after moving files and updating Dockerfile in #1611 
* Runs docker-compose containers as `root` user

## How to test locally

```
PARA_DOCKER_IMAGE_TAG=latestmain-8b9c8f0-23-11-23 PARA_DOCKER_PROFILE=default DOCKER_ONBOARD=true PARA_CHAIN_SPEC=development ./scripts/onboard.sh
```

onboard.shj
```
cc_docker_image_tag="${PARA_DOCKER_IMAGE_TAG:-test-main-latest}"
parachain_spec="${PARA_CHAIN_SPEC:-centrifuge-local}"
parachain_method="${PARA_METHOD:-docker}"

export PARA_DOCKER_IMAGE_TAG=$cc_docker_image_tag
export CC_DOCKER_TAG=$cc_docker_image_tag
export PARA_CHAIN_SPEC=$parachain_spec
if [[ $parachain_method == "docker" ]];
then
  export DOCKER_ONBOARD=true
fi

./scripts/init.sh stop-relay-chain
./scripts/init.sh start-relay-chain
if [[ $parachain_method == "docker" ]];
then
  ./scripts/init.sh start-parachain-docker
else
  sleep 10
  ./scripts/init.sh start-parachain
fi
./scripts/init.sh onboard-parachain

```

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
