### PR TITLE
Split concern for pool benchmark helper

### DIFF
--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -64,22 +64,6 @@ pub mod pallet {
 		) {
 			register_call!(move |(a, b, c)| f(a, b, c));
 		}
-
-		pub fn mock_bench_create_pool(f: impl Fn(T::PoolId, &T::AccountId) + 'static) {
-			register_call!(move |(a, b)| f(a, b));
-		}
-
-		pub fn mock_bench_investor_setup(
-			f: impl Fn(T::PoolId, T::AccountId, T::Balance) + 'static,
-		) {
-			register_call!(move |(a, b, c)| f(a, b, c));
-		}
-
-		pub fn mock_bench_default_investment_id(
-			f: impl Fn(T::PoolId) -> T::TrancheCurrency + 'static + 'static,
-		) {
-			register_call!(f);
-		}
 	}
 
 	impl<T: Config> PoolInspect<T::AccountId, T::CurrencyId> for Pallet<T> {
@@ -131,18 +115,14 @@ pub mod pallet {
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	impl<T: Config> cfg_traits::benchmarking::PoolBenchmarkHelper for Pallet<T> {
+	impl<T: Config> cfg_traits::benchmarking::FundedPoolBenchmarkHelper for Pallet<T> {
 		type AccountId = T::AccountId;
 		type Balance = T::Balance;
 		type PoolId = T::PoolId;
 
-		fn bench_create_pool(a: Self::PoolId, b: &Self::AccountId) {
-			execute_call!((a, b))
-		}
+		fn bench_create_funded_pool(a: Self::PoolId, b: &Self::AccountId) {}
 
-		fn bench_investor_setup(a: Self::PoolId, b: Self::AccountId, c: Self::Balance) {
-			execute_call!((a, b, c))
-		}
+		fn bench_investor_setup(a: Self::PoolId, b: Self::AccountId, c: Self::Balance) {}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
@@ -150,8 +130,6 @@ pub mod pallet {
 		type InvestmentId = T::TrancheCurrency;
 		type PoolId = T::PoolId;
 
-		fn bench_default_investment_id(a: Self::PoolId) -> Self::InvestmentId {
-			execute_call!(a)
-		}
+		fn bench_default_investment_id(a: Self::PoolId) -> Self::InvestmentId {}
 	}
 }

--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -120,9 +120,9 @@ pub mod pallet {
 		type Balance = T::Balance;
 		type PoolId = T::PoolId;
 
-		fn bench_create_funded_pool(a: Self::PoolId, b: &Self::AccountId) {}
+		fn bench_create_funded_pool(_: Self::PoolId, _: &Self::AccountId) {}
 
-		fn bench_investor_setup(a: Self::PoolId, b: Self::AccountId, c: Self::Balance) {}
+		fn bench_investor_setup(_: Self::PoolId, _: Self::AccountId, _: Self::Balance) {}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
@@ -130,6 +130,8 @@ pub mod pallet {
 		type InvestmentId = T::TrancheCurrency;
 		type PoolId = T::PoolId;
 
-		fn bench_default_investment_id(a: Self::PoolId) -> Self::InvestmentId {}
+		fn bench_default_investment_id(_: Self::PoolId) -> Self::InvestmentId {
+			unimplemented!();
+		}
 	}
 }

--- a/libs/test-utils/src/mocks/accountant.rs
+++ b/libs/test-utils/src/mocks/accountant.rs
@@ -172,7 +172,7 @@ macro_rules! impl_mock_accountant {
 				type Balance = $balance;
 				type PoolId = ();
 
-				fn bench_create_pool(_: Self::PoolId, _: &Self::AccountId) {}
+				fn bench_create_funded_pool(_: Self::PoolId, _: &Self::AccountId) {}
 
 				fn bench_investor_setup(_: Self::PoolId, _: Self::AccountId, _: Self::Balance) {}
 			}

--- a/libs/test-utils/src/mocks/accountant.rs
+++ b/libs/test-utils/src/mocks/accountant.rs
@@ -167,7 +167,7 @@ macro_rules! impl_mock_accountant {
 			}
 
 			#[cfg(feature = "runtime-benchmarks")]
-			impl<Tokens> cfg_traits::benchmarking::PoolBenchmarkHelper for $name<Tokens> {
+			impl<Tokens> cfg_traits::benchmarking::FundedPoolBenchmarkHelper for $name<Tokens> {
 				type AccountId = $account_id;
 				type Balance = $balance;
 				type PoolId = ();

--- a/libs/traits/src/benchmarking.rs
+++ b/libs/traits/src/benchmarking.rs
@@ -14,10 +14,19 @@
 pub trait PoolBenchmarkHelper {
 	type PoolId;
 	type AccountId;
-	type Balance;
 
 	/// Create a pool for the given the pool id and the admin.
 	fn bench_create_pool(pool_id: Self::PoolId, admin: &Self::AccountId);
+}
+
+/// Benchmark utility to create funded pools
+pub trait FundedPoolBenchmarkHelper {
+	type PoolId;
+	type AccountId;
+	type Balance;
+
+	/// Create a pool for the given the pool id and the admin.
+	fn bench_create_funded_pool(pool_id: Self::PoolId, admin: &Self::AccountId);
 
 	/// Prepare user to be able to invest, i.e. fund with pool currency and give
 	/// permissions.

--- a/pallets/foreign-investments/src/impls/benchmark_utils.rs
+++ b/pallets/foreign-investments/src/impls/benchmark_utils.rs
@@ -15,7 +15,7 @@ use cfg_primitives::CFG;
 use cfg_traits::{
 	benchmarking::{
 		BenchForeignInvestmentSetupInfo, ForeignInvestmentBenchmarkHelper,
-		InvestmentIdBenchmarkHelper, OrderBookBenchmarkHelper, PoolBenchmarkHelper,
+		FundedPoolBenchmarkHelper, InvestmentIdBenchmarkHelper, OrderBookBenchmarkHelper,
 	},
 	investments::{ForeignInvestment, OrderManager},
 };
@@ -41,8 +41,11 @@ impl<T: Config> ForeignInvestmentBenchmarkHelper for Pallet<T>
 where
 	T::Balance: From<u128>,
 	T::CurrencyId: From<CurrencyId>,
-	T::PoolInspect: PoolBenchmarkHelper<PoolId = T::PoolId, AccountId = T::AccountId, Balance = T::Balance>
-		+ InvestmentIdBenchmarkHelper<PoolId = T::PoolId, InvestmentId = T::InvestmentId>,
+	T::PoolInspect: FundedPoolBenchmarkHelper<
+			PoolId = T::PoolId,
+			AccountId = T::AccountId,
+			Balance = T::Balance,
+		> + InvestmentIdBenchmarkHelper<PoolId = T::PoolId, InvestmentId = T::InvestmentId>,
 	T::TokenSwaps: OrderBookBenchmarkHelper<
 		AccountId = T::AccountId,
 		Balance = T::Balance,
@@ -66,7 +69,10 @@ where
 	) -> BenchForeignInvestmentSetupInfo<Self::AccountId, Self::InvestmentId, Self::CurrencyId> {
 		let pool_id = Default::default();
 		let pool_admin: T::AccountId = frame_benchmarking::account("pool_admin", 0, 0);
-		<T::PoolInspect as PoolBenchmarkHelper>::bench_create_pool(pool_id, &pool_admin);
+		<T::PoolInspect as FundedPoolBenchmarkHelper>::bench_create_funded_pool(
+			pool_id,
+			&pool_admin,
+		);
 
 		// Add bidirectional trading pair and fund both accounts
 		let (investor, funded_trader) =
@@ -88,7 +94,7 @@ where
 		);
 
 		// Grant investor permissions
-		<T::PoolInspect as PoolBenchmarkHelper>::bench_investor_setup(
+		<T::PoolInspect as FundedPoolBenchmarkHelper>::bench_investor_setup(
 			pool_id,
 			investor.clone(),
 			T::Balance::zero(),

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 
 use cfg_traits::{
-	benchmarking::{InvestmentIdBenchmarkHelper, PoolBenchmarkHelper},
+	benchmarking::{FundedPoolBenchmarkHelper, InvestmentIdBenchmarkHelper},
 	investments::{Investment, InvestmentAccountant, OrderManager},
 };
 use cfg_types::orders::FulfillmentWithPrice;
@@ -26,30 +26,30 @@ use crate::{Call, Config, CurrencyOf, Pallet};
 struct Helper<T>(sp_std::marker::PhantomData<T>);
 impl<T: Config> Helper<T>
 where
-	T::Accountant: PoolBenchmarkHelper<AccountId = T::AccountId>
+	T::Accountant: FundedPoolBenchmarkHelper<AccountId = T::AccountId>
 		+ InvestmentIdBenchmarkHelper<
 			InvestmentId = T::InvestmentId,
-			PoolId = <T::Accountant as PoolBenchmarkHelper>::PoolId,
+			PoolId = <T::Accountant as FundedPoolBenchmarkHelper>::PoolId,
 		>,
-	<T::Accountant as PoolBenchmarkHelper>::PoolId: Default + Copy,
+	<T::Accountant as FundedPoolBenchmarkHelper>::PoolId: Default + Copy,
 {
 	fn get_investment_id() -> T::InvestmentId {
 		let pool_id = Default::default();
 		let pool_admin = account("pool_admin", 0, 0);
 
-		T::Accountant::bench_create_pool(pool_id, &pool_admin);
+		T::Accountant::bench_create_funded_pool(pool_id, &pool_admin);
 		T::Accountant::bench_default_investment_id(pool_id)
 	}
 }
 
 #[benchmarks(
 	where
-		T::Accountant: PoolBenchmarkHelper<AccountId = T::AccountId>
+		T::Accountant: FundedPoolBenchmarkHelper<AccountId = T::AccountId>
 			+ InvestmentIdBenchmarkHelper<
 				InvestmentId = T::InvestmentId,
-				PoolId = <T::Accountant as PoolBenchmarkHelper>::PoolId,
+				PoolId = <T::Accountant as FundedPoolBenchmarkHelper>::PoolId,
 			>,
-		<T::Accountant as PoolBenchmarkHelper>::PoolId: Default + Copy,
+		<T::Accountant as FundedPoolBenchmarkHelper>::PoolId: Default + Copy,
 )]
 mod benchmarks {
 	use super::*;

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -13,7 +13,7 @@
 
 use cfg_primitives::CFG;
 use cfg_traits::{
-	benchmarking::PoolBenchmarkHelper,
+	benchmarking::FundedPoolBenchmarkHelper,
 	changes::ChangeGuard,
 	data::DataRegistry,
 	interest::{CompoundingSchedule, InterestAccrual, InterestRate},
@@ -76,8 +76,6 @@ fn config_mocks() {
 	MockPools::mock_account_for(|_| 0);
 	MockPools::mock_withdraw(|_, _, _| Ok(()));
 	MockPools::mock_deposit(|_, _, _| Ok(()));
-	MockPools::mock_bench_create_pool(|_, _| {});
-	MockPools::mock_bench_investor_setup(|_, _, _| {});
 	MockPrices::mock_feed_value(|_, _, _| Ok(()));
 	MockPrices::mock_register_id(|_, _| Ok(()));
 	MockPrices::mock_collection(|_| MockDataCollection::new(|_| Ok(Default::default())));
@@ -95,8 +93,11 @@ where
 	T::CollectionId: From<u16>,
 	T::ItemId: From<u16>,
 	T::PriceId: From<u32>,
-	T::Pool:
-		PoolBenchmarkHelper<PoolId = T::PoolId, AccountId = T::AccountId, Balance = T::Balance>,
+	T::Pool: FundedPoolBenchmarkHelper<
+		PoolId = T::PoolId,
+		AccountId = T::AccountId,
+		Balance = T::Balance,
+	>,
 	T::PriceRegistry: DataFeeder<T::PriceId, T::Balance, T::AccountId>,
 {
 	fn prepare_benchmark() -> T::PoolId {
@@ -106,7 +107,7 @@ where
 		let pool_id = Default::default();
 
 		let pool_admin = account("pool_admin", 0, 0);
-		T::Pool::bench_create_pool(pool_id, &pool_admin);
+		T::Pool::bench_create_funded_pool(pool_id, &pool_admin);
 
 		let loan_admin = account("loan_admin", 0, 0);
 		T::Permissions::add(
@@ -333,7 +334,7 @@ benchmarks! {
 		T::CollectionId: From<u16>,
 		T::ItemId: From<u16>,
 		T::PriceId: From<u32>,
-		T::Pool: PoolBenchmarkHelper<PoolId = T::PoolId, AccountId = T::AccountId, Balance = T::Balance>,
+		T::Pool: FundedPoolBenchmarkHelper<PoolId = T::PoolId, AccountId = T::AccountId, Balance = T::Balance>,
 		T::PriceRegistry: DataFeeder<T::PriceId, T::Balance, T::AccountId>,
 	}
 

--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -456,7 +456,9 @@ impl<T: Config> ChangeGuard for Pallet<T> {
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarks_utils {
 	use cfg_traits::{
-		benchmarking::{InvestmentIdBenchmarkHelper, PoolBenchmarkHelper},
+		benchmarking::{
+			FundedPoolBenchmarkHelper, InvestmentIdBenchmarkHelper, PoolBenchmarkHelper,
+		},
 		investments::Investment,
 	};
 	use cfg_types::{
@@ -471,20 +473,13 @@ mod benchmarks_utils {
 	use super::*;
 
 	const POOL_CURRENCY: CurrencyId = CurrencyId::ForeignAsset(1);
+	const FUNDS: u128 = u64::max_value() as u128;
 
-	impl<T: Config<CurrencyId = CurrencyId>> PoolBenchmarkHelper for Pallet<T>
-	where
-		T::Investments: Investment<T::AccountId, InvestmentId = T::TrancheCurrency>,
-		<T::Investments as Investment<T::AccountId>>::Amount: From<u128>,
-	{
+	impl<T: Config<CurrencyId = CurrencyId>> PoolBenchmarkHelper for Pallet<T> {
 		type AccountId = T::AccountId;
-		type Balance = T::Balance;
 		type PoolId = T::PoolId;
 
 		fn bench_create_pool(pool_id: T::PoolId, admin: &T::AccountId) {
-			const FUNDS: u128 = u64::max_value() as u128;
-			const POOL_ACCOUNT_BALANCE: u128 = u64::max_value() as u128;
-
 			if T::AssetRegistry::metadata(&POOL_CURRENCY).is_none() {
 				frame_support::assert_ok!(T::AssetRegistry::register_asset(
 					Some(POOL_CURRENCY),
@@ -535,8 +530,23 @@ mod benchmarks_utils {
 				POOL_CURRENCY,
 				FUNDS.into(),
 			));
+		}
+	}
+
+	impl<T: Config<CurrencyId = CurrencyId>> FundedPoolBenchmarkHelper for Pallet<T>
+	where
+		T::Investments: Investment<T::AccountId, InvestmentId = T::TrancheCurrency>,
+		<T::Investments as Investment<T::AccountId>>::Amount: From<u128>,
+	{
+		type AccountId = T::AccountId;
+		type Balance = T::Balance;
+		type PoolId = T::PoolId;
+
+		fn bench_create_funded_pool(pool_id: T::PoolId, admin: &T::AccountId) {
+			Self::bench_create_pool(pool_id, admin);
 
 			// Fund pool account
+			const POOL_ACCOUNT_BALANCE: u128 = u64::max_value() as u128;
 			let pool_account = PoolLocator { pool_id }.into_account_truncating();
 			frame_support::assert_ok!(T::Tokens::mint_into(
 				POOL_CURRENCY,


### PR DESCRIPTION
# Description

The previous `PoolBenchmarkHelper` utility made use of investment utilities. This forces you to track investment bounds through the code, which is ok for parts that will end to use investments, but for cases where you only want to create a pool, it is boilerplate and annoying to use, carrying information out of the problem scope. This PR splits the current trait into 2 depending on the usage you require.

## Changes and Descriptions

- Renamed `PoolBenchmarkHelper` to `FundedPoolBenchmarkHelper`, for creating funded pools.
- New `PoolBenchmarkHelper` for only creating just pools.

Required for OracleV2. https://github.com/centrifuge/centrifuge-chain/pull/1629
