### PR TITLE
Fix: LP accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "centrifuge-runtime"
-version = "0.10.24"
+version = "0.10.25"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",

--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -282,9 +282,6 @@ pub enum CrossChainTransferability {
 
 	/// The asset is only transferable through Centrifuge Liquidity Pools
 	LiquidityPools,
-
-	/// The asset is transferable through all available options
-	All(XcmMetadata),
 }
 
 impl CrossChainTransferability {

--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -286,11 +286,11 @@ pub enum CrossChainTransferability {
 
 impl CrossChainTransferability {
 	pub fn includes_xcm(self) -> bool {
-		matches!(self, Self::Xcm(..) | Self::All(..))
+		matches!(self, Self::Xcm(..))
 	}
 
 	pub fn includes_liquidity_pools(self) -> bool {
-		matches!(self, Self::LiquidityPools | Self::All(..))
+		matches!(self, Self::LiquidityPools)
 	}
 }
 

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -124,7 +124,10 @@ pub mod pallet {
 		tokens::{CustomMetadata, LiquidityPoolsWrappedToken},
 		EVMChainId,
 	};
-	use frame_support::{pallet_prelude::*, traits::tokens::Preservation};
+	use frame_support::{
+		pallet_prelude::*,
+		traits::tokens::{Fortitude, Precision, Preservation},
+	};
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::HasCompact;
 	use sp_runtime::{traits::Zero, DispatchError};
@@ -641,14 +644,15 @@ pub mod pallet {
 
 			T::PreTransferFilter::check((who.clone(), receiver.clone(), currency_id))?;
 
-			// Transfer to the domain account for bookkeeping
-			T::Tokens::transfer(
+			// Burn token as we are never the reserve for LP tokens that are not tranche
+			// tokens.
+			T::Tokens::burn_from(
 				currency_id,
 				&who,
-				&Domain::convert(receiver.domain()),
 				amount,
-				// NOTE: Here, we allow death
-				Preservation::Expendable,
+				Precision::Exact,
+				// NOTE: We are enforcing it, as the system needs that
+				Fortitude::Force,
 			)?;
 
 			T::OutboundQueue::submit(

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -804,14 +804,6 @@ pub mod pallet {
 				Error::<T>::TrancheNotFound
 			);
 
-			ensure!(
-				T::Permission::has(
-					PermissionScope::Pool(pool_id),
-					who,
-					Role::PoolRole(PoolRole::PoolAdmin)
-				),
-				Error::<T>::NotPoolAdmin
-			);
 			let investment_id = Self::derive_invest_id(pool_id, tranche_id)?;
 			let metadata = T::AssetRegistry::metadata(&investment_id.into())
 				.ok_or(Error::<T>::TrancheMetadataNotFound)?;
@@ -819,7 +811,7 @@ pub mod pallet {
 			let token_symbol = vec_to_fixed_array(metadata.symbol);
 
 			T::OutboundQueue::submit(
-				T::TreasuryAccount::get(),
+				who,
 				domain,
 				Message::UpdateTrancheTokenMetadata {
 					pool_id,

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centrifuge-runtime"
-version = "0.10.24"
+version = "0.10.25"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge"),
 	impl_name: create_runtime_str!("centrifuge"),
 	authoring_version: 1,
-	spec_version: 1024,
+	spec_version: 1025,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
@@ -1994,7 +1994,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	migrations::UpgradeCentrifuge1024,
+	migrations::UpgradeCentrifuge1025,
 >;
 
 pub struct TransactionConverter;

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -10,7 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-pub type UpgradeCentrifuge1024 = burn_unburned::Migration<super::Runtime>;
+pub type UpgradeCentrifuge1025 = burn_unburned::Migration<super::Runtime>;
 
 // Copyright 2021 Centrifuge Foundation (centrifuge.io).
 //

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -36,10 +36,7 @@ mod burn_unburned {
 		OnRuntimeUpgrade,
 	};
 	use pallet_order_book::weights::Weight;
-	use sp_runtime::{
-		traits::{Convert, Get},
-		TryRuntimeError,
-	};
+	use sp_runtime::traits::{Convert, Get};
 
 	pub struct Migration<T>
 	where
@@ -53,7 +50,7 @@ mod burn_unburned {
 		T: orml_tokens::Config<CurrencyId = CurrencyId> + frame_system::Config,
 	{
 		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, TryRuntimeError> {
+		fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
 			use sp_runtime::traits::Zero;
 
 			let pre_data = orml_tokens::Accounts::<T>::get(
@@ -103,7 +100,7 @@ mod burn_unburned {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(_state: sp_std::vec::Vec<u8>) -> Result<(), TryRuntimeError> {
+		fn post_upgrade(_state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
 			use sp_runtime::traits::Zero;
 
 			let post_data = orml_tokens::Accounts::<T>::get(

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -25,9 +25,7 @@ pub type UpgradeCentrifuge1024 = burn_unburned::Migration<super::Runtime>;
 // GNU General Public License for more details.
 
 mod burn_unburned {
-	use sp_std::vec::Vec;
-
-	const LOG_PREFIX: &'static str = "BurnUnburnedMigration: ";
+	const LOG_PREFIX: &str = "BurnUnburnedMigration: ";
 	const LP_ETH_USDC: CurrencyId = CurrencyId::ForeignAsset(100_001);
 	const ETH_DOMAIN: Domain = Domain::EVM(1);
 
@@ -39,7 +37,7 @@ mod burn_unburned {
 	};
 	use pallet_order_book::weights::Weight;
 	use sp_runtime::{
-		traits::{Convert, Get, Zero},
+		traits::{Convert, Get},
 		TryRuntimeError,
 	};
 
@@ -55,7 +53,9 @@ mod burn_unburned {
 		T: orml_tokens::Config<CurrencyId = CurrencyId> + frame_system::Config,
 	{
 		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, TryRuntimeError> {
+			use sp_runtime::traits::Zero;
+
 			let pre_data = orml_tokens::Accounts::<T>::get(
 				<Domain as Convert<_, T::AccountId>>::convert(ETH_DOMAIN),
 				LP_ETH_USDC,
@@ -72,7 +72,7 @@ mod burn_unburned {
 				pre_data.free
 			);
 
-			Ok(Vec::new())
+			Ok(sp_std::vec::Vec::new())
 		}
 
 		fn on_runtime_upgrade() -> Weight {
@@ -103,7 +103,9 @@ mod burn_unburned {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+		fn post_upgrade(_state: sp_std::vec::Vec<u8>) -> Result<(), TryRuntimeError> {
+			use sp_runtime::traits::Zero;
+
 			let post_data = orml_tokens::Accounts::<T>::get(
 				<Domain as Convert<_, T::AccountId>>::convert(ETH_DOMAIN),
 				LP_ETH_USDC,

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -10,4 +10,108 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-pub type UpgradeCentrifuge1024 = ();
+pub type UpgradeCentrifuge1024 = (burn_unburned::Migration<super::Runtime>);
+
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+mod burn_unburned {
+	use sp_std::vec::Vec;
+	const LP_ETH_USDC: CurrencyId = CurrencyId::ForeignAsset(100_001);
+	const ETH_DOMAIN: Domain = Domain::EVM(1);
+
+	use cfg_types::{domain_address::Domain, tokens::CurrencyId};
+	use frame_support::traits::{
+		fungibles::Mutate,
+		tokens::{Fortitude, Precision},
+		OnRuntimeUpgrade,
+	};
+	use pallet_order_book::weights::Weight;
+	use sp_runtime::{
+		traits::{Convert, Get, Zero},
+		TryRuntimeError,
+	};
+
+	pub struct Migration<T>
+	where
+		T: orml_tokens::Config + frame_system::Config,
+		<T as orml_tokens::Config>::CurrencyId: From<CurrencyId>,
+	{
+		_phantom: sp_std::marker::PhantomData<T>,
+	}
+
+	impl<T> OnRuntimeUpgrade for Migration<T>
+	where
+		T: orml_tokens::Config + frame_system::Config,
+		<T as orml_tokens::Config>::CurrencyId: From<CurrencyId>,
+	{
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			let pre_data = orml_tokens::Accounts::<T>::get(
+				<Domain as Convert<_, T::AccountId>>::convert(ETH_DOMAIN),
+				T::CurrencyId::from(LP_ETH_USDC),
+			);
+
+			if !pre_data.frozen.is_zero() && !pre_data.reserved.is_zero() {
+				log::error!("AccountData of Ethereum domain account has non free balances...");
+			}
+
+			log::info!(
+				"AccountData of Ethereum domain account has free balance of: {:?}",
+				pre_data.free
+			);
+
+			Ok(Vec::new())
+		}
+
+		fn on_runtime_upgrade() -> Weight {
+			let data = orml_tokens::Accounts::<T>::get(
+				<Domain as Convert<_, T::AccountId>>::convert(ETH_DOMAIN),
+				T::CurrencyId::from(LP_ETH_USDC),
+			);
+
+			if let Err(e) = orml_tokens::Pallet::<T>::burn_from(
+				T::CurrencyId::from(LP_ETH_USDC),
+				&<Domain as Convert<_, T::AccountId>>::convert(ETH_DOMAIN),
+				data.free,
+				Precision::Exact,
+				Fortitude::Force,
+			) {
+				log::error!(
+					"Burning from Ethereum domain account failed with: {:?}. Migration failed...",
+					e
+				);
+			}
+
+			T::DbWeight::get().reads(1)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			let post_data = orml_tokens::Accounts::<T>::get(
+				<Domain as Convert<_, T::AccountId>>::convert(ETH_DOMAIN),
+				T::CurrencyId::from(LP_ETH_USDC),
+			);
+
+			if !post_data.free.is_zero()
+				&& !post_data.frozen.is_zero()
+				&& !post_data.reserved.is_zero()
+			{
+				log::error!(
+					"AccountDatat of Ethereum domain account SHOULD be zero. Migration failed."
+				);
+			}
+
+			Ok(())
+		}
+	}
+}

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -10,7 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-pub type UpgradeCentrifuge1024 = (burn_unburned::Migration<super::Runtime>);
+pub type UpgradeCentrifuge1024 = burn_unburned::Migration<super::Runtime>;
 
 // Copyright 2021 Centrifuge Foundation (centrifuge.io).
 //
@@ -26,6 +26,8 @@ pub type UpgradeCentrifuge1024 = (burn_unburned::Migration<super::Runtime>);
 
 mod burn_unburned {
 	use sp_std::vec::Vec;
+
+	const LOG_PREFIX: &'static str = "BurnUnburnedMigration: ";
 	const LP_ETH_USDC: CurrencyId = CurrencyId::ForeignAsset(100_001);
 	const ETH_DOMAIN: Domain = Domain::EVM(1);
 
@@ -62,11 +64,13 @@ mod burn_unburned {
 			);
 
 			if !pre_data.frozen.is_zero() && !pre_data.reserved.is_zero() {
-				log::error!("AccountData of Ethereum domain account has non free balances...");
+				log::error!(
+					"{LOG_PREFIX} AccountData of Ethereum domain account has non free balances..."
+				);
 			}
 
 			log::info!(
-				"AccountData of Ethereum domain account has free balance of: {:?}",
+				"{LOG_PREFIX} AccountData of Ethereum domain account has free balance of: {:?}",
 				pre_data.free
 			);
 
@@ -87,8 +91,13 @@ mod burn_unburned {
 				Fortitude::Force,
 			) {
 				log::error!(
-					"Burning from Ethereum domain account failed with: {:?}. Migration failed...",
+					"{LOG_PREFIX} Burning from Ethereum domain account failed with: {:?}. Migration failed...",
 					e
+				);
+			} else {
+				log::info!(
+					"{LOG_PREFIX} Successfully burned {:?} LP_ETH_USDC from Ethereum domain account",
+					data.free
 				);
 			}
 
@@ -107,8 +116,10 @@ mod burn_unburned {
 				&& !post_data.reserved.is_zero()
 			{
 				log::error!(
-					"AccountDatat of Ethereum domain account SHOULD be zero. Migration failed."
+					"{LOG_PREFIX} AccountData of Ethereum domain account SHOULD be zero. Migration failed."
 				);
+			} else {
+				log::info!("{LOG_PREFIX} Migration successfully finished.")
 			}
 
 			Ok(())

--- a/runtime/common/src/xcm.rs
+++ b/runtime/common/src/xcm.rs
@@ -43,8 +43,7 @@ impl<
 	fn get_fee_per_second(location: &MultiLocation) -> Option<u128> {
 		let metadata = OrmlAssetRegistry::metadata_by_location(location)?;
 		match metadata.additional.transferability {
-			CrossChainTransferability::Xcm(xcm_metadata)
-			| CrossChainTransferability::All(xcm_metadata) => xcm_metadata
+			CrossChainTransferability::Xcm(xcm_metadata) => xcm_metadata
 				.fee_per_second
 				.or_else(|| Some(default_per_second(metadata.decimals))),
 			_ => None,

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -94,7 +94,7 @@ mod utils {
 
 	pub fn xcm_metadata(transferability: CrossChainTransferability) -> Option<XcmMetadata> {
 		match transferability {
-			CrossChainTransferability::Xcm(x) | CrossChainTransferability::All(x) => Some(x),
+			CrossChainTransferability::Xcm(x) => Some(x),
 			_ => None,
 		}
 	}

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -6174,8 +6174,10 @@ mod development {
 						dest_address.clone(),
 						initial_balance.saturating_add(1),
 					),
-					orml_tokens::Error::<T>::BalanceTooLow
+					pallet_liquidity_pools::Error::<T>::BalanceTooLow
 				);
+
+				let pre_total_issuance = orml_tokens::Pallet::<T>::total_issuance(currency_id);
 
 				assert_ok!(pallet_liquidity_pools::Pallet::<T>::transfer(
 					RawOrigin::Signed(source_account.into()).into(),
@@ -6184,14 +6186,9 @@ mod development {
 					amount,
 				));
 
-				// The account to which the currency should have been transferred
-				// to on Centrifuge for bookkeeping purposes.
-				let domain_account: AccountId = Domain::convert(dest_address.domain());
-				// Verify that the correct amount of the token was transferred
-				// to the dest domain account on Centrifuge.
 				assert_eq!(
-					orml_tokens::Pallet::<T>::free_balance(currency_id, &domain_account),
-					amount
+					orml_tokens::Pallet::<T>::total_issuance(currency_id),
+					pre_total_issuance - amount
 				);
 				assert_eq!(
 					orml_tokens::Pallet::<T>::free_balance(currency_id, &source_account.into()),

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -8878,6 +8878,8 @@ mod centrifuge {
 					pallet_transfer_allowlist::Error::<T>::NoAllowanceForDestination
 				);
 
+				let total_issuance_pre = orml_tokens::Pallet::<T>::total_issuance(LP_ETH_USDC);
+
 				assert_ok!(pallet_liquidity_pools::Pallet::<T>::transfer(
 					RawOrigin::Signed(Keyring::Alice.into()).into(),
 					LP_ETH_USDC,
@@ -8885,11 +8887,9 @@ mod centrifuge {
 					lp_eth_usdc(TRANSFER_AMOUNT),
 				));
 
-				let domain_acc = Domain::convert(Domain::EVM(1));
-
 				assert_eq!(
-					orml_tokens::Pallet::<T>::free_balance(LP_ETH_USDC, &domain_acc),
-					lp_eth_usdc(TRANSFER_AMOUNT),
+					orml_tokens::Pallet::<T>::total_issuance(LP_ETH_USDC),
+					total_issuance_pre - lp_eth_usdc(TRANSFER_AMOUNT),
 				);
 			});
 		}

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -1727,20 +1727,10 @@ mod development {
 
 				let tranche_id = default_tranche_id::<T>(pool_id);
 
-				// Should throw if called by anything but `PoolAdmin`
-				assert_noop!(
-					pallet_liquidity_pools::Pallet::<T>::update_tranche_token_metadata(
-						RawOrigin::Signed(Keyring::Alice.into()).into(),
-						pool_id,
-						tranche_id,
-						Domain::EVM(MOONBEAM_EVM_CHAIN_ID),
-					),
-					pallet_liquidity_pools::Error::<T>::NotPoolAdmin
-				);
-
+				// Moving the update to another domain can be called by anyone
 				assert_ok!(
 					pallet_liquidity_pools::Pallet::<T>::update_tranche_token_metadata(
-						RawOrigin::Signed(Keyring::Bob.into()).into(),
+						RawOrigin::Signed(Keyring::Alice.into()).into(),
 						pool_id,
 						tranche_id,
 						Domain::EVM(MOONBEAM_EVM_CHAIN_ID),


### PR DESCRIPTION
# Description
Currently, when tokens are transfered to another domain we are storing them in the domain specific account. That is correct for tranche tokens, as Centrifuge Chain is the reserve for these kind of tokens. But all other tokens that are LP transferable are tokens where the domain is the reserve, hence we need to burn them instead. 

This PR fixes the code to burn instead and furthermore provides a migration for Centrifuge Chain to burn existing tokens. 

NOTE: We must burn all LP tokens from this account, as we are now also deployed on `Celo`, `Arbitrum` and `Base` we must be cautious whether we need to extend the burn-migration to `USDC` from these domains.

## Changes and Descriptions
* use `burn_from` instead of `transfer`
* migration for burning from `Domain` account

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
