### PR TITLE
misc: Clean-up and minors pre 1025

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -47,7 +47,7 @@ jobs:
         run: >
           docker run --rm  --user root --platform=linux/amd64
           -e PACKAGE=${{ matrix.package }} -v /home/runner/.cargo:/cargo-home  
-          -v ${{ github.workspace }}:/build paritytech/srtool:1.73.0-0.12.0
+          -v ${{ github.workspace }}:/build paritytech/srtool:1.75.0-0.14.0
           /srtool/build --app
 
       # Alternative way of running SRTool that allows for "script-like" execution,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "development-runtime"
-version = "0.10.41"
+version = "0.10.42"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",

--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -452,7 +452,10 @@ pub mod usdc {
 	pub const CURRENCY_ID_LP_ETH_GOERLI: CurrencyId = CurrencyId::ForeignAsset(100_001);
 	pub const CURRENCY_ID_LP_BASE: CurrencyId = CurrencyId::ForeignAsset(100_002);
 	pub const CURRENCY_ID_LP_ARB: CurrencyId = CurrencyId::ForeignAsset(100_003);
-	pub const CURRENCY_ID_LP_CELO: CurrencyId = CurrencyId::ForeignAsset(100_004);
+
+	pub const CURRENCY_ID_LP_CELO_WORMHOLE: CurrencyId = CurrencyId::ForeignAsset(100_004);
+	pub const CURRENCY_ID_LP_CELO: CurrencyId = CurrencyId::ForeignAsset(100_006);
+
 	pub const LOCAL_ASSET_ID: LocalAssetId = LocalAssetId(1u32);
 	pub const CURRENCY_ID_LOCAL: CurrencyId = CurrencyId::LocalAsset(LOCAL_ASSET_ID);
 

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1801,7 +1801,7 @@ parameter_types! {
 }
 
 impl pallet_order_book::Config for Runtime {
-	type AdminOrigin = EnsureRoot<AccountId>;
+	type AdminOrigin = EnsureAccountOrRootOr<LpAdminAccount, TwoThirdOfCouncil>;
 	type AssetRegistry = OrmlAssetRegistry;
 	type BalanceIn = Balance;
 	type BalanceOut = Balance;

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -14,7 +14,8 @@ use cfg_primitives::{Balance, PoolId};
 use cfg_types::tokens::{
 	usdc::{
 		CURRENCY_ID_AXELAR, CURRENCY_ID_DOT_NATIVE, CURRENCY_ID_LOCAL, CURRENCY_ID_LP_ARB,
-		CURRENCY_ID_LP_BASE, CURRENCY_ID_LP_CELO, CURRENCY_ID_LP_ETH, LOCAL_ASSET_ID,
+		CURRENCY_ID_LP_BASE, CURRENCY_ID_LP_CELO, CURRENCY_ID_LP_CELO_WORMHOLE, CURRENCY_ID_LP_ETH,
+		LOCAL_ASSET_ID,
 	},
 	CurrencyId, LocalAssetId,
 };
@@ -31,6 +32,7 @@ frame_support::parameter_types! {
 	pub const UsdcEth: CurrencyId = CURRENCY_ID_LP_ETH;
 	pub const UsdcBase: CurrencyId = CURRENCY_ID_LP_BASE;
 	pub const UsdcArb: CurrencyId = CURRENCY_ID_LP_ARB;
+	pub const UsdcCeloWormhole: CurrencyId = CURRENCY_ID_LP_CELO_WORMHOLE;
 	pub const UsdcCelo: CurrencyId = CURRENCY_ID_LP_CELO;
 	pub const MinOrderAmount: Balance = 10u128.pow(6);
 }
@@ -50,6 +52,8 @@ pub type UpgradeCentrifuge1025 = (
 		super::Runtime,
 		LocalCurrencyIdUsdc,
 	>,
+	// Register new canonical USDC on Celo
+	runtime_common::migrations::update_celo_usdcs::Migration<super::Runtime>,
 	// Init local representation for all assets
 	runtime_common::migrations::local_currency::translate_metadata::Migration<
 		super::Runtime,

--- a/runtime/common/src/migrations/mod.rs
+++ b/runtime/common/src/migrations/mod.rs
@@ -32,6 +32,7 @@ pub mod update_celo_usdcs {
 	use hex_literal::hex;
 	use orml_traits::asset_registry::{AssetMetadata, Mutate};
 	use sp_runtime::traits::Get;
+	#[cfg(feature = "try-runtime")]
 	use sp_std::{vec, vec::Vec};
 	use xcm::v3::{
 		Junction::{AccountKey20, GlobalConsensus, PalletInstance},

--- a/runtime/common/src/migrations/mod.rs
+++ b/runtime/common/src/migrations/mod.rs
@@ -32,6 +32,7 @@ pub mod update_celo_usdcs {
 	use hex_literal::hex;
 	use orml_traits::asset_registry::{AssetMetadata, Mutate};
 	use sp_runtime::traits::Get;
+	use sp_std::{vec, vec::Vec};
 	use xcm::v3::{
 		Junction::{AccountKey20, GlobalConsensus, PalletInstance},
 		Junctions::X3,

--- a/runtime/common/src/migrations/mod.rs
+++ b/runtime/common/src/migrations/mod.rs
@@ -19,3 +19,117 @@ pub mod nuke;
 pub mod orml_tokens;
 pub mod precompile_account_codes;
 pub mod transfer_allowlist_currency;
+
+pub mod update_celo_usdcs {
+	use cfg_primitives::Balance;
+	#[cfg(feature = "try-runtime")]
+	use cfg_types::tokens::LocalAssetId;
+	use cfg_types::tokens::{
+		usdc::{CURRENCY_ID_LP_CELO, CURRENCY_ID_LP_CELO_WORMHOLE},
+		CrossChainTransferability, CurrencyId, CustomMetadata,
+	};
+	use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
+	use hex_literal::hex;
+	use orml_traits::asset_registry::{AssetMetadata, Mutate};
+	use sp_runtime::traits::Get;
+	use xcm::v3::{
+		Junction::{AccountKey20, GlobalConsensus, PalletInstance},
+		Junctions::X3,
+		NetworkId::Ethereum,
+	};
+
+	const LOG_PREFIX: &str = "UpdateCeloUsdcs";
+
+	pub struct Migration<T>(sp_std::marker::PhantomData<T>);
+
+	impl<T> OnRuntimeUpgrade for Migration<T>
+	where
+		T: orml_asset_registry::Config<
+			CustomMetadata = CustomMetadata,
+			AssetId = CurrencyId,
+			Balance = Balance,
+		>,
+	{
+		fn on_runtime_upgrade() -> Weight {
+			<orml_asset_registry::Pallet<T> as Mutate>::register_asset(
+				Some(CURRENCY_ID_LP_CELO),
+				AssetMetadata {
+					decimals: 6,
+					name: "LP Celo Wrapped USDC ".as_bytes().to_vec(),
+					symbol: "LpCeloUSDC".as_bytes().to_vec(),
+					existential_deposit: 1000u128,
+					location: Some(
+						X3(
+							PalletInstance(103),
+							GlobalConsensus(Ethereum { chain_id: 42220 }),
+							AccountKey20 {
+								// https://www.circle.com/blog/usdc-now-available-on-celo
+								key: hex!("cebA9300f2b948710d2653dD7B07f33A8B32118C"),
+								network: None,
+							},
+						)
+						.into(),
+					),
+					additional: CustomMetadata {
+						transferability: CrossChainTransferability::LiquidityPools,
+						mintable: false,
+						permissioned: false,
+						pool_currency: true,
+						local_representation: None,
+					},
+				},
+			)
+			.map_err(|e| {
+				log::error!(
+					"{LOG_PREFIX} Failed to register new canonical Celo USDC due to error {:?}",
+					e
+				);
+			})
+			.ok();
+
+			log::info!("{LOG_PREFIX} Done registering new canonical Celo USDC currency");
+
+			<orml_asset_registry::Pallet<T> as Mutate>::update_asset(
+				CURRENCY_ID_LP_CELO_WORMHOLE,
+				None,
+				Some("LP Celo Wrapped Wormhole USDC ".as_bytes().to_vec()),
+				Some("LpCeloWormUSDC ".as_bytes().to_vec()),
+				None,
+				None,
+				None,
+			)
+			.map_err(|e| {
+				log::error!(
+					"{LOG_PREFIX} Failed to update wormhole Celo USDC due to error {:?}",
+					e
+				);
+			})
+			.ok();
+
+			log::info!("{LOG_PREFIX} Done updating wormhole Celo USDC currency");
+
+			T::DbWeight::get().writes(2)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
+			assert!(!orml_asset_registry::Metadata::<T>::contains_key(
+				CURRENCY_ID_LP_CELO
+			));
+
+			log::info!("{LOG_PREFIX} PRE UPGRADE: Finished");
+
+			Ok(vec![])
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+			assert!(orml_asset_registry::Metadata::<T>::contains_key(
+				CURRENCY_ID_LP_CELO
+			));
+
+			log::info!("{LOG_PREFIX} POST UPGRADE: Finished");
+			Ok(())
+		}
+	}
+}

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "development-runtime"
-version = "0.10.41"
+version = "0.10.42"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -157,7 +157,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge-devel"),
 	impl_name: create_runtime_str!("centrifuge-devel"),
 	authoring_version: 1,
-	spec_version: 1041,
+	spec_version: 1042,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
@@ -2037,7 +2037,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	crate::migrations::UpgradeDevelopment1041,
+	crate::migrations::UpgradeDevelopment1042,
 >;
 
 // Frame Order in this block dictates the index of each one in the metadata

--- a/runtime/development/src/migrations.rs
+++ b/runtime/development/src/migrations.rs
@@ -22,7 +22,7 @@ frame_support::parameter_types! {
 	pub const PoolCurrencyAnemoy: CurrencyId = CURRENCY_ID_DOT_NATIVE;
 }
 
-pub type UpgradeDevelopment1041 = (
+pub type UpgradeDevelopment1042 = (
 	// Register LocalUSDC
 	runtime_common::migrations::local_currency::register::Migration<
 		super::Runtime,


### PR DESCRIPTION
# Description
Some minor changes and updates pre 1030 runtime upgrade
Fixes #(issue)

## Changes and Descriptions
* Register new canonical Circle `USDC` on Celo
* Rename existing wormhole `USDC`
  * NOTE: This version is intentionally NOT a variant of `LocalUSDC`
* Bumb version of dev runtime
* Allow Council, root and LpAdmin to set `MarketFeeder` in the order book for now 

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
