### PR TITLE
Oracles: Time validation by a max age threshold

### DIFF
--- a/libs/mocks/src/data.rs
+++ b/libs/mocks/src/data.rs
@@ -31,7 +31,9 @@ pub mod pallet {
 			register_call!(move |(a, b)| f(a, b));
 		}
 
-		pub fn mock_collection(f: impl Fn(&T::CollectionId) -> T::Collection + 'static) {
+		pub fn mock_collection(
+			f: impl Fn(&T::CollectionId) -> Result<T::Collection, DispatchError> + 'static,
+		) {
 			register_call!(f);
 		}
 
@@ -56,7 +58,7 @@ pub mod pallet {
 			execute_call!((a, b))
 		}
 
-		fn collection(a: &T::CollectionId) -> T::Collection {
+		fn collection(a: &T::CollectionId) -> Result<T::Collection, DispatchError> {
 			execute_call!(a)
 		}
 

--- a/libs/traits/src/data.rs
+++ b/libs/traits/src/data.rs
@@ -27,7 +27,7 @@ pub trait DataRegistry<DataId, CollectionId> {
 
 	/// Retrives a collection of data with all data associated to a collection
 	/// id
-	fn collection(collection_id: &CollectionId) -> Self::Collection;
+	fn collection(collection_id: &CollectionId) -> Result<Self::Collection, DispatchError>;
 
 	/// Start listening data changes for a data id in a collection id
 	fn register_id(data_id: &DataId, collection_id: &CollectionId) -> DispatchResult;

--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -70,7 +70,7 @@ fn config_mocks() {
 	MockPools::mock_withdraw(|_, _, _| Ok(()));
 	MockPools::mock_deposit(|_, _, _| Ok(()));
 	MockPrices::mock_register_id(|_, _| Ok(()));
-	MockPrices::mock_collection(|_| MockDataCollection::new(|_| Ok(Default::default())));
+	MockPrices::mock_collection(|_| Ok(MockDataCollection::new(|_| Ok(Default::default()))));
 	MockChangeGuard::mock_note(|_, change| {
 		MockChangeGuard::mock_released(move |_, _| Ok(change.clone()));
 		Ok(sp_core::H256::default())

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -1013,7 +1013,7 @@ pub mod pallet {
 			pool_id: T::PoolId,
 		) -> Result<(T::Balance, u32), DispatchError> {
 			let rates = T::InterestAccrual::rates();
-			let prices = T::PriceRegistry::collection(&pool_id);
+			let prices = T::PriceRegistry::collection(&pool_id)?;
 			let loans = ActiveLoans::<T>::get(pool_id);
 			let values = loans
 				.iter()

--- a/pallets/loans/src/tests/portfolio_valuation.rs
+++ b/pallets/loans/src/tests/portfolio_valuation.rs
@@ -11,10 +11,10 @@ fn config_mocks() {
 	});
 	MockPrices::mock_collection(|pool_id| {
 		assert_eq!(*pool_id, POOL_A);
-		MockDataCollection::new(|id| match *id {
+		Ok(MockDataCollection::new(|id| match *id {
 			REGISTER_PRICE_ID => Ok((PRICE_VALUE, BLOCK_TIME_MS)),
 			_ => Err(PRICE_ID_NO_FOUND),
-		})
+		}))
 	});
 }
 
@@ -195,7 +195,9 @@ fn with_unregister_price_id_and_oracle_not_required() {
 
 		// Suddenty, the oracle set a value
 		MockPrices::mock_collection(|_| {
-			MockDataCollection::new(|_| Ok((PRICE_VALUE * 8, BLOCK_TIME_MS)))
+			Ok(MockDataCollection::new(|_| {
+				Ok((PRICE_VALUE * 8, BLOCK_TIME_MS))
+			}))
 		});
 
 		update_portfolio();

--- a/pallets/oracle-data-collection/src/benchmarking.rs
+++ b/pallets/oracle-data-collection/src/benchmarking.rs
@@ -9,7 +9,7 @@ use crate::{
 
 #[cfg(test)]
 fn init_mocks() {
-	use crate::mock::{MockChangeGuard, MockIsAdmin, MockProvider};
+	use crate::mock::{MockChangeGuard, MockIsAdmin, MockProvider, MockTime};
 
 	MockIsAdmin::mock_check(|_| true);
 	MockProvider::mock_get(|_, _| Ok(Some((Default::default(), Default::default()))));
@@ -17,6 +17,7 @@ fn init_mocks() {
 		MockChangeGuard::mock_released(move |_, _| Ok(change.clone()));
 		Ok(Default::default())
 	});
+	MockTime::mock_now(|| 0);
 }
 
 mod util {
@@ -131,12 +132,41 @@ mod benchmarks {
 			)?;
 		}
 
+		// Worst case expect to read the max age
+		Pallet::<T>::set_collection_max_age(
+			RawOrigin::Signed(admin.clone()).into(),
+			T::CollectionId::default(),
+			T::Timestamp::default(),
+		)
+		.unwrap();
+
 		#[extrinsic_call]
 		update_collection(RawOrigin::Signed(admin), T::CollectionId::default());
 
 		assert_eq!(
-			Collection::<T>::get(T::CollectionId::default()).len() as u32,
+			Collection::<T>::get(T::CollectionId::default())
+				.content
+				.len() as u32,
 			m
+		);
+
+		Ok(())
+	}
+
+	#[benchmark]
+	fn set_collection_max_age() -> Result<(), BenchmarkError> {
+		#[cfg(test)]
+		init_mocks();
+
+		let admin: T::AccountId = whitelisted_caller();
+
+		T::ChangeGuard::bench_create_pool(T::CollectionId::default(), &admin);
+
+		#[extrinsic_call]
+		set_collection_max_age(
+			RawOrigin::Signed(admin),
+			T::CollectionId::default(),
+			T::Timestamp::default(),
 		);
 
 		Ok(())

--- a/pallets/oracle-data-collection/src/benchmarking.rs
+++ b/pallets/oracle-data-collection/src/benchmarking.rs
@@ -4,7 +4,7 @@ use frame_system::RawOrigin;
 
 use crate::{
 	pallet::{Call, Collection, Config, Pallet},
-	types::Change,
+	types::{Change, CollectionInfo},
 };
 
 #[cfg(test)]
@@ -133,10 +133,10 @@ mod benchmarks {
 		}
 
 		// Worst case expect to read the max age
-		Pallet::<T>::set_collection_max_age(
+		Pallet::<T>::set_collection_info(
 			RawOrigin::Signed(admin.clone()).into(),
 			T::CollectionId::default(),
-			T::Timestamp::default(),
+			CollectionInfo::default(),
 		)
 		.unwrap();
 
@@ -154,7 +154,7 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn set_collection_max_age() -> Result<(), BenchmarkError> {
+	fn set_collection_info() -> Result<(), BenchmarkError> {
 		#[cfg(test)]
 		init_mocks();
 
@@ -163,10 +163,10 @@ mod benchmarks {
 		T::ChangeGuard::bench_create_pool(T::CollectionId::default(), &admin);
 
 		#[extrinsic_call]
-		set_collection_max_age(
+		set_collection_info(
 			RawOrigin::Signed(admin),
 			T::CollectionId::default(),
-			T::Timestamp::default(),
+			CollectionInfo::default(),
 		);
 
 		Ok(())

--- a/pallets/oracle-data-collection/src/lib.rs
+++ b/pallets/oracle-data-collection/src/lib.rs
@@ -450,7 +450,7 @@ pub mod pallet {
 			collection_id: &T::CollectionId,
 			timestamp: T::Timestamp,
 		) -> DispatchResult {
-			if let Some(duration) = CollectionInfo::<T>::get(collection_id).value_duration {
+			if let Some(duration) = CollectionInfo::<T>::get(collection_id).value_lifetime {
 				ensure!(
 					T::Time::now().ensure_sub(timestamp)? <= duration,
 					Error::<T>::OracleValueOutdated,
@@ -549,8 +549,8 @@ pub mod types {
 	pub struct CollectionInfo<T: Config> {
 		/// Maximum duration to consider an oracle value non-outdated.
 		/// An oracle value is consider updated if its timestamp is higher
-		/// than `now() - value_duration`
-		pub value_duration: Option<T::Timestamp>,
+		/// than `now() - value_lifetime`
+		pub value_lifetime: Option<T::Timestamp>,
 
 		/// Minimun number of feeders to succesfully aggregate a value.
 		pub min_feeders: u32,
@@ -559,7 +559,7 @@ pub mod types {
 	impl<T: Config> Default for CollectionInfo<T> {
 		fn default() -> Self {
 			Self {
-				value_duration: None,
+				value_lifetime: None,
 				min_feeders: 0,
 			}
 		}

--- a/pallets/oracle-data-collection/src/lib.rs
+++ b/pallets/oracle-data-collection/src/lib.rs
@@ -548,7 +548,7 @@ pub mod types {
 	#[scale_info(skip_type_params(T))]
 	pub struct CollectionInfo<T: Config> {
 		/// Maximum duration to consider an oracle value non-outdated.
-		/// An oracle value is consider updated if its timestam is higher
+		/// An oracle value is consider updated if its timestamp is higher
 		/// than `now() - value_duration`
 		pub value_duration: Option<T::Timestamp>,
 

--- a/pallets/oracle-data-collection/src/lib.rs
+++ b/pallets/oracle-data-collection/src/lib.rs
@@ -434,7 +434,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			if let Some(threshold) = CollectionMaxAges::<T>::get(collection_id) {
 				ensure!(
-					T::Time::now().ensure_sub(timestamp)? < threshold,
+					T::Time::now().ensure_sub(timestamp)? <= threshold,
 					Error::<T>::OracleValueOutdated,
 				);
 			}

--- a/pallets/oracle-data-collection/src/lib.rs
+++ b/pallets/oracle-data-collection/src/lib.rs
@@ -523,7 +523,7 @@ pub mod types {
 	}
 
 	/// A collection cached in memory
-	#[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebug, MaxEncodedLen)]
+	#[derive(Encode, Decode, Clone, TypeInfo, RuntimeDebug, MaxEncodedLen)]
 	#[scale_info(skip_type_params(T))]
 	pub struct CachedCollection<T: Config> {
 		pub content: BoundedBTreeMap<T::OracleKey, OracleValuePair<T>, T::MaxCollectionSize>,
@@ -536,6 +536,12 @@ pub mod types {
 				content: Default::default(),
 				older_timestamp: T::Time::now(),
 			}
+		}
+	}
+
+	impl<T: Config> PartialEq for CachedCollection<T> {
+		fn eq(&self, other: &Self) -> bool {
+			self.content == other.content && self.older_timestamp == other.older_timestamp
 		}
 	}
 

--- a/pallets/oracle-data-collection/src/mock.rs
+++ b/pallets/oracle-data-collection/src/mock.rs
@@ -20,6 +20,8 @@ pub type Timestamp = u64;
 pub type CollectionId = u32;
 pub type ChangeId = H256;
 
+pub const NOW: Timestamp = 1000;
+
 frame_support::parameter_types! {
 	#[derive(Clone, PartialEq, Eq, Debug, TypeInfo, Encode, Decode, MaxEncodedLen)]
 	pub const MaxFeedersPerKey: u32 = 10;
@@ -35,6 +37,7 @@ frame_support::construct_runtime!(
 		MockProvider: cfg_mocks::value_provider::pallet,
 		MockIsAdmin: cfg_mocks::pre_conditions::pallet,
 		MockChangeGuard: cfg_mocks::change_guard::pallet,
+		MockTime: cfg_mocks::time::pallet,
 		OracleCollection: pallet_oracle_data_collection,
 	}
 );
@@ -83,6 +86,10 @@ impl cfg_mocks::change_guard::pallet::Config for Runtime {
 	type PoolId = CollectionId;
 }
 
+impl cfg_mocks::time::pallet::Config for Runtime {
+	type Moment = Timestamp;
+}
+
 impl pallet_oracle_data_collection::Config for Runtime {
 	type AggregationProvider = crate::util::MedianAggregation;
 	type ChangeGuard = MockChangeGuard;
@@ -96,6 +103,7 @@ impl pallet_oracle_data_collection::Config for Runtime {
 	type OracleValue = OracleValue;
 	type RuntimeChange = crate::types::Change<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
+	type Time = MockTime;
 	type Timestamp = Timestamp;
 	type WeightInfo = ();
 }
@@ -108,6 +116,9 @@ pub fn new_test_ext() -> TestExternalities {
 	let mut ext = TestExternalities::new(storage);
 
 	// Bumping to one enables events
-	ext.execute_with(|| System::set_block_number(1));
+	ext.execute_with(|| {
+		System::set_block_number(1);
+		MockTime::mock_now(|| NOW);
+	});
 	ext
 }

--- a/pallets/oracle-data-collection/src/tests.rs
+++ b/pallets/oracle-data-collection/src/tests.rs
@@ -117,7 +117,7 @@ mod util {
 			RuntimeOrigin::signed(ADMIN),
 			COLLECTION_ID,
 			CollectionInfo {
-				value_duration: Some(duration),
+				value_lifetime: Some(duration),
 				min_feeders: limit,
 			}
 		));

--- a/pallets/oracle-data-collection/src/tests.rs
+++ b/pallets/oracle-data-collection/src/tests.rs
@@ -21,6 +21,10 @@ const KEY_ERR: OracleKey = 3;
 const KEY_NONE: OracleKey = 4;
 const CHANGE_ID: ChangeId = H256::repeat_byte(0x42);
 
+// The provider will set value with timestamps between those values:
+const ENOUGH_MAX_AGE: Timestamp = 100;
+const NOT_ENOUGH_MAX_AGE: Timestamp = 20;
+
 mod mock {
 	use super::*;
 
@@ -55,10 +59,10 @@ mod mock {
 		MockProvider::mock_get(|(account, collection_id), key| {
 			assert_eq!(collection_id, &COLLECTION_ID);
 			match (account, key) {
-				(&FEEDER_1, &KEY_A) => Ok(Some((100, 50))),
-				(&FEEDER_2, &KEY_A) => Ok(Some((101, 45))),
-				(&FEEDER_3, &KEY_A) => Ok(Some((102, 55))),
-				(&FEEDER_1, &KEY_B) => Ok(Some((1000, 500))),
+				(&FEEDER_1, &KEY_A) => Ok(Some((100, NOW - 50))),
+				(&FEEDER_2, &KEY_A) => Ok(Some((101, NOW - 55))),
+				(&FEEDER_3, &KEY_A) => Ok(Some((102, NOW - 45))),
+				(&FEEDER_1, &KEY_B) => Ok(Some((1000, NOW))),
 				(&FEEDER_2, &KEY_B) => Ok(None),
 				(&FEEDER_3, &KEY_B) => Ok(None),
 				(&FEEDER_1, &KEY_ERR) => Err(DispatchError::Other("get err")),
@@ -103,6 +107,18 @@ mod util {
 
 		MockChangeGuard::mock_note(|_, _| panic!("no note() mock"));
 		MockChangeGuard::mock_released(|_, _| panic!("no released() mock"));
+		MockIsAdmin::mock_check(|_| panic!("no check() mock"));
+	}
+
+	pub fn set_max_age(duration: Timestamp) {
+		MockIsAdmin::mock_check(|_| true);
+
+		assert_ok!(OracleCollection::set_collection_max_age(
+			RuntimeOrigin::signed(ADMIN),
+			COLLECTION_ID,
+			duration,
+		));
+
 		MockIsAdmin::mock_check(|_| panic!("no check() mock"));
 	}
 }
@@ -152,6 +168,35 @@ fn updating_feeders_wrong_admin() {
 				COLLECTION_ID,
 				KEY_A,
 				feeders
+			),
+			Error::<Runtime>::IsNotAdmin
+		);
+	});
+}
+
+#[test]
+fn update_collection_max_age() {
+	new_test_ext().execute_with(|| {
+		MockIsAdmin::mock_check(|_| true);
+
+		assert_ok!(OracleCollection::set_collection_max_age(
+			RuntimeOrigin::signed(ADMIN),
+			COLLECTION_ID,
+			50
+		));
+	});
+}
+
+#[test]
+fn update_collection_max_age_wrong_admin() {
+	new_test_ext().execute_with(|| {
+		MockIsAdmin::mock_check(|_| false);
+
+		assert_err!(
+			OracleCollection::set_collection_max_age(
+				RuntimeOrigin::signed(ADMIN),
+				COLLECTION_ID,
+				50
 			),
 			Error::<Runtime>::IsNotAdmin
 		);
@@ -220,10 +265,22 @@ fn getting_value() {
 		util::update_feeders(KEY_A, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
 
 		mock::prepare_provider();
-
 		assert_ok!(
 			OracleCollection::get(&KEY_A, &COLLECTION_ID),
-			(101, 50) // Median of both values
+			(101, NOW - 50) // Median of both values
+		);
+	});
+}
+
+#[test]
+fn getting_value_with_max_age() {
+	new_test_ext().execute_with(|| {
+		util::update_feeders(KEY_A, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
+
+		mock::prepare_provider();
+		assert_ok!(
+			OracleCollection::get(&KEY_A, &COLLECTION_ID),
+			(101, NOW - 50) // Median of both values
 		);
 	});
 }
@@ -239,6 +296,20 @@ fn getting_value_not_found() {
 }
 
 #[test]
+fn getting_value_but_outdated() {
+	new_test_ext().execute_with(|| {
+		util::update_feeders(KEY_A, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
+		util::set_max_age(NOT_ENOUGH_MAX_AGE);
+
+		mock::prepare_provider();
+		assert_err!(
+			OracleCollection::get(&KEY_A, &COLLECTION_ID),
+			Error::<Runtime>::OracleValueOutdated,
+		);
+	});
+}
+
+#[test]
 fn update_collection() {
 	new_test_ext().execute_with(|| {
 		util::update_feeders(KEY_A, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
@@ -246,16 +317,15 @@ fn update_collection() {
 		util::update_feeders(KEY_NONE, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
 
 		mock::prepare_provider();
-
 		assert_ok!(OracleCollection::update_collection(
 			RuntimeOrigin::signed(ANY),
 			COLLECTION_ID
 		));
 
-		let collection = OracleCollection::collection(&COLLECTION_ID);
+		let collection = OracleCollection::collection(&COLLECTION_ID).unwrap();
 		assert_eq!(
 			collection.as_vec(),
-			vec![(KEY_A, (101, 50)), (KEY_B, (1000, 500))]
+			vec![(KEY_A, (101, NOW - 50)), (KEY_B, (1000, NOW))]
 		);
 
 		System::assert_last_event(
@@ -269,6 +339,64 @@ fn update_collection() {
 }
 
 #[test]
+fn update_collection_with_max_age() {
+	new_test_ext().execute_with(|| {
+		util::update_feeders(KEY_A, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
+		util::update_feeders(KEY_B, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
+		util::set_max_age(ENOUGH_MAX_AGE);
+
+		mock::prepare_provider();
+		assert_ok!(OracleCollection::update_collection(
+			RuntimeOrigin::signed(ANY),
+			COLLECTION_ID
+		));
+
+		let collection = OracleCollection::collection(&COLLECTION_ID).unwrap();
+		assert_eq!(
+			collection.as_vec(),
+			vec![(KEY_A, (101, NOW - 50)), (KEY_B, (1000, NOW))]
+		);
+	});
+}
+
+#[test]
+fn update_collection_outdated() {
+	new_test_ext().execute_with(|| {
+		util::update_feeders(KEY_A, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
+		util::update_feeders(KEY_B, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
+		util::set_max_age(NOT_ENOUGH_MAX_AGE);
+
+		mock::prepare_provider();
+		assert_err!(
+			OracleCollection::update_collection(RuntimeOrigin::signed(ANY), COLLECTION_ID),
+			Error::<Runtime>::OracleValueOutdated
+		);
+	});
+}
+
+#[test]
+fn update_collection_but_getting_elements_out_of_time() {
+	new_test_ext().execute_with(|| {
+		util::update_feeders(KEY_A, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
+		util::update_feeders(KEY_B, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
+		util::set_max_age(ENOUGH_MAX_AGE);
+
+		mock::prepare_provider();
+		assert_ok!(OracleCollection::update_collection(
+			RuntimeOrigin::signed(ANY),
+			COLLECTION_ID
+		));
+
+		util::set_max_age(NOT_ENOUGH_MAX_AGE);
+
+		assert_err!(
+			OracleCollection::collection(&COLLECTION_ID),
+			Error::<Runtime>::OracleValueOutdated
+		);
+	});
+}
+
+#[test]
 fn update_collection_with_errs() {
 	new_test_ext().execute_with(|| {
 		util::update_feeders(KEY_A, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
@@ -276,7 +404,6 @@ fn update_collection_with_errs() {
 		util::update_feeders(KEY_ERR, vec![FEEDER_1, FEEDER_2, FEEDER_3]);
 
 		mock::prepare_provider();
-
 		assert_err!(
 			OracleCollection::update_collection(RuntimeOrigin::signed(ANY), COLLECTION_ID),
 			DispatchError::Other("get err")
@@ -292,7 +419,7 @@ fn update_collection_empty() {
 			COLLECTION_ID
 		));
 
-		let collection = OracleCollection::collection(&COLLECTION_ID);
+		let collection = OracleCollection::collection(&COLLECTION_ID).unwrap();
 		assert!(collection.as_vec().is_empty());
 
 		System::assert_last_event(
@@ -315,7 +442,7 @@ fn update_collection_with_registrations_but_no_feeders() {
 			COLLECTION_ID
 		));
 
-		let collection = OracleCollection::collection(&COLLECTION_ID);
+		let collection = OracleCollection::collection(&COLLECTION_ID).unwrap();
 
 		// Registered keys without associated feeder are skipped from the collection
 		assert!(collection.as_vec().is_empty());
@@ -334,7 +461,7 @@ fn update_collection_with_feeders_but_no_values() {
 			COLLECTION_ID
 		));
 
-		let collection = OracleCollection::collection(&COLLECTION_ID);
+		let collection = OracleCollection::collection(&COLLECTION_ID).unwrap();
 
 		// Keys with no values are skipped from the collection
 		assert!(collection.as_vec().is_empty());

--- a/pallets/oracle-data-collection/src/weights.rs
+++ b/pallets/oracle-data-collection/src/weights.rs
@@ -14,17 +14,13 @@
 use frame_support::weights::Weight;
 
 pub trait WeightInfo {
-	fn set_collection_max_age() -> Weight;
 	fn propose_update_feeders(feeders: u32) -> Weight;
 	fn apply_update_feeders(feeders: u32) -> Weight;
 	fn update_collection(feeders: u32, keys: u32) -> Weight;
+	fn set_collection_max_age() -> Weight;
 }
 
 impl WeightInfo for () {
-	fn set_collection_max_age() -> Weight {
-		Weight::zero()
-	}
-
 	fn propose_update_feeders(_: u32) -> Weight {
 		Weight::zero()
 	}
@@ -34,6 +30,10 @@ impl WeightInfo for () {
 	}
 
 	fn update_collection(_: u32, _: u32) -> Weight {
+		Weight::zero()
+	}
+
+	fn set_collection_max_age() -> Weight {
 		Weight::zero()
 	}
 }

--- a/pallets/oracle-data-collection/src/weights.rs
+++ b/pallets/oracle-data-collection/src/weights.rs
@@ -14,12 +14,17 @@
 use frame_support::weights::Weight;
 
 pub trait WeightInfo {
+	fn set_collection_max_age() -> Weight;
 	fn propose_update_feeders(feeders: u32) -> Weight;
 	fn apply_update_feeders(feeders: u32) -> Weight;
 	fn update_collection(feeders: u32, keys: u32) -> Weight;
 }
 
 impl WeightInfo for () {
+	fn set_collection_max_age() -> Weight {
+		Weight::zero()
+	}
+
 	fn propose_update_feeders(_: u32) -> Weight {
 		Weight::zero()
 	}

--- a/pallets/oracle-data-collection/src/weights.rs
+++ b/pallets/oracle-data-collection/src/weights.rs
@@ -17,7 +17,7 @@ pub trait WeightInfo {
 	fn propose_update_feeders(feeders: u32) -> Weight;
 	fn apply_update_feeders(feeders: u32) -> Weight;
 	fn update_collection(feeders: u32, keys: u32) -> Weight;
-	fn set_collection_max_age() -> Weight;
+	fn set_collection_info() -> Weight;
 }
 
 impl WeightInfo for () {
@@ -33,7 +33,7 @@ impl WeightInfo for () {
 		Weight::zero()
 	}
 
-	fn set_collection_max_age() -> Weight {
+	fn set_collection_info() -> Weight {
 		Weight::zero()
 	}
 }

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1354,6 +1354,7 @@ impl pallet_oracle_data_collection::Config for Runtime {
 	type OracleValue = Balance;
 	type RuntimeChange = runtime_common::changes::RuntimeChange<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
+	type Time = Timestamp;
 	type Timestamp = Millis;
 	type WeightInfo = weights::pallet_oracle_data_collection::WeightInfo<Self>;
 }

--- a/runtime/altair/src/weights/pallet_oracle_data_collection.rs
+++ b/runtime/altair/src/weights/pallet_oracle_data_collection.rs
@@ -17,4 +17,8 @@ impl<T: frame_system::Config> pallet_oracle_data_collection::WeightInfo for Weig
 	fn update_collection(_: u32, _: u32) -> Weight {
 		Weight::zero()
 	}
+
+	fn set_collection_max_age() -> Weight {
+		Weight::zero()
+	}
 }

--- a/runtime/altair/src/weights/pallet_oracle_data_collection.rs
+++ b/runtime/altair/src/weights/pallet_oracle_data_collection.rs
@@ -18,7 +18,7 @@ impl<T: frame_system::Config> pallet_oracle_data_collection::WeightInfo for Weig
 		Weight::zero()
 	}
 
-	fn set_collection_max_age() -> Weight {
+	fn set_collection_info() -> Weight {
 		Weight::zero()
 	}
 }

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1711,6 +1711,7 @@ impl pallet_oracle_data_collection::Config for Runtime {
 	type OracleValue = Balance;
 	type RuntimeChange = runtime_common::changes::RuntimeChange<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
+	type Time = Timestamp;
 	type Timestamp = Millis;
 	type WeightInfo = weights::pallet_oracle_data_collection::WeightInfo<Self>;
 }

--- a/runtime/centrifuge/src/weights/pallet_oracle_data_collection.rs
+++ b/runtime/centrifuge/src/weights/pallet_oracle_data_collection.rs
@@ -17,4 +17,8 @@ impl<T: frame_system::Config> pallet_oracle_data_collection::WeightInfo for Weig
 	fn update_collection(_: u32, _: u32) -> Weight {
 		Weight::zero()
 	}
+
+	fn set_collection_max_age() -> Weight {
+		Weight::zero()
+	}
 }

--- a/runtime/centrifuge/src/weights/pallet_oracle_data_collection.rs
+++ b/runtime/centrifuge/src/weights/pallet_oracle_data_collection.rs
@@ -18,7 +18,7 @@ impl<T: frame_system::Config> pallet_oracle_data_collection::WeightInfo for Weig
 		Weight::zero()
 	}
 
-	fn set_collection_max_age() -> Weight {
+	fn set_collection_info() -> Weight {
 		Weight::zero()
 	}
 }

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1339,6 +1339,7 @@ impl pallet_oracle_data_collection::Config for Runtime {
 	type OracleValue = Balance;
 	type RuntimeChange = runtime_common::changes::RuntimeChange<Runtime, FastDelay>;
 	type RuntimeEvent = RuntimeEvent;
+	type Time = Timestamp;
 	type Timestamp = Millis;
 	type WeightInfo = weights::pallet_oracle_data_collection::WeightInfo<Self>;
 }

--- a/runtime/development/src/weights/pallet_oracle_data_collection.rs
+++ b/runtime/development/src/weights/pallet_oracle_data_collection.rs
@@ -17,4 +17,8 @@ impl<T: frame_system::Config> pallet_oracle_data_collection::WeightInfo for Weig
 	fn update_collection(_: u32, _: u32) -> Weight {
 		Weight::zero()
 	}
+
+	fn set_collection_max_age() -> Weight {
+		Weight::zero()
+	}
 }

--- a/runtime/development/src/weights/pallet_oracle_data_collection.rs
+++ b/runtime/development/src/weights/pallet_oracle_data_collection.rs
@@ -18,7 +18,7 @@ impl<T: frame_system::Config> pallet_oracle_data_collection::WeightInfo for Weig
 		Weight::zero()
 	}
 
-	fn set_collection_max_age() -> Weight {
+	fn set_collection_info() -> Weight {
 		Weight::zero()
 	}
 }


### PR DESCRIPTION
# Description

We want, as a requirement, to have oracle values validated with a "max age" threshold. Older oracles values must be considered outdated and it's an error to use them.

This error is generated when:
- Getting a collection where one oracle is outdated.
- Getting just an oracle value outdated.
- Updating a collection when an oracle value is outdated.

The threshold is optionally set by the collection by the admin

## Tasks
- [x] Implementation
- [x] Testing
- [x] Benchmarks
- [x] Updated runtimes