### PR TITLE
Docker: solve polkadot relay folder renaming and other small fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 docker
 !docker/scripts
 README.md
+flake*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 **/target/
 .github/
 !scripts/install_toolchain.sh
-docker-compos
 .gitignore
 docker
 !docker/scripts

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@
 docker-compos
 .gitignore
 docker
+!docker/scripts
 README.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -41,7 +41,6 @@ jobs:
           tags: |
             type=semver,pattern={{raw}},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
             type=semver,value=latest,enable=${{ github.event_name == 'release' }}
-            type=edge,event=pr,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
             type=ref,event=tag,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
             type=ref,event=pr,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}PR
             type=ref,event=branch,prefix=${{ matrix.target == 'test' && 'test-' || '' }},suffix=-{{sha}}-${{ env.NOW }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -59,8 +59,7 @@ jobs:
           file: ./docker/centrifuge-chain/Dockerfile
           build-args: |
             FEATURES=${{ matrix.target == 'test' && 'fast-runtime' || '' }}
-          # push: ${{ github.event_name != 'pull_request' }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           # Cache options:
           # https://docs.docker.com/build/ci/github-actions/cache/

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,17 +22,6 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4
         with:
           fetch-depth: 0
-      - name: Free space
-      # https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          # sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-
-      - name: check available docker space
-        run: |
-          docker volume ls
-          df -h
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 #v3

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -70,7 +70,8 @@ jobs:
           file: ./docker/centrifuge-chain/Dockerfile
           build-args: |
             FEATURES=${{ matrix.target == 'test' && 'fast-runtime' || '' }}
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           # Cache options:
           # https://docs.docker.com/build/ci/github-actions/cache/

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -40,10 +40,10 @@ jobs:
           images: centrifugeio/centrifuge-chain
           tags: |
             type=semver,pattern={{raw}},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
-            type=edge,event=pr,suffix={{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
-            type=ref,event=tag,suffix={{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
-            type=ref,event=pr,suffix={{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
-            type=ref,event=branch,prefix=${{ matrix.target == 'test' && 'test-' || '' }}-{{branch}},suffix={{sha}}-${{ env.NOW }}
+            type=edge,event=pr,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
+            type=ref,event=tag,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
+            type=ref,event=pr,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}PR
+            type=ref,event=branch,prefix=${{ matrix.target == 'test' && 'test-' || '' }},suffix=-{{sha}}-${{ env.NOW }}
 
       - name: Configure GHA cache
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v6

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -40,7 +40,7 @@ jobs:
           images: centrifugeio/centrifuge-chain
           tags: |
             type=semver,pattern={{raw}},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
-            type=semver,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=ref,event=tag,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
             type=ref,event=pr,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}PR
             type=ref,event=branch,prefix=${{ matrix.target == 'test' && 'test-' || '' }},suffix=-{{sha}}-${{ env.NOW }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -40,6 +40,7 @@ jobs:
           images: centrifugeio/centrifuge-chain
           tags: |
             type=semver,pattern={{raw}},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
+            type=semver,value=latest,enable=${{ github.event_name == 'release' }}
             type=edge,event=pr,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
             type=ref,event=tag,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}
             type=ref,event=pr,suffix=-{{sha}}-${{ env.NOW }},prefix=${{ matrix.target == 'test' && 'test-' || '' }}PR

--- a/docker/centrifuge-chain/Dockerfile
+++ b/docker/centrifuge-chain/Dockerfile
@@ -29,12 +29,11 @@ FROM --platform=linux/amd64 docker.io/paritytech/ci-linux:production as builder
 # happen to make sure the binary is what we want.
 FROM --platform=linux/amd64 docker.io/library/ubuntu:jammy
 
-	LABEL io.centrifuge.image.authors="guillermo@k-f.co" \
+	LABEL io.centrifuge.image.authors="protocol@k-f.co" \
 		io.centrifuge.image.vendor="Centrifuge" \
 		io.centrifuge.image.title="centrifugeio/centrifuge-chain" \
-		io.centrifuge.image.description="Centrifuge, the layer 1 of RWA. This is the official Centrifuge image with an injected binary." \
+		io.centrifuge.image.description="Centrifuge, the layer 1 of RWA. This is the official Centrifuge (para)chain image" \
 		io.centrifuge.image.source="https://github.com/centrifuge/centrifuge-chain/blob/main/docker/centrifuge-chain/Dockerfile" \
-		# io.centrifuge.image.revision="${VCS_REF}" \
 		io.centrifuge.image.created="${BUILD_DATE}"
 
 	# Add chain resources to image
@@ -53,19 +52,19 @@ FROM --platform=linux/amd64 docker.io/library/ubuntu:jammy
 		chown -R centrifuge:centrifuge /usr/local/bin/centrifuge-chain && \
 		chown -R centrifuge:centrifuge /centrifuge/
 
-COPY ./docker/scripts/entrypoint.sh /centrifuge/entrypoint.sh
-RUN chown -R centrifuge:centrifuge /centrifuge/entrypoint.sh && chmod +x /centrifuge/entrypoint.sh
+	COPY ./docker/scripts/entrypoint.sh /centrifuge/entrypoint.sh
+	RUN chown -R centrifuge:centrifuge /centrifuge/entrypoint.sh && chmod +x /centrifuge/entrypoint.sh
 
 # Running as an non-root is a good security practice
 # in some cases the container can be forced to run as root overriding the next line
 # but by default we want to enforce this.
 USER centrifuge
+
 # checks
 RUN ldd /usr/local/bin/centrifuge-chain && \
 	/usr/local/bin/centrifuge-chain --version
-ENV RUST_BACKTRACE 1
+
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
-
 ENTRYPOINT ["/centrifuge/entrypoint.sh"]
 CMD ["--help"]

--- a/docker/centrifuge-chain/Dockerfile
+++ b/docker/centrifuge-chain/Dockerfile
@@ -16,7 +16,7 @@ FROM --platform=linux/amd64 docker.io/paritytech/ci-linux:production as builder
 	ARG RUSTC_WRAPPER=''
 	ARG SCCACHE_GHA_ENABLED="false"
 
-	COPY . centrifuge-chain
+	COPY . /centrifuge-chain
 	WORKDIR /centrifuge-chain
 	ARG FEATURES=""
 	RUN	FEATURES=$(echo ${FEATURES} | tr -d '"') \

--- a/docker/centrifuge-chain/Dockerfile
+++ b/docker/centrifuge-chain/Dockerfile
@@ -64,7 +64,7 @@ ENV RUST_BACKTRACE 1
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
 COPY ./docker/scripts/entrypoint.sh /centrifuge/entrypoint.sh
+RUN chown -R centrifuge:centrifuge /centrifuge/entrypoint.sh && chmod +x /centrifuge/entrypoint.sh
 
-# ENTRYPOINT ["/usr/local/bin/centrifuge-chain"]
 ENTRYPOINT ["/centrifuge/entrypoint.sh"]
 CMD ["--help"]

--- a/docker/centrifuge-chain/Dockerfile
+++ b/docker/centrifuge-chain/Dockerfile
@@ -53,6 +53,9 @@ FROM --platform=linux/amd64 docker.io/library/ubuntu:jammy
 		chown -R centrifuge:centrifuge /usr/local/bin/centrifuge-chain && \
 		chown -R centrifuge:centrifuge /centrifuge/
 
+COPY ./docker/scripts/entrypoint.sh /centrifuge/entrypoint.sh
+RUN chown -R centrifuge:centrifuge /centrifuge/entrypoint.sh && chmod +x /centrifuge/entrypoint.sh
+
 # Running as an non-root is a good security practice
 # in some cases the container can be forced to run as root overriding the next line
 # but by default we want to enforce this.
@@ -63,8 +66,6 @@ RUN ldd /usr/local/bin/centrifuge-chain && \
 ENV RUST_BACKTRACE 1
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
-COPY ./docker/scripts/entrypoint.sh /centrifuge/entrypoint.sh
-RUN chown -R centrifuge:centrifuge /centrifuge/entrypoint.sh && chmod +x /centrifuge/entrypoint.sh
 
 ENTRYPOINT ["/centrifuge/entrypoint.sh"]
 CMD ["--help"]

--- a/docker/centrifuge-chain/Dockerfile
+++ b/docker/centrifuge-chain/Dockerfile
@@ -1,23 +1,11 @@
 # Inspired by
 # https://github.com/paritytech/polkadot-sdk/blob/master/docker/dockerfiles/polkadot/polkadot_injected_release.Dockerfile
 
-FROM --platform=linux/amd64 docker.io/library/rust:bookworm as builder
+FROM --platform=linux/amd64 docker.io/paritytech/ci-linux:production as builder
   # Defaults
 	ENV RUST_BACKTRACE 1
-	ENV DEBIAN_FRONTEND=noninteractive
-
-	RUN apt-get update && \
-		# apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
-		apt-get install -y \
-			cmake \
-			pkg-config \
-			libssl-dev \
-			git \
-			clang \
-			libclang-dev \
-			protobuf-compiler \
-			curl
-
+  
+  # RustUp
 	COPY ./scripts scripts
 	COPY rust-toolchain.toml ./
 	# RUN rustup update && rustup default
@@ -32,7 +20,7 @@ FROM --platform=linux/amd64 docker.io/library/rust:bookworm as builder
 	WORKDIR /centrifuge-chain
 	ARG FEATURES=""
 	RUN	FEATURES=$(echo ${FEATURES} | tr -d '"') \
-		cargo build "--release" --features=${FEATURES}
+		cargo build --locked --release --features=${FEATURES}
 
 
 # ===== SECOND STAGE ======
@@ -75,6 +63,8 @@ RUN ldd /usr/local/bin/centrifuge-chain && \
 ENV RUST_BACKTRACE 1
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
+COPY docker/scripts/entrypoint.sh /centrifuge/entrypoint.sh
 
-ENTRYPOINT ["/usr/local/bin/centrifuge-chain"]
+# ENTRYPOINT ["/usr/local/bin/centrifuge-chain"]
+ENTRYPOINT ["/centrifuge/entrypoint.sh"]
 CMD ["--help"]

--- a/docker/centrifuge-chain/Dockerfile
+++ b/docker/centrifuge-chain/Dockerfile
@@ -63,7 +63,7 @@ RUN ldd /usr/local/bin/centrifuge-chain && \
 ENV RUST_BACKTRACE 1
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
-COPY docker/scripts/entrypoint.sh /centrifuge/entrypoint.sh
+COPY ./docker/scripts/entrypoint.sh /centrifuge/entrypoint.sh
 
 # ENTRYPOINT ["/usr/local/bin/centrifuge-chain"]
 ENTRYPOINT ["/centrifuge/entrypoint.sh"]

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ -d "/data/relay-chain" ]
+then
+    echo "Detected relay-chain folder. Renaming to polkadot..."
+    mv /data/relay-chain /data/polkadot
+fi
+
+centrifuge-chain "$@"

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -7,7 +7,7 @@ fi
 
 # Fix to account for Polkadot's renaming of their DB folder from
 # relay-chain to polkadot. Probably not needed after all nodes are upgraded
-# beyond Polkadot 0.93.z
+# beyond Polkadot 0.9.42+
 BASE_PATH=""
 for ARG in "$@"
 do

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -1,8 +1,52 @@
 #!/bin/bash
-if [ -d "/data/relay-chain" ]
-then
-    echo "Detected relay-chain folder. Renaming to polkadot..."
-    mv /data/relay-chain /data/polkadot
+if [ "$1" == "--help" ]; then
+    echo "No arguments detected, printing help and exiting..."
+    centrifuge-chain "$@"
+    exit 0
 fi
 
+# Fix to account for Polkadot's renaming of their DB folder from
+# relay-chain to polkadot. Probably not needed after all nodes are upgraded
+# beyond Polkadot 0.93.z
+BASE_PATH=""
+for ARG in "$@"
+do
+    if [[ $ARG == --base-path=* ]]; then
+        BASE_PATH="${ARG#*=}"
+        break
+    fi
+done
+if [ -z "$BASE_PATH" ]
+then
+    BASE_PATH="/data"
+fi
+
+if [ -d "${BASE_PATH}/relay-chain" ]
+then
+    relay_chain_size=$(du -s "${BASE_PATH}/relay-chain" | cut -f1)
+
+    echo "Detected relay-chain folder. Renaming to polkadot..."
+    if [ -d "${BASE_PATH}/polkadot" ]
+    then
+        if [ -d "${BASE_PATH}/polkadot" ]
+        then
+            polkadot_size=$(du -s "${BASE_PATH}/polkadot" | cut -f1)
+            if [ "$polkadot_size" -ge "$relay_chain_size" ]
+            then
+                echo -e "\e[1;31m${BASE_PATH}/polkadot\e[0m folder is larger than or equal to \e[1;31m${BASE_PATH}/relay-chain\e[0m"
+                echo "This is unexpected. Manual check required."
+                echo "HINT: Delete one of the two folders to preserve that DB"
+                exit 1
+            else
+                echo "${BASE_PATH}/polkadot is smaller than ${BASE_PATH}/relay-chain"
+                echo "Creating backup of ${BASE_PATH}/polkadot before replacing it..."
+                mv "${BASE_PATH}/polkadot" "${BASE_PATH}/polkadot.bak"
+                rm -rf "${BASE_PATH}/polkadot"            
+            fi
+        fi    
+    fi
+    mv -f "${BASE_PATH}/relay-chain" "${BASE_PATH}/polkadot"
+fi
+
+# Start the chain
 centrifuge-chain "$@"


### PR DESCRIPTION
Includes:
- Polkadot relays now expect their folder to be named "polkadot" rather than "relay-chain". The new docker container is made aware of this and will rename the folder if needed.
- Dockerfile build based on Parity "rust-ready" production base image
- More lean Dockerfile