### PR TITLE
Refactor (PoC): Use GATs for token swaps traits

### DIFF
--- a/pallets/swaps/src/lib.rs
+++ b/pallets/swaps/src/lib.rs
@@ -63,10 +63,10 @@ pub mod pallet {
 		type CurrencyId: Parameter + Member + Copy + MaxEncodedLen;
 
 		/// The type which exposes token swap order functionality
-		type OrderBook<BalanceFrom, BalanceTo>: TokenSwaps<
+		type OrderBook<BalanceTo, BalanceFrom>: TokenSwaps<
 			Self::AccountId,
-			BalanceFrom,
 			BalanceTo,
+			BalanceFrom,
 			CurrencyId = Self::CurrencyId,
 			OrderId = Self::OrderId,
 		>;


### PR DESCRIPTION
# Description

`TokenSwaps` & `Swaps` traits can be more static if they define `AmoutOut` and `AmountIn` to not mismatch different kinds of amounts. Nevertheless, the "direction" usage of this trait depends on the moment when they are called, and from the pallet perspective we can not define upfront what is "in" or "out", because the direction of their usage is different in each part of the pallet implementation, when the methods are called.

Nevertheless, the GAT Rust feature comes to the rescue, allowing parameterization at the moment of the call, allowing a much cleaner and static API and implementation.

