### PR TITLE
Set correct onchain versions

### DIFF
--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -10,6 +10,11 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+use crate::{OraclePriceCollection, OraclePriceFeed};
+
 /// The migration set for Altair @ Kusama.
 /// It includes all the migrations that have to be applied on that chain.
-pub type UpgradeAltair1035 = ();
+pub type UpgradeAltair1035 = (
+	runtime_common::migrations::increase_storage_version::Migration<OraclePriceFeed, 0, 1>,
+	runtime_common::migrations::increase_storage_version::Migration<OraclePriceCollection, 0, 1>,
+);

--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -10,11 +10,13 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use crate::{OraclePriceCollection, OraclePriceFeed};
+use crate::{ForeignInvestments, OraclePriceCollection, OraclePriceFeed, OrderBook};
 
 /// The migration set for Altair @ Kusama.
 /// It includes all the migrations that have to be applied on that chain.
 pub type UpgradeAltair1035 = (
 	runtime_common::migrations::increase_storage_version::Migration<OraclePriceFeed, 0, 1>,
 	runtime_common::migrations::increase_storage_version::Migration<OraclePriceCollection, 0, 1>,
+	runtime_common::migrations::increase_storage_version::Migration<OrderBook, 0, 1>,
+	runtime_common::migrations::increase_storage_version::Migration<ForeignInvestments, 0, 1>,
 );

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -10,6 +10,11 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+use crate::{OraclePriceCollection, OraclePriceFeed};
+
 /// The migration set for Centrifuge @ Polkadot.
 /// It includes all the migrations that have to be applied on that chain.
-pub type UpgradeCentrifuge1029 = ();
+pub type UpgradeCentrifuge1029 = (
+	runtime_common::migrations::increase_storage_version::Migration<OraclePriceFeed, 0, 1>,
+	runtime_common::migrations::increase_storage_version::Migration<OraclePriceCollection, 0, 1>,
+);

--- a/runtime/common/src/migrations/increase_storage_version.rs
+++ b/runtime/common/src/migrations/increase_storage_version.rs
@@ -77,7 +77,8 @@ where
 	}
 }
 
-/// Simply bumps the storage version of a pallet
+/// Simply bumps the storage version of a pallet.
+/// Similar to the above but it does not check the current version is TO_VERSION
 ///
 /// NOTE: Use with extreme caution! Must ensure beforehand that a migration is
 /// not necessary


### PR DESCRIPTION
# Description

I'm not sure why the new Oracle pallets added have their on-chain version of 0 when it should be 1. It is not an issue now, but it can be if we update them tomorrow, and makes the new Ci job for migrations fail. This PR set them with the correct version.

My hypothesis of why this has happened is that we reused the previous indexes from the previous oracle pallets (`orml-oracle`, and `pallet-data-collection`), and because of this, it has not update the version (even when the pallet names have changed).

The same happens for `Orderbook` and `ForeignInvestments` for `altair`. Altair didn't require reseting the storage but we did not update the version numbers there.