### PR TITLE
Polkadot v1.1.0: Account converter changes

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -36,7 +36,7 @@ use cfg_types::{
 use cfg_utils::vec_to_fixed_array;
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
-use runtime_common::{evm::precompile::H160Addresses, AccountConverter};
+use runtime_common::{account_conversion::AccountConverter, evm::precompile::H160Addresses};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, Properties};
 use serde::{Deserialize, Serialize};

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -36,7 +36,7 @@ use cfg_types::{
 use cfg_utils::vec_to_fixed_array;
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
-use runtime_common::{account_conversion::convert_evm_address, evm::precompile::H160Addresses};
+use runtime_common::{evm::precompile::H160Addresses, AccountConverter};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, Properties};
 use serde::{Deserialize, Serialize};
@@ -557,7 +557,7 @@ fn centrifuge_genesis(
 
 	endowed_accounts.extend(endowed_evm_accounts.into_iter().map(|(addr, id)| {
 		let chain_id = id.unwrap_or_else(|| chain_id.into());
-		convert_evm_address(chain_id, addr)
+		AccountConverter::convert_evm_address(chain_id, addr)
 	}));
 
 	let num_endowed_accounts = endowed_accounts.len();
@@ -700,7 +700,7 @@ fn altair_genesis(
 
 	endowed_accounts.extend(endowed_evm_accounts.into_iter().map(|(addr, id)| {
 		let chain_id = id.unwrap_or_else(|| chain_id.into());
-		convert_evm_address(chain_id, addr)
+		AccountConverter::convert_evm_address(chain_id, addr)
 	}));
 
 	let num_endowed_accounts = endowed_accounts.len();
@@ -829,7 +829,7 @@ fn development_genesis(
 
 	endowed_accounts.extend(endowed_evm_accounts.into_iter().map(|(addr, id)| {
 		let chain_id = id.unwrap_or_else(|| chain_id.into());
-		convert_evm_address(chain_id, addr)
+		AccountConverter::convert_evm_address(chain_id, addr)
 	}));
 
 	let num_endowed_accounts = endowed_accounts.len();

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -88,7 +88,7 @@ use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_runtime_common::{prod_or_fast, BlockHashCount, SlowAdjustingFeeUpdate};
 use runtime_common::{
-	account_conversion::{self, AccountConverter, AccountMapping},
+	account_conversion::{self, AccountConverter, RuntimeAccountConverter},
 	asset_registry,
 	evm::{
 		precompile::Precompiles, BaseFeeThreshold, FindAuthorTruncated, GAS_LIMIT_POV_SIZE_RATIO,
@@ -1849,7 +1849,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
-	type AddressMapping = AccountMapping<Runtime>;
+	type AddressMapping = RuntimeAccountConverter<Runtime>;
 	type BlockGasLimit = BlockGasLimit;
 	type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
 	type CallOrigin = EnsureAddressRoot<AccountId>;
@@ -2374,7 +2374,7 @@ impl_runtime_apis! {
 	// AccountConversionApi
 	impl runtime_common::apis::AccountConversionApi<Block, AccountId> for Runtime {
 		fn conversion_of(location: MultiLocation) -> Option<AccountId> {
-			account_conversion::location_to_account::<LocationToAccountId>(location)
+			AccountConverter::location_to_account::<LocationToAccountId>(location)
 		}
 	}
 

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -88,7 +88,7 @@ use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_runtime_common::{prod_or_fast, BlockHashCount, SlowAdjustingFeeUpdate};
 use runtime_common::{
-	account_conversion::{self, AccountConverter, RuntimeAccountConverter},
+	account_conversion::{AccountConverter, RuntimeAccountConverter},
 	asset_registry,
 	evm::{
 		precompile::Precompiles, BaseFeeThreshold, FindAuthorTruncated, GAS_LIMIT_POV_SIZE_RATIO,

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -91,7 +91,7 @@ use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_runtime_common::{prod_or_fast, BlockHashCount, SlowAdjustingFeeUpdate};
 use runtime_common::{
-	account_conversion::{self, AccountConverter, AccountMapping},
+	account_conversion::{self, AccountConverter, RuntimeAccountConverter},
 	asset_registry,
 	evm::{
 		precompile::Precompiles, BaseFeeThreshold, FindAuthorTruncated, GAS_LIMIT_POV_SIZE_RATIO,
@@ -1963,7 +1963,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
-	type AddressMapping = AccountMapping<Runtime>;
+	type AddressMapping = RuntimeAccountConverter<Runtime>;
 	type BlockGasLimit = BlockGasLimit;
 	type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
 	type CallOrigin = EnsureAddressRoot<AccountId>;
@@ -2421,7 +2421,7 @@ impl_runtime_apis! {
 	// AccountConversionApi
 	impl runtime_common::apis::AccountConversionApi<Block, AccountId> for Runtime {
 		fn conversion_of(location: MultiLocation) -> Option<AccountId> {
-			account_conversion::location_to_account::<LocationToAccountId>(location)
+			AccountConverter::location_to_account::<LocationToAccountId>(location)
 		}
 	}
 

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -91,7 +91,7 @@ use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_runtime_common::{prod_or_fast, BlockHashCount, SlowAdjustingFeeUpdate};
 use runtime_common::{
-	account_conversion::{self, AccountConverter, RuntimeAccountConverter},
+	account_conversion::{AccountConverter, RuntimeAccountConverter},
 	asset_registry,
 	evm::{
 		precompile::Precompiles, BaseFeeThreshold, FindAuthorTruncated, GAS_LIMIT_POV_SIZE_RATIO,

--- a/runtime/common/src/gateway.rs
+++ b/runtime/common/src/gateway.rs
@@ -11,12 +11,11 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::AccountId;
-use pallet_evm::AddressMapping;
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_core::{crypto::AccountId32, Get, H160};
 use sp_runtime::traits::AccountIdConversion;
 
-use crate::account_conversion::AccountMapping;
+use crate::account_conversion::AccountConverter;
 
 pub fn get_gateway_account<T: pallet_evm_chain_id::Config + parachain_info::Config>() -> AccountId {
 	let sender_account: AccountId =
@@ -25,5 +24,5 @@ pub fn get_gateway_account<T: pallet_evm_chain_id::Config + parachain_info::Conf
 	let truncated_sender_account =
 		H160::from_slice(&<AccountId32 as AsRef<[u8; 32]>>::as_ref(&sender_account)[0..20]);
 
-	AccountMapping::<T>::into_account_id(truncated_sender_account)
+	AccountConverter::into_account_id::<T>(truncated_sender_account)
 }

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -95,7 +95,7 @@ use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 use runtime_common::{
-	account_conversion::{self, AccountConverter, AccountMapping},
+	account_conversion::{self, AccountConverter, RuntimeAccountConverter},
 	asset_registry,
 	changes::FastDelay,
 	evm::{
@@ -1941,7 +1941,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
-	type AddressMapping = AccountMapping<Runtime>;
+	type AddressMapping = RuntimeAccountConverter<Runtime>;
 	type BlockGasLimit = BlockGasLimit;
 	type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
 	type CallOrigin = EnsureAddressTruncated;
@@ -2460,7 +2460,7 @@ impl_runtime_apis! {
 	// AccountConversionApi
 	impl runtime_common::apis::AccountConversionApi<Block, AccountId> for Runtime {
 		fn conversion_of(location: MultiLocation) -> Option<AccountId> {
-			account_conversion::location_to_account::<LocationToAccountId>(location)
+			AccountConverter::location_to_account::<LocationToAccountId>(location)
 		}
 	}
 

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -95,7 +95,7 @@ use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, RuntimeDispatchInfo
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 use runtime_common::{
-	account_conversion::{self, AccountConverter, RuntimeAccountConverter},
+	account_conversion::{AccountConverter, RuntimeAccountConverter},
 	asset_registry,
 	changes::FastDelay,
 	evm::{

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -45,7 +45,7 @@ use polkadot_runtime_parachains::{
 	paras::{ParaGenesisArgs, ParaKind},
 };
 use runtime_common::{
-	account_conversion::{convert_evm_address, AccountConverter},
+	account_conversion::AccountConverter,
 	foreign_investments::IdentityPoolCurrencyConverter,
 	xcm::general_key,
 	xcm_fees::{default_per_second, ksm_per_second},
@@ -4773,7 +4773,8 @@ mod development {
 				) {
 					let chain_id = env.parachain_state(|| pallet_evm_chain_id::Pallet::<T>::get());
 
-					let derived_account = convert_evm_address(chain_id, address.to_fixed_bytes());
+					let derived_account =
+						AccountConverter::convert_evm_address(chain_id, address.to_fixed_bytes());
 
 					env.parachain_state_mut(|| {
 						pallet_balances::Pallet::<T>::mint_into(&derived_account.into(), balance)

--- a/runtime/integration-tests/src/utils/evm.rs
+++ b/runtime/integration-tests/src/utils/evm.rs
@@ -13,7 +13,7 @@
 use frame_support::{dispatch::RawOrigin, traits::fungible::Mutate};
 use fudge::primitives::Chain;
 use pallet_evm::FeeCalculator;
-use runtime_common::account_conversion::{convert_evm_address, AccountConverter};
+use runtime_common::account_conversion::AccountConverter;
 use sp_core::{Get, H160, U256};
 
 use crate::{
@@ -28,7 +28,7 @@ pub fn mint_balance_into_derived_account(env: &mut TestEnv, address: H160, balan
 		})
 		.unwrap();
 
-	let derived_account = convert_evm_address(chain_id, address.to_fixed_bytes());
+	let derived_account = AccountConverter::convert_evm_address(chain_id, address.to_fixed_bytes());
 
 	env.with_mut_state(Chain::Para(PARA_ID), || {
 		Balances::mint_into(&derived_account.into(), balance).unwrap()
@@ -43,7 +43,7 @@ pub fn deploy_contract(env: &mut TestEnv, address: H160, code: Vec<u8>) {
 		})
 		.unwrap();
 
-	let derived_address = convert_evm_address(chain_id, address.to_fixed_bytes());
+	let derived_address = AccountConverter::convert_evm_address(chain_id, address.to_fixed_bytes());
 
 	let transaction_create_cost = env
 		.with_state(Chain::Para(PARA_ID), || {


### PR DESCRIPTION
# Description

From this discussion: https://github.com/centrifuge/centrifuge-chain/pull/1756#discussion_r1559105772

A refactor of `AccountConverter`:
- All methods belong to `AccountConverter` type.
- If the method requires the type to have a runtime type, then it uses the wrapper `RuntimeAccountConverter` type. This should only be used by trait demands in pallet configurations. For simple calls, use always `AccountConverter`

Are we in a middle point with this PR @mustermeiszer?