### PR TITLE
fix: `MetadataSet` event dispatch in Pool Registry

### DIFF
--- a/pallets/pool-system/src/impls.rs
+++ b/pallets/pool-system/src/impls.rs
@@ -183,10 +183,6 @@ impl<T: Config> PoolMutate<T::AccountId, T::PoolId> for Pallet<T> {
 				.map_err(|_| Error::<T>::FailedToRegisterTrancheMetadata)?;
 		}
 
-		for (fee_bucket, pool_fee) in pool_fees.into_iter() {
-			T::PoolFees::add_fee(pool_id, fee_bucket, pool_fee)?;
-		}
-
 		let pool_details = PoolDetails {
 			currency,
 			tranches,
@@ -217,6 +213,10 @@ impl<T: Config> PoolMutate<T::AccountId, T::PoolId> for Pallet<T> {
 				.essence::<T::AssetRegistry, T::Balance, T::MaxTokenNameLength, T::MaxTokenSymbolLength>(
 				)?,
 		});
+
+		for (fee_bucket, pool_fee) in pool_fees.into_iter() {
+			T::PoolFees::add_fee(pool_id, fee_bucket, pool_fee)?;
+		}
 
 		T::Permission::add(
 			PermissionScope::Pool(pool_id),

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -2728,8 +2728,26 @@ mod pool_fees {
 			],
 			AUSD_CURRENCY_ID,
 			DEFAULT_POOL_MAX_RESERVE,
-			fees,
+			fees.clone(),
 		));
+
+		if !fees.is_empty() {
+			let pos_pool_creation = System::events()
+				.iter()
+				.position(|e| match e.event {
+					RuntimeEvent::PoolSystem(Event::Created { .. }) => true,
+					_ => false,
+				})
+				.expect("Pool created; qed");
+			let pos_pool_fee_added = System::events()
+				.iter()
+				.position(|e| match e.event {
+					RuntimeEvent::PoolFees(pallet_pool_fees::Event::Added { .. }) => true,
+					_ => false,
+				})
+				.expect("Pool fees added; qed");
+			assert!(pos_pool_creation < pos_pool_fee_added);
+		}
 		test_nav_up(DEFAULT_POOL_ID, NAV_AMOUNT);
 
 		// Force min_epoch_time to 0 without using update


### PR DESCRIPTION
# Description

* Related to #1809
* Context: https://github.com/centrifuge/centrifuge-chain/pull/1809#pullrequestreview-2000792395

## Changes and Descriptions

* Emits `MetadataSet` event for each metadata setting in pool registry, even if the metadata is empty
* Adds corresponding UTs

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
