### PR TITLE
Fix: FI swap correclty with asymmetric ratios

### DIFF
--- a/libs/traits/src/swaps.rs
+++ b/libs/traits/src/swaps.rs
@@ -150,8 +150,8 @@ pub trait Swaps<AccountId> {
 		swap: Swap<Self::Amount, Self::CurrencyId>,
 	) -> Result<SwapStatus<Self::Amount>, DispatchError>;
 
-	/// Cancel (partial or total) a swap. The amount should be expresed in the
-	/// same currency as the the currency_out of the pending amount.
+	/// Cancel a swap partially or completely. The amount should be expressed in
+	/// the same currency as the the currency_out of the pending amount.
 	/// - If there was no previous swap, it errors outs.
 	/// - If there was a swap with other currency out, it errors outs.
 	/// - If there was a swap with same currency out:

--- a/libs/traits/src/swaps.rs
+++ b/libs/traits/src/swaps.rs
@@ -150,6 +150,21 @@ pub trait Swaps<AccountId> {
 		swap: Swap<Self::Amount, Self::CurrencyId>,
 	) -> Result<SwapStatus<Self::Amount>, DispatchError>;
 
+	/// Cancel (partial or total) a swap. The amount should be expresed in the
+	/// same currency as the the currency_out of the pending amount.
+	/// - If there was no previous swap, it errors outs.
+	/// - If there was a swap with other currency out, it errors outs.
+	/// - If there was a swap with same currency out:
+	///   - If the amount is smaller, it decrements it.
+	///   - If the amount is the same, it removes the inverse swap.
+	///   - If the amount is greater, it errors out
+	fn cancel_swap(
+		who: &AccountId,
+		swap_id: Self::SwapId,
+		amount: Self::Amount,
+		currency_id: Self::CurrencyId,
+	) -> DispatchResult;
+
 	/// Returns the pending amount for a pending swap. The direction of the swap
 	/// is determined by the `from_currency` parameter. The amount returned is
 	/// denominated in the same currency as the given `from_currency`.
@@ -157,14 +172,5 @@ pub trait Swaps<AccountId> {
 		who: &AccountId,
 		swap_id: Self::SwapId,
 		from_currency: Self::CurrencyId,
-	) -> Result<Self::Amount, DispatchError>;
-
-	/// Makes a conversion between 2 currencies using the market ratio between
-	/// them
-	// TODO: Should be removed after #1723
-	fn convert_by_market(
-		currency_in: Self::CurrencyId,
-		currency_out: Self::CurrencyId,
-		amount_out: Self::Amount,
 	) -> Result<Self::Amount, DispatchError>;
 }

--- a/pallets/swaps/src/lib.rs
+++ b/pallets/swaps/src/lib.rs
@@ -93,6 +93,13 @@ pub mod pallet {
 
 		/// Failed to retrieve the swap.
 		SwapNotFound,
+
+		/// Emitted when the cancelled amount is greater than the pending amount
+		CancelMoreThanPending,
+
+		/// Emitted when the cancelled currency is different than the pending
+		/// currency
+		CancelDifferentCurrency,
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -130,12 +137,12 @@ pub mod pallet {
 		}
 
 		#[allow(clippy::type_complexity)]
-		fn apply_over_swap(
+		fn apply_over(
 			who: &T::AccountId,
 			new_swap: Swap<T::Balance, T::CurrencyId>,
-			over_swap_id: Option<T::OrderId>,
+			over_order_id: Option<T::OrderId>,
 		) -> Result<(SwapStatus<T::Balance>, Option<T::OrderId>), DispatchError> {
-			match over_swap_id {
+			match over_order_id {
 				None => {
 					let order_id = T::OrderBook::place_order(
 						who.clone(),
@@ -241,6 +248,37 @@ pub mod pallet {
 				}
 			}
 		}
+
+		#[allow(clippy::type_complexity)]
+		fn cancel_over(
+			cancel_amount: T::Balance,
+			currency_id: T::CurrencyId,
+			over_order_id: T::OrderId,
+		) -> Result<Option<T::OrderId>, DispatchError> {
+			let swap = T::OrderBook::get_order_details(over_order_id)
+				.ok_or(Error::<T>::OrderNotFound)?
+				.swap;
+
+			ensure!(
+				swap.currency_out == currency_id,
+				Error::<T>::CancelDifferentCurrency
+			);
+
+			match swap.amount_out.cmp(&cancel_amount) {
+				Ordering::Greater => {
+					let amount_to_swap = swap.amount_out.ensure_sub(cancel_amount)?;
+					T::OrderBook::update_order(over_order_id, amount_to_swap, OrderRatio::Market)?;
+
+					Ok(Some(over_order_id))
+				}
+				Ordering::Equal => {
+					T::OrderBook::cancel_order(over_order_id)?;
+
+					Ok(None)
+				}
+				Ordering::Less => Err(Error::<T>::CancelMoreThanPending)?,
+			}
+		}
 	}
 
 	/// Trait to perform swaps without handling directly an order book
@@ -264,11 +302,26 @@ pub mod pallet {
 
 			let previous_order_id = SwapIdToOrderId::<T>::get((who, swap_id));
 
-			let (status, new_order_id) = Self::apply_over_swap(who, swap, previous_order_id)?;
+			let (status, new_order_id) = Self::apply_over(who, swap, previous_order_id)?;
 
 			Self::update_id(who, swap_id, new_order_id)?;
 
 			Ok(status)
+		}
+
+		fn cancel_swap(
+			who: &T::AccountId,
+			swap_id: Self::SwapId,
+			balance: T::Balance,
+			currency_id: T::CurrencyId,
+		) -> DispatchResult {
+			match SwapIdToOrderId::<T>::get((who, swap_id)) {
+				Some(previous_order_id) => {
+					let order_id = Self::cancel_over(balance, currency_id, previous_order_id)?;
+					Self::update_id(who, swap_id, order_id)
+				}
+				None => Ok(()), // Noop
+			}
 		}
 
 		fn pending_amount(
@@ -281,14 +334,6 @@ pub mod pallet {
 				.filter(|order_info| order_info.swap.currency_out == from_currency)
 				.map(|order_info| order_info.swap.amount_out)
 				.unwrap_or_default())
-		}
-
-		fn convert_by_market(
-			currency_in: Self::CurrencyId,
-			currency_out: Self::CurrencyId,
-			amount_out: Self::Amount,
-		) -> Result<Self::Amount, DispatchError> {
-			T::OrderBook::convert_by_market(currency_in, currency_out, amount_out)
 		}
 	}
 

--- a/pallets/swaps/src/tests.rs
+++ b/pallets/swaps/src/tests.rs
@@ -319,15 +319,14 @@ mod cancel {
 
 			Swaps::update_id(&USER, SWAP_ID, Some(ORDER_ID)).unwrap();
 
-			assert_err!(
-				<Swaps as TSwaps<AccountId>>::cancel_swap(
-					&USER,
-					SWAP_ID,
-					a_to_b(AMOUNT),
-					CURRENCY_B
-				),
-				Error::<Runtime>::CancelDifferentCurrency
-			);
+			assert_ok!(<Swaps as TSwaps<AccountId>>::cancel_swap(
+				&USER,
+				SWAP_ID,
+				a_to_b(AMOUNT),
+				CURRENCY_B
+			));
+
+			assert_swap_id_registered(ORDER_ID);
 		});
 	}
 

--- a/pallets/swaps/src/tests.rs
+++ b/pallets/swaps/src/tests.rs
@@ -2,7 +2,7 @@ use cfg_traits::{
 	swaps::{OrderInfo, OrderRatio, Swap, SwapState, SwapStatus, Swaps as TSwaps},
 	StatusNotificationHook,
 };
-use frame_support::assert_ok;
+use frame_support::{assert_err, assert_ok};
 
 use crate::{mock::*, *};
 
@@ -24,6 +24,17 @@ pub const fn b_to_a(amount_b: Balance) -> Balance {
 	amount_b / RATIO
 }
 
+fn assert_swap_id_registered(order_id: OrderId) {
+	assert_eq!(
+		OrderIdToSwapId::<Runtime>::get(order_id),
+		Some((USER, SWAP_ID))
+	);
+	assert_eq!(
+		SwapIdToOrderId::<Runtime>::get((USER, SWAP_ID)),
+		Some(order_id)
+	);
+}
+
 mod util {
 	use super::*;
 
@@ -36,19 +47,8 @@ mod util {
 	}
 }
 
-mod swaps {
+mod apply {
 	use super::*;
-
-	fn assert_swap_id_registered(order_id: OrderId) {
-		assert_eq!(
-			OrderIdToSwapId::<Runtime>::get(order_id),
-			Some((USER, SWAP_ID))
-		);
-		assert_eq!(
-			SwapIdToOrderId::<Runtime>::get((USER, SWAP_ID)),
-			Some(order_id)
-		);
-	}
 
 	#[test]
 	fn swap_over_no_swap() {
@@ -285,6 +285,156 @@ mod swaps {
 
 			assert_eq!(OrderIdToSwapId::<Runtime>::get(ORDER_ID), None);
 			assert_swap_id_registered(NEW_ORDER_ID);
+		});
+	}
+}
+
+mod cancel {
+	use super::*;
+
+	#[test]
+	fn swap_over_no_swap() {
+		new_test_ext().execute_with(|| {
+			assert_ok!(<Swaps as TSwaps<AccountId>>::cancel_swap(
+				&USER, SWAP_ID, AMOUNT, CURRENCY_A
+			));
+		});
+	}
+
+	#[test]
+	fn swap_over_other_currency() {
+		new_test_ext().execute_with(|| {
+			MockTokenSwaps::mock_get_order_details(move |swap_id| {
+				assert_eq!(swap_id, ORDER_ID);
+
+				Some(OrderInfo {
+					swap: Swap {
+						currency_in: CURRENCY_B,
+						currency_out: CURRENCY_A,
+						amount_out: AMOUNT,
+					},
+					ratio: OrderRatio::Market,
+				})
+			});
+
+			Swaps::update_id(&USER, SWAP_ID, Some(ORDER_ID)).unwrap();
+
+			assert_err!(
+				<Swaps as TSwaps<AccountId>>::cancel_swap(
+					&USER,
+					SWAP_ID,
+					a_to_b(AMOUNT),
+					CURRENCY_B
+				),
+				Error::<Runtime>::CancelDifferentCurrency
+			);
+		});
+	}
+
+	#[test]
+	fn swap_over_greater_swap() {
+		const PREVIOUS_AMOUNT: Balance = AMOUNT + b_to_a(50);
+
+		new_test_ext().execute_with(|| {
+			MockTokenSwaps::mock_get_order_details(|swap_id| {
+				assert_eq!(swap_id, ORDER_ID);
+
+				// Inverse swap
+				Some(OrderInfo {
+					swap: Swap {
+						currency_in: CURRENCY_A,
+						currency_out: CURRENCY_B,
+						amount_out: a_to_b(PREVIOUS_AMOUNT),
+					},
+					ratio: OrderRatio::Market,
+				})
+			});
+			MockTokenSwaps::mock_update_order(|swap_id, amount, ratio| {
+				assert_eq!(swap_id, ORDER_ID);
+				assert_eq!(amount, a_to_b(PREVIOUS_AMOUNT - AMOUNT));
+				assert_eq!(ratio, OrderRatio::Market);
+
+				Ok(())
+			});
+
+			Swaps::update_id(&USER, SWAP_ID, Some(ORDER_ID)).unwrap();
+
+			assert_ok!(<Swaps as TSwaps<AccountId>>::cancel_swap(
+				&USER,
+				SWAP_ID,
+				a_to_b(AMOUNT),
+				CURRENCY_B
+			));
+
+			assert_swap_id_registered(ORDER_ID);
+		});
+	}
+
+	#[test]
+	fn swap_over_same_swap() {
+		new_test_ext().execute_with(|| {
+			MockTokenSwaps::mock_get_order_details(|swap_id| {
+				assert_eq!(swap_id, ORDER_ID);
+
+				// Inverse swap
+				Some(OrderInfo {
+					swap: Swap {
+						currency_in: CURRENCY_A,
+						currency_out: CURRENCY_B,
+						amount_out: a_to_b(AMOUNT),
+					},
+					ratio: OrderRatio::Market,
+				})
+			});
+			MockTokenSwaps::mock_cancel_order(|swap_id| {
+				assert_eq!(swap_id, ORDER_ID);
+				Ok(())
+			});
+
+			Swaps::update_id(&USER, SWAP_ID, Some(ORDER_ID)).unwrap();
+
+			assert_ok!(<Swaps as TSwaps<AccountId>>::cancel_swap(
+				&USER,
+				SWAP_ID,
+				a_to_b(AMOUNT),
+				CURRENCY_B,
+			),);
+
+			assert_eq!(OrderIdToSwapId::<Runtime>::get(ORDER_ID), None);
+			assert_eq!(SwapIdToOrderId::<Runtime>::get((USER, SWAP_ID)), None);
+		});
+	}
+
+	#[test]
+	fn swap_over_smaller_swap() {
+		const PREVIOUS_AMOUNT: Balance = AMOUNT - b_to_a(50);
+
+		new_test_ext().execute_with(|| {
+			MockTokenSwaps::mock_get_order_details(|swap_id| {
+				assert_eq!(swap_id, ORDER_ID);
+
+				// Inverse swap
+				Some(OrderInfo {
+					swap: Swap {
+						currency_in: CURRENCY_A,
+						currency_out: CURRENCY_B,
+						amount_out: a_to_b(PREVIOUS_AMOUNT),
+					},
+					ratio: OrderRatio::Market,
+				})
+			});
+
+			Swaps::update_id(&USER, SWAP_ID, Some(ORDER_ID)).unwrap();
+
+			assert_err!(
+				<Swaps as TSwaps<AccountId>>::cancel_swap(
+					&USER,
+					SWAP_ID,
+					a_to_b(AMOUNT),
+					CURRENCY_B
+				),
+				Error::<Runtime>::CancelMoreThanPending
+			);
 		});
 	}
 }


### PR DESCRIPTION
# Description

# Description

The issue is described in this [thread](https://kflabs.slack.com/archives/C04GJQAM9P0/p1707298087515729)

> When we decrease, and there is an increasing pending swap,  we use the `convert_by_market()` to know upfront the amount we need to cancel to the inverse swap and distinguish from the amount we need to decrease the investment.
Nevertheless, later, inside the swap, `convert_by_market()` is called again in the inverse direction to perform the cancellation of the swap. This works fine. However, with asymmetric ratios (A -> B, ratio: 0.9; B -> A, ratio 0.95), it can lead to obtaining a different swap than expected. In the worst case, it would lead to a NoFund error if the amounts are very fit.

## How it works

Now `pallet-swaps` offer a new method `cancel_swap()` which allows to cancel partially a pending amount. This way, we can cancel an inverse swap (in its currency out denomination) before applying the new swap (in the other currency denomination). Saving us from using `convert_by_market()` in the opposite direction.