### PR TITLE
liquidity-pools: Ensure only pool admins can allow investment currencies

### DIFF
--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -730,6 +730,15 @@ pub mod pallet {
 			// See spec: https://centrifuge.hackmd.io/SERpps-URlG4hkOyyS94-w?view#fn-add_pool_currency
 			let who = ensure_signed(origin)?;
 
+			ensure!(
+				T::Permission::has(
+					PermissionScope::Pool(pool_id),
+					who.clone(),
+					Role::PoolRole(PoolRole::PoolAdmin)
+				),
+				Error::<T>::NotPoolAdmin
+			);
+
 			// Ensure currency is allowed as payment and payout currency for pool
 			let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 			// Required for increasing and collecting investments

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -1422,6 +1422,16 @@ mod development {
 						currency_id,
 					)
 				);
+
+				assert_noop!(
+					pallet_liquidity_pools::Pallet::<T>::allow_investment_currency(
+						RawOrigin::Signed(Keyring::Charlie.into()).into(),
+						pool_id,
+						default_tranche_id::<T>(pool_id),
+						currency_id,
+					),
+					pallet_liquidity_pools::Error::<T>::NotPoolAdmin
+				);
 			});
 		}
 
@@ -1452,7 +1462,7 @@ mod development {
 						[0u8; 16],
 						currency_id,
 					),
-					pallet_liquidity_pools::Error::<T>::PoolNotFound
+					pallet_liquidity_pools::Error::<T>::NotPoolAdmin
 				);
 
 				// Register currency_id with pool_currency set to true


### PR DESCRIPTION
# Description

Fixes #1677 

## Changes and Descriptions

Added a permission check for the pool admin role.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
