### PR TITLE
Centrifuge 1026

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "centrifuge-chain"
-version = "0.10.36"
+version = "0.10.37"
 dependencies = [
  "altair-runtime",
  "async-trait",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "centrifuge-runtime"
-version = "0.10.25"
+version = "0.10.26"
 dependencies = [
  "axelar-gateway-precompile",
  "cfg-primitives",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ is-it-maintained-open-issues = { repository = "centrifuge/centrifuge-chain" }
 
 [package]
 name = "centrifuge-chain"
-version = "0.10.36"
+version = "0.10.37"
 description = "Centrifuge chain implementation in Rust."
 build = "build.rs"
 default-run = "centrifuge-chain"

--- a/runtime/centrifuge/Cargo.toml
+++ b/runtime/centrifuge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centrifuge-runtime"
-version = "0.10.25"
+version = "0.10.26"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -153,7 +153,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("centrifuge"),
 	impl_name: create_runtime_str!("centrifuge"),
 	authoring_version: 1,
-	spec_version: 1025,
+	spec_version: 1026,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
@@ -2061,7 +2061,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	migrations::UpgradeCentrifuge1025,
+	migrations::UpgradeCentrifuge1026,
 >;
 
 // Frame Order in this block dictates the index of each one in the metadata

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -38,7 +38,7 @@ frame_support::parameter_types! {
 	pub const AnnualTreasuryInflationPercent: u32 = 3;
 }
 
-pub type UpgradeCentrifuge1025 = (
+pub type UpgradeCentrifuge1026 = (
 	runtime_common::migrations::epoch_execution::Migration<super::Runtime>,
 	// Migrates the currency used in `pallet-transfer-allowlist` from our global currency to a
 	// special filter currency enum


### PR DESCRIPTION
# Description

Bumps Centrifuge Runtime and Client version by one to signal the addition of #1764 and #1765 to planned runtime upgrade of Centrifuge Chain. As a result, the next Centrifuge runtime version will be 1026 instead of 1025.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
