### PR TITLE
fix: chain spec not deterministic

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -666,10 +666,7 @@ fn centrifuge_genesis(
 				.collect(),
 			collator_reward: 8_325 * MILLI_CFG,
 			treasury_inflation_rate: Rate::saturating_from_rational(3, 100),
-			last_update: std::time::SystemTime::now()
-				.duration_since(std::time::UNIX_EPOCH)
-				.expect("SystemTime before UNIX EPOCH!")
-				.as_secs(),
+			last_update: Default::default(),
 		},
 		block_rewards_base: Default::default(),
 		base_fee: Default::default(),
@@ -768,10 +765,7 @@ fn altair_genesis(
 				.collect(),
 			collator_reward: 98_630 * MILLI_AIR,
 			treasury_inflation_rate: Rate::saturating_from_rational(3, 100),
-			last_update: std::time::SystemTime::now()
-				.duration_since(std::time::UNIX_EPOCH)
-				.expect("SystemTime before UNIX EPOCH!")
-				.as_secs(),
+			last_update: Default::default(),
 		},
 		block_rewards_base: Default::default(),
 		collator_allowlist: Default::default(),
@@ -958,10 +952,7 @@ fn development_genesis(
 				.collect(),
 			collator_reward: 8_325 * MILLI_CFG,
 			treasury_inflation_rate: Rate::saturating_from_rational(3, 100),
-			last_update: std::time::SystemTime::now()
-				.duration_since(std::time::UNIX_EPOCH)
-				.expect("SystemTime before UNIX EPOCH!")
-				.as_secs(),
+			last_update: Default::default(),
 		},
 		base_fee: Default::default(),
 		evm_chain_id: development_runtime::EVMChainIdConfig {


### PR DESCRIPTION
# Description

As part of my #1756 client checks, I noticed that our ephemeral chain specs did not lead to a deterministic chain spec which blocks all our scripts to register such parachain. The root of this was introduced by myself in #1740 by adding a unix timestamp for the block rewards. Since this timestamp is completely irrelevant for ephemeral chains, I changed it to the default value. This will mint a larger amount of treasury inflation in the first session and then go back to normal.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
