### PR TITLE
feat: Polkadot v1.7.2 migrations

### DIFF
--- a/runtime/altair/src/migrations.rs
+++ b/runtime/altair/src/migrations.rs
@@ -12,6 +12,9 @@
 
 use crate::{ForeignInvestments, OraclePriceCollection, OraclePriceFeed, OrderBook};
 
+// Number of identities on Altair Chain on 30.05.2024 was 34
+const IDENTITY_MIGRATION_KEY_LIMIT: u64 = 1000;
+
 /// The migration set for Altair @ Kusama.
 /// It includes all the migrations that have to be applied on that chain.
 pub type UpgradeAltair1035 = (
@@ -20,4 +23,15 @@ pub type UpgradeAltair1035 = (
 	runtime_common::migrations::increase_storage_version::Migration<OrderBook, 0, 1>,
 	runtime_common::migrations::increase_storage_version::Migration<ForeignInvestments, 0, 1>,
 	pallet_collator_selection::migration::v1::MigrateToV1<crate::Runtime>,
+	runtime_common::migrations::loans::AddWithLinearPricing<crate::Runtime>,
+	// As of May 2024, the `pallet_balances::Hold` storage was empty. But better be safe.
+	runtime_common::migrations::hold_reason::MigrateTransferAllowListHolds<
+		crate::Runtime,
+		crate::RuntimeHoldReason,
+	>,
+	// Migrations below this comment originate from Polkadot SDK
+	pallet_xcm::migration::MigrateToLatestXcmVersion<crate::Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<crate::Runtime>,
+	pallet_identity::migration::versioned::V0ToV1<crate::Runtime, IDENTITY_MIGRATION_KEY_LIMIT>,
+	pallet_uniques::migration::MigrateV0ToV1<crate::Runtime, ()>,
 );

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -12,6 +12,9 @@
 
 use crate::{OraclePriceCollection, OraclePriceFeed};
 
+// Number of identities on Centrifuge Chain on 29.05.2024 was 34
+const IDENTITY_MIGRATION_KEY_LIMIT: u64 = 1000;
+
 /// The migration set for Centrifuge @ Polkadot.
 /// It includes all the migrations that have to be applied on that chain.
 pub type UpgradeCentrifuge1029 = (
@@ -19,4 +22,13 @@ pub type UpgradeCentrifuge1029 = (
 	runtime_common::migrations::increase_storage_version::Migration<OraclePriceCollection, 0, 1>,
 	pallet_collator_selection::migration::v1::MigrateToV1<crate::Runtime>,
 	runtime_common::migrations::loans::AddWithLinearPricing<crate::Runtime>,
+	runtime_common::migrations::hold_reason::MigrateTransferAllowListHolds<
+		crate::Runtime,
+		crate::RuntimeHoldReason,
+	>,
+	// Migrations below this comment originate from Polkadot SDK
+	pallet_xcm::migration::MigrateToLatestXcmVersion<crate::Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<crate::Runtime>,
+	pallet_identity::migration::versioned::V0ToV1<crate::Runtime, IDENTITY_MIGRATION_KEY_LIMIT>,
+	pallet_uniques::migration::MigrateV0ToV1<crate::Runtime, ()>,
 );

--- a/runtime/common/src/migrations/hold_reason.rs
+++ b/runtime/common/src/migrations/hold_reason.rs
@@ -1,0 +1,151 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+use frame_support::pallet_prelude::ValueQuery;
+use frame_support::{storage_alias, Blake2_128Concat, BoundedVec, Parameter};
+
+use cfg_primitives::{AccountId, Balance};
+use frame_support::traits::{ConstU32, Get, Len, OnRuntimeUpgrade, VariantCountOf};
+use pallet_balances::IdAmount;
+use pallet_order_book::weights::Weight;
+use pallet_transfer_allowlist::HoldReason;
+#[cfg(feature = "try-runtime")]
+use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{FullCodec, FullEncode};
+use sp_runtime::traits::Member;
+use sp_runtime::SaturatedConversion;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::Saturating;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+use sp_std::vec;
+use sp_std::vec::Vec;
+
+const LOG_PREFIX: &str = "MigrateTransferAllowList HoldReason:";
+
+pub struct MigrateTransferAllowListHolds<T, RuntimeHoldReason>(
+	sp_std::marker::PhantomData<(T, RuntimeHoldReason)>,
+);
+
+type OldHolds = BoundedVec<IdAmount<(), Balance>, ConstU32<10>>;
+type NewHolds<RuntimeHoldReason> =
+	BoundedVec<IdAmount<RuntimeHoldReason, Balance>, VariantCountOf<RuntimeHoldReason>>;
+
+#[storage_alias]
+pub type Holds<T: pallet_balances::Config> =
+	StorageMap<pallet_balances::Pallet<T>, Blake2_128Concat, AccountId, OldHolds, ValueQuery>;
+
+impl<T, RuntimeHoldReason> OnRuntimeUpgrade for MigrateTransferAllowListHolds<T, RuntimeHoldReason>
+where
+	T: pallet_balances::Config<Balance = Balance, RuntimeHoldReason = RuntimeHoldReason>
+		+ pallet_transfer_allowlist::Config
+		+ frame_system::Config<AccountId = AccountId>,
+	<T as pallet_balances::Config>::RuntimeHoldReason: From<pallet_transfer_allowlist::HoldReason>,
+	RuntimeHoldReason: frame_support::traits::VariantCount
+		+ FullCodec
+		+ FullEncode
+		+ Parameter
+		+ Member
+		+ sp_std::fmt::Debug,
+{
+	fn on_runtime_upgrade() -> Weight {
+		let transfer_allowlist_accounts: Vec<AccountId> =
+			pallet_transfer_allowlist::AccountCurrencyTransferAllowance::<T>::iter_keys()
+				.map(|(a, _, _)| a)
+				.collect();
+		let mut weight =
+			T::DbWeight::get().reads(transfer_allowlist_accounts.len().saturated_into());
+
+		pallet_balances::Holds::<T>::translate::<OldHolds, _>(|who, holds| {
+			if Self::account_can_be_migrated(&who, &transfer_allowlist_accounts) {
+				log::info!("{LOG_PREFIX} Migrating hold for account {who:?}");
+				let id_amount = IdAmount::<RuntimeHoldReason, Balance> {
+					id: HoldReason::TransferAllowance.into(),
+					// Non-emptiness ensured above
+					amount: holds[0].amount,
+				};
+				weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+
+				Some(NewHolds::truncate_from(vec![id_amount]))
+			} else {
+				None
+			}
+		});
+
+		log::info!(
+			"{LOG_PREFIX} migrated {:?} accounts",
+			transfer_allowlist_accounts.len()
+		);
+
+		weight
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		let transfer_allowlist_accounts =
+			pallet_transfer_allowlist::AccountCurrencyTransferAllowance::<T>::iter_keys()
+				.map(|(a, _, _)| a)
+				.collect();
+
+		let mut n = 0u64;
+		for (acc, _) in Holds::<T>::iter() {
+			assert!(Self::account_can_be_migrated(
+				&acc,
+				&transfer_allowlist_accounts
+			));
+			n.saturating_accrue(1);
+		}
+
+		log::info!("{LOG_PREFIX} pre checks done");
+		Ok(n.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(pre_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+		let count_pre: u64 = Decode::decode(&mut pre_state.as_slice())
+			.expect("pre_upgrade provides a valid state; qed");
+
+		let holds_post = pallet_balances::Holds::<T>::iter();
+		let count_post: u64 = holds_post.count().saturated_into();
+		assert_eq!(count_pre, count_post);
+
+		for (_, hold) in pallet_balances::Holds::<T>::iter() {
+			assert_eq!(hold.len(), 1);
+			assert_eq!(hold[0].id, HoldReason::TransferAllowance.into());
+		}
+
+		log::info!("{LOG_PREFIX} post checks done");
+		Ok(())
+	}
+}
+
+impl<T, RuntimeHoldReason> MigrateTransferAllowListHolds<T, RuntimeHoldReason>
+where
+	T: pallet_balances::Config
+		+ pallet_transfer_allowlist::Config
+		+ frame_system::Config<AccountId = AccountId>,
+{
+	fn account_can_be_migrated(who: &AccountId, whitelist: &Vec<AccountId>) -> bool {
+		if !whitelist.iter().any(|a| a == who) {
+			log::warn!("{LOG_PREFIX} Account {who:?} is skipped due to missing AccountCurrencyTransferAllowance storage entry");
+			return false;
+		}
+
+		match Holds::<T>::get(who) {
+			holds if holds.len() == 1 => holds.into_inner()[0].id == (),
+			_ => {
+				log::warn!("{LOG_PREFIX} Account {who:?} does not meet Hold storage assumptions");
+				false
+			}
+		}
+	}
+}

--- a/runtime/common/src/migrations/hold_reason.rs
+++ b/runtime/common/src/migrations/hold_reason.rs
@@ -91,7 +91,7 @@ where
 
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
-		let transfer_allowlist_accounts =
+		let transfer_allowlist_accounts: Vec<AccountId> =
 			pallet_transfer_allowlist::AccountCurrencyTransferAllowance::<T>::iter_keys()
 				.map(|(a, _, _)| a)
 				.collect();

--- a/runtime/common/src/migrations/hold_reason.rs
+++ b/runtime/common/src/migrations/hold_reason.rs
@@ -10,25 +10,25 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use frame_support::pallet_prelude::ValueQuery;
-use frame_support::{storage_alias, Blake2_128Concat, BoundedVec, Parameter};
-
 use cfg_primitives::{AccountId, Balance};
-use frame_support::traits::{ConstU32, Get, Len, OnRuntimeUpgrade, VariantCountOf};
+use frame_support::{
+	pallet_prelude::ValueQuery,
+	storage_alias,
+	traits::{ConstU32, Get, Len, OnRuntimeUpgrade, VariantCountOf},
+	Blake2_128Concat, BoundedVec, Parameter,
+};
 use pallet_balances::IdAmount;
 use pallet_order_book::weights::Weight;
 use pallet_transfer_allowlist::HoldReason;
 #[cfg(feature = "try-runtime")]
 use parity_scale_codec::{Decode, Encode};
 use parity_scale_codec::{FullCodec, FullEncode};
-use sp_runtime::traits::Member;
-use sp_runtime::SaturatedConversion;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::Saturating;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::TryRuntimeError;
-use sp_std::vec;
-use sp_std::vec::Vec;
+use sp_runtime::{traits::Member, SaturatedConversion};
+use sp_std::{vec, vec::Vec};
 
 const LOG_PREFIX: &str = "MigrateTransferAllowList HoldReason:";
 

--- a/runtime/common/src/migrations/hold_reason.rs
+++ b/runtime/common/src/migrations/hold_reason.rs
@@ -134,14 +134,14 @@ where
 		+ pallet_transfer_allowlist::Config
 		+ frame_system::Config<AccountId = AccountId>,
 {
-	fn account_can_be_migrated(who: &AccountId, whitelist: &Vec<AccountId>) -> bool {
+	fn account_can_be_migrated(who: &AccountId, whitelist: &[AccountId]) -> bool {
 		if !whitelist.iter().any(|a| a == who) {
 			log::warn!("{LOG_PREFIX} Account {who:?} is skipped due to missing AccountCurrencyTransferAllowance storage entry");
 			return false;
 		}
 
 		match Holds::<T>::get(who) {
-			holds if holds.len() == 1 => holds.into_inner()[0].id == (),
+			holds if holds.len() == 1 => true,
 			_ => {
 				log::warn!("{LOG_PREFIX} Account {who:?} does not meet Hold storage assumptions");
 				false

--- a/runtime/common/src/migrations/mod.rs
+++ b/runtime/common/src/migrations/mod.rs
@@ -12,6 +12,7 @@
 
 //! Centrifuge Runtime-Common Migrations
 
+pub mod hold_reason;
 pub mod increase_storage_version;
 pub mod loans;
 pub mod nuke;

--- a/runtime/development/src/migrations.rs
+++ b/runtime/development/src/migrations.rs
@@ -16,6 +16,9 @@ parameter_types! {
 	pub const AnnualTreasuryInflationPercent: u32 = 3;
 }
 
+// Number of identities on Dev and Demo Chain on 30.05.2024 was both 0
+const IDENTITY_MIGRATION_KEY_LIMIT: u64 = 1000;
+
 /// The migration set for Development & Demo.
 /// It includes all the migrations that have to be applied on that chain.
 pub type UpgradeDevelopment1047 = (
@@ -30,11 +33,10 @@ pub type UpgradeDevelopment1047 = (
 	// v0 -> v1
 	runtime_common::migrations::nuke::ResetPallet<crate::Democracy, crate::RocksDbWeight, 0>,
 	// v0 -> v1
-	pallet_xcm::migration::v1::VersionUncheckedMigrateToV1<crate::Runtime>,
+	runtime_common::migrations::nuke::ResetPallet<crate::PolkadotXcm, crate::RocksDbWeight, 0>,
 	runtime_common::migrations::increase_storage_version::Migration<crate::PoolSystem, 0, 2>,
 	runtime_common::migrations::increase_storage_version::Migration<crate::InterestAccrual, 0, 3>,
 	runtime_common::migrations::increase_storage_version::Migration<crate::Investments, 0, 1>,
-	runtime_common::migrations::increase_storage_version::Migration<crate::BlockRewards, 0, 2>,
 	runtime_common::migrations::increase_storage_version::Migration<crate::OraclePriceFeed, 0, 1>,
 	runtime_common::migrations::increase_storage_version::Migration<
 		crate::OraclePriceCollection,
@@ -42,14 +44,25 @@ pub type UpgradeDevelopment1047 = (
 		1,
 	>,
 	runtime_common::migrations::increase_storage_version::Migration<crate::OrmlAssetRegistry, 0, 2>,
-	// Reset Block rewards
+	// Reset Block rewards on Demo which is at v0
 	runtime_common::migrations::nuke::ResetPallet<crate::BlockRewards, crate::RocksDbWeight, 0>,
+	// Reset Block rewards on Dev which is at v2
+	runtime_common::migrations::nuke::ResetPallet<crate::BlockRewards, crate::RocksDbWeight, 2>,
 	pallet_block_rewards::migrations::init::InitBlockRewards<
 		crate::Runtime,
 		CollatorReward,
 		AnnualTreasuryInflationPercent,
 	>,
 	runtime_common::migrations::loans::AddWithLinearPricing<crate::Runtime>,
+	runtime_common::migrations::hold_reason::MigrateTransferAllowListHolds<
+		crate::Runtime,
+		crate::RuntimeHoldReason,
+	>,
+	// Migrations below this comment originate from Polkadot SDK
+	pallet_xcm::migration::MigrateToLatestXcmVersion<crate::Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<crate::Runtime>,
+	pallet_identity::migration::versioned::V0ToV1<crate::Runtime, IDENTITY_MIGRATION_KEY_LIMIT>,
+	pallet_uniques::migration::MigrateV0ToV1<crate::Runtime, ()>,
 );
 
 mod cleanup_foreign_investments {


### PR DESCRIPTION
# Description

* Provides necessary migrations for Polkadot v1.7.2 including migration of 
``` diff
- type RuntimeHoldReason = ()
+ type RuntimeHoldReason = RuntimeHoldReason
```
* Fixes existing migrations for Dev and Demo
* Tested against all runtimes Dev, Demo, Altair and Centrifuge

## Note

One decoding error is left in the logs but this does not require a migration and will be fixed just by upgrading to the newer Polkadot SDK version. It was an oversight from the frame team and should have bumped the `ParachainSystem` storage version as well as required a migration. Check [this conversation](https://github.com/paritytech/polkadot-sdk/issues/4603) for more info.

```
[2024-05-31T08:00:55Z ERROR runtime::executive] `try_decode_entire_state` failed with 1 errors
[2024-05-31T08:00:55Z ERROR runtime::executive] - 0. error: `ParachainSystem::HostConfiguration` key `0x45323df7cc47150b3930e2666b0aa313c522231880238a0c56021b8744a00743` is undecodable
```

## Try runtime logs

### Centrifuge Chain

```
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "OraclePriceFeed" from StorageVersion(0) to StorageVersion(1)
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "OraclePriceCollection" from StorageVersion(0) to StorageVersion(1)
[2024-05-31T08:00:54Z INFO  runtime::collator-selection] Sorted 3 Invulnerables, upgraded storage to version 1
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Pre checks done!
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Starting migration v3 -> v4
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 4139607887
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Migrated 1 pools
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Post checks done!
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: pre checks done
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: Migrating hold for account 5dbb2cec05b6bda775f7945827b887b0e7b5245eae8b4ef266c60820c9377185 (5EBbuv9o...)
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: Migrating hold for account 1817f8ef1bd20183ac50551a983c3ccac5d8ef4dc01b668e557c48c7296fb336 (5CcJ8MnA...)
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: migrated 3 accounts
[2024-05-31T08:00:54Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: post checks done
[2024-05-31T08:00:54Z INFO  frame_support::migrations] 🚚 Pallet "XcmpQueue" VersionedMigration migrating storage version from 3 to 4.
[2024-05-31T08:00:54Z INFO  runtime::identity::migration::v1] pre-upgrade state contains '35' identities.
[2024-05-31T08:00:54Z INFO  frame_support::migrations] 🚚 Pallet "Identity" VersionedMigration migrating storage version from 0 to 1.
[2024-05-31T08:00:54Z INFO  runtime::identity::migration::v1] running storage migration from version 0 to version 1.
[2024-05-31T08:00:54Z INFO  pallet_identity::migration::v1] all 35 identities migrated
[2024-05-31T08:00:54Z INFO  pallet_identity::migration::v1] post-upgrade expects '35' identities to have been migrated.
[2024-05-31T08:00:54Z INFO  runtime::identity::migration::v1] migrated all identities.
[2024-05-31T08:00:54Z INFO  frame_support::migrations] 🚚 Pallet "Uniques" VersionedMigration migrating storage version from 0 to 1.
[2024-05-31T08:00:54Z INFO  runtime::uniques] Storage migration v1 for uniques finished.
[2024-05-31T08:00:54Z INFO  runtime::frame-support] ⚠️ Ethereum declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `NoStorageVersionSet`
[2024-05-31T08:00:55Z ERROR runtime::executive] `try_decode_entire_state` failed with 1 errors
[2024-05-31T08:00:55Z ERROR runtime::executive] - 0. error: `ParachainSystem::HostConfiguration` key `0x45323df7cc47150b3930e2666b0aa313c522231880238a0c56021b8744a00743` is undecodable
```

### Dev

```
2024-05-31T08:02:48Z INFO  runtime::collator-selection] Sorted 1 Invulnerables, upgraded storage to version 1
[2024-05-31T08:02:48Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments Storage cleanup can be skipped because all keys can be decoded
[2024-05-31T08:02:48Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments pre_upgrade done!
[2024-05-31T08:02:48Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments Initiating removal of undecodable keys
[2024-05-31T08:02:48Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments Removed 0 undecodable keys
[2024-05-31T08:02:48Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments post_upgrade done with 0 remaining storage keys!
[2024-05-31T08:02:48Z INFO  runtime::multisig] [1019210] ✍️ Number of calls to refund and delete: 0
[2024-05-31T08:02:48Z INFO  runtime::multisig] [1019210] ✍️ MigrateToV1 should be removed
[2024-05-31T08:02:48Z INFO  runtime::balances] Migration did not execute. This probably should be removed
[2024-05-31T08:02:48Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 2 but would instead upgrade from StorageVersion(2) to StorageVersion(2)
[2024-05-31T08:02:48Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 3 but would instead upgrade from StorageVersion(3) to StorageVersion(3)
[2024-05-31T08:02:48Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 1 but would instead upgrade from StorageVersion(1) to StorageVersion(1)
[2024-05-31T08:02:48Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 1 but would instead upgrade from StorageVersion(1) to StorageVersion(1)
[2024-05-31T08:02:48Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 1 but would instead upgrade from StorageVersion(1) to StorageVersion(1)
[2024-05-31T08:02:48Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 2 but would instead upgrade from StorageVersion(2) to StorageVersion(2)
[2024-05-31T08:02:48Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Pre migration checks successful
[2024-05-31T08:02:48Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Initiating migration
[2024-05-31T08:02:48Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Checking whether group is ready
[2024-05-31T08:02:48Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Checking whether session data is set
[2024-05-31T08:02:48Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Getting list of collators
[2024-05-31T08:02:48Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Checking stake of collator d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d (5GrwvaEF...)
[2024-05-31T08:02:48Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Migration not necessary because all data is already initialized
[2024-05-31T08:02:48Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Post migration checks successful
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Pre checks done!
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Starting migration v3 -> v4
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 1809273630
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 956565333
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 402696383
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 2110880079
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 1422410123
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 824886453
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 3579462907
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 2339351143
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Migrated 8 pools
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Post checks done!
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: pre checks done
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: migrated 0 accounts
[2024-05-31T08:02:48Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: post checks done
[2024-05-31T08:02:48Z INFO  frame_support::migrations] 🚚 Pallet "XcmpQueue" VersionedMigration migrating storage version from 3 to 4.
[2024-05-31T08:02:48Z INFO  runtime::identity::migration::v1] pre-upgrade state contains '0' identities.
[2024-05-31T08:02:48Z INFO  frame_support::migrations] 🚚 Pallet "Identity" VersionedMigration migrating storage version from 0 to 1.
[2024-05-31T08:02:48Z INFO  runtime::identity::migration::v1] running storage migration from version 0 to version 1.
[2024-05-31T08:02:48Z INFO  pallet_identity::migration::v1] all 0 identities migrated
[2024-05-31T08:02:48Z INFO  pallet_identity::migration::v1] post-upgrade expects '0' identities to have been migrated.
[2024-05-31T08:02:48Z INFO  runtime::identity::migration::v1] migrated all identities.
[2024-05-31T08:02:48Z INFO  frame_support::migrations] 🚚 Pallet "Uniques" VersionedMigration migrating storage version from 0 to 1.
[2024-05-31T08:02:48Z INFO  runtime::uniques] Storage migration v1 for uniques finished.
[2024-05-31T08:02:48Z ERROR try-runtime] Detected multiple errors while executing `try_on_runtime_upgrade`:
[2024-05-31T08:02:48Z ERROR try-runtime] Other("Pallet on-chain version must match with ON_CHAIN_VERSION")
[2024-05-31T08:02:48Z ERROR try-runtime] Other("Pallet on-chain version must match with ON_CHAIN_VERSION")
[2024-05-31T08:02:48Z ERROR try-runtime] Other("Pallet on-chain version must match with ON_CHAIN_VERSION")
[2024-05-31T08:02:48Z ERROR try-runtime] Other("Pallet on-chain version must match with ON_CHAIN_VERSION")
[2024-05-31T08:02:48Z ERROR try-runtime] Other("Pallet is already updated")
[2024-05-31T08:02:48Z INFO  runtime::frame-support] ⚠️ Ethereum declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `NoStorageVersionSet`
```

### Demo

```
[2024-05-31T08:03:37Z INFO  runtime::collator-selection] Sorted 3 Invulnerables, upgraded storage to version 1
[2024-05-31T08:03:37Z ERROR frame_support::storage] key failed to decode at [70, 74, 237, 145, 57, 25, 186, 185, 47, 121, 243, 199, 183, 157, 40, 247, 239, 186, 193, 94, 147, 243, 120, 17, 137, 94, 38, 6, 5, 205, 196, 135, 164, 245, 206, 214, 102, 137, 87, 187, 42, 154, 149, 78, 126, 80, 245, 181, 4, 0, 0, 0, 0, 0, 0, 0]: Error
[2024-05-31T08:03:37Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments Failed to decode 1 keys, cleanup necessary
[2024-05-31T08:03:37Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments pre_upgrade done!
[2024-05-31T08:03:37Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments Initiating removal of undecodable keys
[2024-05-31T08:03:37Z ERROR runtime::storage] Corrupted state at `0x464aed913919bab92f79f3c7b79d28f7efbac15e93f37811895e260605cdc487a4f5ced6668957bb2a9a954e7e50f5b50400000000000000`: Error
[2024-05-31T08:03:37Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments Removed 1 undecodable keys
[2024-05-31T08:03:37Z INFO  development_runtime::migrations::cleanup_foreign_investments] CleanupForeignInvestments post_upgrade done with 4 remaining storage keys!
[2024-05-31T08:03:37Z INFO  runtime::multisig] [2686646] ✍️ Number of calls to refund and delete: 0
[2024-05-31T08:03:37Z INFO  runtime::balances] Storage to version 1
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-Preimage: nuking pallet...
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-Preimage: storage cleared successful
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-Preimage: iteration result. backend: 3 unique: 3 loops: 3
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-Democracy: nuking pallet...
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-Democracy: storage cleared successful
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-Democracy: iteration result. backend: 5 unique: 5 loops: 5
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-PolkadotXcm: nuking pallet...
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-PolkadotXcm: storage cleared successful
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-PolkadotXcm: iteration result. backend: 20 unique: 20 loops: 20
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "PoolSystem" from StorageVersion(0) to StorageVersion(2)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "InterestAccrual" from StorageVersion(0) to StorageVersion(3)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "Investments" from StorageVersion(0) to StorageVersion(1)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "OraclePriceFeed" from StorageVersion(0) to StorageVersion(1)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "OraclePriceCollection" from StorageVersion(0) to StorageVersion(1)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Increasing storage version of "OrmlAssetRegistry" from StorageVersion(0) to StorageVersion(2)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-BlockRewards: nuking pallet...
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-BlockRewards: storage cleared successful
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::nuke] Nuke-BlockRewards: iteration result. backend: 2 unique: 2 loops: 2
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Pre migration checks successful
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Initiating migration
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Checking whether group is ready
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Checking whether session data is set
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Getting list of collators
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Checking stake of collator 3027018a7cea497a2b6f09b331d0c9859ab23c6cf45d4aba272d2cf0334d972c (5D9qk39Y...)
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Attaching currency to collator group
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Setting session data
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Adding stake for collator 3027018a7cea497a2b6f09b331d0c9859ab23c6cf45d4aba272d2cf0334d972c (5D9qk39Y...)
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Adding stake for collator 62538b6a495208d1d9ec7aae58269946e613af51b9f6691052c455d0e039fe7b (5EHdNHVe...)
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Adding stake for collator 8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48 (5FHneW46...)
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Migration complete
[2024-05-31T08:03:37Z INFO  pallet_block_rewards::migrations::init] InitBlockRewards Post migration checks successful
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Pre checks done!
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Starting migration v3 -> v4
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 2706400740
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 503513827
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 99
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 2666134719
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 2057175059
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 2869156029
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 2659193339
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 1
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 75741337
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: updated portfolio for pool_id: 2
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Migrated 10 pools
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Post checks done!
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: pre checks done
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: Migrating hold for account 45c5e948851d99b075ad21bca0c226ab1e63958dbbc7bc61c6420a77ae9d419d (5DeBxEaq...)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: Migrating hold for account 0d6df5ab3f582f317b4ac3646f0dd4559a6d2de99a739eb5b172d50deb78270a (5CNK9LM7...)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: Migrating hold for account 8c3a2c5c8ce81ea248aa6b8eb80b274adcc1bcb63abfd4d323046ac7e1c1ddd5 (5FEZqo4V...)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: Migrating hold for account df0c54ea9608c8b59f4b79a6c02a01d84c9ef29d7c0dedcc456751d3780ae557 (5H7ACUnS...)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: Migrating hold for account 1f6209e3f9e80177740f86aa321d31e99b5560c41966ca50d58c961870353484 (5CmrTvzq...)
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: migrated 20 accounts
[2024-05-31T08:03:37Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: post checks done
[2024-05-31T08:03:37Z INFO  frame_support::migrations] 🚚 Pallet "XcmpQueue" VersionedMigration migrating storage version from 3 to 4.
[2024-05-31T08:03:37Z INFO  runtime::identity::migration::v1] pre-upgrade state contains '0' identities.
[2024-05-31T08:03:37Z INFO  frame_support::migrations] 🚚 Pallet "Identity" VersionedMigration migrating storage version from 0 to 1.
[2024-05-31T08:03:37Z INFO  runtime::identity::migration::v1] running storage migration from version 0 to version 1.
[2024-05-31T08:03:37Z INFO  pallet_identity::migration::v1] all 0 identities migrated
[2024-05-31T08:03:37Z INFO  pallet_identity::migration::v1] post-upgrade expects '0' identities to have been migrated.
[2024-05-31T08:03:37Z INFO  runtime::identity::migration::v1] migrated all identities.
[2024-05-31T08:03:37Z INFO  frame_support::migrations] 🚚 Pallet "Uniques" VersionedMigration migrating storage version from 0 to 1.
[2024-05-31T08:03:37Z INFO  runtime::uniques] Storage migration v1 for uniques finished.
[2024-05-31T08:03:37Z INFO  runtime::frame-support] ⚠️ Ethereum declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `NoStorageVersionSet`
```

### Altair

```
[2024-05-31T08:02:00Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 1 but would instead upgrade from StorageVersion(1) to StorageVersion(1)
[2024-05-31T08:02:00Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 1 but would instead upgrade from StorageVersion(1) to StorageVersion(1)
[2024-05-31T08:02:00Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 1 but would instead upgrade from StorageVersion(1) to StorageVersion(1)
[2024-05-31T08:02:00Z WARN  runtime_common::migrations::increase_storage_version] BumpStorageVersion: Mismatching versions. Wanted to upgrade from 0 to 1 but would instead upgrade from StorageVersion(1) to StorageVersion(1)
[2024-05-31T08:02:00Z INFO  runtime::collator-selection] Sorted 3 Invulnerables, upgraded storage to version 1
[2024-05-31T08:02:00Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Pre checks done!
[2024-05-31T08:02:00Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Starting migration v3 -> v4
[2024-05-31T08:02:00Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Migrated 0 pools
[2024-05-31T08:02:00Z INFO  runtime_common::migrations::loans] LoansMigrationToV4: Post checks done!
[2024-05-31T08:02:00Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: pre checks done
[2024-05-31T08:02:00Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: migrated 0 accounts
[2024-05-31T08:02:00Z INFO  runtime_common::migrations::hold_reason] MigrateTransferAllowList HoldReason: post checks done
[2024-05-31T08:02:00Z INFO  frame_support::migrations] 🚚 Pallet "XcmpQueue" VersionedMigration migrating storage version from 3 to 4.
[2024-05-31T08:02:00Z INFO  runtime::identity::migration::v1] pre-upgrade state contains '34' identities.
[2024-05-31T08:02:00Z INFO  frame_support::migrations] 🚚 Pallet "Identity" VersionedMigration migrating storage version from 0 to 1.
[2024-05-31T08:02:00Z INFO  runtime::identity::migration::v1] running storage migration from version 0 to version 1.
[2024-05-31T08:02:00Z INFO  pallet_identity::migration::v1] all 34 identities migrated
[2024-05-31T08:02:00Z INFO  pallet_identity::migration::v1] post-upgrade expects '34' identities to have been migrated.
[2024-05-31T08:02:00Z INFO  runtime::identity::migration::v1] migrated all identities.
[2024-05-31T08:02:00Z INFO  frame_support::migrations] 🚚 Pallet "Uniques" VersionedMigration migrating storage version from 0 to 1.
[2024-05-31T08:02:00Z INFO  runtime::uniques] Storage migration v1 for uniques finished.
[2024-05-31T08:02:00Z INFO  runtime::frame-support] ⚠️ Ethereum declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `NoStorageVersionSet`
[2024-05-31T08:02:00Z ERROR runtime::executive] `try_decode_entire_state` failed with 1 errors
[2024-05-31T08:02:00Z ERROR runtime::executive] - 0. error: `ParachainSystem::HostConfiguration` key `0x45323df7cc47150b3930e2666b0aa313c522231880238a0c56021b8744a00743` is undecodable
```

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
