### PR TITLE
Fix Docker workflow triggers

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -56,22 +56,22 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      # - name: Build and push centrifugeio/centrifuge-chain
-      #   uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5
-      #   with:
-      #     context: .
-      #     file: ./docker/centrifuge-chain/Dockerfile
-      #     build-args: |
-      #       FEATURES=${{ matrix.target == 'test' && 'fast-runtime' || '' }}
-      #     push: ${{ github.event_name != 'pull_request' }}
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     # Cache options:
-      #     # https://docs.docker.com/build/ci/github-actions/cache/
-      #     cache-from: type=gha
-      #     # cache-from: type=registry,ref=centrifugeio/centrifuge-chain:${{ github.ref }}
-      #     # https://docs.docker.com/build/cache/backends/inline/
-      #     cache-to: type=gha, mode=max
-      #     # cache-to: type=registry,ref=centrifugeio/centrifuge-chain:${{ github.ref }}, mode=max
+      - name: Build and push centrifugeio/centrifuge-chain
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5
+        with:
+          context: .
+          file: ./docker/centrifuge-chain/Dockerfile
+          build-args: |
+            FEATURES=${{ matrix.target == 'test' && 'fast-runtime' || '' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          # Cache options:
+          # https://docs.docker.com/build/ci/github-actions/cache/
+          cache-from: type=gha
+          # cache-from: type=registry,ref=centrifugeio/centrifuge-chain:${{ github.ref }}
+          # https://docs.docker.com/build/cache/backends/inline/
+          cache-to: type=gha, mode=max
+          # cache-to: type=registry,ref=centrifugeio/centrifuge-chain:${{ github.ref }}, mode=max
 
       - name: Update DockerHub descriptions
         if: contains(github.ref, 'refs/tags/release-v')
@@ -89,7 +89,8 @@ jobs:
         with:
           append_body: true
           body: |
-            Docker tags updated: ${{ steps.meta.outputs.tags }}
+            **Docker tags:** 
+               ${{ steps.meta.outputs.tags }}
 
       - if: failure()
         name: Check available space after build failed

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,7 +7,7 @@ on:
   release:
     # Release logic:
     #  https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=unpublished#release
-    types: [published, released, prereleased, created, edited ] # GITHUB_REF == tag pushed with the release
+    types: [published, released, edited ] # GITHUB_REF == tag pushed with the release
   pull_request:
     paths:
       - ".github/workflows/build-docker.yml"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,10 +1,13 @@
 name: Docker Build
 on:
   # Keep in mind the Docker tagging on the "metadata" step if you add new triggers
+  workflow_dispatch: # In case a repo contributor needs a specific docker tag built.
   push:
     branches: [main]
   release:
-    types: [created] # GITHUB_REF == tag pushed with the release
+    # Release logic:
+    #  https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=unpublished#release
+    types: [published, released, prereleased, created, edited ] # GITHUB_REF == tag pushed with the release
   pull_request:
     paths:
       - ".github/workflows/build-docker.yml"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -80,6 +80,14 @@ jobs:
           repository: centrifuge/centrifuge-chain
           short-description: ${{ github.event.repository.description }}
           enable-url-completion: true
+          
+      - name: Update GitHub release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          append_body: true
+          body: |
+            Docker Image: [`${{ steps.meta.outputs.tags[0] }}`](https://hub.docker.com/layers/centrifugeio/centrifuge-chain/${{ steps.meta.outputs.tags[0] }})
 
       - if: failure()
         name: Check available space after build failed

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -82,7 +82,7 @@ jobs:
           enable-url-completion: true
           
       - name: Update GitHub release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && matrix.target == 'release'
         uses: softprops/action-gh-release@v1
         with:
           append_body: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,7 +7,7 @@ on:
   release:
     # Release logic:
     #  https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=unpublished#release
-    types: [published, released, edited ] # GITHUB_REF == tag pushed with the release
+    types: [ created ] # GITHUB_REF == tag pushed with the release
   pull_request:
     paths:
       - ".github/workflows/build-docker.yml"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           append_body: true
           body: |
-            Docker Image: [`${{ steps.meta.outputs.tags[0] }}`](https://hub.docker.com/layers/centrifugeio/centrifuge-chain/${{ steps.meta.outputs.tags[0] }})
+            Docker tags updated: ${{ steps.meta.outputs.tags }}
 
       - if: failure()
         name: Check available space after build failed

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -21,6 +21,8 @@ jobs:
       matrix:
         target: [ release, test ]
     runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: write    
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4
         with:
@@ -54,22 +56,22 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Build and push centrifugeio/centrifuge-chain
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5
-        with:
-          context: .
-          file: ./docker/centrifuge-chain/Dockerfile
-          build-args: |
-            FEATURES=${{ matrix.target == 'test' && 'fast-runtime' || '' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          # Cache options:
-          # https://docs.docker.com/build/ci/github-actions/cache/
-          cache-from: type=gha
-          # cache-from: type=registry,ref=centrifugeio/centrifuge-chain:${{ github.ref }}
-          # https://docs.docker.com/build/cache/backends/inline/
-          cache-to: type=gha, mode=max
-          # cache-to: type=registry,ref=centrifugeio/centrifuge-chain:${{ github.ref }}, mode=max
+      # - name: Build and push centrifugeio/centrifuge-chain
+      #   uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5
+      #   with:
+      #     context: .
+      #     file: ./docker/centrifuge-chain/Dockerfile
+      #     build-args: |
+      #       FEATURES=${{ matrix.target == 'test' && 'fast-runtime' || '' }}
+      #     push: ${{ github.event_name != 'pull_request' }}
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     # Cache options:
+      #     # https://docs.docker.com/build/ci/github-actions/cache/
+      #     cache-from: type=gha
+      #     # cache-from: type=registry,ref=centrifugeio/centrifuge-chain:${{ github.ref }}
+      #     # https://docs.docker.com/build/cache/backends/inline/
+      #     cache-to: type=gha, mode=max
+      #     # cache-to: type=registry,ref=centrifugeio/centrifuge-chain:${{ github.ref }}, mode=max
 
       - name: Update DockerHub descriptions
         if: contains(github.ref, 'refs/tags/release-v')


### PR DESCRIPTION
This PR:
- Adds an on-demand trigger in case a manual docker tag is needed
- Adjusts when a release triggers a docker build and push
- Auto-comments on the release notes adding the docker tags