### PR TITLE
Fix: linear accrual not overpassing maturity

### DIFF
--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -14,7 +14,7 @@ use sp_runtime::{
 	},
 	DispatchError,
 };
-use sp_std::{cmp::min, collections::btree_map::BTreeMap};
+use sp_std::collections::btree_map::BTreeMap;
 
 use crate::{
 	entities::{
@@ -359,8 +359,7 @@ impl<T: Config> ActiveLoan<T> {
 				inner.adjust(Adjustment::Increase(amount.balance()?))?
 			}
 			ActivePricing::External(inner) => {
-				let when = T::Time::now();
-				inner.adjust(Adjustment::Increase(amount.external()?), Zero::zero(), when)?
+				inner.adjust(Adjustment::Increase(amount.external()?), Zero::zero())?
 			}
 		}
 
@@ -434,8 +433,7 @@ impl<T: Config> ActiveLoan<T> {
 			}
 			ActivePricing::External(inner) => {
 				let principal = amount.principal.external()?;
-				let when = min(T::Time::now(), self.schedule.maturity.date());
-				inner.adjust(Adjustment::Decrease(principal), amount.interest, when)?;
+				inner.adjust(Adjustment::Decrease(principal), amount.interest)?;
 			}
 		}
 

--- a/pallets/loans/src/entities/loans.rs
+++ b/pallets/loans/src/entities/loans.rs
@@ -14,7 +14,7 @@ use sp_runtime::{
 	},
 	DispatchError,
 };
-use sp_std::collections::btree_map::BTreeMap;
+use sp_std::{cmp::min, collections::btree_map::BTreeMap};
 
 use crate::{
 	entities::{
@@ -359,7 +359,8 @@ impl<T: Config> ActiveLoan<T> {
 				inner.adjust(Adjustment::Increase(amount.balance()?))?
 			}
 			ActivePricing::External(inner) => {
-				inner.adjust(Adjustment::Increase(amount.external()?), Zero::zero())?
+				let when = T::Time::now();
+				inner.adjust(Adjustment::Increase(amount.external()?), Zero::zero(), when)?
 			}
 		}
 
@@ -433,7 +434,8 @@ impl<T: Config> ActiveLoan<T> {
 			}
 			ActivePricing::External(inner) => {
 				let principal = amount.principal.external()?;
-				inner.adjust(Adjustment::Decrease(principal), amount.interest)?;
+				let when = min(T::Time::now(), self.schedule.maturity.date());
+				inner.adjust(Adjustment::Decrease(principal), amount.interest, when)?;
 			}
 		}
 

--- a/pallets/loans/src/entities/pricing/external.rs
+++ b/pallets/loans/src/entities/pricing/external.rs
@@ -143,6 +143,10 @@ impl<T: Config> ExternalActivePricing<T> {
 		self.info.price_id
 	}
 
+	pub fn settlement_price_updated(&self) -> Seconds {
+		self.settlement_price_updated
+	}
+
 	pub fn has_registered_price(&self, pool_id: T::PoolId) -> bool {
 		T::PriceRegistry::get(&self.info.price_id, &pool_id).is_ok()
 	}
@@ -298,6 +302,7 @@ impl<T: Config> ExternalActivePricing<T> {
 		&mut self,
 		amount_adj: Adjustment<ExternalAmount<T>>,
 		interest: T::Balance,
+		when: Seconds,
 	) -> DispatchResult {
 		self.outstanding_quantity = amount_adj
 			.clone()
@@ -313,7 +318,7 @@ impl<T: Config> ExternalActivePricing<T> {
 
 		self.interest.adjust_debt(interest_adj)?;
 		self.latest_settlement_price = amount_adj.abs().settlement_price;
-		self.settlement_price_updated = T::Time::now();
+		self.settlement_price_updated = when;
 
 		Ok(())
 	}

--- a/pallets/loans/src/tests/mod.rs
+++ b/pallets/loans/src/tests/mod.rs
@@ -11,7 +11,7 @@ use super::{
 	entities::{
 		changes::{Change, InternalMutation, LoanMutation},
 		input::{PrincipalInput, RepaidInput},
-		loans::{ActiveLoan, LoanInfo},
+		loans::{ActiveLoan, ActiveLoanInfo, LoanInfo},
 		pricing::{
 			external::{ExternalAmount, ExternalPricing, MaxBorrowAmount as ExtMaxBorrowAmount},
 			internal::{InternalPricing, MaxBorrowAmount as IntMaxBorrowAmount},

--- a/pallets/loans/src/tests/repay_loan.rs
+++ b/pallets/loans/src/tests/repay_loan.rs
@@ -824,7 +824,7 @@ fn with_external_pricing_and_overdue() {
 		util::borrow_loan(loan_id, PrincipalInput::External(amount));
 
 		// The loan is overdue
-		advance_time(YEAR * DAY);
+		advance_time(YEAR + DAY);
 
 		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
 		config_mocks(amount.balance().unwrap());

--- a/pallets/loans/src/tests/repay_loan.rs
+++ b/pallets/loans/src/tests/repay_loan.rs
@@ -824,7 +824,7 @@ fn with_external_pricing_and_overdue() {
 		util::borrow_loan(loan_id, PrincipalInput::External(amount));
 
 		// The loan is overdue
-		advance_time(YEAR * 2);
+		advance_time(YEAR * DAY);
 
 		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
 		config_mocks(amount.balance().unwrap());
@@ -839,14 +839,12 @@ fn with_external_pricing_and_overdue() {
 			},
 		));
 
-		let active_loan = util::get_loan(loan_id);
-
-		let settlement_price_updated = match active_loan.pricing() {
-			ActivePricing::External(inner) => inner.settlement_price_updated(),
-			_ => unreachable!(),
-		};
-
-		// We must never overpass madurity date
-		assert_eq!(active_loan.maturity_date(), settlement_price_updated);
+		assert_eq!(
+			ActiveLoanInfo::try_from((POOL_A, util::get_loan(loan_id)))
+				.unwrap()
+				.current_price
+				.unwrap(),
+			NOTIONAL
+		);
 	});
 }


### PR DESCRIPTION
# Description

[slack thread](https://kflabs.slack.com/archives/C04GJQAM9P0/p1715955299145219?thread_ts=1715935675.464829&cid=C04GJQAM9P0)

We need to avoid computing points in the line of linear accrual if the time overpass the maturity time, instead, we want to clamp the value to `notional` (which is the same when the time is just maturity)