### PR TITLE
feat: cash valuation method

### DIFF
--- a/libs/types/src/lib.rs
+++ b/libs/types/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::unit_arg)]
 
 //! Common-types of the Centrifuge chain.
+
 pub mod adjustments;
 pub mod consts;
 pub mod domain_address;

--- a/pallets/loans/docs/types.md
+++ b/pallets/loans/docs/types.md
@@ -86,7 +86,8 @@ package valuation {
 
     enum ValuationMethod {
         DiscountedCashFlows: DiscountedCashFlows
-        OutstandingDebt
+        OutstandingDebt,
+        Cash
     }
 
     ValuationMethod *--> DiscountedCashFlows

--- a/pallets/loans/src/entities/pricing/internal.rs
+++ b/pallets/loans/src/entities/pricing/internal.rs
@@ -99,7 +99,7 @@ impl<T: Config> InternalActivePricing<T> {
 					origination_date,
 				)?)
 			}
-			ValuationMethod::OutstandingDebt => Ok(debt),
+			ValuationMethod::OutstandingDebt | ValuationMethod::Cash => Ok(debt),
 		}
 	}
 

--- a/pallets/loans/src/types/valuation.rs
+++ b/pallets/loans/src/types/valuation.rs
@@ -106,6 +106,10 @@ pub enum ValuationMethod<Rate> {
 	DiscountedCashFlow(DiscountedCashFlow<Rate>),
 	/// Outstanding debt valuation
 	OutstandingDebt,
+	/// Equal to OutstandingDebt but signals
+	/// that the given loan is i.e. an account
+	/// holding cash
+	Cash,
 }
 
 impl<Rate> ValuationMethod<Rate>
@@ -115,7 +119,7 @@ where
 	pub fn is_valid(&self) -> bool {
 		match self {
 			ValuationMethod::DiscountedCashFlow(dcf) => dcf.discount_rate.per_year() <= One::one(),
-			ValuationMethod::OutstandingDebt => true,
+			ValuationMethod::OutstandingDebt | ValuationMethod::Cash => true,
 		}
 	}
 }


### PR DESCRIPTION
# Description
Currently, off-on-ramping on-chain takes a lot of time. Hence, we want an intermediate cash-position-loan that represents off-chain cash positions taken from a pool. I.e. an account that we use for bookkeeping. 

## Changes and Descriptions
In order to reflect that non-interest bearing asset as a pure off-chain cash position this PR adds a `ValuationMethod::Cash` which is just an alias for `ValuationMethod::OutstandingDebt`.


# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
