### PR TITLE
Loans: use mocked timer

### DIFF
--- a/pallets/loans/src/benchmarking.rs
+++ b/pallets/loans/src/benchmarking.rs
@@ -61,7 +61,7 @@ type MaxRateCountOf<T> = <<T as Config>::InterestAccrual as InterestAccrual<
 fn config_mocks() {
 	use cfg_mocks::pallet_mock_data::util::MockDataCollection;
 
-	use crate::tests::mock::{MockChangeGuard, MockPermissions, MockPools, MockPrices};
+	use crate::tests::mock::{MockChangeGuard, MockPermissions, MockPools, MockPrices, MockTimer};
 
 	MockPermissions::mock_add(|_, _, _| Ok(()));
 	MockPermissions::mock_has(|_, _, _| true);
@@ -75,6 +75,7 @@ fn config_mocks() {
 		MockChangeGuard::mock_released(move |_, _| Ok(change.clone()));
 		Ok(sp_core::H256::default())
 	});
+	MockTimer::mock_now(|| 0);
 }
 
 struct Helper<T>(sp_std::marker::PhantomData<T>);

--- a/pallets/loans/src/tests/mock.rs
+++ b/pallets/loans/src/tests/mock.rs
@@ -22,7 +22,7 @@ use frame_support::{
 	derive_impl,
 	traits::{
 		tokens::nonfungibles::{Create, Mutate},
-		AsEnsureOriginWithArg, ConstU64, Hooks, UnixTime,
+		AsEnsureOriginWithArg, Hooks, UnixTime,
 	},
 };
 use frame_system::{EnsureRoot, EnsureSigned};
@@ -96,7 +96,7 @@ pub type ChangeId = H256;
 frame_support::construct_runtime!(
 	pub enum Runtime {
 		System: frame_system,
-		Timer: pallet_timestamp,
+		MockTimer: cfg_mocks::time::pallet,
 		Balances: pallet_balances,
 		Uniques: pallet_uniques,
 		InterestAccrual: pallet_interest_accrual,
@@ -120,11 +120,8 @@ impl frame_system::Config for Runtime {
 	type Block = frame_system::mocking::MockBlock<Runtime>;
 }
 
-impl pallet_timestamp::Config for Runtime {
-	type MinimumPeriod = ConstU64<BLOCK_TIME_MS>;
+impl cfg_mocks::time::pallet::Config for Runtime {
 	type Moment = Millis;
-	type OnTimestampSet = ();
-	type WeightInfo = ();
 }
 
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
@@ -162,7 +159,7 @@ impl pallet_interest_accrual::Config for Runtime {
 	type MaxRateCount = MaxActiveLoansPerPool;
 	type Rate = Rate;
 	type RuntimeEvent = RuntimeEvent;
-	type Time = Timer;
+	type Time = MockTimer;
 	type Weights = ();
 }
 
@@ -215,14 +212,14 @@ impl pallet_loans::Config for Runtime {
 	type Rate = Rate;
 	type RuntimeChange = Change<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
-	type Time = Timer;
+	type Time = MockTimer;
 	type WeightInfo = ();
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut ext = System::externalities();
 	ext.execute_with(|| {
-		advance_time(BLOCK_TIME);
+		MockTimer::mock_now(|| BLOCK_TIME.as_millis() as u64);
 
 		Uniques::create_collection(&COLLECTION_A, &BORROWER, &ASSET_COLLECTION_OWNER).unwrap();
 		Uniques::mint_into(&COLLECTION_A, &ASSET_AA.1, &BORROWER).unwrap();
@@ -237,10 +234,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 pub fn now() -> Duration {
-	<Timer as UnixTime>::now()
+	<MockTimer as UnixTime>::now()
 }
 
 pub fn advance_time(elapsed: Duration) {
-	Timer::set_timestamp(Timer::get() + elapsed.as_millis() as u64);
+	let before = now();
+	MockTimer::mock_now(move || (before + elapsed).as_millis() as u64);
 	InterestAccrual::on_initialize(0);
 }


### PR DESCRIPTION
# Description

Some benchmark testing with loans is a bit annoying because the log is filled with a lot of `pallet_timestamps` errors, adding noise to the debugging process. This PR removes that pallet and use the `MockTimer` instead