### PR TITLE
Fix: mostly non failable runtime-api

### DIFF
--- a/pallets/pool-fees/src/lib.rs
+++ b/pallets/pool-fees/src/lib.rs
@@ -211,6 +211,7 @@ pub mod pallet {
 	///
 	/// Lifetime of a storage entry: Forever, inherited from pool lifetime.
 	#[pallet::storage]
+	#[pallet::getter(fn portfolio_valuation)]
 	pub(crate) type PortfolioValuation<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat,

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -139,12 +139,19 @@ where
 {
 	let mut pool = pallet_pool_system::Pool::<T>::get(pool_id)
 		.ok_or(pallet_pool_system::Error::<T>::NoSuchPool)?;
-	let (nav_loans, _) =
-		pallet_loans::Pallet::<T>::update_portfolio_valuation_for_pool(pool_id, price_input)?;
+
+	let nav_loans =
+		pallet_loans::Pallet::<T>::update_portfolio_valuation_for_pool(pool_id, price_input)
+			.map(|(nav_loans, _)| nav_loans)
+			.unwrap_or_else(|| pallet_loans::Pallet::<T>::portfolio_valuation(pool_id).value());
+
 	let (nav_fees, _) = pallet_pool_fees::Pallet::<T>::update_portfolio_valuation_for_pool(
 		pool_id,
 		&mut pool.reserve.total,
-	)?;
+	)
+	.map(|(nav_fees, _)| nav_fees)
+	.unwrap_or_else(|| pallet_pool_fees::Pallet::<T>::portfolio_valuation(pool_id).value());
+
 	let nav = Nav::new(nav_loans, nav_fees);
 	let total = nav
 		.total(pool.reserve.total)

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -143,14 +143,14 @@ where
 	let nav_loans =
 		pallet_loans::Pallet::<T>::update_portfolio_valuation_for_pool(pool_id, price_input)
 			.map(|(nav_loans, _)| nav_loans)
-			.unwrap_or_else(|| pallet_loans::Pallet::<T>::portfolio_valuation(pool_id).value());
+			.unwrap_or_else(|_| pallet_loans::Pallet::<T>::portfolio_valuation(pool_id).value());
 
 	let (nav_fees, _) = pallet_pool_fees::Pallet::<T>::update_portfolio_valuation_for_pool(
 		pool_id,
 		&mut pool.reserve.total,
 	)
 	.map(|(nav_fees, _)| nav_fees)
-	.unwrap_or_else(|| pallet_pool_fees::Pallet::<T>::portfolio_valuation(pool_id).value());
+	.unwrap_or_else(|_| pallet_pool_fees::Pallet::<T>::portfolio_valuation(pool_id).value());
 
 	let nav = Nav::new(nav_loans, nav_fees);
 	let total = nav

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -140,17 +140,19 @@ where
 	let mut pool = pallet_pool_system::Pool::<T>::get(pool_id)
 		.ok_or(pallet_pool_system::Error::<T>::NoSuchPool)?;
 
+	let prev_nav_loans = pallet_loans::Pallet::<T>::portfolio_valuation(pool_id).value();
 	let nav_loans =
 		pallet_loans::Pallet::<T>::update_portfolio_valuation_for_pool(pool_id, price_input)
 			.map(|(nav_loans, _)| nav_loans)
-			.unwrap_or_else(|_| pallet_loans::Pallet::<T>::portfolio_valuation(pool_id).value());
+			.unwrap_or(prev_nav_loans);
 
-	let (nav_fees, _) = pallet_pool_fees::Pallet::<T>::update_portfolio_valuation_for_pool(
+	let prev_fees_loans = pallet_pool_fees::Pallet::<T>::portfolio_valuation(pool_id).value();
+	let nav_fees = pallet_pool_fees::Pallet::<T>::update_portfolio_valuation_for_pool(
 		pool_id,
 		&mut pool.reserve.total,
 	)
 	.map(|(nav_fees, _)| nav_fees)
-	.unwrap_or_else(|_| pallet_pool_fees::Pallet::<T>::portfolio_valuation(pool_id).value());
+	.unwrap_or(prev_fees_loans);
 
 	let nav = Nav::new(nav_loans, nav_fees);
 	let total = nav


### PR DESCRIPTION
# Description
The NAV runtime-apis need to be super stable for the UI. This defaults them to use the latest computed price if the latest calculation fails. 

## Changes and Descriptions
* use previously computed valuation amount for `nav_loans`
* use previously computed valuation amount for `nav_fees`
 
# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
