### PR TITLE
Fix: storage version mismatch + burn-unburned decoding issue

### DIFF
--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -81,6 +81,13 @@ pub type UpgradeAltair1034 = (
 		crate::Runtime,
 		AnnualTreasuryInflationPercent,
 	>,
+	// Bump balances storage version from v0 to v1 and mark balance of CheckingAccount as inactive,
+	// see https://github.com/paritytech/substrate/pull/12813
+	pallet_balances::migration::MigrateToTrackInactive<super::Runtime, super::CheckingAccount, ()>,
+	// Assets were already migrated to V3 MultiLocation but version not increased from 0 to 2
+	runtime_common::migrations::increase_storage_version::Migration<crate::OrmlAssetRegistry>,
+	// Data was already moved but storage version not increased from 0 to 4
+	runtime_common::migrations::increase_storage_version::Migration<crate::Council>,
 );
 
 #[allow(clippy::upper_case_acronyms)]

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -85,9 +85,9 @@ pub type UpgradeAltair1034 = (
 	// see https://github.com/paritytech/substrate/pull/12813
 	pallet_balances::migration::MigrateToTrackInactive<super::Runtime, super::CheckingAccount, ()>,
 	// Assets were already migrated to V3 MultiLocation but version not increased from 0 to 2
-	runtime_common::migrations::increase_storage_version::Migration<crate::OrmlAssetRegistry>,
+	runtime_common::migrations::increase_storage_version::Migration<crate::OrmlAssetRegistry, 0, 2>,
 	// Data was already moved but storage version not increased from 0 to 4
-	runtime_common::migrations::increase_storage_version::Migration<crate::Council>,
+	runtime_common::migrations::increase_storage_version::Migration<crate::Council, 0, 4>,
 );
 
 #[allow(clippy::upper_case_acronyms)]

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -51,13 +51,16 @@ pub type UpgradeCentrifuge1025 = (
 		LocalCurrencyIdUsdc,
 	>,
 	// Register new canonical USDC on Celo
-	runtime_common::migrations::update_celo_usdcs::Migration<super::Runtime>,
-	// Init local representation for all assets
+	runtime_common::migrations::update_celo_usdcs::AddNewCeloUsdc<super::Runtime>,
+	// Update custom metadata by initiating local representation for all assets
 	runtime_common::migrations::local_currency::translate_metadata::Migration<
 		super::Runtime,
 		UsdcVariants,
 		LocalAssetIdUsdc,
 	>,
+	// Change name and symbol of Celo Wormhole USDC
+	// NOTE: Needs to happen after metadata translation because expects new CustomMetadata
+	runtime_common::migrations::update_celo_usdcs::UpdateWormholeUsdc<super::Runtime>,
 	// Switch pool currency from Polkadot USDC to Local USDC
 	runtime_common::migrations::local_currency::migrate_pool_currency::Migration<
 		super::Runtime,

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -80,7 +80,7 @@ pub type UpgradeCentrifuge1025 = (
 	// see https://github.com/paritytech/substrate/pull/12813
 	pallet_balances::migration::MigrateToTrackInactive<super::Runtime, super::CheckingAccount, ()>,
 	// Assets were already migrated to V3 MultiLocation but version not increased from 0 to 2
-	runtime_common::migrations::increase_storage_version::Migration<crate::OrmlAssetRegistry>,
+	runtime_common::migrations::increase_storage_version::Migration<crate::OrmlAssetRegistry, 0, 2>,
 	// Burns tokens from other domains that are falsly not burned when they were transferred back
 	// to their domain
 	burn_unburned::Migration<super::Runtime>,

--- a/runtime/common/src/migrations/increase_storage_version.rs
+++ b/runtime/common/src/migrations/increase_storage_version.rs
@@ -1,0 +1,54 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+use frame_support::{
+	traits::{GetStorageVersion, OnRuntimeUpgrade, PalletInfoAccess, StorageVersion},
+	weights::{constants::RocksDbWeight, Weight},
+};
+
+/// Simply bumps the storage version of a pallet
+///
+/// NOTE: Use with caution! Must ensure beforehand that a migration is not
+/// necessary
+pub struct Migration<P>(sp_std::marker::PhantomData<P>);
+impl<P> OnRuntimeUpgrade for Migration<P>
+where
+	P: GetStorageVersion<CurrentStorageVersion = StorageVersion> + PalletInfoAccess,
+{
+	fn on_runtime_upgrade() -> Weight {
+		log::info!(
+			"BumpStorageVersion: Increasing storage version of {:?} from {:?} to {:?}",
+			P::name(),
+			P::on_chain_storage_version(),
+			P::current_storage_version()
+		);
+		P::current_storage_version().put::<P>();
+		RocksDbWeight::get().writes(1)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, sp_runtime::DispatchError> {
+		assert!(
+			P::on_chain_storage_version() < P::current_storage_version(),
+			"Onchain {:?} vs current pallet version {:?}",
+			P::on_chain_storage_version(),
+			P::current_storage_version(),
+		);
+		Ok(sp_std::vec![])
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+		assert_eq!(P::on_chain_storage_version(), P::current_storage_version());
+		Ok(())
+	}
+}

--- a/runtime/common/src/migrations/mod.rs
+++ b/runtime/common/src/migrations/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod asset_registry_xcmv3;
 pub mod epoch_execution;
+pub mod increase_storage_version;
 pub mod local_currency;
 pub mod nuke;
 pub mod orml_tokens;

--- a/runtime/common/src/migrations/mod.rs
+++ b/runtime/common/src/migrations/mod.rs
@@ -24,7 +24,6 @@ pub mod transfer_allowlist_currency;
 pub mod update_celo_usdcs {
 	use cfg_primitives::Balance;
 	#[cfg(feature = "try-runtime")]
-	use cfg_types::tokens::LocalAssetId;
 	use cfg_types::tokens::{
 		usdc::{CURRENCY_ID_LP_CELO, CURRENCY_ID_LP_CELO_WORMHOLE},
 		CrossChainTransferability, CurrencyId, CustomMetadata,

--- a/runtime/common/src/migrations/mod.rs
+++ b/runtime/common/src/migrations/mod.rs
@@ -23,7 +23,6 @@ pub mod transfer_allowlist_currency;
 
 pub mod update_celo_usdcs {
 	use cfg_primitives::Balance;
-	#[cfg(feature = "try-runtime")]
 	use cfg_types::tokens::{
 		usdc::{CURRENCY_ID_LP_CELO, CURRENCY_ID_LP_CELO_WORMHOLE},
 		CrossChainTransferability, CurrencyId, CustomMetadata,


### PR DESCRIPTION
# Description

Fixes storage version mismatch of external dependencies as well as the decoding issue for the `burn_unburned` migration

##  try-runtime logs

### Centrifuge

NOTE: The burned amount might be a bit outdated as my snapshot is a few days old. 
```
[2024-02-28T14:30:19Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("centrifuge")] [Version: 1024] [Code hash: 0xe9ec...5a97]
[2024-02-28T14:30:19Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("centrifuge")] [Version: 1025] [Code hash: 0x28cb...c817]
[2024-02-28T14:30:19Z INFO  try_runtime_core::commands::on_runtime_upgrade] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::epoch_execution] EpochExecutionMigration:  EpochExecution count pre migration is 0
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::epoch_execution] EpochExecutionMigration:  EpochExecutionV2 count post migration is 0
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  PRE UPGRADE: Starting...
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  Counted 2 keys in old allowance storage.
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  Counted 2 keys in old delay storage.
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  PRE UPGRADE: Finished.
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  Migrating allowlist storage keys started...
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  Migrating allowlist storage keys finished.
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  POST UPGRADE: Starting...
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  POST UPGRADE: Finished.
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Clear pallet "Claims": nuking pallet prefix...
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Clear pallet "Claims": storage cleared successful
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Clear pallet "Claims": iteration result. backend: 406 unique: 406 loops: 406
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::register] RegisterLocalCurrency PRE UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::register] RegisterLocalCurrency Done registering local currency
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::register] RegisterLocalCurrency POST UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::update_celo_usdcs] AddNewCeloUsdc PRE UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::update_celo_usdcs] AddNewCeloUsdc Done registering new canonical Celo USDC currency
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::update_celo_usdcs] AddNewCeloUsdc POST UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata PRE UPGRADE: Finished with 15 registered assets
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Set local representation of asset variant ForeignAsset(100003)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant ForeignAsset(3)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant ForeignAsset(100005)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant LocalAsset(LocalAssetId(1))
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Set local representation of asset variant ForeignAsset(100006)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant ForeignAsset(5)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Set local representation of asset variant ForeignAsset(6)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Native
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Set local representation of asset variant ForeignAsset(100002)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant ForeignAsset(1)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Set local representation of asset variant ForeignAsset(100001)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant ForeignAsset(4)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant ForeignAsset(100004)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Set local representation of asset variant ForeignAsset(2)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(4139607887, [151, 170, 101, 242, 62, 123, 224, 159, 205, 98, 208, 85, 77, 46, 146, 115])
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Done translating asset metadata
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata CheckAssetIntegrity: Local meta exists
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Checking asset ForeignAsset(6)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Checking asset ForeignAsset(2)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Checking asset ForeignAsset(100001)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Checking asset ForeignAsset(100002)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Checking asset ForeignAsset(100003)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Checking asset ForeignAsset(100006)
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata POST UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::update_celo_usdcs] UpdateCeloWormholeUsdc PRE UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::update_celo_usdcs] UpdateCeloWormholeUsdc Done updating wormhole Celo USDC currency
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::update_celo_usdcs] UpdateCeloWormholeUsdc POST UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::migrate_pool_currency] MigratePoolCurrency PRE UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::migrate_pool_currency] MigratePoolCurrency Migrated pool currency
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::local_currency::migrate_pool_currency] MigratePoolCurrency POST UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Clear pallet "Migration": nuking pallet prefix...
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Clear pallet "Migration": storage cleared successful
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Clear pallet "Migration": iteration result. backend: 1 unique: 1 loops: 1
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::precompile_account_codes] precompile::AccountCodes: Inserting precompile account codes
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::precompile_account_codes] precompile::AccountCodes: Added new 1 account codes
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Nuke-OrderBook: nuking pallet...
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Nuke-OrderBook: storage cleared successful
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::nuke] Nuke-OrderBook: iteration result. backend: 16 unique: 16 loops: 16
[2024-02-28T14:30:20Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation PRE UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation Translated ActiveSessionData
[2024-02-28T14:30:20Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation Translated NextSessionChanges
[2024-02-28T14:30:20Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation POST UPGRADE: Finished
[2024-02-28T14:30:20Z INFO  runtime::balances] Storage to version 1
[2024-02-28T14:30:20Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "OrmlAssetRegistry" from StorageVersion(0) to StorageVersion(2)
[2024-02-28T14:30:20Z INFO  centrifuge_runtime::migrations::burn_unburned] BurnUnburnedMigration:  AccountData of Ethereum domain account has free balance of: 3500026000000
[2024-02-28T14:30:20Z INFO  centrifuge_runtime::migrations::burn_unburned] BurnUnburnedMigration:  Successfully burned 3500026000000 LP_ETH_USDC from Ethereum domain account
[2024-02-28T14:30:20Z INFO  centrifuge_runtime::migrations::burn_unburned] BurnUnburnedMigration:  Migration successfully finished.
[2024-02-28T14:30:20Z INFO  runtime::frame-support] ⚠️ ParachainSystem declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(2)`
[2024-02-28T14:30:20Z ERROR runtime::frame-support] OraclePriceFeed: On chain storage version StorageVersion(0) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:30:20Z ERROR runtime::frame-support] OraclePriceCollection: On chain storage version StorageVersion(0) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:30:20Z INFO  runtime::frame-support] ⚠️ XcmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(3)` vs current storage version `StorageVersion(2)`
[2024-02-28T14:30:20Z ERROR runtime::frame-support] XcmpQueue: On chain storage version StorageVersion(3) doesn't match current storage version StorageVersion(2).
[2024-02-28T14:30:20Z INFO  runtime::frame-support] ⚠️ PolkadotXcm declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`
[2024-02-28T14:30:20Z INFO  runtime::frame-support] ⚠️ DmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(1)`
[2024-02-28T14:30:20Z ERROR runtime::frame-support] DmpQueue: On chain storage version StorageVersion(2) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:30:20Z INFO  runtime::frame-support] ⚠️ Ethereum declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `NoStorageVersionSet`
```

### Altair

Unfortunately, there exist a few currency ids on Altair which cannot be decoded. We need to go back in time much further. I have spend quite some time on this without success. However, the AUSD balance is the correct one here.

```
[2024-02-28T14:39:36Z INFO  remote-ext] initialized state externalities with storage root 0x907c9e6cca2f6e2130afa1a4eb70ce5ecc9189dd956cd732ca6644e43e515636 and state_version V0
[2024-02-28T14:39:36Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("altair")] [Version: 1027] [Code hash: 0x34d2...6343]
[2024-02-28T14:39:37Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("altair")] [Version: 1034] [Code hash: 0x7932...485a]
[2024-02-28T14:39:37Z INFO  try_runtime_core::commands::on_runtime_upgrade] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::translate_asset_metadata] TranslateMetadata PRE UPGRADE: Finished with 5 registered assets
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::translate_asset_metadata] TranslateMetadata Done translating asset metadata
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::translate_asset_metadata] TranslateMetadata POST UPGRADE: Finished
[2024-02-28T14:39:38Z ERROR frame_support::storage] (key, value) failed to decode at [206, 171, 181, 23, 175, 131, 191, 94, 198, 102, 51, 20, 164, 91, 11, 163, 142, 231, 65, 138, 101, 49, 23, 61, 96, 209, 246, 168, 45, 143, 77, 81, 14, 146, 103, 243, 186, 79, 175, 118, 176, 54, 118, 166, 23, 214, 239, 194, 192, 153, 124, 79, 43, 58, 131, 235, 7, 239, 116, 168, 103, 207, 103, 42, 37, 162, 163, 12, 198, 26, 188, 147, 109, 204, 153, 77, 247, 123, 168, 74, 50, 103, 157, 214, 62, 218, 185, 100, 4]: Error
[2024-02-28T14:39:38Z ERROR frame_support::storage] (key, value) failed to decode at [206, 171, 181, 23, 175, 131, 191, 94, 198, 102, 51, 20, 164, 91, 11, 163, 142, 231, 65, 138, 101, 49, 23, 61, 96, 209, 246, 168, 45, 143, 77, 81, 94, 207, 253, 123, 108, 15, 120, 117, 27, 170, 157, 40, 30, 11, 250, 58, 109, 111, 100, 108, 112, 121, 47, 116, 114, 115, 114, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 103, 157, 214, 62, 218, 185, 100, 4]: Error
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD PRE-UPGRADE: Counted accounts to be migrated is 8 with total issuance of 4997544866265088
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Migrating account with balance: 14394124964
[2024-02-28T14:39:38Z ERROR frame_support::storage] (key, value) failed to decode at [206, 171, 181, 23, 175, 131, 191, 94, 198, 102, 51, 20, 164, 91, 11, 163, 142, 231, 65, 138, 101, 49, 23, 61, 96, 209, 246, 168, 45, 143, 77, 81, 14, 146, 103, 243, 186, 79, 175, 118, 176, 54, 118, 166, 23, 214, 239, 194, 192, 153, 124, 79, 43, 58, 131, 235, 7, 239, 116, 168, 103, 207, 103, 42, 37, 162, 163, 12, 198, 26, 188, 147, 109, 204, 153, 77, 247, 123, 168, 74, 50, 103, 157, 214, 62, 218, 185, 100, 4]: Error
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Migrating account with balance: 100000200000
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Migrating account with balance: 4495868262140705
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Migrating account with balance: 0
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Migrating account with balance: 500085605875036
[2024-02-28T14:39:38Z ERROR frame_support::storage] (key, value) failed to decode at [206, 171, 181, 23, 175, 131, 191, 94, 198, 102, 51, 20, 164, 91, 11, 163, 142, 231, 65, 138, 101, 49, 23, 61, 96, 209, 246, 168, 45, 143, 77, 81, 94, 207, 253, 123, 108, 15, 120, 117, 27, 170, 157, 40, 30, 11, 250, 58, 109, 111, 100, 108, 112, 121, 47, 116, 114, 115, 114, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 103, 157, 214, 62, 218, 185, 100, 4]: Error
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Migrating account with balance: 792322400000
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Migrating account with balance: 490676000000
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Migrating account with balance: 193605524383
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Number of migrated accounts: 8
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD Done
[2024-02-28T14:39:38Z INFO  altair_runtime::migrations::ausd_to_foreign] MigrateAUSD POST-UPGRADE: Done
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-Loans: nuking pallet...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-Loans: storage cleared successful
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-Loans: iteration result. backend: 1 unique: 1 loops: 1
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-InterestAccrual: nuking pallet...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-InterestAccrual: storage cleared successful
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-InterestAccrual: iteration result. backend: 3 unique: 3 loops: 3
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-PoolSystem: nuking pallet...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-PoolSystem: storage cleared successful
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-PoolSystem: iteration result. backend: 4 unique: 4 loops: 4
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-Investments: Pallet prefix doesn't exist, storage is empty already
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-Investments: nuking pallet...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-Investments: storage cleared successful
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Nuke-Investments: iteration result. backend: 0 unique: 0 loops: 0
[2024-02-28T14:39:38Z INFO  pallet_rewards::migrations::new_instance] 💶 Rewards: Pre funding ED checks successful
[2024-02-28T14:39:38Z INFO  pallet_rewards::migrations::new_instance] 💶 Rewards: Initiating ED funding to sovereign pallet account
[2024-02-28T14:39:38Z INFO  pallet_rewards::migrations::new_instance] 💶 Rewards: Post funding ED checks successful
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: pre-upgrade: started
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Found 5 LocationToAssetId keys
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Found 5 Metadata keys
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: pre-upgrade: done
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: on_runtime_upgrade: started
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Found 5 LocationToAssetId keys
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Found 5 Metadata keys
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Cleared all LocationToAssetId entries successfully
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: LocationToAssetId clearing iteration result. backend: 5 unique: 5 loops: 5
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] Cleared all Metadata entries successfully
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Metadata clearing iteration result. backend: 5 unique: 5 loops: 5
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Starting migration of 4 assets
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: on_runtime_upgrade: completed!
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: post-upgrade: started
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Found 4 LocationToAssetId keys
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: Found 4 Metadata keys
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::asset_registry_xcmv3] 💎 AssetRegistryMultilocationToXCMV3: post_upgrade: storage was updated!
[2024-02-28T14:39:38Z INFO  runtime::frame-support] ⚠️ DmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`
[2024-02-28T14:39:38Z ERROR runtime::frame-support] DmpQueue: On chain storage version StorageVersion(2) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:39:38Z INFO  runtime::frame-support] ⚠️ XcmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(2)`
[2024-02-28T14:39:38Z ERROR runtime::frame-support] XcmpQueue: On chain storage version StorageVersion(3) doesn't match current storage version StorageVersion(2).
[2024-02-28T14:39:38Z INFO  pallet_xcm::migration::v1] Migrated VersionNotifyTarget (13, 0, 2) to (13, Weight { ref_time: 0, proof_size: 65536 }, 2)
[2024-02-28T14:39:38Z INFO  pallet_xcm::migration::v1] v1 applied successfully
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::precompile_account_codes] precompile::AccountCodes: Inserting precompile account codes
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::precompile_account_codes] precompile::AccountCodes: Added new 14 account codes
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  PRE UPGRADE: Starting...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  Counted 0 keys in old allowance storage.
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  Counted 0 keys in old delay storage.
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  PRE UPGRADE: Finished.
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  Migrating allowlist storage keys started...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  Migrating allowlist storage keys finished.
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  POST UPGRADE: Starting...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::transfer_allowlist_currency] TransferAllowlist-CurrencyMigration:  POST UPGRADE: Finished.
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Clear pallet "NftSales": nuking pallet prefix...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Clear pallet "NftSales": storage cleared successful
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Clear pallet "NftSales": iteration result. backend: 370 unique: 370 loops: 370
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Clear pallet "Migration": Pallet prefix doesn't exist, storage is empty already
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Clear pallet "Migration": nuking pallet prefix...
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Clear pallet "Migration": storage cleared successful
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::nuke] Clear pallet "Migration": iteration result. backend: 0 unique: 0 loops: 0
[2024-02-28T14:39:38Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation PRE UPGRADE: Finished
[2024-02-28T14:39:38Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation Translated ActiveSessionData
[2024-02-28T14:39:38Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation Translated NextSessionChanges
[2024-02-28T14:39:38Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation POST UPGRADE: Finished
[2024-02-28T14:39:38Z INFO  runtime::balances] Storage to version 1
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "OrmlAssetRegistry" from StorageVersion(0) to StorageVersion(2)
[2024-02-28T14:39:38Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "Council" from StorageVersion(0) to StorageVersion(4)
[2024-02-28T14:39:38Z ERROR try-runtime] Detected multiple errors while executing `try_on_runtime_upgrade`:
[2024-02-28T14:39:38Z ERROR try-runtime] Other("On chain and current storage version do not match. Missing runtime upgrade?")
[2024-02-28T14:39:38Z ERROR try-runtime] Other("On chain and current storage version do not match. Missing runtime upgrade?")
[2024-02-28T14:39:38Z ERROR try-runtime] Other("Can only upgrade from PoolSystem version 1")
[2024-02-28T14:39:38Z INFO  runtime::frame-support] ⚠️ ParachainSystem declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(2)`
[2024-02-28T14:39:38Z ERROR runtime::frame-support] OrderBook: On chain storage version StorageVersion(0) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:39:38Z ERROR runtime::frame-support] OraclePriceFeed: On chain storage version StorageVersion(0) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:39:38Z ERROR runtime::frame-support] OraclePriceCollection: On chain storage version StorageVersion(0) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:39:38Z INFO  runtime::frame-support] ⚠️ XcmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(3)` vs current storage version `StorageVersion(2)`
[2024-02-28T14:39:38Z ERROR runtime::frame-support] XcmpQueue: On chain storage version StorageVersion(3) doesn't match current storage version StorageVersion(2).
[2024-02-28T14:39:38Z INFO  runtime::frame-support] ⚠️ PolkadotXcm declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`
[2024-02-28T14:39:38Z INFO  runtime::frame-support] ⚠️ DmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(1)`
[2024-02-28T14:39:38Z ERROR runtime::frame-support] DmpQueue: On chain storage version StorageVersion(2) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:39:38Z INFO  runtime::frame-support] ⚠️ Ethereum declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `NoStorageVersionSet`
```

### Dev

```
[2024-02-28T14:42:39Z WARN  try-runtime::cli] `--snapshot-path` is deprecated and will be removed some time after Jan 2024. Use `--path` instead.
[2024-02-28T14:42:39Z INFO  remote-ext] Loading snapshot from "epoch-dev-1.snap"
✅ Loaded snapshot (0.01s)
[2024-02-28T14:42:39Z INFO  remote-ext] initialized state externalities with storage root 0x335662bbb144b9892c489da0294e7005033bc5c15eaa2f3390c16c73735e5dc4 and state_version V0
[2024-02-28T14:42:39Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("centrifuge-devel")] [Version: 1037] [Code hash: 0x9248...62b4]
[2024-02-28T14:42:39Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("centrifuge-devel")] [Version: 1042] [Code hash: 0xb2ff...7fea]
[2024-02-28T14:42:39Z INFO  try_runtime_core::commands::on_runtime_upgrade] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::register] RegisterLocalCurrency PRE UPGRADE: Finished
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::register] RegisterLocalCurrency Done registering local currency
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::register] RegisterLocalCurrency POST UPGRADE: Finished
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata PRE UPGRADE: Finished with 12 registered assets
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(3515519799, [193, 142, 115, 81, 110, 218, 14, 3, 140, 80, 246, 171, 7, 91, 116, 236])
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant LocalAsset(LocalAssetId(1))
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(956565333, [250, 100, 113, 107, 238, 111, 17, 247, 51, 93, 71, 17, 135, 42, 22, 70])
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant ForeignAsset(1)
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(956565333, [143, 10, 87, 6, 189, 53, 231, 71, 0, 219, 149, 93, 236, 157, 209, 105])
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(3515519799, [236, 101, 40, 229, 177, 168, 153, 254, 212, 119, 119, 177, 153, 99, 177, 166])
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Set local representation of asset variant ForeignAsset(100001)
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(1809273630, [132, 94, 120, 226, 64, 119, 231, 100, 188, 241, 224, 132, 73, 165, 114, 16])
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(956565333, [246, 51, 234, 233, 230, 188, 61, 77, 108, 36, 54, 29, 72, 223, 103, 91])
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant ForeignAsset(2)
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(402696383, [84, 49, 200, 110, 6, 9, 61, 220, 62, 87, 119, 117, 51, 255, 21, 4])
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Skipping setting local representation of asset variant Tranche(402696383, [211, 57, 177, 27, 210, 117, 77, 176, 13, 18, 74, 36, 225, 181, 172, 10])
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Done translating asset metadata
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata CheckAssetIntegrity: Local meta exists
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata Checking asset ForeignAsset(100001)
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::local_currency::translate_metadata] TranslateMetadata POST UPGRADE: Finished
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::epoch_execution] EpochExecutionMigration:  EpochExecution count pre migration is 1
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::epoch_execution] EpochExecutionMigration:  EpochExecutionV2 count post migration is 1
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::nuke] Nuke-OrderBook: nuking pallet...
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::nuke] Nuke-OrderBook: storage cleared successful
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::nuke] Nuke-OrderBook: iteration result. backend: 1 unique: 1 loops: 1
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::nuke] Nuke-TransferAllowList: nuking pallet...
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::nuke] Nuke-TransferAllowList: storage cleared successful
[2024-02-28T14:42:40Z INFO  runtime_common::migrations::nuke] Nuke-TransferAllowList: iteration result. backend: 1 unique: 1 loops: 1
[2024-02-28T14:42:40Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation PRE UPGRADE: Finished
[2024-02-28T14:42:40Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation Translated ActiveSessionData
[2024-02-28T14:42:40Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation Translated NextSessionChanges
[2024-02-28T14:42:40Z INFO  pallet_block_rewards::migrations::v2] RelativeTreasuryInflation POST UPGRADE: Finished
[2024-02-28T14:42:40Z INFO  runtime::frame-support] ⚠️ ParachainSystem declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(2)`
[2024-02-28T14:42:40Z INFO  runtime::frame-support] ⚠️ XcmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(3)` vs current storage version `StorageVersion(2)`
[2024-02-28T14:42:40Z ERROR runtime::frame-support] XcmpQueue: On chain storage version StorageVersion(3) doesn't match current storage version StorageVersion(2).
[2024-02-28T14:42:40Z INFO  runtime::frame-support] ⚠️ PolkadotXcm declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`
[2024-02-28T14:42:40Z INFO  runtime::frame-support] ⚠️ DmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(1)`
[2024-02-28T14:42:40Z ERROR runtime::frame-support] DmpQueue: On chain storage version StorageVersion(2) doesn't match current storage version StorageVersion(1).
[2024-02-28T14:42:40Z INFO  runtime::frame-support] ⚠️ Ethereum declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `NoStorageVersionSet`
```

Based on 
# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
