### PR TITLE
remarks: Add pool ID to loan variant

### DIFF
--- a/runtime/common/src/remarks.rs
+++ b/runtime/common/src/remarks.rs
@@ -10,7 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_primitives::LoanId;
+use cfg_primitives::{LoanId, PoolId};
 use frame_support::{dispatch::TypeInfo, parameter_types, BoundedVec};
 use sp_runtime::codec::{Decode, Encode};
 use sp_std::vec;
@@ -29,7 +29,7 @@ pub enum Remark {
 	Named(BoundedVec<u8, MaxNamedRemark>),
 
 	/// Association with a loan
-	Loan(LoanId),
+	Loan(PoolId, LoanId),
 }
 
 impl Default for Remark {


### PR DESCRIPTION
# Description

Loan IDs are not unique, therefore, we need to add the `PoolId` to the `Loan` variant of the `Remark` enum.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
