### PR TITLE
Fix: transfer debt event with updated repaid amount

### DIFF
--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -838,7 +838,7 @@ pub mod pallet {
 				Err(Error::<T>::UnrelatedChangeId)?
 			};
 
-			let (_, _count) = Self::transfer_debt_action(
+			let (repaid_amount, _count) = Self::transfer_debt_action(
 				&who,
 				pool_id,
 				from_loan_id,
@@ -945,7 +945,7 @@ pub mod pallet {
 			repaid_amount: RepaidInput<T>,
 			borrow_amount: PrincipalInput<T>,
 			permissionless: bool,
-		) -> Result<(T::Balance, u32), DispatchError> {
+		) -> Result<(RepaidInput<T>, u32), DispatchError> {
 			ensure!(
 				from_loan_id != to_loan_id,
 				Error::<T>::TransferDebtToSameLoan
@@ -962,7 +962,7 @@ pub mod pallet {
 			let count =
 				Self::borrow_action(who, pool_id, to_loan_id, &borrow_amount, permissionless)?;
 
-			Ok((repaid_amount.repaid_amount()?.total()?, count))
+			Ok((repaid_amount, count))
 		}
 
 		/// Set the maturity date of the loan to this instant.

--- a/pallets/loans/src/tests/mod.rs
+++ b/pallets/loans/src/tests/mod.rs
@@ -18,7 +18,7 @@ use super::{
 			ActivePricing, Pricing,
 		},
 	},
-	pallet::{ActiveLoans, CreatedLoan, Error, LastLoanId, PortfolioValuation},
+	pallet::{ActiveLoans, CreatedLoan, Error, Event, LastLoanId, PortfolioValuation},
 	types::{
 		policy::{WriteOffRule, WriteOffStatus, WriteOffTrigger},
 		valuation::{DiscountedCashFlow, ValuationMethod},

--- a/pallets/loans/src/tests/repay_loan.rs
+++ b/pallets/loans/src/tests/repay_loan.rs
@@ -162,18 +162,29 @@ fn with_success_half_amount() {
 		let loan_id = util::create_loan(util::base_internal_loan());
 		util::borrow_loan(loan_id, PrincipalInput::Internal(COLLATERAL_VALUE / 2));
 
+		let amount = RepaidInput {
+			principal: PrincipalInput::Internal(COLLATERAL_VALUE / 2),
+			interest: 1234, /* Will not be used */
+			unscheduled: 0,
+		};
+
 		config_mocks(COLLATERAL_VALUE / 2);
 		assert_ok!(Loans::repay(
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,
-			RepaidInput {
-				principal: PrincipalInput::Internal(COLLATERAL_VALUE / 2),
-				interest: 0,
-				unscheduled: 0,
-			},
+			amount.clone()
 		));
 		assert_eq!(0, util::current_loan_debt(loan_id));
+
+		System::assert_last_event(RuntimeEvent::Loans(Event::Repaid {
+			pool_id: POOL_A,
+			loan_id: loan_id,
+			amount: RepaidInput {
+				interest: 0,
+				..amount
+			},
+		}));
 	});
 }
 

--- a/pallets/loans/src/tests/transfer_debt.rs
+++ b/pallets/loans/src/tests/transfer_debt.rs
@@ -361,7 +361,7 @@ fn with_success_internals() {
 
 		let repay_amount = RepaidInput {
 			principal: PrincipalInput::Internal(COLLATERAL_VALUE),
-			interest: 0,
+			interest: 1234, /* Will not be used */
 			unscheduled: 0,
 		};
 		let borrow_amount = PrincipalInput::Internal(COLLATERAL_VALUE);
@@ -372,8 +372,8 @@ fn with_success_internals() {
 			POOL_A,
 			loan_1,
 			loan_2,
-			repay_amount,
-			borrow_amount,
+			repay_amount.clone(),
+			borrow_amount.clone(),
 		));
 
 		assert_ok!(Loans::apply_transfer_debt(
@@ -384,6 +384,17 @@ fn with_success_internals() {
 
 		assert_eq!(0, util::current_loan_debt(loan_1));
 		assert_eq!(COLLATERAL_VALUE, util::current_loan_debt(loan_2));
+
+		System::assert_last_event(RuntimeEvent::Loans(Event::DebtTransferred {
+			pool_id: POOL_A,
+			from_loan_id: loan_1,
+			to_loan_id: loan_2,
+			repaid_amount: RepaidInput {
+				interest: 0,
+				..repay_amount
+			},
+			borrow_amount,
+		}));
 	});
 }
 


### PR DESCRIPTION
# Description

`TransferEvent` was set with the initial `repaid_amount`. That amount changes once it is processed and could not be the amount that it's really applied.

