### PR TITLE
lp-gateway: Add queue for outbound messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7440,6 +7440,7 @@ name = "pallet-liquidity-pools-gateway"
 version = "0.0.1"
 dependencies = [
  "cfg-mocks",
+ "cfg-primitives",
  "cfg-traits",
  "cfg-types",
  "cfg-utils",

--- a/libs/mocks/src/liquidity_pools.rs
+++ b/libs/mocks/src/liquidity_pools.rs
@@ -1,8 +1,8 @@
 use cfg_traits::liquidity_pools::Codec;
-use parity_scale_codec::{Decode, Encode, Error, Input};
+use parity_scale_codec::{Decode, Encode, Error, Input, MaxEncodedLen};
 use scale_info::TypeInfo;
 
-#[derive(Debug, Eq, PartialEq, Clone, Encode, Decode, TypeInfo)]
+#[derive(Debug, Eq, PartialEq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub enum MessageMock {
 	First,
 	Second,

--- a/libs/mocks/src/liquidity_pools_gateway_routers.rs
+++ b/libs/mocks/src/liquidity_pools_gateway_routers.rs
@@ -28,7 +28,9 @@ pub mod pallet {
 			register_call!(move |()| f());
 		}
 
-		pub fn mock_send(f: impl Fn(T::AccountId, MessageMock) -> DispatchResult + 'static) {
+		pub fn mock_send(
+			f: impl Fn(T::AccountId, MessageMock) -> DispatchResultWithPostInfo + 'static,
+		) {
 			register_call!(move |(sender, message)| f(sender, message));
 		}
 	}
@@ -41,7 +43,7 @@ pub mod pallet {
 			execute_call!(())
 		}
 
-		fn send(sender: Self::Sender, message: MessageMock) -> DispatchResult {
+		fn send(sender: Self::Sender, message: MessageMock) -> DispatchResultWithPostInfo {
 			execute_call!((sender, message))
 		}
 	}
@@ -68,7 +70,10 @@ impl<T: pallet::Config> RouterMock<T> {
 		pallet::Pallet::<T>::mock_init(f)
 	}
 
-	pub fn mock_send(&self, f: impl Fn(T::AccountId, MessageMock) -> DispatchResult + 'static) {
+	pub fn mock_send(
+		&self,
+		f: impl Fn(T::AccountId, MessageMock) -> DispatchResultWithPostInfo + 'static,
+	) {
 		pallet::Pallet::<T>::mock_send(f)
 	}
 }
@@ -83,7 +88,7 @@ impl<T: pallet::Config> Router for RouterMock<T> {
 		pallet::Pallet::<T>::init()
 	}
 
-	fn send(&self, sender: Self::Sender, message: Self::Message) -> DispatchResult {
+	fn send(&self, sender: Self::Sender, message: Self::Message) -> DispatchResultWithPostInfo {
 		pallet::Pallet::<T>::send(sender, message)
 	}
 }
@@ -105,5 +110,5 @@ trait MockedRouter {
 	fn init() -> DispatchResult;
 
 	/// Send the message to the router's destination.
-	fn send(sender: Self::Sender, message: Self::Message) -> DispatchResult;
+	fn send(sender: Self::Sender, message: Self::Message) -> DispatchResultWithPostInfo;
 }

--- a/libs/primitives/src/lib.rs
+++ b/libs/primitives/src/lib.rs
@@ -179,6 +179,9 @@ pub mod types {
 
 	/// The representation of a pool fee identifier
 	pub type PoolFeeId = u64;
+
+	/// The type for outbound LP message nonces.
+	pub type OutboundMessageNonce = u64;
 }
 
 /// Common constants for all runtimes

--- a/libs/traits/src/liquidity_pools.rs
+++ b/libs/traits/src/liquidity_pools.rs
@@ -11,7 +11,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use frame_support::dispatch::DispatchResult;
+use frame_support::dispatch::{DispatchResult, DispatchResultWithPostInfo};
 use parity_scale_codec::Input;
 use sp_std::vec::Vec;
 
@@ -34,7 +34,7 @@ pub trait Router {
 	fn init(&self) -> DispatchResult;
 
 	/// Send the message to the router's destination.
-	fn send(&self, sender: Self::Sender, message: Self::Message) -> DispatchResult;
+	fn send(&self, sender: Self::Sender, message: Self::Message) -> DispatchResultWithPostInfo;
 }
 
 /// The trait required for processing outbound messages.

--- a/pallets/liquidity-pools-gateway/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/Cargo.toml
@@ -32,6 +32,7 @@ cfg-utils = { path = "../../libs/utils", default-features = false }
 
 [dev-dependencies]
 cfg-mocks = { path = "../../libs/mocks", features = ["std"] }
+cfg-primitives = { path = "../../libs/primitives" }
 hex-literal = "0.4.1"
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43" }

--- a/pallets/liquidity-pools-gateway/routers/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/routers/src/mock.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use cfg_mocks::{pallet_mock_liquidity_pools, pallet_mock_routers, MessageMock, RouterMock};
-use cfg_primitives::{BLOCK_STORAGE_LIMIT, MAX_POV_SIZE};
+use cfg_primitives::{OutboundMessageNonce, BLOCK_STORAGE_LIMIT, MAX_POV_SIZE};
 use cfg_traits::TryConvert;
 use cfg_types::domain_address::DomainAddress;
 use cumulus_primitives_core::{
@@ -153,6 +153,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = MessageMock;
 	type OriginRecovery = MockOriginRecovery;
+	type OutboundMessageNonce = OutboundMessageNonce;
 	type Router = RouterMock<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/pallets/liquidity-pools-gateway/routers/src/routers/axelar_evm.rs
+++ b/pallets/liquidity-pools-gateway/routers/src/routers/axelar_evm.rs
@@ -11,7 +11,7 @@
 // GNU General Public License for more details.
 use cfg_traits::liquidity_pools::Codec;
 use ethabi::{Contract, Function, Param, ParamType, Token};
-use frame_support::dispatch::{DispatchError, DispatchResult};
+use frame_support::dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo};
 use frame_system::pallet_prelude::OriginFor;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::{
@@ -61,7 +61,7 @@ where
 
 	/// Encodes the message to the required format,
 	/// then executes the EVM call using the generic EVM router.
-	pub fn do_send(&self, sender: AccountIdOf<T>, msg: MessageOf<T>) -> DispatchResult {
+	pub fn do_send(&self, sender: AccountIdOf<T>, msg: MessageOf<T>) -> DispatchResultWithPostInfo {
 		let eth_msg = get_axelar_encoded_msg(
 			msg.serialize(),
 			self.evm_chain.clone().into_inner(),

--- a/pallets/liquidity-pools-gateway/routers/src/routers/axelar_xcm.rs
+++ b/pallets/liquidity-pools-gateway/routers/src/routers/axelar_xcm.rs
@@ -11,7 +11,7 @@
 // GNU General Public License for more details.
 
 use cfg_traits::liquidity_pools::Codec;
-use frame_support::dispatch::DispatchResult;
+use frame_support::dispatch::{DispatchResult, DispatchResultWithPostInfo};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::{bounded::BoundedVec, ConstU32, H160};
@@ -53,7 +53,7 @@ where
 
 	/// Encodes the message to the required format,
 	/// then executes the EVM call using the generic XCM router.
-	pub fn do_send(&self, sender: AccountIdOf<T>, msg: MessageOf<T>) -> DispatchResult {
+	pub fn do_send(&self, sender: AccountIdOf<T>, msg: MessageOf<T>) -> DispatchResultWithPostInfo {
 		let contract_call = get_axelar_encoded_msg(
 			msg.serialize(),
 			self.axelar_target_chain.clone().into_inner(),

--- a/pallets/liquidity-pools-gateway/routers/src/routers/ethereum_xcm.rs
+++ b/pallets/liquidity-pools-gateway/routers/src/routers/ethereum_xcm.rs
@@ -11,7 +11,10 @@
 // GNU General Public License for more details.
 use cfg_traits::liquidity_pools::Codec;
 use ethabi::{Bytes, Contract};
-use frame_support::{dispatch::DispatchResult, sp_runtime::DispatchError};
+use frame_support::{
+	dispatch::{DispatchResult, DispatchResultWithPostInfo},
+	sp_runtime::DispatchError,
+};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, vec, vec::Vec};
@@ -43,7 +46,7 @@ where
 
 	/// Encodes the message to the required format and executes the
 	/// call via the XCM router.
-	pub fn do_send(&self, sender: AccountIdOf<T>, msg: MessageOf<T>) -> DispatchResult {
+	pub fn do_send(&self, sender: AccountIdOf<T>, msg: MessageOf<T>) -> DispatchResultWithPostInfo {
 		let contract_call = get_encoded_contract_call(msg.serialize())
 			.map_err(|_| DispatchError::Other("encoded contract call retrieval"))?;
 

--- a/pallets/liquidity-pools-gateway/routers/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/routers/src/tests.rs
@@ -169,7 +169,7 @@ mod evm_router {
 				let res = router.do_send(test_data.sender, test_data.msg);
 
 				assert_eq!(
-					res.err().unwrap(),
+					res.err().unwrap().error,
 					pallet_evm::Error::<Runtime>::BalanceLow.into()
 				);
 			});
@@ -483,7 +483,7 @@ mod axelar_evm {
 				let res = domain_router.send(test_data.sender, test_data.msg);
 
 				assert_eq!(
-					res.err().unwrap(),
+					res.err().unwrap().error,
 					pallet_evm::Error::<Runtime>::BalanceLow.into()
 				);
 			});

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -707,7 +707,7 @@ pub mod pallet {
 
 			let router = DomainRouters::<T>::get(domain).ok_or(DispatchErrorWithPostInfo {
 				post_info: PostDispatchInfo {
-					actual_weight: Some(read_weight.clone()),
+					actual_weight: Some(read_weight),
 					pays_fee: Pays::Yes,
 				},
 				error: Error::<T>::RouterNotFound.into(),

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -60,6 +60,11 @@ impl<T: Config> From<RelayerMessageDecodingError> for Error<T> {
 pub mod pallet {
 	const BYTES_U32: usize = 4;
 	const BYTES_ACCOUNT_20: usize = 20;
+
+	/// Some gateway routers do not return an actual weight when sending a
+	/// message, thus, this default is required, and it's based on:
+	///
+	/// https://github.com/centrifuge/centrifuge-chain/pull/1696#discussion_r1456370592
 	const DEFAULT_WEIGHT_REF_TIME: u64 = 5_000_000_000;
 
 	use frame_support::dispatch::PostDispatchInfo;
@@ -537,7 +542,7 @@ pub mod pallet {
 
 					FailedOutboundMessages::<T>::insert(nonce, (domain, sender, message, e.error));
 
-					Err(e.error)
+					Ok(())
 				}
 			}
 		}
@@ -576,7 +581,7 @@ pub mod pallet {
 						error: e.error,
 					});
 
-					Err(e.error)
+					Ok(())
 				}
 			}
 		}

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -2,6 +2,7 @@ use cfg_mocks::{
 	pallet_mock_liquidity_pools, pallet_mock_routers, pallet_mock_try_convert, MessageMock,
 	RouterMock,
 };
+use cfg_primitives::OutboundMessageNonce;
 use cfg_types::domain_address::DomainAddress;
 use frame_system::EnsureRoot;
 use sp_core::{crypto::AccountId32, ConstU128, ConstU16, ConstU32, ConstU64, H256};
@@ -111,6 +112,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = MessageMock;
 	type OriginRecovery = MockOriginRecovery;
+	type OutboundMessageNonce = OutboundMessageNonce;
 	type Router = RouterMock<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -79,7 +79,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type HoldIdentifier = ();
 	type MaxFreezes = ();
-	type MaxHolds = frame_support::traits::ConstU32<1>;
+	type MaxHolds = ConstU32<1>;
 	type MaxLocks = ();
 	type MaxReserves = ();
 	type ReserveIdentifier = ();

--- a/pallets/liquidity-pools-gateway/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/src/tests.rs
@@ -29,7 +29,6 @@ mod utils {
 
 	pub fn event_exists<E: Into<MockEvent>>(e: E) {
 		let e: MockEvent = e.into();
-		let _ee = frame_system::Pallet::<Runtime>::events();
 		assert!(frame_system::Pallet::<Runtime>::events()
 			.iter()
 			.any(|ev| ev.event == e));
@@ -1097,7 +1096,7 @@ mod outbound_queue_impl {
 
 			let expected_nonce = OutboundMessageNonce::one();
 
-			let queue_entry = OutboundMessageQueue::<Runtime>::take(expected_nonce)
+			let queue_entry = OutboundMessageQueue::<Runtime>::get(expected_nonce)
 				.expect("an entry is added to the queue");
 
 			let gateway_sender = <Runtime as Config>::Sender::get();

--- a/pallets/liquidity-pools-gateway/src/weights.rs
+++ b/pallets/liquidity-pools-gateway/src/weights.rs
@@ -19,6 +19,8 @@ pub trait WeightInfo {
 	fn add_relayer() -> Weight;
 	fn remove_relayer() -> Weight;
 	fn process_msg() -> Weight;
+	fn process_outbound_message() -> Weight;
+	fn process_failed_outbound_message() -> Weight;
 }
 
 // NOTE: We use temporary weights here. `execute_epoch` is by far our heaviest
@@ -97,5 +99,27 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(8))
 			.saturating_add(RocksDbWeight::get().writes((6_u64).saturating_mul(N)))
 			.saturating_add(Weight::from_parts(0, 17774).saturating_mul(N))
+	}
+
+	fn process_outbound_message() -> Weight {
+		// TODO: BENCHMARK CORRECTLY
+		//
+		// NOTE: Reasonable weight taken from `PoolSystem::set_max_reserve`
+		//       This one has one read and one write for sure and possible one
+		//       read for `AdminOrigin`
+		Weight::from_parts(30_117_000, 5991)
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+
+	fn process_failed_outbound_message() -> Weight {
+		// TODO: BENCHMARK CORRECTLY
+		//
+		// NOTE: Reasonable weight taken from `PoolSystem::set_max_reserve`
+		//       This one has one read and one write for sure and possible one
+		//       read for `AdminOrigin`
+		Weight::from_parts(30_117_000, 5991)
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(1))
 	}
 }

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -1,7 +1,7 @@
 use cfg_traits::{liquidity_pools::Codec, Seconds};
 use cfg_utils::{decode, decode_be_bytes, encode_be};
 use frame_support::RuntimeDebug;
-use parity_scale_codec::{Decode, Encode, Input};
+use parity_scale_codec::{Decode, Encode, Input, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_std::{vec, vec::Vec};
 
@@ -28,7 +28,7 @@ pub const TOKEN_SYMBOL_SIZE: usize = 32;
 ///
 /// NOTE: The sender of a message cannot ensure whether the
 /// corresponding receiver rejects it.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum Message<Domain, PoolId, TrancheId, Balance, Ratio>
 where
 	Domain: Codec,

--- a/runtime/altair/src/liquidity_pools.rs
+++ b/runtime/altair/src/liquidity_pools.rs
@@ -90,6 +90,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = LiquidityPoolsMessage;
 	type OriginRecovery = crate::LiquidityPoolsAxelarGateway;
+	type OutboundMessageNonce = u64;
 	type Router = liquidity_pools_gateway_routers::DomainRouter<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/runtime/altair/src/liquidity_pools.rs
+++ b/runtime/altair/src/liquidity_pools.rs
@@ -11,7 +11,8 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::{
-	liquidity_pools::GeneralCurrencyPrefix, AccountId, Balance, PalletIndex, PoolId, TrancheId,
+	liquidity_pools::GeneralCurrencyPrefix, AccountId, Balance, OutboundMessageNonce, PalletIndex,
+	PoolId, TrancheId,
 };
 use cfg_types::{
 	fixed_point::Ratio,
@@ -90,7 +91,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = LiquidityPoolsMessage;
 	type OriginRecovery = crate::LiquidityPoolsAxelarGateway;
-	type OutboundMessageNonce = u64;
+	type OutboundMessageNonce = OutboundMessageNonce;
 	type Router = liquidity_pools_gateway_routers::DomainRouter<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/runtime/centrifuge/src/liquidity_pools.rs
+++ b/runtime/centrifuge/src/liquidity_pools.rs
@@ -108,6 +108,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = LiquidityPoolsMessage;
 	type OriginRecovery = LiquidityPoolsAxelarGateway;
+	type OutboundMessageNonce = u64;
 	type Router = liquidity_pools_gateway_routers::DomainRouter<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/runtime/centrifuge/src/liquidity_pools.rs
+++ b/runtime/centrifuge/src/liquidity_pools.rs
@@ -11,8 +11,8 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::{
-	liquidity_pools::GeneralCurrencyPrefix, AccountId, Balance, EnsureRootOr, PalletIndex, PoolId,
-	TrancheId, TwoThirdOfCouncil,
+	liquidity_pools::GeneralCurrencyPrefix, AccountId, Balance, EnsureRootOr, OutboundMessageNonce,
+	PalletIndex, PoolId, TrancheId, TwoThirdOfCouncil,
 };
 use cfg_types::{
 	fixed_point::Ratio,
@@ -108,7 +108,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = LiquidityPoolsMessage;
 	type OriginRecovery = LiquidityPoolsAxelarGateway;
-	type OutboundMessageNonce = u64;
+	type OutboundMessageNonce = OutboundMessageNonce;
 	type Router = liquidity_pools_gateway_routers::DomainRouter<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/runtime/common/src/xcm.rs
+++ b/runtime/common/src/xcm.rs
@@ -126,6 +126,7 @@ mod test {
 		pallet_mock_liquidity_pools, pallet_mock_routers, pallet_mock_try_convert, MessageMock,
 		RouterMock,
 	};
+	use cfg_primitives::OutboundMessageNonce;
 	use frame_support::{assert_ok, traits::EnsureOrigin};
 	use frame_system::EnsureRoot;
 	use pallet_liquidity_pools_gateway::{EnsureLocal, GatewayOrigin};
@@ -218,6 +219,7 @@ mod test {
 		type MaxIncomingMessageSize = ConstU32<1024>;
 		type Message = MessageMock;
 		type OriginRecovery = MockOriginRecovery;
+		type OutboundMessageNonce = OutboundMessageNonce;
 		type Router = RouterMock<Runtime>;
 		type RuntimeEvent = RuntimeEvent;
 		type RuntimeOrigin = RuntimeOrigin;

--- a/runtime/development/src/liquidity_pools.rs
+++ b/runtime/development/src/liquidity_pools.rs
@@ -12,7 +12,7 @@
 
 use cfg_primitives::{
 	liquidity_pools::GeneralCurrencyPrefix, AccountId, Balance, EnsureRootOr, HalfOfCouncil,
-	PalletIndex, PoolId, TrancheId,
+	OutboundMessageNonce, PalletIndex, PoolId, TrancheId,
 };
 use cfg_types::{
 	fixed_point::Ratio,
@@ -93,7 +93,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = LiquidityPoolsMessage;
 	type OriginRecovery = LiquidityPoolsAxelarGateway;
-	type OutboundMessageNonce = u64;
+	type OutboundMessageNonce = OutboundMessageNonce;
 	type Router = liquidity_pools_gateway_routers::DomainRouter<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/runtime/development/src/liquidity_pools.rs
+++ b/runtime/development/src/liquidity_pools.rs
@@ -93,6 +93,7 @@ impl pallet_liquidity_pools_gateway::Config for Runtime {
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;
 	type Message = LiquidityPoolsMessage;
 	type OriginRecovery = LiquidityPoolsAxelarGateway;
+	type OutboundMessageNonce = u64;
 	type Router = liquidity_pools_gateway_routers::DomainRouter<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;


### PR DESCRIPTION
# Description

Fixes #1694 

## Changes and Descriptions

- Added storage for outbound messages.
- Added `on-idle` hook logic for processing outbound messages.
- Added `DispatchResultWithPostInfo` to routers for retrieving weight.
- Added storage for failed outbound messages.
- Added extrinsics for manually executing messages.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
