### PR TITLE
Fix benchmark issue in development

### DIFF
--- a/runtime/common/src/changes.rs
+++ b/runtime/common/src/changes.rs
@@ -65,15 +65,20 @@ pub struct FastDelay;
 
 impl<T: Changeable> From<RuntimeChange<T, FastDelay>> for PoolChangeProposal {
 	fn from(runtime_change: RuntimeChange<T, FastDelay>) -> Self {
-		let new_requirements = runtime_change
-			.requirement_list()
-			.into_iter()
-			.map(|req| match req {
-				Requirement::DelayTime(_) => Requirement::DelayTime(60), // 1 min
-				req => req,
-			});
+		if cfg!(feature = "runtime-benchmarks") {
+			PoolChangeProposal::new([])
+		} else {
+			let new_requirements =
+				runtime_change
+					.requirement_list()
+					.into_iter()
+					.map(|req| match req {
+						Requirement::DelayTime(_) => Requirement::DelayTime(60), // 1 min
+						req => req,
+					});
 
-		PoolChangeProposal::new(new_requirements)
+			PoolChangeProposal::new(new_requirements)
+		}
 	}
 }
 


### PR DESCRIPTION
The version of `RuntimeChange` with the `FastDelay` option was not the special case required for benchmarking

[slack thread](https://kflabs.slack.com/archives/C04GJQAM9P0/p1701440777599979)