### PR TITLE
Oracles: Protect from configuring with duplicated feeders

### DIFF
--- a/pallets/oracle-data-collection/src/benchmarking.rs
+++ b/pallets/oracle-data-collection/src/benchmarking.rs
@@ -1,6 +1,5 @@
 use cfg_traits::{benchmarking::PoolBenchmarkHelper, changes::ChangeGuard, ValueProvider};
 use frame_benchmarking::{v2::*, whitelisted_caller};
-use frame_support::storage::bounded_vec::BoundedVec;
 use frame_system::RawOrigin;
 
 use crate::{
@@ -25,16 +24,18 @@ mod util {
 
 	pub fn last_change_id_for<T>(
 		key: T::OracleKey,
-		feeders: &BoundedVec<T::FeederId, T::MaxFeedersPerKey>,
+		feeders: impl IntoIterator<Item = T::FeederId>,
 	) -> T::Hash
 	where
 		T: Config,
 		T::CollectionId: Default,
 	{
+		let feeders = crate::util::feeders_from(feeders).unwrap();
+
 		// Emulate to note a change to later apply it
 		T::ChangeGuard::note(
 			T::CollectionId::default(),
-			Change::<T>::Feeders(key, feeders.clone()).into(),
+			Change::<T>::Feeders(key, feeders).into(),
 		)
 		.unwrap()
 	}
@@ -62,11 +63,7 @@ mod benchmarks {
 
 		T::ChangeGuard::bench_create_pool(T::CollectionId::default(), &admin);
 
-		let feeders = (0..n)
-			.map(Into::into)
-			.collect::<Vec<_>>()
-			.try_into()
-			.unwrap();
+		let feeders = crate::util::feeders_from((0..n).map(Into::into)).unwrap();
 
 		#[extrinsic_call]
 		propose_update_feeders(
@@ -88,13 +85,10 @@ mod benchmarks {
 
 		T::ChangeGuard::bench_create_pool(T::CollectionId::default(), &admin);
 
-		let feeders: BoundedVec<_, _> = (0..n)
-			.map(Into::into)
-			.collect::<Vec<_>>()
-			.try_into()
-			.unwrap();
+		let feeder_ids = (0..n).map(Into::into);
+		let feeders = crate::util::feeders_from::<_, T::MaxFeedersPerKey>(feeder_ids).unwrap();
 
-		let change_id = util::last_change_id_for::<T>(T::OracleKey::default(), &feeders);
+		let change_id = util::last_change_id_for::<T>(T::OracleKey::default(), feeders);
 
 		#[extrinsic_call]
 		apply_update_feeders(
@@ -115,11 +109,8 @@ mod benchmarks {
 
 		T::ChangeGuard::bench_create_pool(T::CollectionId::default(), &admin);
 
-		let feeders: BoundedVec<T::FeederId, _> = (0..n)
-			.map(Into::into)
-			.collect::<Vec<_>>()
-			.try_into()
-			.unwrap();
+		let feeder_ids = (0..n).map(Into::<T::FeederId>::into);
+		let feeders = crate::util::feeders_from::<_, T::MaxFeedersPerKey>(feeder_ids).unwrap();
 
 		// n feeders using m keys
 		for k in 0..m {
@@ -136,7 +127,7 @@ mod benchmarks {
 			Pallet::<T>::apply_update_feeders(
 				RawOrigin::Signed(admin.clone()).into(),
 				T::CollectionId::default(),
-				util::last_change_id_for::<T>(key, &feeders),
+				util::last_change_id_for::<T>(key, feeders.clone()),
 			)?;
 		}
 

--- a/runtime/common/src/oracle.rs
+++ b/runtime/common/src/oracle.rs
@@ -41,6 +41,22 @@ impl<O: OriginTrait> PartialEq for Feeder<O> {
 
 impl<O: OriginTrait> Eq for Feeder<O> {}
 
+impl<O: OriginTrait> PartialOrd for Feeder<O> {
+	fn partial_cmp(&self, other: &Self) -> Option<sp_std::cmp::Ordering> {
+		// Since the inner object could not be PartialOrd,
+		// we compare their encoded representations
+		self.0.encode().partial_cmp(&other.encode())
+	}
+}
+
+impl<O: OriginTrait> Ord for Feeder<O> {
+	fn cmp(&self, other: &Self) -> sp_std::cmp::Ordering {
+		// Since the inner object could not be Ord,
+		// we compare their encoded representations
+		self.0.encode().cmp(&other.encode())
+	}
+}
+
 #[cfg(feature = "runtime-benchmarks")]
 impl<O: OriginTrait<AccountId = AccountId>> From<u32> for Feeder<O> {
 	fn from(value: u32) -> Self {

--- a/runtime/common/src/oracle.rs
+++ b/runtime/common/src/oracle.rs
@@ -43,9 +43,7 @@ impl<O: OriginTrait> Eq for Feeder<O> {}
 
 impl<O: OriginTrait> PartialOrd for Feeder<O> {
 	fn partial_cmp(&self, other: &Self) -> Option<sp_std::cmp::Ordering> {
-		// Since the inner object could not be PartialOrd,
-		// we compare their encoded representations
-		self.0.encode().partial_cmp(&other.encode())
+		Some(self.cmp(other))
 	}
 }
 

--- a/runtime/integration-tests/src/generic/cases/loans.rs
+++ b/runtime/integration-tests/src/generic/cases/loans.rs
@@ -298,7 +298,7 @@ fn oracle_priced<T: Runtime>() {
 	let mut env = common::initialize_state_for_loans::<RuntimeEnv<T>, T>();
 
 	env.parachain_state_mut(|| {
-		utils::oracle::update_feeders::<T>(POOL_ADMIN.id(), POOL_A, PRICE_A, &[Feeder::root()]);
+		utils::oracle::update_feeders::<T>(POOL_ADMIN.id(), POOL_A, PRICE_A, [Feeder::root()]);
 		utils::oracle::feed_from_root::<T>(PRICE_A, PRICE_VALUE_A);
 	});
 
@@ -350,7 +350,7 @@ fn portfolio_valuated_by_oracle<T: Runtime>() {
 	let mut env = common::initialize_state_for_loans::<RuntimeEnv<T>, T>();
 
 	env.parachain_state_mut(|| {
-		utils::oracle::update_feeders::<T>(POOL_ADMIN.id(), POOL_A, PRICE_A, &[Feeder::root()]);
+		utils::oracle::update_feeders::<T>(POOL_ADMIN.id(), POOL_A, PRICE_A, [Feeder::root()]);
 	});
 
 	let info = env.parachain_state(|| {

--- a/runtime/integration-tests/src/generic/utils/mod.rs
+++ b/runtime/integration-tests/src/generic/utils/mod.rs
@@ -217,18 +217,13 @@ pub mod oracle {
 		admin: AccountId,
 		pool_id: PoolId,
 		price_id: OracleKey,
-		feeders: &[Feeder<T::RuntimeOriginExt>],
+		feeders: impl IntoIterator<Item = Feeder<T::RuntimeOriginExt>>,
 	) {
 		pallet_oracle_data_collection::Pallet::<T>::propose_update_feeders(
 			RawOrigin::Signed(admin.clone()).into(),
 			pool_id,
 			price_id,
-			feeders
-				.iter()
-				.cloned()
-				.collect::<Vec<_>>()
-				.try_into()
-				.unwrap(),
+			pallet_oracle_data_collection::util::feeders_from(feeders).unwrap(),
 		)
 		.unwrap();
 


### PR DESCRIPTION
# Description

We should avoid configuring the feeders with a vector to prevent the caller from adding duplicated feeders. Instead of checking duplications in runtime, we can ensure this behavior in the type system using a set.

* Depends on https://github.com/centrifuge/centrifuge-chain/pull/1658
