### PR TITLE
Feat: Add new oracle key

### DIFF
--- a/libs/types/src/oracles.rs
+++ b/libs/types/src/oracles.rs
@@ -1,3 +1,4 @@
+use cfg_primitives::{LoanId, PoolId};
 use frame_support::pallet_prelude::RuntimeDebug;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
@@ -26,10 +27,18 @@ pub type Isin = [u8; 12];
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum OracleKey {
 	/// Identify a Isin price
+	#[codec(index = 0)]
 	Isin(Isin),
 
 	/// Identify a conversion from the first currency to the second one
+	#[codec(index = 1)]
 	ConversionRatio(CurrencyId, CurrencyId),
+
+	/// Identifies a single pool-loan-id combination.
+	/// This key is a fallback solution if no other keys are applicable for the
+	/// given oracle.
+	#[codec(index = 2)]
+	PoolLoanId(PoolId, LoanId),
 }
 
 impl From<(CurrencyId, CurrencyId)> for OracleKey {


### PR DESCRIPTION
# Description
The DYF will have shares of other funds as its assets. Those fund holdings are valued by an oracle, but have not a valid registered ISIN we could use. Hence, this fallback key will allow to specifically value a given object in the `pallet-loans`.

## Changes and Descriptions
* Adds a new variant in `enum OracleKey`
* Fixes all variants by using `#[codec(index = ...)`

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
