### PR TITLE
fix: permit token mux calls for `ProxyType::Borrow`

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -560,7 +560,11 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				RuntimeCall::PoolSystem(pallet_pool_system::Call::submit_solution{..}) |
 				RuntimeCall::PoolSystem(pallet_pool_system::Call::execute_epoch{..}) |
 				RuntimeCall::Utility(pallet_utility::Call::batch_all{..}) |
-				RuntimeCall::Utility(pallet_utility::Call::batch{..})
+				RuntimeCall::Utility(pallet_utility::Call::batch{..}) |
+				// Borrowers should be able to swap back and forth between local currencies and their variants
+				RuntimeCall::TokenMux(pallet_token_mux::Call::burn {..}) |
+				RuntimeCall::TokenMux(pallet_token_mux::Call::deposit {..}) |
+				RuntimeCall::TokenMux(pallet_token_mux::Call::match_swap {..})
 			),
 			ProxyType::Invest => matches!(
 				c,

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -680,22 +680,26 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			ProxyType::Borrow => matches!(
 				c,
 				RuntimeCall::Loans(pallet_loans::Call::create { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::borrow { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::repay { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::write_off { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::apply_loan_mutation { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::close { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::apply_write_off_policy { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::update_portfolio_valuation { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::propose_transfer_debt { .. }) |
-                RuntimeCall::Loans(pallet_loans::Call::apply_transfer_debt { .. }) |
-                // Borrowers should be able to close and execute an epoch
-                // in order to get liquidity from repayments in previous epochs.
+				RuntimeCall::Loans(pallet_loans::Call::borrow { .. }) |
+				RuntimeCall::Loans(pallet_loans::Call::repay { .. }) |
+				RuntimeCall::Loans(pallet_loans::Call::write_off { .. }) |
+				RuntimeCall::Loans(pallet_loans::Call::apply_loan_mutation { .. }) |
+				RuntimeCall::Loans(pallet_loans::Call::close { .. }) |
+				RuntimeCall::Loans(pallet_loans::Call::apply_write_off_policy { .. }) |
+				RuntimeCall::Loans(pallet_loans::Call::update_portfolio_valuation { .. }) |
+				RuntimeCall::Loans(pallet_loans::Call::propose_transfer_debt { .. }) |
+				RuntimeCall::Loans(pallet_loans::Call::apply_transfer_debt { .. }) |
+				// Borrowers should be able to close and execute an epoch
+				// in order to get liquidity from repayments in previous epochs.
 				RuntimeCall::PoolSystem(pallet_pool_system::Call::close_epoch{..}) |
 				RuntimeCall::PoolSystem(pallet_pool_system::Call::submit_solution{..}) |
 				RuntimeCall::PoolSystem(pallet_pool_system::Call::execute_epoch{..}) |
 				RuntimeCall::Utility(pallet_utility::Call::batch_all{..}) |
-				RuntimeCall::Utility(pallet_utility::Call::batch{..})
+				RuntimeCall::Utility(pallet_utility::Call::batch{..}) |
+				// Borrowers should be able to swap back and forth between local currencies and their variants
+				RuntimeCall::TokenMux(pallet_token_mux::Call::burn {..}) |
+				RuntimeCall::TokenMux(pallet_token_mux::Call::deposit {..}) |
+				RuntimeCall::TokenMux(pallet_token_mux::Call::match_swap {..})
 			),
 			ProxyType::Invest => matches!(
 				c,

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -570,7 +570,11 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 RuntimeCall::PoolSystem(pallet_pool_system::Call::submit_solution { .. }) |
                 RuntimeCall::PoolSystem(pallet_pool_system::Call::execute_epoch { .. }) |
                 RuntimeCall::Utility(pallet_utility::Call::batch_all { .. }) |
-                RuntimeCall::Utility(pallet_utility::Call::batch { .. })
+                RuntimeCall::Utility(pallet_utility::Call::batch { .. }) |
+				// Borrowers should be able to swap back and forth between local currencies and their variants
+				RuntimeCall::TokenMux(pallet_token_mux::Call::burn {..}) |
+				RuntimeCall::TokenMux(pallet_token_mux::Call::deposit {..}) |
+				RuntimeCall::TokenMux(pallet_token_mux::Call::match_swap {..})
 			),
 			ProxyType::Invest => matches!(
 				c,


### PR DESCRIPTION
# Description

Adds `TokenMux` call permissions to `ProxyType::Borrow` 

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
