### PR TITLE
BlockRewards: Fix how it handle ED for Staking currency.

### DIFF
--- a/pallets/block-rewards/src/lib.rs
+++ b/pallets/block-rewards/src/lib.rs
@@ -50,7 +50,7 @@ use frame_support::{
 	storage::transactional,
 	traits::{
 		fungible::{Inspect as FungibleInspect, Mutate as FungibleMutate},
-		fungibles::Mutate,
+		fungibles::{Inspect, Mutate},
 		tokens::{Balance, Fortitude, Precision},
 		OneSessionHandler,
 	},
@@ -132,9 +132,6 @@ pub mod pallet {
 		/// Type used to handle balances.
 		type Balance: Balance + MaxEncodedLen + FixedPointOperand + MaybeSerializeDeserialize;
 
-		#[pallet::constant]
-		type ExistentialDeposit: Get<Self::Balance>;
-
 		/// Type used to handle group weights.
 		type Weight: Parameter + MaxEncodedLen + EnsureAdd + Unsigned + FixedPointOperand + Default;
 
@@ -147,8 +144,12 @@ pub mod pallet {
 			> + CurrencyGroupChange<GroupId = u32, CurrencyId = <Self as Config>::CurrencyId>;
 
 		/// The type used to handle currency minting and burning for collators.
-		type Tokens: Mutate<Self::AccountId, AssetId = <Self as Config>::CurrencyId, Balance = Self::Balance>
-			+ FungibleMutate<Self::AccountId>
+		type Tokens: Mutate<Self::AccountId>
+			+ Inspect<
+				Self::AccountId,
+				AssetId = <Self as Config>::CurrencyId,
+				Balance = Self::Balance,
+			> + FungibleMutate<Self::AccountId>
 			+ FungibleInspect<Self::AccountId, Balance = Self::Balance>;
 
 		/// The currency type of the artificial block rewards currency.
@@ -314,10 +315,13 @@ impl<T: Config> Pallet<T> {
 	///  * deposit_stake (4 reads, 4 writes): Currency, Group, StakeAccount,
 	///    Account
 	pub(crate) fn do_init_collator(who: &T::AccountId) -> DispatchResult {
+		let existential_deposit =
+			<T::Tokens as Inspect<T::AccountId>>::minimum_balance(T::StakeCurrencyId::get());
+
 		<T::Tokens as Mutate<T::AccountId>>::mint_into(
 			T::StakeCurrencyId::get(),
 			who,
-			T::StakeAmount::get().saturating_add(T::ExistentialDeposit::get()),
+			T::StakeAmount::get().saturating_add(existential_deposit),
 		)?;
 		T::Rewards::deposit_stake(T::StakeCurrencyId::get(), who, T::StakeAmount::get())
 	}

--- a/pallets/block-rewards/src/tests.rs
+++ b/pallets/block-rewards/src/tests.rs
@@ -1,4 +1,4 @@
-use cfg_primitives::{CFG, SECONDS_PER_YEAR};
+use cfg_primitives::SECONDS_PER_YEAR;
 use cfg_types::{
 	fixed_point::Rate,
 	tokens::{CurrencyId, StakingCurrency},
@@ -13,7 +13,7 @@ use crate::mock::*;
 // The Reward amount
 // NOTE: This value needs to be > ExistentialDeposit, otherwise the tests will
 // fail as it's not allowed to transfer a value below the ED threshold.
-const REWARD: u128 = 100 * CFG + ExistentialDeposit::get();
+const REWARD: u128 = 100 * BALANCE_ED;
 
 #[test]
 fn check_special_privileges() {
@@ -105,7 +105,7 @@ fn joining_leaving_collators() {
 			<Tokens as fungibles::Inspect<AccountId>>::total_issuance(CurrencyId::Staking(
 				StakingCurrency::BlockRewards
 			)),
-			<Test as Config>::StakeAmount::get() as u128 + ExistentialDeposit::get()
+			<Test as Config>::StakeAmount::get() as u128 + REWARD_CURRENCY_ED
 		);
 
 		advance_session();
@@ -126,7 +126,7 @@ fn joining_leaving_collators() {
 			<Tokens as fungibles::Inspect::<AccountId>>::total_issuance(CurrencyId::Staking(
 				StakingCurrency::BlockRewards
 			)),
-			<Test as Config>::StakeAmount::get() as u128 + ExistentialDeposit::get()
+			<Test as Config>::StakeAmount::get() as u128 + REWARD_CURRENCY_ED
 		);
 
 		advance_session();
@@ -149,7 +149,7 @@ fn joining_leaving_collators() {
 			<Tokens as fungibles::Inspect::<AccountId>>::total_issuance(CurrencyId::Staking(
 				StakingCurrency::BlockRewards
 			)),
-			2 * <Test as Config>::StakeAmount::get() as u128 + 3 * ExistentialDeposit::get()
+			2 * <Test as Config>::StakeAmount::get() as u128 + 3 * REWARD_CURRENCY_ED
 		);
 
 		advance_session();
@@ -173,7 +173,7 @@ fn joining_leaving_collators() {
 			<Tokens as fungibles::Inspect::<AccountId>>::total_issuance(CurrencyId::Staking(
 				StakingCurrency::BlockRewards
 			)),
-			3 * <Test as Config>::StakeAmount::get() as u128 + 5 * ExistentialDeposit::get()
+			3 * <Test as Config>::StakeAmount::get() as u128 + 5 * REWARD_CURRENCY_ED
 		);
 	});
 }
@@ -223,10 +223,7 @@ fn single_claim_reward() {
 				Balances::total_balance(&TreasuryPalletId::get().into_account_truncating()),
 				0
 			);
-			assert_eq!(
-				Balances::total_issuance(),
-				REWARD + ExistentialDeposit::get()
-			);
+			assert_eq!(Balances::total_issuance(), REWARD + BALANCE_ED);
 			assert_eq!(Balances::free_balance(&1), REWARD);
 		});
 }
@@ -244,7 +241,7 @@ fn collator_rewards_greater_than_remainder() {
 				Balances::free_balance(&TreasuryPalletId::get().into_account_truncating());
 
 			// EPOCH 0 -> EPOCH
-			let total_issuance = ExistentialDeposit::get();
+			let total_issuance = BALANCE_ED;
 			assert_eq!(Balances::total_issuance(), total_issuance);
 			MockTime::mock_now(|| SECONDS_PER_YEAR * 1000);
 			advance_session();

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1240,7 +1240,6 @@ impl pallet_block_rewards::Config for Runtime {
 	type AuthorityId = AuraId;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type ExistentialDeposit = ExistentialDeposit;
 	type MaxCollators = MaxAuthorities;
 	type Rate = Rate;
 	type Rewards = BlockRewardsBase;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1254,7 +1254,6 @@ impl pallet_block_rewards::Config for Runtime {
 	type AuthorityId = AuraId;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type ExistentialDeposit = ExistentialDeposit;
 	type MaxCollators = MaxAuthorities;
 	type Rate = Rate;
 	type Rewards = BlockRewardsBase;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -28,7 +28,11 @@ pub mod transfer_filter;
 pub mod xcm;
 
 use cfg_primitives::Balance;
-use cfg_types::{fee_keys::FeeKey, pools::PoolNav, tokens::CurrencyId};
+use cfg_types::{
+	fee_keys::FeeKey,
+	pools::PoolNav,
+	tokens::{CurrencyId, StakingCurrency},
+};
 use orml_traits::GetByKey;
 use pallet_loans::entities::input::PriceCollectionInput;
 use pallet_pool_system::Nav;
@@ -81,6 +85,7 @@ where
 	fn get(currency_id: &CurrencyId) -> Balance {
 		match currency_id {
 			CurrencyId::Native => T::ExistentialDeposit::get(),
+			CurrencyId::Staking(StakingCurrency::BlockRewards) => T::ExistentialDeposit::get(),
 			currency_id => orml_asset_registry::Pallet::<T>::metadata(currency_id)
 				.map(|metadata| metadata.existential_deposit)
 				.unwrap_or_default(),

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1247,7 +1247,7 @@ type CollatorSelectionUpdateOrigin = EitherOfDiverse<
 
 // Implement Collator Selection pallet configuration trait for the runtime
 impl pallet_collator_selection::Config for Runtime {
-	type Currency = Tokens;
+	type Currency = Balances;
 	// should be a multiple of session or things will get inconsistent
 	type KickThreshold = Period;
 	type MaxCandidates = MaxCandidates;
@@ -1738,7 +1738,6 @@ impl pallet_block_rewards::Config for Runtime {
 	type AuthorityId = AuraId;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type ExistentialDeposit = ExistentialDeposit;
 	type MaxCollators = MaxAuthorities;
 	type Rate = Rate;
 	type Rewards = BlockRewardsBase;


### PR DESCRIPTION
# Description

I guess this comes from the previous upgrade when balance/and currencies force `ExistentialDeposit` usage.

Issue 1: We're using an `ED` denominated in `CFG` for the `StakingCurrency`. This is not critical if both currencies use the same denomination, but we should use the correct `ED` for Staking. 

Issue 2: Because `Staking` currencies were not in the asset registry. From `orml_tokens` perspective, the `ED` is `0` while from `block-rewards` perspective it's `1 * MICRO_CFG`. I guess this is not a problem for us right now, but it should be fixed to avoid future problems.