### PR TITLE
fix: build docker on draft release

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   release:
-    types: [unpublished] # GITHUB_REF == tag pushed with the release
+    types: [created] # GITHUB_REF == tag pushed with the release
   pull_request:
     paths:
       - ".github/workflows/build-docker.yml"


### PR DESCRIPTION
# Description

The docker build is intented to be triggered for 
* Pushes onto `main`
* Release drafts (saved without publishing or saved with publish independent of the release type)

Right now, the release part triggers on unpublishing an existing release.

## Release triggers

Aggregated from https://docs.github.com/en/webhooks/webhook-events-and-payloads#webhook-payload-object-35

> * published: a release, pre-release, or draft of a release is published
> * unpublished: a release or pre-release is deleted
> * created: a draft is saved, or a release or pre-release is published without previously being saved as a draft
> * edited: a release, pre-release, or draft release is edited
> * deleted: a release, pre-release, or draft release is deleted
> * prereleased: a pre-release is created
> * released: a release or draft of a release is published, or a pre-release is changed to a release

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
