### PR TITLE
Fix: FI compute orders correclty for asymmetric ratios

### DIFF
--- a/pallets/foreign-investments/src/entities.rs
+++ b/pallets/foreign-investments/src/entities.rs
@@ -163,7 +163,7 @@ impl<T: Config> InvestmentInfo<T> {
 		who: &T::AccountId,
 		investment_id: T::InvestmentId,
 		foreign_amount: T::ForeignBalance,
-	) -> Result<SwapOf<T>, DispatchError> {
+	) -> Result<(SwapOf<T>, T::ForeignBalance), DispatchError> {
 		let pool_currency = pool_currency_of::<T>(investment_id)?;
 
 		// We do not want to decrease the whole `foreign_amount` from the investment
@@ -183,19 +183,14 @@ impl<T: Config> InvestmentInfo<T> {
 
 		self.decrease_investment(who, investment_id, pool_investment_decrement)?;
 
-		// It's ok to use the market ratio because this amount will be
-		// cancelled in this instant.
-		let increasing_pool_amount = T::TokenSwaps::convert_by_market(
-			pool_currency,
-			self.foreign_currency,
-			min(foreign_amount, increasing_foreign_amount).into(),
-		)?;
-
-		Ok(Swap {
-			currency_in: self.foreign_currency,
-			currency_out: pool_currency,
-			amount_out: increasing_pool_amount.ensure_add(pool_investment_decrement.into())?,
-		})
+		Ok((
+			Swap {
+				currency_in: self.foreign_currency,
+				currency_out: pool_currency,
+				amount_out: pool_investment_decrement.into(),
+			},
+			min(foreign_amount, increasing_foreign_amount),
+		))
 	}
 
 	/// This method is performed after resolve the swap

--- a/pallets/foreign-investments/src/tests.rs
+++ b/pallets/foreign-investments/src/tests.rs
@@ -6,6 +6,7 @@ use cfg_types::investments::{
 	CollectedAmount, ExecutedForeignCollect, ExecutedForeignDecreaseInvest, Swap, SwapState,
 };
 use frame_support::{assert_err, assert_ok};
+use sp_runtime::traits::Zero;
 use sp_std::sync::{Arc, Mutex};
 
 use crate::{
@@ -216,6 +217,7 @@ mod swaps {
 					&USER,
 					INVESTMENT_ID,
 					Action::Investment,
+					Zero::zero(),
 					Swap {
 						currency_in: POOL_CURR,
 						currency_out: FOREIGN_CURR,
@@ -263,6 +265,7 @@ mod swaps {
 					&USER,
 					INVESTMENT_ID,
 					Action::Investment,
+					Zero::zero(),
 					Swap {
 						currency_out: FOREIGN_CURR,
 						currency_in: POOL_CURR,
@@ -314,6 +317,7 @@ mod swaps {
 					&USER,
 					INVESTMENT_ID,
 					Action::Investment,
+					Zero::zero(),
 					Swap {
 						currency_out: FOREIGN_CURR,
 						currency_in: POOL_CURR,
@@ -360,6 +364,7 @@ mod swaps {
 					&USER,
 					INVESTMENT_ID,
 					Action::Investment,
+					Zero::zero(),
 					Swap {
 						currency_out: FOREIGN_CURR,
 						currency_in: POOL_CURR,
@@ -423,6 +428,7 @@ mod swaps {
 					&USER,
 					INVESTMENT_ID,
 					Action::Investment,
+					Zero::zero(),
 					Swap {
 						currency_out: FOREIGN_CURR,
 						currency_in: POOL_CURR,


### PR DESCRIPTION
# Description

The issue is described in this [thread](https://kflabs.slack.com/archives/C04GJQAM9P0/p1707298087515729)

> When we decrease, and there is an increasing pending swap,  we use the `convert_by_market()` to know upfront the amount we need to cancel to the inverse swap and distinguish from the amount we need to decrease the investment.
Nevertheless, later, inside the swap, `convert_by_market()` is called again in the inverse direction to perform the cancellation of the swap. This works fine. However, with asymmetric ratios (A -> B, ratio: 0.9; B -> A, ratio 0.95), it can lead to obtaining a different swap than expected. In the worst case, it would lead to a NoFund error if the amounts are very fit.

This is a non-pretty fix that works. Nevertheless, I would wait until I have the `pallet-swaps` refactor, where I think it can be fixed much more cleanly.