### PR TITLE
Feat: Enhance Error Resolution EVM

### DIFF
--- a/pallets/ethereum-transaction/Cargo.toml
+++ b/pallets/ethereum-transaction/Cargo.toml
@@ -40,7 +40,7 @@ cfg-traits = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 
-pallet-balances = { workspace = true , default-features = true }
+pallet-balances = { workspace = true, default-features = true }
 pallet-evm-precompile-simple = { workspace = true, default-features = true }
 pallet-timestamp = { workspace = true, default-features = true }
 

--- a/pallets/ethereum-transaction/Cargo.toml
+++ b/pallets/ethereum-transaction/Cargo.toml
@@ -40,7 +40,7 @@ cfg-traits = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 
-pallet-balances = { workspace = true }
+pallet-balances = { workspace = true , default-features = true }
 pallet-evm-precompile-simple = { workspace = true, default-features = true }
 pallet-timestamp = { workspace = true, default-features = true }
 

--- a/pallets/ethereum-transaction/src/lib.rs
+++ b/pallets/ethereum-transaction/src/lib.rs
@@ -157,11 +157,11 @@ pub mod pallet {
 			//       if the execution failed. But we can check that manually by
 			//       querying the `Pending` storage of the pallet-ethereum.
 			let pending = pallet_ethereum::Pending::<T>::get();
-			let last = pending.last().ok_or(DispatchError::Other(
+			let (_, _, receipt) = pending.last().ok_or(DispatchError::Other(
 				"Ethereuem not adding pending storage. Unexpected.",
 			))?;
 
-			if Pallet::<T>::valid_code(&last.2) {
+			if Pallet::<T>::valid_code(receipt) {
 				Ok(info)
 			} else {
 				Err(Error::<T>::EvmExecutionFailed.into())

--- a/pallets/ethereum-transaction/src/tests.rs
+++ b/pallets/ethereum-transaction/src/tests.rs
@@ -4,7 +4,7 @@ use pallet_evm::{AddressMapping, Error::BalanceLow};
 use sp_core::{crypto::AccountId32, H160, U256};
 
 use super::mock::*;
-use crate::pallet::Nonce;
+use crate::{pallet::Nonce, Error};
 
 mod utils {
 	use super::*;
@@ -101,22 +101,17 @@ mod call {
 
 			assert_eq!(Nonce::<Runtime>::get(), U256::from(0));
 
-			// NOTE: We can not check for errors as the internal `pallet-ethereum` logic
-			//       does not transform an EVM error into an Substrate error and return
-			//       `Ok(..)` in theses cases.
-			//
-			//       We can also not mimic the `pallet-ethereum::Pallet::<T>::transact(..)`
-			//       code path as some needed parts are private.
-			assert_ok!(<EthereumTransaction as EthereumTransactor>::call(
-				sender,
-				to,
-				data.as_slice(),
-				value,
-				gas_price,
-				gas_limit,
-			));
-
-			assert_eq!(Nonce::<Runtime>::get(), U256::from(1));
+			assert_eq!(
+				<EthereumTransaction as EthereumTransactor>::call(
+					sender,
+					to,
+					data.as_slice(),
+					value,
+					gas_price,
+					gas_limit,
+				),
+				Err(Error::<Runtime>::EvmExecutionFailed.into())
+			);
 		});
 	}
 }

--- a/pallets/liquidity-pools-gateway/routers/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/routers/src/tests.rs
@@ -55,7 +55,7 @@ mod evm_router {
 				target_contract_address: test_contract_address,
 				target_contract_hash: test_contract_hash,
 				fee_values: FeeValues {
-					value: U256::from(10),
+					value: U256::from(0),
 					gas_limit: U256::from(10),
 					gas_price: U256::from(10),
 				},
@@ -337,7 +337,7 @@ mod axelar_evm {
 				target_contract_address: axelar_contract_address,
 				target_contract_hash: axelar_contract_hash,
 				fee_values: FeeValues {
-					value: U256::from(10),
+					value: U256::from(0),
 					gas_limit: U256::from(10),
 					gas_price: U256::from(10),
 				},

--- a/runtime/integration-tests/src/evm/ethereum_transaction.rs
+++ b/runtime/integration-tests/src/evm/ethereum_transaction.rs
@@ -147,8 +147,7 @@ async fn call() {
 			U256::from(0x100000),
 		);
 
-		// NOTE: WE CAN NOTE CHECK WHETHER THE EVM ERRORS OUT
-		assert!(res.is_ok());
+		assert!(res.is_err());
 	})
 	.unwrap();
 }

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -4854,8 +4854,8 @@ mod development {
 					target_contract_address: axelar_contract_address,
 					target_contract_hash: axelar_contract_hash,
 					fee_values: FeeValues {
-						value: U256::from(10),
-						gas_limit: U256::from(transaction_call_cost + 10_000),
+						value: U256::from(0),
+						gas_limit: U256::from(transaction_call_cost + 1_000_000),
 						gas_price: U256::from(10),
 					},
 				};


### PR DESCRIPTION
# Description
Currently, the EVM does never error out if the execution of the EVM failed for some reason. In most case it will be an active `Revert` faced from some checks on the EVM side. 

But Substrate does not see that. It will only see an okay, resulting in wrong assumptions. 

NOTE: 
This change does mean that the EVM side DOES change but the Substrate side is still transactional. In most cases the EVM side will only contain fee-payment and new `Pending` appends.

## Changes and Descriptions
* Check last `Pending` to fetch status code of transaction

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
