### PR TITLE
Fast runtime change handle by pool

### DIFF
--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -438,7 +438,11 @@ impl<T: Config> ChangeGuard for Pallet<T> {
 			allowed &= match requirement {
 				Requirement::NextEpoch => submitted_time < pool.epoch.last_closed,
 				Requirement::DelayTime(secs) => {
-					T::Time::now().saturating_sub(submitted_time) >= secs as u64
+					let secs = match T::FastChanges::get() {
+						Some(fixed_secs) => fixed_secs,
+						None => secs as u64,
+					};
+					T::Time::now().saturating_sub(submitted_time) >= secs
 				}
 				Requirement::BlockedByLockedRedemptions => true, // TODO: #1407
 			}

--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -358,6 +358,11 @@ pub mod pallet {
 		#[pallet::constant]
 		type PoolDeposit: Get<Self::Balance>;
 
+		/// Enable fast runtime changes, overwriting the waiting time with a
+		/// fixed value. `None` value means the normal behaviour.
+		/// Used for testnets.
+		type FastChanges: Get<Option<Seconds>>;
+
 		/// The origin permitted to create pools
 		type PoolCreateOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 

--- a/pallets/pool-system/src/mock.rs
+++ b/pallets/pool-system/src/mock.rs
@@ -318,6 +318,8 @@ parameter_types! {
 	pub const MaxTokenSymbolLength: u32 = 32;
 
 	pub const PoolDeposit: Balance = 1 * CURRENCY;
+
+	pub const NoFastChanges: Option<u64> = None;
 }
 
 impl Config for Runtime {
@@ -330,6 +332,7 @@ impl Config for Runtime {
 	type DefaultMaxNAVAge = DefaultMaxNAVAge;
 	type DefaultMinEpochTime = DefaultMinEpochTime;
 	type EpochId = PoolEpochId;
+	type FastChanges = NoFastChanges;
 	type Investments = Investments;
 	type MaxNAVAgeUpperBound = MaxNAVAgeUpperBound;
 	type MaxTokenNameLength = MaxTokenNameLength;

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1494,6 +1494,7 @@ impl pallet_pool_system::Config for Runtime {
 	type DefaultMaxNAVAge = DefaultMaxNAVAge;
 	type DefaultMinEpochTime = DefaultMinEpochTime;
 	type EpochId = PoolEpochId;
+	type FastChanges = runtime_common::changes::NoFastChanges;
 	type Investments = Investments;
 	type MaxNAVAgeUpperBound = MaxNAVAgeUpperBound;
 	type MaxTokenNameLength = MaxTrancheNameLengthBytes;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1490,6 +1490,7 @@ impl pallet_pool_system::Config for Runtime {
 	type DefaultMaxNAVAge = DefaultMaxNAVAge;
 	type DefaultMinEpochTime = DefaultMinEpochTime;
 	type EpochId = PoolEpochId;
+	type FastChanges = runtime_common::changes::NoFastChanges;
 	type Investments = Investments;
 	type MaxNAVAgeUpperBound = MaxNAVAgeUpperBound;
 	type MaxTokenNameLength = MaxTrancheNameLengthBytes;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -242,43 +242,9 @@ pub mod changes {
 		}
 	}
 
-	pub mod fast {
-		use pallet_pool_system::pool_types::changes::Requirement;
-
-		use super::*;
-		const SECONDS_PER_WEEK: u32 = 60;
-
-		#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-		pub struct RuntimeChange<T: pallet_loans::Config>(super::RuntimeChange<T>);
-
-		impl<T: pallet_loans::Config> From<RuntimeChange<T>> for PoolChangeProposal {
-			fn from(runtime_change: RuntimeChange<T>) -> Self {
-				PoolChangeProposal::new(
-					PoolChangeProposal::from(runtime_change.0)
-						.requirements()
-						.map(|req| match req {
-							Requirement::DelayTime(_) => Requirement::DelayTime(SECONDS_PER_WEEK),
-							req => req,
-						}),
-				)
-			}
-		}
-
-		/// Used for building CfgChanges in pallet-loans
-		impl<T: pallet_loans::Config> From<LoansChange<T>> for RuntimeChange<T> {
-			fn from(loan_change: LoansChange<T>) -> RuntimeChange<T> {
-				Self(loan_change.into())
-			}
-		}
-
-		/// Used for recovering LoanChange in pallet-loans
-		impl<T: pallet_loans::Config> TryInto<LoansChange<T>> for RuntimeChange<T> {
-			type Error = DispatchError;
-
-			fn try_into(self) -> Result<LoansChange<T>, DispatchError> {
-				self.0.try_into()
-			}
-		}
+	frame_support::parameter_types! {
+		pub const FastChanges: Option<u64> = Some(60); // 1 min
+		pub const NoFastChanges: Option<u64> = None;
 	}
 }
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1054,6 +1054,7 @@ impl pallet_pool_system::Config for Runtime {
 	type DefaultMaxNAVAge = DefaultMaxNAVAge;
 	type DefaultMinEpochTime = DefaultMinEpochTime;
 	type EpochId = PoolEpochId;
+	type FastChanges = runtime_common::changes::FastChanges;
 	type Investments = Investments;
 	type MaxNAVAgeUpperBound = MaxNAVAgeUpperBound;
 	type MaxTokenNameLength = MaxTrancheNameLengthBytes;
@@ -1071,7 +1072,7 @@ impl pallet_pool_system::Config for Runtime {
 	type PoolDeposit = PoolDeposit;
 	type PoolId = PoolId;
 	type Rate = Rate;
-	type RuntimeChange = runtime_common::changes::fast::RuntimeChange<Runtime>;
+	type RuntimeChange = runtime_common::changes::RuntimeChange<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;
@@ -1385,7 +1386,7 @@ impl pallet_loans::Config for Runtime {
 	type PriceRegistry = PriceCollector;
 	type Quantity = Quantity;
 	type Rate = Rate;
-	type RuntimeChange = runtime_common::changes::fast::RuntimeChange<Runtime>;
+	type RuntimeChange = runtime_common::changes::RuntimeChange<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type WeightInfo = weights::pallet_loans::WeightInfo<Self>;


### PR DESCRIPTION
# Description

The fast version of `RuntimeChange` exists to avoid waiting a week in testnets to make changes through the pool. Although the correct solution works, it implies a lot of boilerplate each time a new `Change` is added to the system. The "hack" should be handled just at one point of the process instead of for each change. 

This PR moves the action to the pool system under a new config type.

**WARNING**: This PR modifies the `RuntimeChange` type used in `development`, so this would require migration or living with it. It only affects to `development`.