### PR TITLE
Remove custom implementation for `MaxEncodingLen`

### DIFF
--- a/pallets/liquidity-pools-gateway/routers/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/routers/Cargo.toml
@@ -34,7 +34,6 @@ pallet-evm = { workspace = true }
 
 # Custom crates
 cfg-traits = { workspace = true }
-cfg-types = { workspace = true }
 
 # Local pallets
 pallet-ethereum-transaction = { workspace = true }
@@ -42,6 +41,7 @@ pallet-liquidity-pools-gateway = { workspace = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }
+cfg-types = { workspace = true, default-features = true }
 
 cumulus-primitives-core = { workspace = true, default-features = true }
 
@@ -65,7 +65,6 @@ pallet-balances = { workspace = true, default-features = true }
 default = ["std"]
 std = [
   "parity-scale-codec/std",
-  "cfg-types/std",
   "cfg-traits/std",
   "cfg-mocks/std",
   "hex/std",

--- a/pallets/liquidity-pools-gateway/routers/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/routers/Cargo.toml
@@ -40,8 +40,8 @@ pallet-ethereum-transaction = { workspace = true }
 pallet-liquidity-pools-gateway = { workspace = true }
 
 [dev-dependencies]
-lazy_static = { workspace = true }
 cfg-types = { workspace = true, default-features = true }
+lazy_static = { workspace = true }
 
 cumulus-primitives-core = { workspace = true, default-features = true }
 

--- a/pallets/liquidity-pools/src/routers.rs
+++ b/pallets/liquidity-pools/src/routers.rs
@@ -15,7 +15,7 @@ pub enum Router<CurrencyId> {
 
 /// XcmDomain gathers all the required fields to build and send remote
 /// calls to a specific XCM-based Domain.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct XcmDomain<CurrencyId> {
 	/// the xcm multilocation of the domain
@@ -32,29 +32,4 @@ pub struct XcmDomain<CurrencyId> {
 	pub fee_currency: CurrencyId,
 	/// The max gas_limit we want to propose for a remote evm execution
 	pub max_gas_limit: u64,
-}
-
-// NOTE: Remove this custom implementation once the following underlying data
-// implements MaxEncodedLen:
-/// * Polkadot Repo: xcm::VersionedMultiLocation
-/// * PureStake Repo: pallet_xcm_transactor::Config<Self = T>::CurrencyId
-impl<CurrencyId> MaxEncodedLen for XcmDomain<CurrencyId>
-where
-	XcmDomain<CurrencyId>: Encode,
-{
-	fn max_encoded_len() -> usize {
-		// The domain's `VersionedMultiLocation` (custom bound)
-		staging_xcm::latest::MultiLocation::max_encoded_len()
-			// From the enum wrapping of `VersionedMultiLocation`
-			.saturating_add(1)
-			// The ethereum xcm call index (default bound)
-			.saturating_add(BoundedVec::<
-				u8,
-				ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
-			>::max_encoded_len())
-			// The contract address (default bound)
-			.saturating_add(H160::max_encoded_len())
-			// The fee currency (custom bound)
-			.saturating_add(cfg_types::tokens::CurrencyId::max_encoded_len())
-	}
 }

--- a/pallets/pool-system/src/pool_types.rs
+++ b/pallets/pool-system/src/pool_types.rs
@@ -148,7 +148,7 @@ pub struct PoolParameters {
 	pub max_nav_age: Seconds,
 }
 
-#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct PoolChanges<Rate, StringLimit, MaxTranches>
 where
 	StringLimit: Get<u32>,
@@ -158,31 +158,6 @@ where
 	pub tranche_metadata: Change<BoundedVec<TrancheMetadata<StringLimit>, MaxTranches>>,
 	pub min_epoch_time: Change<Seconds>,
 	pub max_nav_age: Change<Seconds>,
-}
-
-// NOTE: Can be removed once orml_traits::Change impls MaxEncodedLen
-// https://github.com/open-web3-stack/open-runtime-module-library/pull/867
-impl<Rate, StringLimit, MaxTranches> MaxEncodedLen for PoolChanges<Rate, StringLimit, MaxTranches>
-where
-	StringLimit: Get<u32>,
-	MaxTranches: Get<u32>,
-	PoolChanges<Rate, StringLimit, MaxTranches>: Encode,
-	BoundedVec<TrancheUpdate<Rate>, MaxTranches>: MaxEncodedLen,
-	BoundedVec<TrancheMetadata<StringLimit>, MaxTranches>: MaxEncodedLen,
-	Seconds: MaxEncodedLen,
-{
-	fn max_encoded_len() -> usize {
-		// The tranches (default bound)
-		BoundedVec::<TrancheUpdate<Rate>, MaxTranches>::max_encoded_len()
-			// The tranche metadata (default bound)
-			.saturating_add(
-				BoundedVec::<TrancheMetadata<StringLimit>, MaxTranches>::max_encoded_len(),
-			)
-			// The min epoc time and max nav age (default bounds)
-			.saturating_add(Seconds::max_encoded_len().saturating_mul(2))
-			// From the `Change` enum which wraps all four fields of Self
-			.saturating_add(4)
-	}
 }
 
 /// Information about the deposit that has been taken to create a pool


### PR DESCRIPTION
# Description

We had some `MaxEncodingLen` traits implemented manually for some types. Since `polkadot-v1.1.0`, it seems we can get rid of our custom implementation and let Rust do it for us.

**NOTE**: Blocked until `v1.1.0`