### PR TITLE
pool fees: explicit handling of zero amounts

### DIFF
--- a/pallets/pool-fees/src/lib.rs
+++ b/pallets/pool-fees/src/lib.rs
@@ -557,20 +557,22 @@ pub mod pallet {
 
 			ActiveFees::<T>::mutate(pool_id, bucket, |fees| {
 				for fee in fees.iter_mut() {
-					T::Tokens::transfer(
-						pool_currency,
-						&T::PalletId::get().into_account_truncating(),
-						&fee.destination,
-						fee.amounts.disbursement,
-						Preservation::Expendable,
-					)?;
+					if !fee.amounts.disbursement.is_zero() {
+						T::Tokens::transfer(
+							pool_currency,
+							&T::PalletId::get().into_account_truncating(),
+							&fee.destination,
+							fee.amounts.disbursement,
+							Preservation::Expendable,
+						)?;
 
-					Self::deposit_event(Event::<T>::Paid {
-						pool_id,
-						fee_id: fee.id,
-						amount: fee.amounts.disbursement,
-						destination: fee.destination.clone(),
-					});
+						Self::deposit_event(Event::<T>::Paid {
+							pool_id,
+							fee_id: fee.id,
+							amount: fee.amounts.disbursement,
+							destination: fee.destination.clone(),
+						});
+					}
 
 					fee.amounts.disbursement = T::Balance::zero();
 				}

--- a/pallets/pool-fees/src/lib.rs
+++ b/pallets/pool-fees/src/lib.rs
@@ -297,6 +297,10 @@ pub mod pallet {
 		UnauthorizedEdit,
 		/// Attempted to charge a fee of unchargeable type.
 		CannotBeCharged,
+		/// Attempted to charge with zero amount
+		NothingCharged,
+		/// Attempted to uncharge with zero amount
+		NothingUncharged,
 	}
 
 	#[pallet::call]
@@ -394,6 +398,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
+			ensure!(!amount.is_zero(), Error::<T>::NothingCharged);
+
 			let (pool_id, pending) = Self::mutate_active_fee(fee_id, |fee| {
 				ensure!(
 					fee.destination == who,
@@ -430,6 +436,8 @@ pub mod pallet {
 			amount: T::Balance,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
+
+			ensure!(!amount.is_zero(), Error::<T>::NothingUncharged);
 
 			let (pool_id, pending) = Self::mutate_active_fee(fee_id, |fee| {
 				ensure!(

--- a/pallets/pool-fees/src/tests.rs
+++ b/pallets/pool-fees/src/tests.rs
@@ -294,6 +294,16 @@ mod extrinsics {
 		}
 
 		#[test]
+		fn charge_fee_nothing() {
+			ExtBuilder::default().build().execute_with(|| {
+				assert_noop!(
+					PoolFees::charge_fee(RuntimeOrigin::signed(ANY), 1, 0),
+					Error::<Runtime>::NothingCharged
+				);
+			})
+		}
+
+		#[test]
 		fn charge_fee_wrong_origin() {
 			ExtBuilder::default().build().execute_with(|| {
 				add_fees(vec![default_fixed_fee()]);
@@ -330,6 +340,16 @@ mod extrinsics {
 				assert_noop!(
 					PoolFees::charge_fee(RuntimeOrigin::signed(DESTINATION), 1, 1),
 					DispatchError::Arithmetic(ArithmeticError::Overflow)
+				);
+			})
+		}
+
+		#[test]
+		fn uncharge_fee_nothing() {
+			ExtBuilder::default().build().execute_with(|| {
+				assert_noop!(
+					PoolFees::uncharge_fee(RuntimeOrigin::signed(ANY), 1, 0),
+					Error::<Runtime>::NothingUncharged
 				);
 			})
 		}


### PR DESCRIPTION
# Description

* Changes behavior of pool fees event `Paid` to only be dispatched for non-zero amounts
* Throws `NothingCharged` / `NothingUncharged` error for attempts to (un)charge zero amounts

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
