### PR TITLE
fix: foreign investment amount

### DIFF
--- a/pallets/foreign-investments/src/impls.rs
+++ b/pallets/foreign-investments/src/impls.rs
@@ -6,7 +6,7 @@ use cfg_traits::{
 };
 use cfg_types::investments::CollectedAmount;
 use frame_support::pallet_prelude::*;
-use sp_runtime::traits::Zero;
+use sp_runtime::traits::{EnsureAdd, Zero};
 use sp_std::marker::PhantomData;
 
 use crate::{
@@ -132,7 +132,14 @@ impl<T: Config> ForeignInvestment<T::AccountId> for Pallet<T> {
 		who: &T::AccountId,
 		investment_id: T::InvestmentId,
 	) -> Result<T::Balance, DispatchError> {
-		T::Investment::investment(who, investment_id)
+		Ok(T::Investment::investment(who, investment_id)?.ensure_add(
+			Swaps::<T>::pending_amount_for(
+				who,
+				investment_id,
+				Action::Investment,
+				pool_currency_of::<T>(investment_id)?,
+			),
+		)?)
 	}
 
 	fn redemption(

--- a/pallets/foreign-investments/src/tests.rs
+++ b/pallets/foreign-investments/src/tests.rs
@@ -411,7 +411,11 @@ mod investment {
 				})
 			);
 
-			assert_eq!(ForeignInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
+			assert_eq!(
+				ForeignInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(AMOUNT))
+			);
+			assert_eq!(MockInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
 		});
 	}
 
@@ -442,7 +446,11 @@ mod investment {
 				})
 			);
 
-			assert_eq!(ForeignInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
+			assert_eq!(
+				ForeignInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(AMOUNT + AMOUNT))
+			);
+			assert_eq!(MockInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
 		});
 	}
 
@@ -527,7 +535,11 @@ mod investment {
 				})
 			);
 
-			assert_eq!(ForeignInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
+			assert_eq!(
+				ForeignInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(AMOUNT * 3 / 4))
+			);
+			assert_eq!(MockInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
 		});
 	}
 
@@ -579,6 +591,10 @@ mod investment {
 
 			assert_eq!(
 				ForeignInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(AMOUNT))
+			);
+			assert_eq!(
+				MockInvestment::investment(&USER, INVESTMENT_ID),
 				Ok(foreign_to_pool(AMOUNT / 4))
 			);
 		});
@@ -597,6 +613,14 @@ mod investment {
 			));
 
 			util::fulfill_last_swap(Action::Investment, foreign_to_pool(3 * AMOUNT / 4));
+			assert_eq!(
+				ForeignInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(AMOUNT))
+			);
+			assert_eq!(
+				MockInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(3 * AMOUNT / 4))
+			);
 
 			assert_ok!(ForeignInvestment::decrease_foreign_investment(
 				&USER,
@@ -615,6 +639,10 @@ mod investment {
 
 			assert_eq!(
 				ForeignInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(AMOUNT / 2))
+			);
+			assert_eq!(
+				MockInvestment::investment(&USER, INVESTMENT_ID),
 				Ok(foreign_to_pool(AMOUNT / 2))
 			);
 		});
@@ -658,6 +686,10 @@ mod investment {
 
 			assert_eq!(
 				ForeignInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(AMOUNT * 3 / 2))
+			);
+			assert_eq!(
+				MockInvestment::investment(&USER, INVESTMENT_ID),
 				Ok(foreign_to_pool(3 * AMOUNT / 4))
 			);
 		});
@@ -704,6 +736,7 @@ mod investment {
 			);
 
 			assert_eq!(ForeignInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
+			assert_eq!(MockInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
 		});
 	}
 
@@ -764,6 +797,10 @@ mod investment {
 				ForeignInvestment::investment(&USER, INVESTMENT_ID),
 				Ok(foreign_to_pool(AMOUNT / 4))
 			);
+			assert_eq!(
+				MockInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(AMOUNT / 4))
+			);
 		});
 	}
 
@@ -816,9 +853,12 @@ mod investment {
 					decrease_swapped_amount: 0,
 				})
 			);
-
 			assert_eq!(
 				ForeignInvestment::investment(&USER, INVESTMENT_ID),
+				Ok(foreign_to_pool(3 * AMOUNT / 4))
+			);
+			assert_eq!(
+				MockInvestment::investment(&USER, INVESTMENT_ID),
 				Ok(foreign_to_pool(AMOUNT / 4))
 			);
 		});
@@ -864,6 +904,7 @@ mod investment {
 			);
 
 			assert_eq!(ForeignInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
+			assert_eq!(MockInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
 		});
 	}
 
@@ -910,6 +951,7 @@ mod investment {
 				ForeignInvestment::investment(&USER, INVESTMENT_ID),
 				Ok(foreign_to_pool(0))
 			);
+			assert_eq!(MockInvestment::investment(&USER, INVESTMENT_ID), Ok(0));
 		});
 	}
 
@@ -931,6 +973,10 @@ mod investment {
 
 				assert_eq!(
 					ForeignInvestment::investment(&USER, INVESTMENT_ID),
+					Ok(foreign_to_pool(AMOUNT))
+				);
+				assert_eq!(
+					MockInvestment::investment(&USER, INVESTMENT_ID),
 					Ok(foreign_to_pool(AMOUNT))
 				);
 			});
@@ -970,6 +1016,10 @@ mod investment {
 
 				assert_eq!(
 					ForeignInvestment::investment(&USER, INVESTMENT_ID),
+					Ok(foreign_to_pool(0))
+				);
+				assert_eq!(
+					MockInvestment::investment(&USER, INVESTMENT_ID),
 					Ok(foreign_to_pool(0))
 				);
 


### PR DESCRIPTION
# Description

* Adds the pending foreign-to-pool swapping amount to the foreign investment amount `ForeignInvestment::investment`
* Required for cancelling a foreign investment if there is any swapping amount into pool currency

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
