### PR TITLE
Add asset_registry mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,6 +1158,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "xcm",
 ]
 
 [[package]]

--- a/libs/mocks/Cargo.toml
+++ b/libs/mocks/Cargo.toml
@@ -24,6 +24,7 @@ cfg-primitives = { path = "../primitives", default-features = false }
 cfg-traits = { path = "../traits", default-features = false }
 cfg-types = { path = "../types", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.43" }
+xcm = { workspace = true }
 
 mock-builder = { workspace = true }
 
@@ -42,6 +43,7 @@ std = [
   "sp-io/std",
   "sp-runtime/std",
   "orml-traits/std",
+  "xcm/std",
   "mock-builder/std",
 ]
 runtime-benchmarks = [

--- a/libs/mocks/src/asset_registry.rs
+++ b/libs/mocks/src/asset_registry.rs
@@ -1,0 +1,121 @@
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use mock_builder::{execute_call, register_call};
+	use orml_traits::asset_registry::{AssetMetadata, Inspect, Mutate};
+	use xcm::{v3::prelude::MultiLocation, VersionedMultiLocation};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type AssetId;
+		type Balance;
+		type CustomMetadata: Parameter + Member + TypeInfo;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	pub(super) type CallIds<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		<Blake2_128 as frame_support::StorageHasher>::Output,
+		mock_builder::CallId,
+	>;
+
+	impl<T: Config> Pallet<T> {
+		pub fn mock_asset_id(f: impl Fn(&MultiLocation) -> Option<T::AssetId> + 'static) {
+			register_call!(f);
+		}
+
+		pub fn mock_metadata(
+			f: impl Fn(&T::AssetId) -> Option<AssetMetadata<T::Balance, T::CustomMetadata>> + 'static,
+		) {
+			register_call!(f);
+		}
+
+		pub fn mock_metadata_by_location(
+			f: impl Fn(&MultiLocation) -> Option<AssetMetadata<T::Balance, T::CustomMetadata>> + 'static,
+		) {
+			register_call!(f);
+		}
+
+		pub fn mock_location(
+			f: impl Fn(&T::AssetId) -> Result<Option<MultiLocation>, DispatchError> + 'static,
+		) {
+			register_call!(f);
+		}
+
+		pub fn mock_register_asset(
+			f: impl Fn(
+					Option<T::AssetId>,
+					AssetMetadata<T::Balance, T::CustomMetadata>,
+				) -> DispatchResult
+				+ 'static,
+		) {
+			register_call!(move |(a, b)| f(a, b));
+		}
+
+		pub fn mock_update_asset(
+			f: impl Fn(
+					T::AssetId,
+					Option<u32>,
+					Option<Vec<u8>>,
+					Option<Vec<u8>>,
+					Option<T::Balance>,
+					Option<Option<VersionedMultiLocation>>,
+					Option<T::CustomMetadata>,
+				) -> DispatchResult
+				+ 'static,
+		) {
+			register_call!(move |(a, b, c, d, e, g, h)| f(a, b, c, d, e, g, h));
+		}
+	}
+
+	impl<T: Config> Inspect for Pallet<T> {
+		type AssetId = T::AssetId;
+		type Balance = T::Balance;
+		type CustomMetadata = T::CustomMetadata;
+
+		fn asset_id(a: &MultiLocation) -> Option<Self::AssetId> {
+			execute_call!(a)
+		}
+
+		fn metadata(
+			a: &Self::AssetId,
+		) -> Option<AssetMetadata<Self::Balance, Self::CustomMetadata>> {
+			execute_call!(a)
+		}
+
+		fn metadata_by_location(
+			a: &MultiLocation,
+		) -> Option<AssetMetadata<Self::Balance, Self::CustomMetadata>> {
+			execute_call!(a)
+		}
+
+		fn location(a: &Self::AssetId) -> Result<Option<MultiLocation>, DispatchError> {
+			execute_call!(a)
+		}
+	}
+
+	impl<T: Config> Mutate for Pallet<T> {
+		fn register_asset(
+			a: Option<Self::AssetId>,
+			b: AssetMetadata<Self::Balance, Self::CustomMetadata>,
+		) -> DispatchResult {
+			execute_call!((a, b))
+		}
+
+		fn update_asset(
+			a: Self::AssetId,
+			b: Option<u32>,
+			c: Option<Vec<u8>>,
+			d: Option<Vec<u8>>,
+			e: Option<Self::Balance>,
+			g: Option<Option<VersionedMultiLocation>>,
+			h: Option<Self::CustomMetadata>,
+		) -> DispatchResult {
+			execute_call!((a, b, c, d, e, g, h))
+		}
+	}
+}

--- a/libs/mocks/src/lib.rs
+++ b/libs/mocks/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod asset_registry;
 pub mod change_guard;
 pub mod currency_conversion;
 pub mod data;


### PR DESCRIPTION
# Description

The current `cfg_test_utils::impl_mock_registry!` macro works pretty well for most of the cases, establishing the base functionality for an asset registry. But added a mock builder version for cases where we wanted to test some border cases related to the asset registry.

This PR is not mandatory at all and can be left unmerged here until the mock is required by any pallet. 