### PR TITLE
Proposal: ensure symmetric ratios for orderbook

### DIFF
--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -644,8 +644,13 @@ pub mod pallet {
 		) -> Result<T::Ratio, DispatchError> {
 			let feeder = MarketFeederId::<T>::get()?;
 
-			T::RatioProvider::get(&feeder, &(currency_from, currency_to))?
-				.ok_or(Error::<T>::MarketRatioNotFound.into())
+			if currency_to < currency_from {
+				T::RatioProvider::get(&feeder, &(currency_to, currency_from))?
+					.map(|ratio| ratio.reciprocal().unwrap_or(Zero::zero()))
+			} else {
+				T::RatioProvider::get(&feeder, &(currency_from, currency_to))?
+			}
+			.ok_or(Error::<T>::MarketRatioNotFound.into())
 		}
 
 		/// `ratio` is the value you multiply `amount_from` to obtain


### PR DESCRIPTION
# Description

We want to avoid issues with asymmetric prices, ensuring we only work internally on-chain with symmetric prices. 

This is a simple proposal to achieve this while maintaing the Oracle requirement:

- Any feeder can feed anything without restrictions at that point.

### How it works: 

Order book will only look for ratios when the first currency argument is "less" than the second currency argument. It means the currency value compared by `PartialOrd` is less than the second one. If the asking price is the inverse, then orderbook will compute the reciprocal ratio. It means that feeders must feed using first the currency with "less" value in the `ConversionRatio(CurrencyId, CurrencyId)` type in order to be a valid ratio used in orderbook.

### Possible problems: 
- Can UI easly determine `currency_a` < `currency_b`? 
  - I think it could, first checking variant order and later checking variant value (which is always an integer).
