### PR TITLE
feat: relative treasury inflation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6751,6 +6751,7 @@ dependencies = [
 name = "pallet-block-rewards"
 version = "0.1.0"
 dependencies = [
+ "cfg-mocks",
  "cfg-primitives",
  "cfg-traits",
  "cfg-types",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -46,7 +46,10 @@ use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, Properties};
 use serde::{Deserialize, Serialize};
 use sp_core::{crypto::UncheckedInto, sr25519, Encode, Pair, Public, H160};
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_runtime::{
+	traits::{IdentifyAccount, Verify},
+	FixedPointNumber,
+};
 use xcm::{
 	latest::MultiLocation,
 	prelude::{GeneralIndex, GeneralKey, PalletInstance, Parachain, X2, X3},
@@ -61,6 +64,7 @@ pub type DevelopmentChainSpec =
 
 use altair_runtime::evm::AltairPrecompiles;
 use centrifuge_runtime::evm::CentrifugePrecompiles;
+use cfg_types::fixed_point::Rate;
 use development_runtime::evm::DevelopmentPrecompiles;
 
 /// Helper function to generate a crypto pair from seed
@@ -661,7 +665,11 @@ fn centrifuge_genesis(
 				.map(|(acc, _)| acc)
 				.collect(),
 			collator_reward: 8_325 * MILLI_CFG,
-			total_reward: 10_048 * CFG,
+			treasury_inflation_rate: Rate::saturating_from_rational(3, 100),
+			last_update: std::time::SystemTime::now()
+				.duration_since(std::time::UNIX_EPOCH)
+				.expect("SystemTime before UNIX EPOCH!")
+				.as_secs(),
 		},
 		block_rewards_base: Default::default(),
 		base_fee: Default::default(),
@@ -756,7 +764,11 @@ fn altair_genesis(
 				.map(|(acc, _)| acc)
 				.collect(),
 			collator_reward: 98_630 * MILLI_AIR,
-			total_reward: 98_630 * MILLI_AIR * 100,
+			treasury_inflation_rate: Rate::saturating_from_rational(3, 100),
+			last_update: std::time::SystemTime::now()
+				.duration_since(std::time::UNIX_EPOCH)
+				.expect("SystemTime before UNIX EPOCH!")
+				.as_secs(),
 		},
 		block_rewards_base: Default::default(),
 		collator_allowlist: Default::default(),
@@ -939,7 +951,11 @@ fn development_genesis(
 				.map(|(acc, _)| acc)
 				.collect(),
 			collator_reward: 8_325 * MILLI_CFG,
-			total_reward: 10_048 * CFG,
+			treasury_inflation_rate: Rate::saturating_from_rational(3, 100),
+			last_update: std::time::SystemTime::now()
+				.duration_since(std::time::UNIX_EPOCH)
+				.expect("SystemTime before UNIX EPOCH!")
+				.as_secs(),
 		},
 		base_fee: Default::default(),
 		evm_chain_id: development_runtime::EVMChainIdConfig {

--- a/pallets/block-rewards/Cargo.toml
+++ b/pallets/block-rewards/Cargo.toml
@@ -32,6 +32,7 @@ sp-std = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 
 [dev-dependencies]
+cfg-mocks = { workspace = true, default-features = true }
 orml-tokens = { workspace = true, default-features = true }
 orml-traits = { workspace = true, default-features = true }
 pallet-balances = { workspace = true, default-features = true }

--- a/pallets/block-rewards/src/benchmarking.rs
+++ b/pallets/block-rewards/src/benchmarking.rs
@@ -1,6 +1,6 @@
 use cfg_primitives::CFG;
 use cfg_types::tokens::CurrencyId;
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
+use frame_benchmarking::v2::*;
 use frame_support::{
 	assert_ok,
 	traits::{fungibles::Inspect, Currency as CurrencyT},
@@ -14,56 +14,85 @@ use crate::{pallet::Config, Pallet as BlockRewards};
 const REWARD: u128 = 1 * CFG;
 const SEED: u32 = 0;
 
-benchmarks! {
-	where_clause {
-		where
+#[benchmarks(
+where
 		T::Balance: From<u128>,
 		T::BlockNumber: From<u32> + One,
 		T::Weight: From<u32>,
 		<T as Config>::Tokens: Inspect<T::AccountId> + CurrencyT<T::AccountId>,
 		<T as Config>::CurrencyId: From<CurrencyId>,
-	}
+)]
+mod benchmarks {
+	use super::*;
 
-	claim_reward {
-		let caller = whitelisted_caller();
-		let beneficiary: T::AccountId =  account("collator", 0, SEED);
+	#[benchmark]
+	fn claim_reward() -> Result<(), BenchmarkError> {
+		let caller: T::AccountId = account("caller", 0, SEED);
+		let beneficiary: T::AccountId = account("collator", 0, SEED);
 
 		assert_ok!(BlockRewards::<T>::do_init_collator(&beneficiary));
-		assert_ok!(T::Rewards::reward_group(T::StakeGroupId::get(), REWARD.into()));
+		assert_ok!(T::Rewards::reward_group(
+			T::StakeGroupId::get(),
+			REWARD.into()
+		));
 		assert!(T::Rewards::is_ready(T::StakeGroupId::get()));
 		assert!(
-			!T::Rewards::compute_reward(
-				T::StakeCurrencyId::get(),
-				&beneficiary,
-			).unwrap().is_zero()
+			!T::Rewards::compute_reward(T::StakeCurrencyId::get(), &beneficiary,)
+				.unwrap()
+				.is_zero()
 		);
-		let before = <T::Tokens as Inspect<T::AccountId>>::balance(CurrencyId::Native.into(), &beneficiary);
+		let before =
+			<T::Tokens as Inspect<T::AccountId>>::balance(CurrencyId::Native.into(), &beneficiary);
 
-	}: _(RawOrigin::Signed(caller), beneficiary.clone())
-	verify {
-		let num_collators: u128 = BlockRewards::<T>::next_session_changes().collator_count.unwrap_or(
-			BlockRewards::<T>::active_session_data().collator_count
-		).into();
-		// Does not get entire reward since another collator is auto-staked via genesis config
-		assert_eq!(<T::Tokens as Inspect<T::AccountId>>::balance(CurrencyId::Native.into(), &beneficiary).saturating_sub(before), (REWARD / (num_collators + 1)).into());
+		#[extrinsic_call]
+		claim_reward(RawOrigin::Signed(caller), beneficiary.clone());
+
+		let num_collators: u128 = BlockRewards::<T>::next_session_changes()
+			.collator_count
+			.unwrap_or(BlockRewards::<T>::active_session_data().collator_count)
+			.into();
+		// Does not get entire reward since another collator is auto-staked via genesis
+		// config
+		assert_eq!(
+			<T::Tokens as Inspect<T::AccountId>>::balance(CurrencyId::Native.into(), &beneficiary)
+				.saturating_sub(before),
+			(REWARD / (num_collators + 1)).into()
+		);
+
+		Ok(())
 	}
 
-	set_collator_reward_per_session {
-	}: _(RawOrigin::Root, REWARD.into())
-	verify {
-		assert_eq!(BlockRewards::<T>::next_session_changes().collator_reward, Some(REWARD.into()));
+	#[benchmark]
+	fn set_collator_reward_per_session() -> Result<(), BenchmarkError> {
+		#[extrinsic_call]
+		set_collator_reward_per_session(RawOrigin::Root, REWARD.into());
+
+		assert_eq!(
+			BlockRewards::<T>::next_session_changes().collator_reward,
+			Some(REWARD.into())
+		);
+
+		Ok(())
 	}
 
-	set_annual_treasury_inflation_rate {
+	#[benchmark]
+	fn set_annual_treasury_inflation_rate() -> Result<(), BenchmarkError> {
 		let rate = T::Rate::saturating_from_rational(1, 2);
-	}: _(RawOrigin::Root, rate)
-	verify {
-		assert_eq!(BlockRewards::<T>::next_session_changes().treasury_inflation_rate, Some(rate));
-	}
-}
 
-impl_benchmark_test_suite!(
-	BlockRewards,
-	crate::mock::ExtBuilder::default().build(),
-	crate::mock::Test,
-);
+		#[extrinsic_call]
+		set_annual_treasury_inflation_rate(RawOrigin::Root, rate);
+
+		assert_eq!(
+			BlockRewards::<T>::next_session_changes().treasury_inflation_rate,
+			Some(rate)
+		);
+
+		Ok(())
+	}
+
+	impl_benchmark_test_suite!(
+		BlockRewards,
+		crate::mock::ExtBuilder::default().build(),
+		crate::mock::Test,
+	);
+}

--- a/pallets/block-rewards/src/lib.rs
+++ b/pallets/block-rewards/src/lib.rs
@@ -13,10 +13,10 @@
 //! # BlockRewards Pallet
 //!
 //! The BlockRewards pallet provides functionality for distributing rewards to
-//! different accounts with different currencies.
-//! The distribution happens when an session (a constant time interval)
-//! finalizes. Users cannot stake manually as their collator membership is
-//! syncronized via a provider.
+//! different accounts with different currencies as well as configuring an
+//! annual treasury inflation. The distribution happens when a session (a
+//! constant time interval) finalizes. Users cannot stake manually as their
+//! collator membership is synchronized via a provider.
 //! Thus, when new collators join, they will automatically be staked and
 //! vice-versa when collators leave, they are unstaked.
 //!
@@ -24,8 +24,8 @@
 //!
 //! - Claiming the reward given for a staked currency. The reward will be the
 //!   native network's token.
-//! - Admin methods to configure the reward amount for collators and an optional
-//!   beneficiary.
+//! - Admin methods to configure the reward amount for collators and the annual
+//!   treasury inflation.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(test)]
@@ -120,7 +120,7 @@ pub mod pallet {
 
 	use super::*;
 
-	pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {

--- a/pallets/block-rewards/src/lib.rs
+++ b/pallets/block-rewards/src/lib.rs
@@ -43,23 +43,26 @@ mod benchmarking;
 use cfg_traits::{
 	self,
 	rewards::{AccountRewards, CurrencyGroupChange, GroupRewards},
+	Seconds, TimeAsSecs,
 };
+use cfg_types::fixed_point::FixedPointNumberExtension;
 use frame_support::{
 	pallet_prelude::*,
 	storage::transactional,
 	traits::{
+		fungible::{Inspect as FungibleInspect, Mutate as FungibleMutate},
 		fungibles::Mutate,
 		tokens::{Balance, Fortitude, Precision},
-		Currency as CurrencyT, OnUnbalanced, OneSessionHandler,
+		OneSessionHandler,
 	},
-	DefaultNoBound,
+	DefaultNoBound, PalletId,
 };
 use frame_system::pallet_prelude::*;
 use num_traits::sign::Unsigned;
 pub use pallet::*;
 use sp_runtime::{
-	traits::{EnsureAdd, EnsureMul, EnsureSub, Zero},
-	FixedPointOperand, SaturatedConversion, Saturating,
+	traits::{AccountIdConversion, EnsureAdd, EnsureMul, Zero},
+	FixedPointNumber, FixedPointOperand, SaturatedConversion, Saturating,
 };
 use sp_std::{mem, vec::Vec};
 pub use weights::WeightInfo;
@@ -79,20 +82,22 @@ pub struct CollatorChanges<T: Config> {
 pub struct SessionData<T: Config> {
 	/// Amount of rewards per session for a single collator.
 	pub(crate) collator_reward: T::Balance,
-	/// Total amount of rewards per session
-	/// NOTE: Is ensured to be at least collator_reward * collator_count.
-	pub(crate) total_reward: T::Balance,
 	/// Number of current collators.
 	/// NOTE: Updated automatically and thus not adjustable via extrinsic.
 	pub collator_count: u32,
+	/// The annual treasury inflation rate
+	pub(crate) treasury_inflation_rate: T::Rate,
+	/// The timestamp of the last update used for inflation proration
+	pub(crate) last_update: Seconds,
 }
 
 impl<T: Config> Default for SessionData<T> {
 	fn default() -> Self {
 		Self {
-			collator_reward: T::Balance::zero(),
-			total_reward: T::Balance::zero(),
 			collator_count: 0,
+			collator_reward: T::Balance::zero(),
+			treasury_inflation_rate: T::Rate::zero(),
+			last_update: Seconds::zero(),
 		}
 	}
 }
@@ -105,13 +110,10 @@ impl<T: Config> Default for SessionData<T> {
 pub struct SessionChanges<T: Config> {
 	pub collators: CollatorChanges<T>,
 	pub collator_count: Option<u32>,
-	collator_reward: Option<T::Balance>,
-	total_reward: Option<T::Balance>,
+	pub collator_reward: Option<T::Balance>,
+	treasury_inflation_rate: Option<T::Rate>,
+	last_update: Seconds,
 }
-
-pub(crate) type NegativeImbalanceOf<T> = <<T as Config>::Currency as CurrencyT<
-	<T as frame_system::Config>::AccountId,
->>::NegativeImbalance;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -129,11 +131,7 @@ pub mod pallet {
 		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		/// Type used to handle balances.
-		type Balance: Balance
-			+ MaxEncodedLen
-			+ FixedPointOperand
-			+ Into<<<Self as Config>::Currency as CurrencyT<Self::AccountId>>::Balance>
-			+ MaybeSerializeDeserialize;
+		type Balance: Balance + MaxEncodedLen + FixedPointOperand + MaybeSerializeDeserialize;
 
 		#[pallet::constant]
 		type ExistentialDeposit: Get<Self::Balance>;
@@ -150,8 +148,9 @@ pub mod pallet {
 			> + CurrencyGroupChange<GroupId = u32, CurrencyId = <Self as Config>::CurrencyId>;
 
 		/// The type used to handle currency minting and burning for collators.
-		type Currency: Mutate<Self::AccountId, AssetId = <Self as Config>::CurrencyId, Balance = Self::Balance>
-			+ CurrencyT<Self::AccountId>;
+		type Tokens: Mutate<Self::AccountId, AssetId = <Self as Config>::CurrencyId, Balance = Self::Balance>
+			+ FungibleMutate<Self::AccountId>
+			+ FungibleInspect<Self::AccountId, Balance = Self::Balance>;
 
 		/// The currency type of the artificial block rewards currency.
 		type CurrencyId: Parameter
@@ -177,18 +176,16 @@ pub mod pallet {
 		type StakeGroupId: Get<u32>;
 
 		/// Max number of changes of the same type enqueued to apply in the next
-		/// session. Max calls to [`Pallet::set_collator_reward()`] or to
-		/// [`Pallet::set_total_reward()`] with the same id.
+		/// session. Max calls to [`Pallet::set_collator_reward_per_session()`]
+		/// or to [`Pallet::set_annual_inflation_rate()`] with the same id.
 		#[pallet::constant]
 		type MaxChangesPerSession: Get<u32> + TypeInfo + sp_std::fmt::Debug + Clone + PartialEq;
 
 		#[pallet::constant]
 		type MaxCollators: Get<u32> + TypeInfo + sp_std::fmt::Debug + Clone + PartialEq;
 
-		/// Target of receiving non-collator-rewards.
-		/// NOTE: If set to none, collators are the only group receiving
-		/// rewards.
-		type Beneficiary: OnUnbalanced<NegativeImbalanceOf<Self>>;
+		/// Treasury pallet
+		type TreasuryPalletId: Get<PalletId>;
 
 		/// The identifier type for an authority.
 		type AuthorityId: Member
@@ -197,7 +194,18 @@ pub mod pallet {
 			+ MaybeSerializeDeserialize
 			+ MaxEncodedLen;
 
-		/// Information of runtime weightsk
+		/// The inflation rate type
+		type Rate: Parameter
+			+ Member
+			+ FixedPointNumberExtension
+			+ TypeInfo
+			+ MaybeSerializeDeserialize
+			+ MaxEncodedLen;
+
+		/// The source of truth for the current time in seconds
+		type Time: TimeAsSecs;
+
+		/// Information of runtime weights
 		type WeightInfo: WeightInfo;
 	}
 
@@ -221,7 +229,7 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		NewSession {
 			collator_reward: T::Balance,
-			total_reward: T::Balance,
+			treasury_inflation_rate: T::Rate,
 			last_changes: SessionChanges<T>,
 		},
 		SessionAdvancementFailed {
@@ -234,14 +242,14 @@ pub mod pallet {
 		/// Limit of max calls with same id to [`Pallet::set_collator_reward()`]
 		/// or [`Pallet::set_total_reward()`] reached.
 		MaxChangesPerSessionReached,
-		InsufficientTotalReward,
 	}
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub collators: Vec<T::AccountId>,
 		pub collator_reward: T::Balance,
-		pub total_reward: T::Balance,
+		pub treasury_inflation_rate: T::Rate,
+		pub last_update: Seconds,
 	}
 
 	#[cfg(feature = "std")]
@@ -250,7 +258,8 @@ pub mod pallet {
 			GenesisConfig {
 				collators: Default::default(),
 				collator_reward: Default::default(),
-				total_reward: Default::default(),
+				treasury_inflation_rate: Default::default(),
+				last_update: Default::default(),
 			}
 		}
 	}
@@ -265,7 +274,8 @@ pub mod pallet {
 			ActiveSessionData::<T>::mutate(|session_data| {
 				session_data.collator_count = self.collators.len().saturated_into();
 				session_data.collator_reward = self.collator_reward;
-				session_data.total_reward = self.total_reward;
+				session_data.treasury_inflation_rate = self.treasury_inflation_rate;
+				session_data.last_update = self.last_update;
 			});
 
 			// Enables rewards already in genesis session.
@@ -292,62 +302,34 @@ pub mod pallet {
 		/// next sessions. Current session is not affected by this call.
 		#[pallet::weight(T::WeightInfo::set_collator_reward())]
 		#[pallet::call_index(1)]
-		pub fn set_collator_reward(
+		pub fn set_collator_reward_per_session(
 			origin: OriginFor<T>,
 			collator_reward_per_session: T::Balance,
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
-			NextSessionChanges::<T>::try_mutate(|changes| {
-				let current = ActiveSessionData::<T>::get();
-				let total_collator_rewards = collator_reward_per_session.saturating_mul(
-					changes
-						.collator_count
-						.unwrap_or(current.collator_count)
-						.into(),
-				);
-				let total_rewards = changes.total_reward.unwrap_or(current.total_reward);
-				ensure!(
-					total_rewards >= total_collator_rewards,
-					Error::<T>::InsufficientTotalReward
-				);
+			NextSessionChanges::<T>::mutate(|c| {
+				c.collator_reward = Some(collator_reward_per_session);
+			});
 
-				changes.collator_reward = Some(collator_reward_per_session);
-				Ok(())
-			})
+			Ok(())
 		}
 
-		/// Admin method to set the total reward distribution for the next
+		/// Admin method to set the treasury inflation rate for the next
 		/// sessions. Current session is not affected by this call.
-		///
-		/// Throws if total_reward < collator_reward * collator_count.
 		#[pallet::weight(T::WeightInfo::set_total_reward())]
 		#[pallet::call_index(2)]
-		pub fn set_total_reward(
+		pub fn set_annual_treasury_inflation_rate(
 			origin: OriginFor<T>,
-			total_reward_per_session: T::Balance,
+			treasury_inflation_rate: T::Rate,
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
-			NextSessionChanges::<T>::try_mutate(|changes| {
-				let current = ActiveSessionData::<T>::get();
-				let total_collator_rewards = changes
-					.collator_reward
-					.unwrap_or(current.collator_reward)
-					.saturating_mul(
-						changes
-							.collator_count
-							.unwrap_or(current.collator_count)
-							.into(),
-					);
-				ensure!(
-					total_reward_per_session >= total_collator_rewards,
-					Error::<T>::InsufficientTotalReward
-				);
+			NextSessionChanges::<T>::mutate(|c| {
+				c.treasury_inflation_rate = Some(treasury_inflation_rate);
+			});
 
-				changes.total_reward = Some(total_reward_per_session);
-				Ok(())
-			})
+			Ok(())
 		}
 	}
 }
@@ -361,10 +343,10 @@ impl<T: Config> Pallet<T> {
 	///  * deposit_stake (4 reads, 4 writes): Currency, Group, StakeAccount,
 	///    Account
 	pub(crate) fn do_init_collator(who: &T::AccountId) -> DispatchResult {
-		T::Currency::mint_into(
+		<T::Tokens as Mutate<T::AccountId>>::mint_into(
 			T::StakeCurrencyId::get(),
 			who,
-			T::StakeAmount::get() + T::ExistentialDeposit::get(),
+			T::StakeAmount::get().saturating_add(T::ExistentialDeposit::get()),
 		)?;
 		T::Rewards::deposit_stake(T::StakeCurrencyId::get(), who, T::StakeAmount::get())
 	}
@@ -379,9 +361,9 @@ impl<T: Config> Pallet<T> {
 		//       would get killed and down the line our orml-tokens prevents
 		//       that.
 		//
-		//       I.e. this means stake curreny issuance will grow over time if many
+		//       I.e. this means stake currency issuance will grow over time if many
 		//       collators leave and join.
-		T::Currency::burn_from(
+		<T::Tokens as Mutate<T::AccountId>>::burn_from(
 			T::StakeCurrencyId::get(),
 			who,
 			amount,
@@ -389,6 +371,20 @@ impl<T: Config> Pallet<T> {
 			Fortitude::Polite,
 		)
 		.map(|_| ())
+	}
+
+	/// Calculates the inflation proration based on the annual configuration and
+	/// the session duration in seconds
+	pub(crate) fn calculate_epoch_treasury_inflation(
+		annual_inflation_rate: T::Rate,
+		last_update: Seconds,
+	) -> T::Balance {
+		let total_issuance = <T::Tokens as FungibleInspect<T::AccountId>>::total_issuance();
+		let session_duration = T::Time::now().saturating_sub(last_update);
+		let inflation_proration =
+			cfg_types::pools::saturated_rate_proration(annual_inflation_rate, session_duration);
+
+		inflation_proration.saturating_mul_int(total_issuance)
 	}
 
 	/// Apply session changes and distribute rewards.
@@ -404,18 +400,25 @@ impl<T: Config> Pallet<T> {
 					// Reward collator group of last session
 					let total_collator_reward = session_data
 						.collator_reward
-						.ensure_mul(session_data.collator_count.into())?
-						.min(session_data.total_reward);
+						.ensure_mul(session_data.collator_count.into())?;
 					T::Rewards::reward_group(T::StakeGroupId::get(), total_collator_reward)?;
 
-					// Handle remaining reward
-					let remaining = session_data
-						.total_reward
-						.ensure_sub(total_collator_reward)?;
-					if !remaining.is_zero() {
-						let reward = T::Currency::issue(remaining.into());
-						// If configured, assigns reward to Beneficiary, else automatically drops it
-						T::Beneficiary::on_unbalanced(reward);
+					// Handle treasury inflation
+					let treasury_inflation = Self::calculate_epoch_treasury_inflation(
+						session_data.treasury_inflation_rate,
+						session_data.last_update,
+					);
+					if !treasury_inflation.is_zero() {
+						let _ = <T::Tokens as FungibleMutate<T::AccountId>>::mint_into(
+							&T::TreasuryPalletId::get().into_account_truncating(),
+							treasury_inflation,
+						)
+						.map_err(|e| {
+							log::error!(
+								"Failed to mint treasury inflation for session due to error {:?}",
+								e
+							)
+						});
 					}
 
 					num_joining = changes.collators.inc.len().saturated_into();
@@ -433,15 +436,17 @@ impl<T: Config> Pallet<T> {
 					session_data.collator_reward = changes
 						.collator_reward
 						.unwrap_or(session_data.collator_reward);
-					session_data.total_reward =
-						changes.total_reward.unwrap_or(session_data.total_reward);
+					session_data.treasury_inflation_rate = changes
+						.treasury_inflation_rate
+						.unwrap_or(session_data.treasury_inflation_rate);
 					session_data.collator_count = changes
 						.collator_count
 						.unwrap_or(session_data.collator_count);
+					session_data.last_update = T::Time::now();
 
 					Self::deposit_event(Event::NewSession {
-						total_reward: session_data.total_reward,
 						collator_reward: session_data.collator_reward,
+						treasury_inflation_rate: session_data.treasury_inflation_rate,
 						last_changes: mem::take(changes),
 					});
 

--- a/pallets/block-rewards/src/migrations.rs
+++ b/pallets/block-rewards/src/migrations.rs
@@ -10,8 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_traits::{rewards::CurrencyGroupChange, TimeAsSecs};
-use cfg_types::fixed_point::Rate;
+use cfg_traits::TimeAsSecs;
 use frame_support::{
 	dispatch::GetStorageVersion,
 	inherent::Vec,
@@ -20,7 +19,7 @@ use frame_support::{
 };
 #[cfg(feature = "try-runtime")]
 use sp_runtime::DispatchError;
-use sp_runtime::{BoundedVec, SaturatedConversion};
+use sp_runtime::FixedPointNumber;
 use sp_std::marker::PhantomData;
 #[cfg(feature = "try-runtime")]
 use {
@@ -29,127 +28,271 @@ use {
 	parity_scale_codec::{Decode, Encode},
 };
 
-use crate::{ActiveSessionData, Config, Pallet, SessionData};
+use crate::{pallet, Config, Pallet, SessionData};
 
-pub struct InitBlockRewards<T, CollatorReward, TreasuryInflationRate>(
-	PhantomData<(T, CollatorReward, TreasuryInflationRate)>,
-);
-
-fn get_collators<T: pallet_collator_selection::Config>() -> Vec<T::AccountId> {
-	let candidates = BoundedVec::<
-		T::AccountId,
-		<T as pallet_collator_selection::Config>::MaxCandidates,
-	>::truncate_from(
-		pallet_collator_selection::Pallet::<T>::candidates()
-			.into_iter()
-			.map(|c| c.who)
-			.collect(),
-	);
-	pallet_collator_selection::Pallet::<T>::assemble_collators(candidates)
+fn inflation_rate<T: Config>(percent: u32) -> T::Rate {
+	T::Rate::saturating_from_rational(percent, 100)
 }
 
-impl<T, CollatorReward, TreasuryInflationRate> OnRuntimeUpgrade
-	for InitBlockRewards<T, CollatorReward, TreasuryInflationRate>
-where
-	T: frame_system::Config
-		+ Config<Balance = u128, Rate = Rate>
-		+ pallet_collator_selection::Config,
-	<T as Config>::Balance: From<u128>,
-	CollatorReward: Get<<T as Config>::Balance>,
-	TreasuryInflationRate: Get<<T as Config>::Rate>,
-	<T as Config>::Rate: From<Rate>,
-{
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
-		assert_eq!(
-			Pallet::<T>::on_chain_storage_version(),
-			StorageVersion::new(0),
-			"On-chain storage version should be 0 (default)"
+pub mod init {
+	use cfg_traits::rewards::CurrencyGroupChange;
+	use sp_runtime::{BoundedVec, SaturatedConversion};
+
+	use super::*;
+
+	const LOG_PREFIX: &str = "InitBlockRewards";
+	pub struct InitBlockRewards<T, CollatorReward, AnnualTreasuryInflationPercent>(
+		PhantomData<(T, CollatorReward, AnnualTreasuryInflationPercent)>,
+	);
+
+	fn get_collators<T: pallet_collator_selection::Config>() -> Vec<T::AccountId> {
+		let candidates = BoundedVec::<
+			T::AccountId,
+			<T as pallet_collator_selection::Config>::MaxCandidates,
+		>::truncate_from(
+			pallet_collator_selection::Pallet::<T>::candidates()
+				.into_iter()
+				.map(|c| c.who)
+				.collect(),
 		);
-		let collators = get_collators::<T>();
-		assert!(!collators.is_empty());
-
-		assert!(!CollatorReward::get().is_zero());
-
-		log::info!("💰 BlockRewards: Pre migration checks successful");
-
-		Ok(collators.encode())
+		pallet_collator_selection::Pallet::<T>::assemble_collators(candidates)
 	}
 
-	// Weight: 2 + collator_count reads and writes
-	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		if Pallet::<T>::on_chain_storage_version() == StorageVersion::new(0) {
-			log::info!("💰 BlockRewards: Initiating migration");
-			let mut weight: Weight = Weight::zero();
-
+	impl<T, CollatorReward, AnnualTreasuryInflationPercent> OnRuntimeUpgrade
+		for InitBlockRewards<T, CollatorReward, AnnualTreasuryInflationPercent>
+	where
+		T: frame_system::Config + Config<Balance = u128> + pallet_collator_selection::Config,
+		<T as Config>::Balance: From<u128>,
+		CollatorReward: Get<<T as Config>::Balance>,
+		AnnualTreasuryInflationPercent: Get<u32>,
+	{
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+			assert_eq!(
+				Pallet::<T>::on_chain_storage_version(),
+				StorageVersion::new(0),
+				"On-chain storage version should be 0 (default)"
+			);
 			let collators = get_collators::<T>();
-			weight.saturating_accrue(T::DbWeight::get().reads(2));
+			assert!(!collators.is_empty());
 
-			<T as Config>::Rewards::attach_currency(
-				<T as Config>::StakeCurrencyId::get(),
-				<T as Config>::StakeGroupId::get(),
-			)
-			.map_err(|e| log::error!("Failed to attach currency to collator group: {:?}", e))
-			.ok();
+			assert!(!CollatorReward::get().is_zero());
 
-			ActiveSessionData::<T>::set(SessionData::<T> {
-				collator_count: collators.len().saturated_into(),
-				collator_reward: CollatorReward::get().into(),
-				treasury_inflation_rate: TreasuryInflationRate::get().into(),
-				last_update: T::Time::now(),
-			});
-			weight.saturating_accrue(T::DbWeight::get().writes(1));
+			log::info!("{LOG_PREFIX} Pre migration checks successful");
+
+			Ok(collators.encode())
+		}
+
+		// Weight: 2 + collator_count reads and writes
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			if Pallet::<T>::on_chain_storage_version() == StorageVersion::new(0) {
+				log::info!("{LOG_PREFIX} Initiating migration");
+				let mut weight: Weight = Weight::zero();
+
+				let collators = get_collators::<T>();
+				weight.saturating_accrue(T::DbWeight::get().reads(2));
+
+				<T as Config>::Rewards::attach_currency(
+					<T as Config>::StakeCurrencyId::get(),
+					<T as Config>::StakeGroupId::get(),
+				)
+				.map_err(|e| log::error!("Failed to attach currency to collator group: {:?}", e))
+				.ok();
+
+				pallet::ActiveSessionData::<T>::set(SessionData::<T> {
+					collator_count: collators.len().saturated_into(),
+					collator_reward: CollatorReward::get().into(),
+					treasury_inflation_rate: inflation_rate::<T>(
+						AnnualTreasuryInflationPercent::get(),
+					),
+					last_update: T::Time::now(),
+				});
+				weight.saturating_accrue(T::DbWeight::get().writes(1));
+
+				for collator in collators.iter() {
+					// NOTE: Benching not required as num of collators <= 10.
+					Pallet::<T>::do_init_collator(collator)
+						.map_err(|e| {
+							log::error!("Failed to init genesis collators for rewards: {:?}", e);
+						})
+						.ok();
+					weight.saturating_accrue(T::DbWeight::get().reads_writes(6, 6));
+				}
+				Pallet::<T>::current_storage_version().put::<Pallet<T>>();
+				weight.saturating_add(T::DbWeight::get().writes(1))
+			} else {
+				// wrong storage version
+				log::info!(
+					"{LOG_PREFIX} Migration did not execute. This probably should be removed"
+				);
+				T::DbWeight::get().reads_writes(1, 0)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(pre_state: Vec<u8>) -> Result<(), DispatchError> {
+			assert_eq!(
+				Pallet::<T>::on_chain_storage_version(),
+				Pallet::<T>::current_storage_version(),
+				"On-chain storage version should be updated"
+			);
+			let collators: Vec<T::AccountId> = Decode::decode(&mut pre_state.as_slice())
+				.expect("pre_upgrade provides a valid state; qed");
+
+			assert_eq!(
+				Pallet::<T>::active_session_data(),
+				SessionData::<T> {
+					collator_count: collators.len().saturated_into(),
+					collator_reward: CollatorReward::get().into(),
+					treasury_inflation_rate: inflation_rate::<T>(
+						AnnualTreasuryInflationPercent::get()
+					),
+					last_update: T::Time::now(),
+				}
+			);
 
 			for collator in collators.iter() {
-				// NOTE: Benching not required as num of collators <= 10.
-				Pallet::<T>::do_init_collator(collator)
-					.map_err(|e| {
-						log::error!("Failed to init genesis collators for rewards: {:?}", e);
-					})
-					.ok();
-				weight.saturating_accrue(T::DbWeight::get().reads_writes(6, 6));
+				assert!(!<T as Config>::Rewards::account_stake(
+					<T as Config>::StakeCurrencyId::get(),
+					collator,
+				)
+				.is_zero())
 			}
-			Pallet::<T>::current_storage_version().put::<Pallet<T>>();
-			weight.saturating_add(T::DbWeight::get().writes(1))
-		} else {
-			// wrong storage version
-			log::info!(
-				"💰 BlockRewards: Migration did not execute. This probably should be removed"
-			);
-			T::DbWeight::get().reads_writes(1, 0)
+
+			log::info!("{LOG_PREFIX} Post migration checks successful");
+
+			Ok(())
 		}
 	}
+}
 
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(pre_state: Vec<u8>) -> Result<(), DispatchError> {
-		assert_eq!(
-			Pallet::<T>::on_chain_storage_version(),
-			StorageVersion::new(1),
-			"On-chain storage version should be updated"
-		);
-		let collators: Vec<T::AccountId> = Decode::decode(&mut pre_state.as_slice())
-			.expect("pre_ugprade provides a valid state; qed");
+pub mod v2 {
+	use frame_support::{
+		pallet_prelude::ValueQuery, storage_alias, DefaultNoBound, RuntimeDebugNoBound,
+	};
+	use parity_scale_codec::MaxEncodedLen;
+	use scale_info::TypeInfo;
+	use sp_runtime::TryRuntimeError;
 
-		assert_eq!(
-			Pallet::<T>::active_session_data(),
-			SessionData::<T> {
-				collator_count: collators.len().saturated_into(),
-				collator_reward: CollatorReward::get().into(),
-				treasury_inflation_rate: TreasuryInflationRate::get().into(),
-				last_update: T::Time::now(),
+	use super::*;
+	use crate::{CollatorChanges, SessionChanges};
+
+	const LOG_PREFIX: &str = "RelativeTreasuryInflation";
+
+	#[derive(
+		Encode, Decode, TypeInfo, DefaultNoBound, MaxEncodedLen, PartialEq, Eq, RuntimeDebugNoBound,
+	)]
+	#[scale_info(skip_type_params(T))]
+	struct OldSessionData<T: Config> {
+		pub collator_reward: T::Balance,
+		pub total_reward: T::Balance,
+		pub collator_count: u32,
+	}
+
+	#[derive(
+		PartialEq,
+		Clone,
+		DefaultNoBound,
+		Encode,
+		Decode,
+		TypeInfo,
+		MaxEncodedLen,
+		RuntimeDebugNoBound,
+	)]
+	#[scale_info(skip_type_params(T))]
+	struct OldSessionChanges<T: Config> {
+		pub collators: CollatorChanges<T>,
+		pub collator_count: Option<u32>,
+		pub collator_reward: Option<T::Balance>,
+		pub total_reward: Option<T::Balance>,
+	}
+
+	#[storage_alias]
+	type ActiveSessionData<T: Config> = StorageValue<Pallet<T>, OldSessionData<T>, ValueQuery>;
+	#[storage_alias]
+	type NextSessionChanges<T: Config> = StorageValue<Pallet<T>, OldSessionChanges<T>, ValueQuery>;
+
+	pub struct RelativeTreasuryInflationMigration<T, InflationRate>(
+		PhantomData<(T, InflationRate)>,
+	);
+
+	impl<T, InflationPercentage> OnRuntimeUpgrade
+		for RelativeTreasuryInflationMigration<T, InflationPercentage>
+	where
+		T: Config,
+		InflationPercentage: Get<u32>,
+	{
+		fn on_runtime_upgrade() -> Weight {
+			if Pallet::<T>::on_chain_storage_version() == StorageVersion::new(1) {
+				let active = ActiveSessionData::<T>::take();
+				let next = NextSessionChanges::<T>::take();
+
+				pallet::ActiveSessionData::<T>::put(SessionData {
+					collator_reward: active.collator_reward,
+					collator_count: active.collator_count,
+					treasury_inflation_rate: inflation_rate::<T>(InflationPercentage::get()),
+					last_update: T::Time::now(),
+				});
+				log::info!("{LOG_PREFIX} Translated ActiveSessionData");
+
+				pallet::NextSessionChanges::<T>::put(SessionChanges {
+					collators: next.collators,
+					collator_count: next.collator_count,
+					collator_reward: next.collator_reward,
+					treasury_inflation_rate: Some(inflation_rate::<T>(InflationPercentage::get())),
+					last_update: T::Time::now(),
+				});
+				log::info!("{LOG_PREFIX} Translated NextSessionChanges");
+				Pallet::<T>::current_storage_version().put::<Pallet<T>>();
+
+				T::DbWeight::get().reads_writes(1, 5)
+			} else {
+				log::info!("{LOG_PREFIX} BlockRewards pallet already on version 2, migration can be removed");
+				T::DbWeight::get().reads(1)
 			}
-		);
-
-		for collator in collators.iter() {
-			assert!(!<T as Config>::Rewards::account_stake(
-				<T as Config>::StakeCurrencyId::get(),
-				collator,
-			)
-			.is_zero())
 		}
 
-		log::info!("💰 BlockRewards: Post migration checks successful");
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			assert_eq!(
+				Pallet::<T>::on_chain_storage_version(),
+				StorageVersion::new(1),
+			);
+			assert!(
+				Pallet::<T>::on_chain_storage_version() < Pallet::<T>::current_storage_version()
+			);
 
-		Ok(())
+			let active = ActiveSessionData::<T>::get();
+			let next = NextSessionChanges::<T>::get();
+
+			log::info!("{LOG_PREFIX} PRE UPGRADE: Finished");
+
+			Ok((active, next).encode())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(pre_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			let (old_active, old_next): (OldSessionData<T>, OldSessionChanges<T>) =
+				Decode::decode(&mut pre_state.as_slice()).expect("Pre state valid; qed");
+			let active = pallet::ActiveSessionData::<T>::get();
+			let next = pallet::NextSessionChanges::<T>::get();
+
+			assert_eq!(old_active.collator_reward, active.collator_reward);
+			assert_eq!(old_active.collator_count, active.collator_count);
+			assert_eq!(old_next.collators, next.collators);
+			assert_eq!(old_next.collator_count, next.collator_count);
+			assert_eq!(old_next.collator_reward, next.collator_reward);
+			assert_eq!(
+				next.treasury_inflation_rate,
+				Some(inflation_rate::<T>(InflationPercentage::get()))
+			);
+			assert_eq!(
+				Pallet::<T>::current_storage_version(),
+				Pallet::<T>::on_chain_storage_version()
+			);
+
+			log::info!("{LOG_PREFIX} POST UPGRADE: Finished");
+			Ok(())
+		}
 	}
 }

--- a/pallets/block-rewards/src/tests.rs
+++ b/pallets/block-rewards/src/tests.rs
@@ -1,5 +1,10 @@
-use cfg_types::tokens::{CurrencyId, StakingCurrency};
+use cfg_primitives::{CFG, SECONDS_PER_YEAR};
+use cfg_types::{
+	fixed_point::Rate,
+	tokens::{CurrencyId, StakingCurrency},
+};
 use frame_support::{assert_noop, assert_ok, traits::fungibles};
+use num_traits::One;
 use sp_runtime::traits::BadOrigin;
 
 use super::*;
@@ -8,17 +13,17 @@ use crate::mock::*;
 // The Reward amount
 // NOTE: This value needs to be > ExistentialDeposit, otherwise the tests will
 // fail as it's not allowed to transfer a value below the ED threshold.
-const REWARD: u128 = 100 + ExistentialDeposit::get();
+const REWARD: u128 = 100 * CFG + ExistentialDeposit::get();
 
 #[test]
 fn check_special_privileges() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
-			BlockRewards::set_collator_reward(RuntimeOrigin::signed(2), 10),
+			BlockRewards::set_collator_reward_per_session(RuntimeOrigin::signed(2), 10),
 			BadOrigin
 		);
 		assert_noop!(
-			BlockRewards::set_total_reward(RuntimeOrigin::signed(2), 100),
+			BlockRewards::set_annual_treasury_inflation_rate(RuntimeOrigin::signed(2), Rate::one()),
 			BadOrigin
 		);
 	});
@@ -26,138 +31,68 @@ fn check_special_privileges() {
 
 #[test]
 fn collator_reward_change() {
-	ExtBuilder::default()
-		.set_total_reward(REWARD)
-		.build()
-		.execute_with(|| {
-			// EPOCH 0
-			assert_ok!(BlockRewards::set_collator_reward(
-				RuntimeOrigin::root(),
-				REWARD
-			));
-			assert_eq!(
-				NextSessionChanges::<Test>::get().collator_reward,
-				Some(REWARD)
-			);
-			assert_eq!(ActiveSessionData::<Test>::get().collator_reward, 0);
+	ExtBuilder::default().build().execute_with(|| {
+		// EPOCH 0
+		assert_ok!(BlockRewards::set_collator_reward_per_session(
+			RuntimeOrigin::root(),
+			REWARD
+		));
+		assert_eq!(
+			NextSessionChanges::<Test>::get().collator_reward,
+			Some(REWARD)
+		);
+		assert_eq!(ActiveSessionData::<Test>::get().collator_reward, 0);
 
-			advance_session();
+		advance_session();
 
-			// EPOCH 1
-			assert_eq!(NextSessionChanges::<Test>::get().collator_reward, None);
-			assert_eq!(ActiveSessionData::<Test>::get().collator_reward, REWARD);
+		// EPOCH 1
+		assert_eq!(NextSessionChanges::<Test>::get().collator_reward, None);
+		assert_eq!(ActiveSessionData::<Test>::get().collator_reward, REWARD);
 
-			advance_session();
+		advance_session();
 
-			// EPOCH 2
-			assert_eq!(ActiveSessionData::<Test>::get().collator_reward, REWARD);
-		});
-}
-
-#[test]
-fn collator_reward_change_throws() {
-	ExtBuilder::default()
-		.set_total_reward(1)
-		.set_collator_reward(0)
-		.build()
-		.execute_with(|| {
-			assert_ok!(BlockRewards::set_collator_reward(RuntimeOrigin::root(), 1));
-			assert_noop!(
-				BlockRewards::set_collator_reward(RuntimeOrigin::root(), 2),
-				Error::<Test>::InsufficientTotalReward
-			);
-		});
+		// EPOCH 2
+		assert_eq!(ActiveSessionData::<Test>::get().collator_reward, REWARD);
+	});
 }
 
 #[test]
 fn total_reward_change_isolated() {
 	ExtBuilder::default().build().execute_with(|| {
 		// EPOCH 0
-		assert_ok!(BlockRewards::set_total_reward(
+		assert_ok!(BlockRewards::set_annual_treasury_inflation_rate(
 			RuntimeOrigin::root(),
-			REWARD
+			Rate::one()
 		));
-		assert_eq!(NextSessionChanges::<Test>::get().total_reward, Some(REWARD));
-		assert_eq!(ActiveSessionData::<Test>::get().total_reward, 0);
+		assert_eq!(
+			NextSessionChanges::<Test>::get().treasury_inflation_rate,
+			Some(Rate::one())
+		);
+		assert_eq!(
+			ActiveSessionData::<Test>::get().treasury_inflation_rate,
+			Rate::zero()
+		);
 
 		advance_session();
 
 		// EPOCH 1
-		assert_eq!(NextSessionChanges::<Test>::get().total_reward, None);
-		assert_eq!(ActiveSessionData::<Test>::get().total_reward, REWARD);
+		assert_eq!(
+			NextSessionChanges::<Test>::get().treasury_inflation_rate,
+			None
+		);
+		assert_eq!(
+			ActiveSessionData::<Test>::get().treasury_inflation_rate,
+			Rate::one()
+		);
 
 		advance_session();
 
 		// EPOCH 2
-		assert_eq!(ActiveSessionData::<Test>::get().total_reward, REWARD);
+		assert_eq!(
+			ActiveSessionData::<Test>::get().treasury_inflation_rate,
+			Rate::one()
+		);
 	});
-}
-
-#[test]
-fn total_reward_change_over_sessions() {
-	ExtBuilder::default()
-		.set_total_reward(REWARD)
-		.build()
-		.execute_with(|| {
-			// EPOCH 0
-			assert_ok!(BlockRewards::set_collator_reward(
-				RuntimeOrigin::root(),
-				REWARD
-			));
-			assert_ok!(BlockRewards::set_total_reward(
-				RuntimeOrigin::root(),
-				REWARD
-			));
-			assert_eq!(
-				NextSessionChanges::<Test>::get().collator_reward,
-				Some(REWARD)
-			);
-			assert_eq!(ActiveSessionData::<Test>::get().collator_reward, 0);
-			assert_eq!(NextSessionChanges::<Test>::get().total_reward, Some(REWARD));
-			assert_eq!(ActiveSessionData::<Test>::get().total_reward, REWARD);
-
-			advance_session();
-
-			// EPOCH 1
-			assert_eq!(NextSessionChanges::<Test>::get().collator_reward, None);
-			assert_eq!(ActiveSessionData::<Test>::get().collator_reward, REWARD);
-			assert_eq!(NextSessionChanges::<Test>::get().total_reward, None);
-			assert_eq!(ActiveSessionData::<Test>::get().total_reward, REWARD);
-
-			// Total reward update must be at least 2 * collator_reward since collator size
-			// increases by one
-			assert_eq!(ActiveSessionData::<Test>::get().collator_count, 1);
-			assert_eq!(NextSessionChanges::<Test>::get().collator_count, Some(2));
-			assert_noop!(
-				BlockRewards::set_total_reward(RuntimeOrigin::root(), 2 * REWARD - 1),
-				Error::<Test>::InsufficientTotalReward
-			);
-			assert_ok!(BlockRewards::set_total_reward(
-				RuntimeOrigin::root(),
-				2 * REWARD
-			));
-			assert_eq!(
-				NextSessionChanges::<Test>::get().total_reward,
-				Some(2 * REWARD)
-			);
-
-			advance_session();
-
-			// EPOCH 2
-			assert_eq!(NextSessionChanges::<Test>::get().collator_reward, None);
-			assert_eq!(ActiveSessionData::<Test>::get().collator_reward, REWARD);
-			assert_eq!(NextSessionChanges::<Test>::get().total_reward, None);
-			assert_eq!(ActiveSessionData::<Test>::get().total_reward, 2 * REWARD);
-
-			// Total reward update must be at least 3 * collator_reward since collator size
-			// increases by one
-			assert_eq!(ActiveSessionData::<Test>::get().collator_count, 2);
-			assert_eq!(NextSessionChanges::<Test>::get().collator_count, Some(3));
-			assert_noop!(
-				BlockRewards::set_total_reward(RuntimeOrigin::root(), 3 * REWARD - 1),
-				Error::<Test>::InsufficientTotalReward
-			);
-		});
 }
 
 #[test]
@@ -247,7 +182,6 @@ fn joining_leaving_collators() {
 fn single_claim_reward() {
 	ExtBuilder::default()
 		.set_collator_reward(REWARD)
-		.set_total_reward(10 * REWARD)
 		.build()
 		.execute_with(|| {
 			assert!(<Test as Config>::Rewards::is_ready(
@@ -258,8 +192,6 @@ fn single_claim_reward() {
 				<Test as Config>::StakeAmount::get() as u128
 			);
 			assert_eq!(ActiveSessionData::<Test>::get().collator_reward, REWARD);
-			assert_eq!(ActiveSessionData::<Test>::get().total_reward, 10 * REWARD);
-			assert_eq!(mock::RewardRemainderUnbalanced::get(), 0);
 
 			// EPOCH 0 -> EPOCH 1
 			advance_session();
@@ -278,7 +210,7 @@ fn single_claim_reward() {
 			);
 
 			assert_ok!(BlockRewards::claim_reward(RuntimeOrigin::signed(2), 1));
-			System::assert_last_event(mock::RuntimeEvent::Rewards(
+			System::assert_last_event(RuntimeEvent::Rewards(
 				pallet_rewards::Event::RewardClaimed {
 					group_id: <Test as Config>::StakeGroupId::get(),
 					currency_id: <Test as Config>::StakeCurrencyId::get(),
@@ -286,10 +218,14 @@ fn single_claim_reward() {
 					amount: REWARD,
 				},
 			));
-			assert_eq!(Balances::total_balance(&TREASURY_ADDRESS), 9 * REWARD);
+			// NOTE: Was not set
+			assert_eq!(
+				Balances::total_balance(&TreasuryPalletId::get().into_account_truncating()),
+				0
+			);
 			assert_eq!(
 				Balances::total_issuance(),
-				10 * REWARD + ExistentialDeposit::get()
+				REWARD + ExistentialDeposit::get()
 			);
 			assert_eq!(Balances::free_balance(&1), REWARD);
 		});
@@ -297,16 +233,24 @@ fn single_claim_reward() {
 
 #[test]
 fn collator_rewards_greater_than_remainder() {
+	let rate = Rate::saturating_from_rational(1, 10);
+
 	ExtBuilder::default()
 		.set_collator_reward(REWARD)
-		.set_total_reward(2 * REWARD)
+		.set_treasury_inflation_rate(rate)
 		.build()
 		.execute_with(|| {
-			// EPOCH 0 -> EPOCH 1
+			let initial_treasury_balance =
+				Balances::free_balance(&TreasuryPalletId::get().into_account_truncating());
+
+			// EPOCH 0 -> EPOCH
+			let total_issuance = ExistentialDeposit::get();
+			assert_eq!(Balances::total_issuance(), total_issuance);
+			MockTime::mock_now(|| SECONDS_PER_YEAR * 1000);
 			advance_session();
 
 			// EPOCH 0 had one collator [1].
-			// Thus, equal distribution of total_reward to collator and Treasury.
+			// Thus, equal they get all.
 			assert_eq!(
 				<Test as Config>::Rewards::compute_reward(
 					<Test as Config>::StakeCurrencyId::get(),
@@ -314,17 +258,26 @@ fn collator_rewards_greater_than_remainder() {
 				),
 				Ok(REWARD)
 			);
+			let total_issuance_without_treasury = total_issuance + REWARD;
+			let treasury_inflation = total_issuance_without_treasury / 10;
 			assert_eq!(
 				Balances::total_issuance(),
-				2 * REWARD + ExistentialDeposit::get()
+				total_issuance_without_treasury + treasury_inflation
 			);
-			assert_eq!(Balances::total_balance(&TREASURY_ADDRESS), REWARD);
+			assert_eq!(
+				Balances::free_balance(&TreasuryPalletId::get().into_account_truncating()),
+				initial_treasury_balance + treasury_inflation
+			);
 
 			// EPOCH 1 -> EPOCH 2
+			MockTime::mock_now(|| 2 * SECONDS_PER_YEAR * 1000);
 			advance_session();
 
 			// EPOCH 1 had one collator [1].
-			// Thus, equal distribution of total_reward to collator and Treasury.
+			// Thus, reward is minted only once.
+			let total_issuance_without_treasury = total_issuance_without_treasury + REWARD;
+			let treasury_inflation =
+				treasury_inflation + (treasury_inflation + total_issuance_without_treasury) / 10;
 			assert_eq!(
 				<Test as Config>::Rewards::compute_reward(
 					<Test as Config>::StakeCurrencyId::get(),
@@ -332,17 +285,21 @@ fn collator_rewards_greater_than_remainder() {
 				),
 				Ok(2 * REWARD)
 			);
-			assert_eq!(Balances::total_balance(&TREASURY_ADDRESS), 2 * REWARD);
 			assert_eq!(
 				Balances::total_issuance(),
-				4 * REWARD + ExistentialDeposit::get()
+				total_issuance_without_treasury + treasury_inflation
+			);
+			assert_eq!(
+				Balances::free_balance(&TreasuryPalletId::get().into_account_truncating()),
+				initial_treasury_balance + treasury_inflation
 			);
 
 			// EPOCH 2 -> EPOCH 3
+			MockTime::mock_now(|| 3 * SECONDS_PER_YEAR * 1000);
 			advance_session();
 
 			// EPOCH 2 had two collators [2, 3].
-			// Thus, both consume the entire total_reward.
+			// Thus, both receive the reward.
 			// Additionally, 1 should not have higher claimable reward.
 			assert_eq!(
 				<Test as Config>::Rewards::compute_reward(
@@ -360,43 +317,52 @@ fn collator_rewards_greater_than_remainder() {
 					Ok(REWARD)
 				);
 			}
-			assert_eq!(Balances::total_balance(&TREASURY_ADDRESS), 2 * REWARD);
+			let total_issuance_without_treasury = total_issuance_without_treasury + 2 * REWARD;
+			let treasury_inflation =
+				treasury_inflation + (treasury_inflation + total_issuance_without_treasury) / 10;
 			assert_eq!(
 				Balances::total_issuance(),
-				6 * REWARD + ExistentialDeposit::get()
+				total_issuance_without_treasury + treasury_inflation
+			);
+			assert_eq!(
+				Balances::free_balance(&TreasuryPalletId::get().into_account_truncating()),
+				initial_treasury_balance + treasury_inflation
 			);
 
 			// EPOCH 3 -> EPOCH 4
+			MockTime::mock_now(|| 4 * SECONDS_PER_YEAR * 1000);
 			advance_session();
 
 			// EPOCH 3 had three collators [3, 4, 5].
-			// Thus, all three consume the entire total_reward
-			// and reseive less than collator_reward each.
-			assert_eq!(
-				<Test as Config>::Rewards::compute_reward(
-					<Test as Config>::StakeCurrencyId::get(),
-					&3
-				),
-				Ok(REWARD + 2 * REWARD / 3)
-			);
-			assert_eq!(
-				<Test as Config>::Rewards::compute_reward(
-					<Test as Config>::StakeCurrencyId::get(),
-					&4
-				),
-				Ok(2 * REWARD / 3)
-			);
-			assert_eq!(
-				<Test as Config>::Rewards::compute_reward(
-					<Test as Config>::StakeCurrencyId::get(),
-					&5
-				),
-				Ok(2 * REWARD / 3)
-			);
-			assert_eq!(Balances::total_balance(&TREASURY_ADDRESS), 2 * REWARD);
+			// Thus, all three get the reward whereas [1, 2] do not.
+			for collator in [1, 3].iter() {
+				assert_eq!(
+					<Test as Config>::Rewards::compute_reward(
+						<Test as Config>::StakeCurrencyId::get(),
+						collator
+					),
+					Ok(2 * REWARD)
+				);
+			}
+			for collator in [2, 4, 5].iter() {
+				assert_eq!(
+					<Test as Config>::Rewards::compute_reward(
+						<Test as Config>::StakeCurrencyId::get(),
+						collator
+					),
+					Ok(REWARD)
+				);
+			}
+			let total_issuance_without_treasury = total_issuance_without_treasury + 3 * REWARD;
+			let treasury_inflation =
+				treasury_inflation + (treasury_inflation + total_issuance_without_treasury) / 10;
 			assert_eq!(
 				Balances::total_issuance(),
-				8 * REWARD + ExistentialDeposit::get()
+				total_issuance_without_treasury + treasury_inflation
+			);
+			assert_eq!(
+				Balances::free_balance(&TreasuryPalletId::get().into_account_truncating()),
+				initial_treasury_balance + treasury_inflation
 			);
 		});
 }
@@ -405,7 +371,6 @@ fn collator_rewards_greater_than_remainder() {
 fn late_claiming_works() {
 	ExtBuilder::default()
 		.set_collator_reward(REWARD)
-		.set_total_reward(2 * REWARD)
 		.set_run_to_block(100)
 		.build()
 		.execute_with(|| {
@@ -432,7 +397,6 @@ fn late_claiming_works() {
 fn duplicate_claiming_works_but_ineffective() {
 	ExtBuilder::default()
 		.set_collator_reward(REWARD)
-		.set_total_reward(2 * REWARD)
 		.set_run_to_block(100)
 		.build()
 		.execute_with(|| {
@@ -470,4 +434,21 @@ fn duplicate_claiming_works_but_ineffective() {
 				},
 			));
 		});
+}
+
+#[test]
+fn calculate_epoch_treasury_inflation() {
+	let rate = Rate::saturating_from_rational(1, 10);
+
+	ExtBuilder::default().build().execute_with(|| {
+		MockTime::mock_now(|| 0);
+		let inflation = Balances::total_issuance();
+		assert_eq!(BlockRewards::calculate_epoch_treasury_inflation(rate, 0), 0);
+
+		MockTime::mock_now(|| SECONDS_PER_YEAR * 1000);
+		assert_eq!(
+			BlockRewards::calculate_epoch_treasury_inflation(rate, 0),
+			inflation / 10
+		);
+	})
 }

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1221,20 +1221,19 @@ impl pallet_block_rewards::Config for Runtime {
 	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type AuthorityId = AuraId;
 	type Balance = Balance;
-	// Must not set this as long as we don't want to mint the rewards.
-	// By setting this to (), the remainder of TotalRewards - CollatorRewards
-	// will be dropped. Else it would be transferred to the configured Beneficiary.
-	type Beneficiary = ();
-	type Currency = Tokens;
 	type CurrencyId = CurrencyId;
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxChangesPerSession = MaxChangesPerEpoch;
 	type MaxCollators = MaxAuthorities;
+	type Rate = Rate;
 	type Rewards = BlockRewardsBase;
 	type RuntimeEvent = RuntimeEvent;
 	type StakeAmount = StakeAmount;
 	type StakeCurrencyId = BlockRewardCurrency;
 	type StakeGroupId = CollatorGroupId;
+	type Time = Timestamp;
+	type Tokens = Tokens;
+	type TreasuryPalletId = TreasuryPalletId;
 	type Weight = u64;
 	type WeightInfo = weights::pallet_block_rewards::WeightInfo<Runtime>;
 }

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -23,6 +23,7 @@ use orml_traits::asset_registry::AssetMetadata;
 frame_support::parameter_types! {
 	pub const NftSalesPalletName: &'static str = "NftSales";
 	pub const MigrationPalletName: &'static str = "Migration";
+	pub const AnnualTreasuryInflationPercent: u32 = 3;
 }
 
 /// The migration set for Altair 1034 @ Kusama. It includes all the migrations
@@ -75,6 +76,11 @@ pub type UpgradeAltair1034 = (
 	runtime_common::migrations::nuke::KillPallet<NftSalesPalletName, crate::RocksDbWeight>,
 	// Removes unused migration pallet
 	runtime_common::migrations::nuke::KillPallet<MigrationPalletName, crate::RocksDbWeight>,
+	// Apply relative treasury inflation
+	pallet_block_rewards::migrations::v2::RelativeTreasuryInflationMigration<
+		crate::Runtime,
+		AnnualTreasuryInflationPercent,
+	>,
 );
 
 #[allow(clippy::upper_case_acronyms)]

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1237,18 +1237,20 @@ impl pallet_block_rewards::Config for Runtime {
 	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type AuthorityId = AuraId;
 	type Balance = Balance;
-	// Must not change this as long as we want to mint rewards into the treasury
-	type Beneficiary = Treasury;
-	type Currency = Tokens;
 	type CurrencyId = CurrencyId;
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxChangesPerSession = MaxChangesPerEpoch;
 	type MaxCollators = MaxAuthorities;
+	type Rate = Rate;
 	type Rewards = BlockRewardsBase;
 	type RuntimeEvent = RuntimeEvent;
 	type StakeAmount = StakeAmount;
 	type StakeCurrencyId = BlockRewardCurrency;
 	type StakeGroupId = CollatorGroupId;
+	type Time = Timestamp;
+	type Tokens = Tokens;
+	// Must not change this as long as we want to mint rewards into the treasury
+	type TreasuryPalletId = TreasuryPalletId;
 	type Weight = u64;
 	type WeightInfo = weights::pallet_block_rewards::WeightInfo<Runtime>;
 }

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -33,6 +33,7 @@ frame_support::parameter_types! {
 	pub const UsdcArb: CurrencyId = CURRENCY_ID_LP_ARB;
 	pub const UsdcCelo: CurrencyId = CURRENCY_ID_LP_CELO;
 	pub const MinOrderAmount: Balance = 10u128.pow(6);
+	pub const AnnualTreasuryInflationPercent: u32 = 3;
 }
 
 pub type UpgradeCentrifuge1025 = (
@@ -98,6 +99,11 @@ pub type UpgradeCentrifuge1025 = (
 	runtime_common::migrations::nuke::KillPallet<MigrationPalletName, crate::RocksDbWeight>,
 	// Sets account codes for all precompiles
 	runtime_common::migrations::precompile_account_codes::Migration<crate::Runtime>,
+	// Apply relative treasury inflation
+	pallet_block_rewards::migrations::v2::RelativeTreasuryInflationMigration<
+		crate::Runtime,
+		AnnualTreasuryInflationPercent,
+	>,
 );
 
 // Copyright 2021 Centrifuge Foundation (centrifuge.io).

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1732,17 +1732,19 @@ impl pallet_block_rewards::Config for Runtime {
 	type AdminOrigin = EnsureRootOr<HalfOfCouncil>;
 	type AuthorityId = AuraId;
 	type Balance = Balance;
-	type Beneficiary = Treasury;
-	type Currency = Tokens;
 	type CurrencyId = CurrencyId;
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxChangesPerSession = MaxChangesPerEpoch;
 	type MaxCollators = MaxAuthorities;
+	type Rate = Rate;
 	type Rewards = BlockRewardsBase;
 	type RuntimeEvent = RuntimeEvent;
 	type StakeAmount = StakeAmount;
 	type StakeCurrencyId = BlockRewardCurrency;
 	type StakeGroupId = CollatorGroupId;
+	type Time = Timestamp;
+	type Tokens = Tokens;
+	type TreasuryPalletId = TreasuryPalletId;
 	type Weight = u64;
 	type WeightInfo = weights::pallet_block_rewards::WeightInfo<Runtime>;
 }

--- a/runtime/development/src/migrations.rs
+++ b/runtime/development/src/migrations.rs
@@ -20,6 +20,7 @@ frame_support::parameter_types! {
 	pub const LocalAssetIdUsdc: LocalAssetId = LOCAL_ASSET_ID;
 	pub const LocalCurrencyIdUsdc: CurrencyId = CURRENCY_ID_LOCAL;
 	pub const PoolCurrencyAnemoy: CurrencyId = CURRENCY_ID_DOT_NATIVE;
+	pub const AnnualTreasuryInflationPercent: u32 = 3;
 }
 
 pub type UpgradeDevelopment1041 = (
@@ -42,5 +43,10 @@ pub type UpgradeDevelopment1041 = (
 		crate::TransferAllowList,
 		crate::RocksDbWeight,
 		0,
+	>,
+	// Apply relative treasury inflation
+	pallet_block_rewards::migrations::v2::RelativeTreasuryInflationMigration<
+		crate::Runtime,
+		AnnualTreasuryInflationPercent,
 	>,
 );

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -4142,7 +4142,6 @@ mod development {
 
 					let sender = <T as pallet_liquidity_pools_gateway::Config>::Sender::get();
 
-					dbg!(frame_system::Pallet::<T>::events());
 					assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
 						e.event
 							== pallet_liquidity_pools_gateway::Event::<T>::OutboundMessageSubmitted {
@@ -4244,7 +4243,6 @@ mod development {
 						increase_msg
 					));
 
-					dbg!(frame_system::Pallet::<T>::events());
 					assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
 						e.event
 							== pallet_liquidity_pools_gateway::Event::<T>::OutboundMessageSubmitted {


### PR DESCRIPTION
# Description

Fixes https://github.com/centrifuge/centrifuge-chain/issues/1495

The current treasury inflation is based on absolute numbers and thus diverging from the annual 3% on which the community decided both for Altair ([-> RFC](https://gov.centrifuge.io/t/rfc-altair-block-rewards-activation-and-treasury-burning-proposal/5503)) as well as Centrifuge ([-> CP6](https://gov.centrifuge.io/t/rfc-updating-cp6-block-rewards/5839)). This PR fills this gap by switching to a relative treasury inflation. As a result, all three runtimes have the exact same block rewards configuration now except for different collator reward amounts.

## Now

Inside `pallet-block-rewards`, the annual treasury inflation rate is stored. On each new session, collators receive their reward. Moreover, the treasury is funded with the proration based on the configured rate and session duration in seconds:

```
treasury_inflation_per_session = annual_treasury_rate / SECONDS_PER_YEAR * session_duration_in_secs
session_duration_in_secs  = now - last_update
```

Before, the rewards configuration revolved around an absolute `total_amount` per session which was first distributed to the collators and the remainder minted into the treasury, if configured in the runtime (true for Centrifuge, false for Altair). For Altair, we also need to burn 15,752,730 AIR (equivalent of annual Treasury block rewards) which can be batched with the runtime upgrade proposal

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
