### PR TITLE
fix: polkadot v1.1.0 client

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -61,13 +61,16 @@ It runs a [collator](https://wiki.polkadot.network/docs/learn-collator) node:
     Similar to the relay chain, you can explore the parachain using the [polkadot.js (on localhost:11936)](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A11936#/explorer) client.
     You will see the block production frozen until you connect it to the relay chain.
 
-    By default, the initialized parachain will have the id `2000`.
-    If you need more than one parachain or choose other chain specifications,
-    you can set `PARA_ID` or `PARA_CHAIN_SPEC`, example:
+   By default, the initialized parachain will have the id `2000`.
+   Please note that for ephemeral chains specs such as `development`, `centrifuge-local` or `altair-local`, the
+   parachain ID is currently hardcoded.
+   If you need to customize it, please open an issue and we will add such a feature.
+   If choose other chain specifications, you can set the `PARA_CHAIN_SPEC` env var, e.g.:
     ```bash
-    PARA_ID=2001 ./scripts/init.sh start-parachain
+    PARA_CHAIN_SPEC=development ./scripts/init.sh start-parachain
     ```
-    The different `PARA_CHAIN_SPEC` values can be found at [`src/command.rs`](src/command.rs) under the `load_spec()` function.
+   The different `PARA_CHAIN_SPEC` values can be found at [`src/command.rs`](src/command.rs) under the `load_spec()`
+   function.
 
 3. Onboard the parachain
     This step will have the targeted parachain onboarded in the relay chain. The parachain will NOT produce blocks until this step is completed successfully.
@@ -109,9 +112,12 @@ Lint the source code with `cargo fmt --all`. This excludes certain paths (define
     See more [here](docs/runtime-upgrade.md).
 
 ## Generate new Spec and Parachain files
-This script will take a valid chain-spec chain_id, a parachain_id and a flag to build new spec or not, and will output genesis spec (raw and plain), wasm and state files.
+
+This script will take a valid chain-spec chain_id and a flag to build new spec or not, and will output genesis spec (raw
+and plain), wasm and state files.
+
 ```shell
-./scripts/export_parachain_files.sh charcoal-staging 10001 true
+./scripts/export_parachain_files.sh demo true
 ```
 Adapt parameters accordingly.
 

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -141,47 +141,6 @@ pub fn centrifuge_config() -> CentrifugeChainSpec {
 	.unwrap()
 }
 
-pub fn centrifuge_dev(para_id: ParaId) -> CentrifugeChainSpec {
-	let mut properties = Properties::new();
-	properties.insert("tokenSymbol".into(), "DCFG".into());
-	properties.insert("tokenDecimals".into(), currency_decimals::NATIVE.into());
-
-	CentrifugeChainSpec::from_genesis(
-		"Centrifuge Dev",
-		"centrifuge_dev",
-		ChainType::Live,
-		move || {
-			centrifuge_genesis(
-				vec![
-					(
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
-						get_from_seed::<AuraId>("Alice"),
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Bob"),
-						get_from_seed::<AuraId>("Bob"),
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Charlie"),
-						get_from_seed::<AuraId>("Charlie"),
-					),
-				],
-				endowed_accounts(),
-				endowed_evm_accounts(),
-				Some(100000000 * CFG),
-				para_id,
-				council_members_bootstrap(),
-			)
-		},
-		vec![],
-		None,
-		None,
-		None,
-		Some(properties),
-		development_extensions(para_id.into()),
-	)
-}
-
 pub fn centrifuge_local(para_id: ParaId) -> CentrifugeChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "DCFG".into());
@@ -218,83 +177,11 @@ pub fn catalyst_config() -> CentrifugeChainSpec {
 		.unwrap()
 }
 
-pub fn catalyst_local(para_id: ParaId) -> CentrifugeChainSpec {
-	let mut properties = Properties::new();
-	properties.insert("tokenSymbol".into(), "NCFG".into());
-	properties.insert("tokenDecimals".into(), currency_decimals::NATIVE.into());
-
-	CentrifugeChainSpec::from_genesis(
-		"Catalyst Local",
-		"catalyst_local",
-		ChainType::Local,
-		move || {
-			centrifuge_genesis(
-				vec![(
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_from_seed::<AuraId>("Alice"),
-				)],
-				endowed_accounts(),
-				endowed_evm_accounts(),
-				Some(10000000 * CFG),
-				para_id,
-				Default::default(),
-			)
-		},
-		vec![],
-		None,
-		None,
-		None,
-		Some(properties),
-		development_extensions(para_id.into()),
-	)
-}
-
 pub fn altair_config() -> AltairChainSpec {
 	AltairChainSpec::from_json_bytes(
 		&include_bytes!("../res/genesis/altair-genesis-spec-raw.json")[..],
 	)
 	.unwrap()
-}
-
-pub fn altair_dev(para_id: ParaId) -> AltairChainSpec {
-	let mut properties = Properties::new();
-	properties.insert("tokenSymbol".into(), "DAIR".into());
-	properties.insert("tokenDecimals".into(), currency_decimals::NATIVE.into());
-
-	AltairChainSpec::from_genesis(
-		"Altair Dev",
-		"altair_dev",
-		ChainType::Live,
-		move || {
-			altair_genesis(
-				vec![
-					(
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
-						get_from_seed::<AuraId>("Alice"),
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Bob"),
-						get_from_seed::<AuraId>("Bob"),
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Charlie"),
-						get_from_seed::<AuraId>("Charlie"),
-					),
-				],
-				endowed_accounts(),
-				endowed_evm_accounts(),
-				Some(100000000 * AIR),
-				para_id,
-				council_members_bootstrap(),
-			)
-		},
-		vec![],
-		None,
-		None,
-		None,
-		Some(properties),
-		development_extensions(para_id.into()),
-	)
 }
 
 pub fn altair_local(para_id: ParaId) -> AltairChainSpec {
@@ -317,76 +204,6 @@ pub fn altair_local(para_id: ParaId) -> AltairChainSpec {
 				Some(100000000 * AIR),
 				para_id,
 				council_members_bootstrap(),
-			)
-		},
-		vec![],
-		None,
-		None,
-		None,
-		Some(properties),
-		development_extensions(para_id.into()),
-	)
-}
-
-pub fn antares_config() -> AltairChainSpec {
-	AltairChainSpec::from_json_bytes(&include_bytes!("../res/antares-spec-raw.json")[..]).unwrap()
-}
-
-pub fn antares_local(para_id: ParaId) -> AltairChainSpec {
-	let mut properties = Properties::new();
-	properties.insert("tokenSymbol".into(), "NAIR".into());
-	properties.insert("tokenDecimals".into(), currency_decimals::NATIVE.into());
-
-	AltairChainSpec::from_genesis(
-		"Antares Local",
-		"antares_local",
-		ChainType::Local,
-		move || {
-			altair_genesis(
-				vec![(
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_from_seed::<AuraId>("Alice"),
-				)],
-				endowed_accounts(),
-				endowed_evm_accounts(),
-				Some(10000000 * AIR),
-				para_id,
-				Default::default(),
-			)
-		},
-		vec![],
-		None,
-		None,
-		None,
-		Some(properties),
-		development_extensions(para_id.into()),
-	)
-}
-
-pub fn charcoal_config() -> AltairChainSpec {
-	AltairChainSpec::from_json_bytes(&include_bytes!("../res/charcoal-spec-raw.json")[..]).unwrap()
-}
-
-pub fn charcoal_local(para_id: ParaId) -> AltairChainSpec {
-	let mut properties = Properties::new();
-	properties.insert("tokenSymbol".into(), "CAIR".into());
-	properties.insert("tokenDecimals".into(), currency_decimals::NATIVE.into());
-
-	AltairChainSpec::from_genesis(
-		"Charcoal Local",
-		"charcoal_local",
-		ChainType::Local,
-		move || {
-			altair_genesis(
-				vec![(
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_from_seed::<AuraId>("Alice"),
-				)],
-				endowed_accounts(),
-				endowed_evm_accounts(),
-				Some(10000000 * AIR),
-				para_id,
-				Default::default(),
 			)
 		},
 		vec![],
@@ -442,37 +259,6 @@ pub fn development(para_id: ParaId) -> DevelopmentChainSpec {
 		"Dev Live",
 		"devel_live",
 		ChainType::Live,
-		move || {
-			development_genesis(
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				vec![(
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_from_seed::<AuraId>("Alice"),
-				)],
-				endowed_accounts(),
-				endowed_evm_accounts(),
-				Some(10000000 * CFG),
-				para_id,
-			)
-		},
-		vec![],
-		None,
-		None,
-		None,
-		Some(properties),
-		development_extensions(para_id.into()),
-	)
-}
-
-pub fn development_local(para_id: ParaId) -> DevelopmentChainSpec {
-	let mut properties = Properties::new();
-	properties.insert("tokenSymbol".into(), "DEVEL".into());
-	properties.insert("tokenDecimals".into(), currency_decimals::NATIVE.into());
-
-	DevelopmentChainSpec::from_genesis(
-		"Dev Local",
-		"devel_local",
-		ChainType::Local,
 		move || {
 			development_genesis(
 				get_account_id_from_seed::<sr25519::Public>("Alice"),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -30,7 +30,7 @@ use crate::{
 	service::{evm, AltairRuntimeExecutor, CentrifugeRuntimeExecutor, DevelopmentRuntimeExecutor},
 };
 
-const LOCAL_PARA_ID: ParaId = ParaId(2000);
+pub const LOCAL_PARA_ID: ParaId = ParaId::new(2000u32);
 
 enum ChainIdentity {
 	Altair,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -30,6 +30,8 @@ use crate::{
 	service::{evm, AltairRuntimeExecutor, CentrifugeRuntimeExecutor, DevelopmentRuntimeExecutor},
 };
 
+const LOCAL_PARA_ID: ParaId = ParaId(2000);
+
 enum ChainIdentity {
 	Altair,
 	Centrifuge,
@@ -62,26 +64,23 @@ impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
 	}
 }
 
-fn load_spec(
-	id: &str,
-	para_id: ParaId,
-) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
+fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	match id {
 		"centrifuge" => Ok(Box::new(chain_spec::centrifuge_config())),
-		"centrifuge-dev" => Ok(Box::new(chain_spec::centrifuge_dev(para_id))),
-		"centrifuge-local" => Ok(Box::new(chain_spec::centrifuge_local(para_id))),
+		"centrifuge-dev" => Ok(Box::new(chain_spec::centrifuge_dev(LOCAL_PARA_ID))),
+		"centrifuge-local" => Ok(Box::new(chain_spec::centrifuge_local(LOCAL_PARA_ID))),
 		"altair" => Ok(Box::new(chain_spec::altair_config())),
-		"altair-dev" => Ok(Box::new(chain_spec::altair_dev(para_id))),
-		"altair-local" => Ok(Box::new(chain_spec::altair_local(para_id))),
+		"altair-dev" => Ok(Box::new(chain_spec::altair_dev(LOCAL_PARA_ID))),
+		"altair-local" => Ok(Box::new(chain_spec::altair_local(LOCAL_PARA_ID))),
 		"catalyst" => Ok(Box::new(chain_spec::catalyst_config())),
-		"catalyst-local" => Ok(Box::new(chain_spec::catalyst_local(para_id))),
+		"catalyst-local" => Ok(Box::new(chain_spec::catalyst_local(LOCAL_PARA_ID))),
 		"antares" => Ok(Box::new(chain_spec::antares_config())),
-		"antares-local" => Ok(Box::new(chain_spec::antares_local(para_id))),
+		"antares-local" => Ok(Box::new(chain_spec::antares_local(LOCAL_PARA_ID))),
 		"charcoal" => Ok(Box::new(chain_spec::charcoal_config())),
-		"charcoal-local" => Ok(Box::new(chain_spec::charcoal_local(para_id))),
-		"demo" => Ok(Box::new(chain_spec::demo(para_id))),
-		"development" => Ok(Box::new(chain_spec::development(para_id))),
-		"development-local" => Ok(Box::new(chain_spec::development_local(para_id))),
+		"charcoal-local" => Ok(Box::new(chain_spec::charcoal_local(LOCAL_PARA_ID))),
+		"demo" => Ok(Box::new(chain_spec::demo(LOCAL_PARA_ID))),
+		"development" => Ok(Box::new(chain_spec::development(LOCAL_PARA_ID))),
+		"development-local" => Ok(Box::new(chain_spec::development_local(LOCAL_PARA_ID))),
 		"" => Err(String::from("No Chain-id provided")),
 
 		path => {
@@ -133,7 +132,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		load_spec(id, self.parachain_id.unwrap_or(10001).into())
+		load_spec(id)
 	}
 }
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -46,11 +46,7 @@ impl IdentifyChain for dyn sc_service::ChainSpec {
 	fn identify(&self) -> ChainIdentity {
 		if self.id().starts_with("centrifuge") || self.id().starts_with("catalyst") {
 			ChainIdentity::Centrifuge
-		} else if self.id().starts_with("altair")
-			|| self.id().starts_with("charcoal")
-			|| self.id().starts_with("antares")
-			|| self.id().starts_with("algol")
-		{
+		} else if self.id().starts_with("altair") {
 			ChainIdentity::Altair
 		} else {
 			ChainIdentity::Development
@@ -67,20 +63,12 @@ impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
 fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	match id {
 		"centrifuge" => Ok(Box::new(chain_spec::centrifuge_config())),
-		"centrifuge-dev" => Ok(Box::new(chain_spec::centrifuge_dev(LOCAL_PARA_ID))),
 		"centrifuge-local" => Ok(Box::new(chain_spec::centrifuge_local(LOCAL_PARA_ID))),
 		"altair" => Ok(Box::new(chain_spec::altair_config())),
-		"altair-dev" => Ok(Box::new(chain_spec::altair_dev(LOCAL_PARA_ID))),
 		"altair-local" => Ok(Box::new(chain_spec::altair_local(LOCAL_PARA_ID))),
 		"catalyst" => Ok(Box::new(chain_spec::catalyst_config())),
-		"catalyst-local" => Ok(Box::new(chain_spec::catalyst_local(LOCAL_PARA_ID))),
-		"antares" => Ok(Box::new(chain_spec::antares_config())),
-		"antares-local" => Ok(Box::new(chain_spec::antares_local(LOCAL_PARA_ID))),
-		"charcoal" => Ok(Box::new(chain_spec::charcoal_config())),
-		"charcoal-local" => Ok(Box::new(chain_spec::charcoal_local(LOCAL_PARA_ID))),
 		"demo" => Ok(Box::new(chain_spec::demo(LOCAL_PARA_ID))),
 		"development" => Ok(Box::new(chain_spec::development(LOCAL_PARA_ID))),
-		"development-local" => Ok(Box::new(chain_spec::development_local(LOCAL_PARA_ID))),
 		"" => Err(String::from("No Chain-id provided")),
 
 		path => {

--- a/scripts/check_benchmarks.sh
+++ b/scripts/check_benchmarks.sh
@@ -25,10 +25,10 @@ then
   chain="development-local"
 elif [[ $runtime == "centrifuge" ]];
 then
-  chain="centrifuge-dev"
+  chain="centrifuge-local"
 elif [[ $runtime == "altair" ]];
 then
-  chain="altair-dev"
+  chain="altair-local"
 else
   echo "Unknown runtime. Aborting!"
   exit 1;

--- a/scripts/export_parachain_files.sh
+++ b/scripts/export_parachain_files.sh
@@ -3,11 +3,10 @@
 set -e
 
 chain_name=$1
-parachain_id=$2
-should_build=$3
+should_build=$2
 
-if [[ $chain_name == "" || $parachain_id == "" ]]; then
-  echo "Chain Name or Parachain ID argument not provided"
+if [[ $chain_name == "" ]]; then
+  echo "Chain Name argument not provided"
   exit 1
 fi
 
@@ -20,11 +19,11 @@ fi
 if [[ $should_build == "true" ]]; then
   echo "Building Spec for $chain_name"
   $PWD/target/release/centrifuge-chain build-spec --chain $chain_name --disable-default-bootnode > node/res/$chain_name-spec.json
-  sed -i.bu "s/\"parachainId\": 10001/\"parachainId\": $parachain_id/g" node/res/$chain_name-spec.json
+  sed -i.bu "s/\"parachainId\": 2000/" node/res/$chain_name-spec.json
   $PWD/target/release/centrifuge-chain build-spec --chain node/res/$chain_name-spec.json --disable-default-bootnode --raw > node/res/$chain_name-spec-raw.json
   rm node/res/$chain_name-spec.json.bu
 fi
 
 echo "Exporting State & Wasm"
-$PWD/target/release/centrifuge-chain export-genesis-state --chain node/res/$chain_name-spec-raw.json --parachain-id $parachain_id > $chain_name-genesis-state
+$PWD/target/release/centrifuge-chain export-genesis-state --chain node/res/$chain_name-spec-raw.json > $chain_name-genesis-state
 $PWD/target/release/centrifuge-chain export-genesis-wasm --chain node/res/$chain_name-spec-raw.json > $chain_name-genesis-wasm

--- a/scripts/runtime_benchmarks.sh
+++ b/scripts/runtime_benchmarks.sh
@@ -45,11 +45,11 @@ then
 elif [[ $runtime == "centrifuge" ]];
 then
   runtime_path="runtime/centrifuge"
-  chain="centrifuge-dev"
+  chain="centrifuge-local"
 elif [[ $runtime == "altair" ]];
 then
   runtime_path="runtime/altair"
-  chain="altair-dev"
+  chain="altair-local"
 else
   echo "Unknown runtime. Aborting!"
   exit 1;


### PR DESCRIPTION
# Description

Context: https://github.com/centrifuge/centrifuge-chain/pull/1756/files#r1562566212

* Deprecates `parachain-id` CLI argument which was a custom addition for a few CLI arguments inherited from Substrate
  * Sets para id `2000` for ephemeral chain specs `development`, `centrifuge-local`, `altair-local`
  * Removes defaulting to `10001` para id if not set in CLI
* Removes deprecated chain specs `charcoal`, `algol`, `centrifuge-dev` (basically `centrifuge-local with 2 more funded accounts) and `altair-dev` (basically `altair-local` with 2 more funded accounts)

Fixes #(issue)

* Local parachain deploymentg

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
