### PR TITLE
Polkadot-1.7.2: restricted transfer location changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11652,6 +11652,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex",
  "hex-literal",
  "log",
  "num_enum 0.5.11",

--- a/libs/types/src/locations.rs
+++ b/libs/types/src/locations.rs
@@ -15,19 +15,18 @@ use frame_support::RuntimeDebugNoBound;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::crypto::AccountId32;
-// Please note that if this version change,
-// a migration could be required in those places where
-// RestrictedTransferLocation is stored
-use staging_xcm::v4::Location;
+use sp_std::boxed::Box;
+use staging_xcm::VersionedLocation;
 
 use crate::domain_address::DomainAddress;
+
 /// Location types for destinations that can receive restricted transfers
 #[derive(Clone, RuntimeDebugNoBound, Encode, Decode, Eq, PartialEq, MaxEncodedLen, TypeInfo)]
 pub enum RestrictedTransferLocation {
 	/// Local chain account sending destination.
 	Local(AccountId),
 	/// XCM Location sending destinations.
-	Xcm(Location),
+	Xcm(Box<VersionedLocation>),
 	/// DomainAddress sending location from a liquidity pools' instance
 	Address(DomainAddress),
 }

--- a/libs/types/src/locations.rs
+++ b/libs/types/src/locations.rs
@@ -14,6 +14,7 @@ use cfg_primitives::AccountId;
 use frame_support::RuntimeDebugNoBound;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use sp_core::crypto::AccountId32;
 // Please note that if this version change,
 // a migration could be required in those places where
 // RestrictedTransferLocation is stored
@@ -29,4 +30,10 @@ pub enum RestrictedTransferLocation {
 	Xcm(Location),
 	/// DomainAddress sending location from a liquidity pools' instance
 	Address(DomainAddress),
+}
+
+impl From<AccountId32> for RestrictedTransferLocation {
+	fn from(value: AccountId32) -> Self {
+		Self::Local(value)
+	}
 }

--- a/libs/types/src/locations.rs
+++ b/libs/types/src/locations.rs
@@ -26,7 +26,7 @@ pub enum RestrictedTransferLocation {
 	/// Local chain account sending destination.
 	Local(AccountId),
 	/// XCM Location sending destinations.
-	XCM(Location),
+	Xcm(Location),
 	/// DomainAddress sending location from a liquidity pools' instance
 	Address(DomainAddress),
 }

--- a/libs/types/src/locations.rs
+++ b/libs/types/src/locations.rs
@@ -14,9 +14,10 @@ use cfg_primitives::AccountId;
 use frame_support::RuntimeDebugNoBound;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
-use sp_core::{crypto::AccountId32, H256};
-use sp_runtime::traits::{BlakeTwo256, Hash};
-use staging_xcm::VersionedLocation;
+// Please note that if this version change,
+// a migration could be required in those places where
+// RestrictedTransferLocation is stored
+use staging_xcm::v4::Location;
 
 use crate::domain_address::DomainAddress;
 /// Location types for destinations that can receive restricted transfers
@@ -24,35 +25,8 @@ use crate::domain_address::DomainAddress;
 pub enum RestrictedTransferLocation {
 	/// Local chain account sending destination.
 	Local(AccountId),
-	/// XCM MultiLocation sending destinations.
-	/// Using hash value here as Multilocation is large -- v1 is 512 bytes, but
-	/// next largest is only 40 bytes other values aren't hashed as we have
-	/// blake2 hashing on storage map keys, and we don't want the extra overhead
-	XCM(H256),
+	/// XCM Location sending destinations.
+	XCM(Location),
 	/// DomainAddress sending location from a liquidity pools' instance
 	Address(DomainAddress),
-}
-
-impl From<AccountId32> for RestrictedTransferLocation {
-	fn from(value: AccountId32) -> Self {
-		Self::Local(value)
-	}
-}
-
-impl From<VersionedLocation> for RestrictedTransferLocation {
-	fn from(vml: VersionedLocation) -> Self {
-		// using hash here as multilocation is significantly larger than any other enum
-		// type here -- 592 bytes, vs 40 bytes for domain address (next largest)
-		Self::XCM(BlakeTwo256::hash(&vml.encode()))
-
-		// TODO-1.7: I'm afraid of locations translated from v3 to v4 will
-		// generate a different hash here. How this affect our current chain
-		// state?
-	}
-}
-
-impl From<DomainAddress> for RestrictedTransferLocation {
-	fn from(da: DomainAddress) -> Self {
-		Self::Address(da)
-	}
 }

--- a/pallets/restricted-xtokens/src/lib.rs
+++ b/pallets/restricted-xtokens/src/lib.rs
@@ -51,37 +51,37 @@ use staging_xcm::{v4::prelude::*, VersionedAsset, VersionedAssets, VersionedLoca
 pub enum TransferEffects<AccountId, CurrencyId, Balance> {
 	Transfer {
 		sender: AccountId,
-		destination: Location,
+		destination: VersionedLocation,
 		currency_id: CurrencyId,
 		amount: Balance,
 	},
 	TransferMultiAsset {
 		sender: AccountId,
-		destination: Location,
+		destination: VersionedLocation,
 		asset: Asset,
 	},
 	TransferWithFee {
 		sender: AccountId,
-		destination: Location,
+		destination: VersionedLocation,
 		currency_id: CurrencyId,
 		amount: Balance,
 		fee: Balance,
 	},
 	TransferMultiAssetWithFee {
 		sender: AccountId,
-		destination: Location,
+		destination: VersionedLocation,
 		asset: Asset,
 		fee_asset: Asset,
 	},
 	TransferMultiCurrencies {
 		sender: AccountId,
-		destination: Location,
+		destination: VersionedLocation,
 		currencies: Vec<(CurrencyId, Balance)>,
 		fee: (CurrencyId, Balance),
 	},
 	TransferMultiAssets {
 		sender: AccountId,
-		destination: Location,
+		destination: VersionedLocation,
 		assets: Assets,
 		fee_asset: Asset,
 	},
@@ -130,14 +130,11 @@ pub mod pallet {
 			dest: Box<VersionedLocation>,
 			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
-			let destination: Location = (*dest.clone())
-				.try_into()
-				.map_err(|()| Error::<T>::BadVersion)?;
 			let sender = ensure_signed(origin.clone())?;
 
 			T::PreTransfer::check(TransferEffects::Transfer {
 				sender,
-				destination,
+				destination: (*dest.clone()),
 				currency_id: currency_id.clone(),
 				amount,
 			})?;
@@ -175,13 +172,10 @@ pub mod pallet {
 			let multi_asset: Asset = (*asset.clone())
 				.try_into()
 				.map_err(|()| Error::<T>::BadVersion)?;
-			let destination: Location = (*dest.clone())
-				.try_into()
-				.map_err(|()| Error::<T>::BadVersion)?;
 
 			T::PreTransfer::check(TransferEffects::TransferMultiAsset {
 				sender,
-				destination,
+				destination: (*dest.clone()),
 				asset: multi_asset,
 			})?;
 
@@ -220,13 +214,10 @@ pub mod pallet {
 			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
-			let destination: Location = (*dest.clone())
-				.try_into()
-				.map_err(|()| Error::<T>::BadVersion)?;
 
 			T::PreTransfer::check(TransferEffects::TransferWithFee {
 				sender,
-				destination,
+				destination: (*dest.clone()),
 				currency_id: currency_id.clone(),
 				amount,
 				fee,
@@ -279,13 +270,10 @@ pub mod pallet {
 			let fee_asset: Asset = (*fee.clone())
 				.try_into()
 				.map_err(|()| Error::<T>::BadVersion)?;
-			let destination: Location = (*dest.clone())
-				.try_into()
-				.map_err(|()| Error::<T>::BadVersion)?;
 
 			T::PreTransfer::check(TransferEffects::TransferMultiAssetWithFee {
 				sender,
-				destination,
+				destination: (*dest.clone()),
 				asset: multi_asset,
 				fee_asset,
 			})?;
@@ -324,16 +312,13 @@ pub mod pallet {
 			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
-			let destination: Location = (*dest.clone())
-				.try_into()
-				.map_err(|()| Error::<T>::BadVersion)?;
 			let fee = currencies
 				.get(fee_item as usize)
 				.ok_or(orml_xtokens::Error::<T>::AssetIndexNonExistent)?;
 
 			T::PreTransfer::check(TransferEffects::TransferMultiCurrencies {
 				sender,
-				destination,
+				destination: (*dest.clone()),
 				currencies: currencies.clone(),
 				fee: fee.clone(),
 			})?;
@@ -375,16 +360,13 @@ pub mod pallet {
 			let multi_assets: Assets = (*assets.clone())
 				.try_into()
 				.map_err(|()| Error::<T>::BadVersion)?;
-			let destination: Location = (*dest.clone())
-				.try_into()
-				.map_err(|()| Error::<T>::BadVersion)?;
 			let fee_asset: &Asset = multi_assets
 				.get(fee_item as usize)
 				.ok_or(orml_xtokens::Error::<T>::AssetIndexNonExistent)?;
 
 			T::PreTransfer::check(TransferEffects::TransferMultiAssets {
 				sender,
-				destination,
+				destination: (*dest.clone()),
 				assets: multi_assets.clone(),
 				fee_asset: fee_asset.clone(),
 			})?;

--- a/pallets/transfer-allowlist/src/lib.rs
+++ b/pallets/transfer-allowlist/src/lib.rs
@@ -109,15 +109,7 @@ pub mod pallet {
 		type Deposit: Get<DepositBalanceOf<Self>>;
 
 		/// Type containing the locations a transfer can be sent to.
-		type Location: Member
-			+ Debug
-			+ Eq
-			+ PartialEq
-			+ TypeInfo
-			+ Encode
-			+ EncodeLike
-			+ Decode
-			+ MaxEncodedLen;
+		type Location: Member + TypeInfo + Encode + EncodeLike + Decode + MaxEncodedLen;
 
 		/// Type for pallet weights
 		type WeightInfo: WeightInfo;

--- a/pallets/transfer-allowlist/src/mock.rs
+++ b/pallets/transfer-allowlist/src/mock.rs
@@ -15,14 +15,19 @@ use frame_support::{derive_impl, traits::ConstU64, Deserialize, Serialize};
 use frame_system::pallet_prelude::BlockNumberFor;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
-use sp_runtime::{traits::CheckedAdd, BuildStorage};
+use sp_core::crypto::AccountId32;
+use sp_runtime::{
+	traits::{CheckedAdd, IdentityLookup},
+	BuildStorage,
+};
 
 use crate as transfer_allowlist;
 
 pub(crate) const STARTING_BLOCK: u64 = 50;
-pub(crate) const SENDER: u64 = 0x1;
-pub(crate) const ACCOUNT_RECEIVER: u64 = 0x2;
-pub(crate) const FEE_DEFICIENT_SENDER: u64 = 0x3;
+pub(crate) const SENDER: AccountId32 = AccountId32::new([1u8; 32]);
+pub(crate) const ACCOUNT_RECEIVER: AccountId32 = AccountId32::new([2u8; 32]);
+pub(crate) const FEE_DEFICIENT_SENDER: AccountId32 = AccountId32::new([3u8; 32]);
+pub(crate) const OTHER_RECEIVER: AccountId32 = AccountId32::new([100u8; 32]);
 
 type Balance = u64;
 
@@ -37,7 +42,24 @@ frame_support::construct_runtime!(
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
+	type AccountId = AccountId32;
 	type Block = frame_system::mocking::MockBlock<Runtime>;
+	type Lookup = IdentityLookup<Self::AccountId>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
+impl pallet_balances::Config for Runtime {
+	type AccountStore = System;
+}
+
+impl transfer_allowlist::Config for Runtime {
+	type CurrencyId = FilterCurrency;
+	type Deposit = ConstU64<10>;
+	type Location = Location;
+	type ReserveCurrency = Balances;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type WeightInfo = ();
 }
 
 #[derive(
@@ -55,28 +77,17 @@ impl frame_system::Config for Runtime {
 	Serialize,
 )]
 pub enum Location {
-	TestLocal(u64),
+	TestLocal(AccountId32),
 }
 
-impl From<u64> for Location {
-	fn from(a: u64) -> Self {
+impl From<AccountId32> for Location {
+	fn from(a: AccountId32) -> Self {
 		Self::TestLocal(a)
 	}
 }
 
-#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
-impl pallet_balances::Config for Runtime {
-	type AccountStore = System;
-}
-
-impl transfer_allowlist::Config for Runtime {
-	type CurrencyId = FilterCurrency;
-	type Deposit = ConstU64<10>;
-	type Location = Location;
-	type ReserveCurrency = Balances;
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeHoldReason = RuntimeHoldReason;
-	type WeightInfo = ();
+pub(crate) fn local_location(receiver: AccountId32) -> Location {
+	receiver.into()
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/transfer-allowlist/src/tests.rs
+++ b/pallets/transfer-allowlist/src/tests.rs
@@ -12,13 +12,13 @@ fn add_transfer_allowance_works() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_eq!(
 			TransferAllowList::get_account_currency_transfer_allowance((
 				SENDER,
 				TEST_CURRENCY_ID,
-				<Runtime as Config>::Location::from(ACCOUNT_RECEIVER)
+				local_location(ACCOUNT_RECEIVER)
 			))
 			.unwrap(),
 			AllowanceDetails {
@@ -48,7 +48,7 @@ fn add_transfer_allowance_updates_with_delay_set() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_ok!(TransferAllowList::add_allowance_delay(
 			RuntimeOrigin::signed(SENDER),
@@ -58,7 +58,7 @@ fn add_transfer_allowance_updates_with_delay_set() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		),);
 
 		// only one allowance has been created, should still only have 1 reserve
@@ -67,7 +67,7 @@ fn add_transfer_allowance_updates_with_delay_set() {
 			TransferAllowList::get_account_currency_transfer_allowance((
 				SENDER,
 				TEST_CURRENCY_ID,
-				<Runtime as Config>::Location::from(ACCOUNT_RECEIVER)
+				local_location(ACCOUNT_RECEIVER)
 			))
 			.unwrap(),
 			AllowanceDetails {
@@ -98,13 +98,13 @@ fn add_transfer_allowance_multiple_dests_increments_correctly() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_eq!(Balances::reserved_balance(&SENDER), 10);
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			100u64.into(),
+			local_location(OTHER_RECEIVER),
 		));
 		// verify reserve incremented for second allowance
 		assert_eq!(Balances::reserved_balance(&SENDER), 20);
@@ -128,11 +128,15 @@ fn transfer_allowance_allows_correctly_with_allowance_set() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_eq!(
-			TransferAllowList::allowance(SENDER.into(), ACCOUNT_RECEIVER.into(), TEST_CURRENCY_ID),
-			Ok(Some(ACCOUNT_RECEIVER.into()))
+			TransferAllowList::allowance(
+				SENDER.into(),
+				local_location(ACCOUNT_RECEIVER),
+				TEST_CURRENCY_ID
+			),
+			Ok(Some(local_location(ACCOUNT_RECEIVER)))
 		)
 	})
 }
@@ -143,10 +147,14 @@ fn transfer_allowance_blocks_when_account_not_allowed() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_err!(
-			TransferAllowList::allowance(SENDER.into(), 55u64.into(), TEST_CURRENCY_ID),
+			TransferAllowList::allowance(
+				SENDER.into(),
+				local_location(OTHER_RECEIVER),
+				TEST_CURRENCY_ID
+			),
 			Error::<Runtime>::NoAllowanceForDestination,
 		)
 	})
@@ -164,10 +172,14 @@ fn transfer_allowance_blocks_correctly_when_before_start_block() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_err!(
-			TransferAllowList::allowance(SENDER.into(), ACCOUNT_RECEIVER.into(), TEST_CURRENCY_ID),
+			TransferAllowList::allowance(
+				SENDER.into(),
+				local_location(ACCOUNT_RECEIVER),
+				TEST_CURRENCY_ID
+			),
 			Error::<Runtime>::NoAllowanceForDestination,
 		)
 	})
@@ -179,11 +191,15 @@ fn transfer_allowance_blocks_correctly_when_after_blocked_at_block() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_eq!(
-			TransferAllowList::allowance(SENDER.into(), ACCOUNT_RECEIVER.into(), TEST_CURRENCY_ID),
-			Ok(Some(ACCOUNT_RECEIVER.into()))
+			TransferAllowList::allowance(
+				SENDER.into(),
+				local_location(ACCOUNT_RECEIVER),
+				TEST_CURRENCY_ID
+			),
+			Ok(Some(local_location(ACCOUNT_RECEIVER)))
 		)
 	})
 }
@@ -194,19 +210,19 @@ fn remove_transfer_allowance_works() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_ok!(TransferAllowList::remove_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		// ensure blocked at set to restrict transfers
 		assert_eq!(
 			TransferAllowList::get_account_currency_transfer_allowance((
 				SENDER,
 				TEST_CURRENCY_ID,
-				<Runtime as Config>::Location::from(ACCOUNT_RECEIVER)
+				local_location(ACCOUNT_RECEIVER)
 			))
 			.unwrap(),
 			AllowanceDetails {
@@ -241,7 +257,7 @@ fn remove_transfer_allowance_with_delay_works() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_ok!(TransferAllowList::add_allowance_delay(
 			RuntimeOrigin::signed(SENDER),
@@ -251,13 +267,13 @@ fn remove_transfer_allowance_with_delay_works() {
 		assert_ok!(TransferAllowList::remove_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_eq!(
 			TransferAllowList::get_account_currency_transfer_allowance((
 				SENDER,
 				TEST_CURRENCY_ID,
-				<Runtime as Config>::Location::from(ACCOUNT_RECEIVER)
+				local_location(ACCOUNT_RECEIVER)
 			))
 			.unwrap(),
 			AllowanceDetails {
@@ -298,12 +314,12 @@ fn purge_transfer_allowance_works() {
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_ok!(TransferAllowList::remove_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_eq!(Balances::reserved_balance(&SENDER), 10);
 		advance_n_blocks::<Runtime>(6u64);
@@ -312,14 +328,14 @@ fn purge_transfer_allowance_works() {
 		assert_ok!(TransferAllowList::purge_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		// verify removed
 		assert_eq!(
 			TransferAllowList::get_account_currency_transfer_allowance((
 				SENDER,
 				TEST_CURRENCY_ID,
-				<Runtime as Config>::Location::from(ACCOUNT_RECEIVER)
+				local_location(ACCOUNT_RECEIVER)
 			)),
 			None
 		);
@@ -349,7 +365,7 @@ fn purge_transfer_allowance_non_existant_transfer_allowance() {
 			TransferAllowList::purge_transfer_allowance(
 				RuntimeOrigin::signed(SENDER),
 				TEST_CURRENCY_ID,
-				ACCOUNT_RECEIVER.into(),
+				local_location(ACCOUNT_RECEIVER)
 			),
 			Error::<Runtime>::NoMatchingAllowance
 		);
@@ -369,20 +385,20 @@ fn purge_transfer_allowance_when_multiple_present_for_sender_currency_properly_d
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 		assert_eq!(Balances::reserved_balance(&SENDER), 10);
 
 		assert_ok!(TransferAllowList::add_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			100u64.into(),
+			local_location(OTHER_RECEIVER),
 		));
 		assert_eq!(Balances::reserved_balance(&SENDER), 20);
 		assert_ok!(TransferAllowList::remove_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 
 		advance_n_blocks::<Runtime>(6u64);
@@ -391,7 +407,7 @@ fn purge_transfer_allowance_when_multiple_present_for_sender_currency_properly_d
 		assert_ok!(TransferAllowList::purge_transfer_allowance(
 			RuntimeOrigin::signed(SENDER),
 			TEST_CURRENCY_ID,
-			ACCOUNT_RECEIVER.into(),
+			local_location(ACCOUNT_RECEIVER)
 		));
 
 		// verify correct reserve decrement
@@ -402,7 +418,7 @@ fn purge_transfer_allowance_when_multiple_present_for_sender_currency_properly_d
 			TransferAllowList::get_account_currency_transfer_allowance((
 				SENDER,
 				TEST_CURRENCY_ID,
-				<Runtime as Config>::Location::from(ACCOUNT_RECEIVER)
+				local_location(ACCOUNT_RECEIVER)
 			)),
 			None
 		);
@@ -412,7 +428,7 @@ fn purge_transfer_allowance_when_multiple_present_for_sender_currency_properly_d
 			TransferAllowList::get_account_currency_transfer_allowance((
 				SENDER,
 				TEST_CURRENCY_ID,
-				<Runtime as Config>::Location::from(100u64)
+				local_location(OTHER_RECEIVER)
 			))
 			.unwrap(),
 			AllowanceDetails {

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -18,6 +18,9 @@ const IDENTITY_MIGRATION_KEY_LIMIT: u64 = 1000;
 /// The migration set for Centrifuge @ Polkadot.
 /// It includes all the migrations that have to be applied on that chain.
 pub type UpgradeCentrifuge1029 = (
+	runtime_common::migrations::restricted_location::MigrateRestrictedTransferLocation<
+		crate::Runtime,
+	>,
 	runtime_common::migrations::increase_storage_version::Migration<OraclePriceFeed, 0, 1>,
 	runtime_common::migrations::increase_storage_version::Migration<OraclePriceCollection, 0, 1>,
 	pallet_collator_selection::migration::v1::MigrateToV1<crate::Runtime>,

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -18,9 +18,6 @@ const IDENTITY_MIGRATION_KEY_LIMIT: u64 = 1000;
 /// The migration set for Centrifuge @ Polkadot.
 /// It includes all the migrations that have to be applied on that chain.
 pub type UpgradeCentrifuge1029 = (
-	runtime_common::migrations::restricted_location::MigrateRestrictedTransferLocation<
-		crate::Runtime,
-	>,
 	runtime_common::migrations::increase_storage_version::Migration<OraclePriceFeed, 0, 1>,
 	runtime_common::migrations::increase_storage_version::Migration<OraclePriceCollection, 0, 1>,
 	pallet_collator_selection::migration::v1::MigrateToV1<crate::Runtime>,
@@ -34,4 +31,7 @@ pub type UpgradeCentrifuge1029 = (
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<crate::Runtime>,
 	pallet_identity::migration::versioned::V0ToV1<crate::Runtime, IDENTITY_MIGRATION_KEY_LIMIT>,
 	pallet_uniques::migration::MigrateV0ToV1<crate::Runtime, ()>,
+	runtime_common::migrations::restricted_location::MigrateRestrictedTransferLocation<
+		crate::Runtime,
+	>,
 );

--- a/runtime/centrifuge/src/migrations.rs
+++ b/runtime/centrifuge/src/migrations.rs
@@ -10,10 +10,25 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+use cfg_primitives::AccountId;
+use frame_support::parameter_types;
+use sp_std::{vec, vec::Vec};
+
 use crate::{OraclePriceCollection, OraclePriceFeed};
 
 // Number of identities on Centrifuge Chain on 29.05.2024 was 34
 const IDENTITY_MIGRATION_KEY_LIMIT: u64 = 1000;
+
+parameter_types! {
+	// Address used by Anemoy to withdraw in AssetHub
+	// 4dTeMxuPJCK7zQGhFcgCivSJqBs9Wo2SuMSQeYCCuVJ9xrE2 --> 5Fc9NzKzJZwZvgjQBmSKtvZmJ5oP6B49DFC5dXZhTETjrSzo
+	pub AccountMap: Vec<(AccountId, AccountId)> = vec![
+		(
+			AccountId::new(hex_literal::hex!("5dbb2cec05b6bda775f7945827b887b0e7b5245eae8b4ef266c60820c9377185")),
+			AccountId::new(hex_literal::hex!("10c03288a534d77418e3c19e745dfbc952423e179e1e3baa89e287092fc7802f"))
+		)
+	];
+}
 
 /// The migration set for Centrifuge @ Polkadot.
 /// It includes all the migrations that have to be applied on that chain.
@@ -33,5 +48,6 @@ pub type UpgradeCentrifuge1029 = (
 	pallet_uniques::migration::MigrateV0ToV1<crate::Runtime, ()>,
 	runtime_common::migrations::restricted_location::MigrateRestrictedTransferLocation<
 		crate::Runtime,
+		AccountMap,
 	>,
 );

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 documentation.workspace = true
 
 [dependencies]
+hex = { workspace = true }
 hex-literal = { workspace = true }
 log = { workspace = true }
 num_enum = { workspace = true }

--- a/runtime/common/src/migrations/mod.rs
+++ b/runtime/common/src/migrations/mod.rs
@@ -17,6 +17,7 @@ pub mod increase_storage_version;
 pub mod loans;
 pub mod nuke;
 pub mod precompile_account_codes;
+pub mod restricted_location;
 
 pub mod utils {
 	use frame_support::storage::unhashed;

--- a/runtime/common/src/migrations/restricted_location.rs
+++ b/runtime/common/src/migrations/restricted_location.rs
@@ -1,0 +1,126 @@
+use cfg_primitives::AccountId;
+use cfg_types::{locations::RestrictedTransferLocation, tokens::CurrencyId};
+use frame_support::{
+	traits::{Get, OnRuntimeUpgrade},
+	weights::Weight,
+};
+use pallet_transfer_allowlist::AccountCurrencyTransferAllowance;
+use parity_scale_codec::Encode;
+use sp_core::H256;
+use sp_runtime::traits::{BlakeTwo256, Hash};
+use staging_xcm::v4;
+
+mod old {
+	use cfg_primitives::AccountId;
+	use cfg_types::{domain_address::DomainAddress, tokens::CurrencyId};
+	use frame_support::{pallet_prelude::*, storage_alias};
+	use frame_system::pallet_prelude::*;
+	use pallet_transfer_allowlist::AllowanceDetails;
+	use sp_core::H256;
+	use staging_xcm::v3;
+
+	#[derive(
+		Clone, RuntimeDebugNoBound, Encode, Decode, Eq, PartialEq, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum RestrictedTransferLocation {
+		Local(AccountId),
+		XCM(H256),
+		Address(DomainAddress),
+	}
+
+	#[storage_alias]
+	pub type AccountCurrencyTransferAllowance<T: pallet_transfer_allowlist::Config> = StorageNMap<
+		pallet_transfer_allowlist::Pallet<T>,
+		(
+			NMapKey<Twox64Concat, AccountId>,
+			NMapKey<Twox64Concat, CurrencyId>,
+			NMapKey<Blake2_128Concat, RestrictedTransferLocation>,
+		),
+		AllowanceDetails<BlockNumberFor<T>>,
+		OptionQuery,
+	>;
+
+	pub fn create_apps_location_v3(account_id: &AccountId) -> v3::Location {
+		// Ref: https://github.com/centrifuge/apps/blob/b59bdd34561a4ccd90e0d803c14a3729fc2f3a6d/centrifuge-app/src/utils/usePermissions.tsx#L386
+		//v3::Location::new(1, v3::Junctions::X2((), ()))
+		todo!()
+	}
+}
+
+const LOG_PREFIX: &str = "MigrateRestrictedTransferLocation:";
+
+pub struct MigrateRestrictedTransferLocation<T>(sp_std::marker::PhantomData<T>);
+impl<T> OnRuntimeUpgrade for MigrateRestrictedTransferLocation<T>
+where
+	T: pallet_transfer_allowlist::Config<
+		AccountId = AccountId,
+		CurrencyId = CurrencyId,
+		Location = RestrictedTransferLocation,
+	>,
+{
+	fn on_runtime_upgrade() -> Weight {
+		log::info!("{LOG_PREFIX} Check keys to migrate...");
+
+		let mut weight = Weight::zero();
+
+		let key_translations = old::AccountCurrencyTransferAllowance::<T>::iter_keys()
+			.filter_map(|(account_id, currency_id, old_restricted_location)| {
+				weight.saturating_accrue(T::DbWeight::get().reads(1));
+				match old_restricted_location {
+					old::RestrictedTransferLocation::XCM(hash) => {
+						migrate_location_key(&account_id, hash).map(|new_restricted_location| {
+							(
+								(account_id.clone(), currency_id, old_restricted_location),
+								(account_id, currency_id, new_restricted_location),
+							)
+						})
+					}
+					_ => None,
+				}
+			})
+			.collect::<Vec<_>>();
+
+		for (old_key, new_key) in key_translations {
+			log::info!("{LOG_PREFIX} Remove {old_key:?} and add {new_key:?}");
+
+			let value = old::AccountCurrencyTransferAllowance::<T>::get(&old_key);
+			old::AccountCurrencyTransferAllowance::<T>::remove(old_key);
+			AccountCurrencyTransferAllowance::<T>::set(new_key, value);
+
+			weight.saturating_accrue(T::DbWeight::get().writes(2));
+		}
+
+		weight
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+		todo!()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(pre_state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		todo!()
+	}
+}
+
+fn migrate_location_key(account_id: &AccountId, hash: H256) -> Option<RestrictedTransferLocation> {
+	let old_location = old::create_apps_location_v3(account_id);
+	if BlakeTwo256::hash(&old_location.encode()) == hash {
+		match v4::Location::try_from(old_location) {
+			Ok(location) => {
+				log::info!("{LOG_PREFIX} Hash: '{hash}' migrated!");
+				let new_restricted_location = RestrictedTransferLocation::XCM(location);
+
+				Some(new_restricted_location)
+			}
+			Err(_) => {
+				log::error!("{LOG_PREFIX} Non isometric location v3 -> v4");
+				None
+			}
+		}
+	} else {
+		log::error!("{LOG_PREFIX} Hash can not be recovered");
+		None
+	}
+}

--- a/runtime/common/src/migrations/restricted_location.rs
+++ b/runtime/common/src/migrations/restricted_location.rs
@@ -9,8 +9,8 @@ use parity_scale_codec::Encode;
 use sp_arithmetic::traits::SaturatedConversion;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Hash};
-use sp_std::vec::Vec;
-use staging_xcm::v4;
+use sp_std::{boxed::Box, vec::Vec};
+use staging_xcm::{v4, VersionedLocation};
 
 mod old {
 	use cfg_primitives::AccountId;
@@ -158,7 +158,8 @@ where
 			match v4::Location::try_from(old_location) {
 				Ok(location) => {
 					log::info!("{LOG_PREFIX} Hash: '{hash}' migrated!");
-					let new_restricted_location = RestrictedTransferLocation::Xcm(location);
+					let new_restricted_location =
+						RestrictedTransferLocation::Xcm(Box::new(VersionedLocation::V4(location)));
 
 					Some(new_restricted_location)
 				}

--- a/runtime/common/src/migrations/restricted_location.rs
+++ b/runtime/common/src/migrations/restricted_location.rs
@@ -6,6 +6,7 @@ use frame_support::{
 };
 use pallet_transfer_allowlist::AccountCurrencyTransferAllowance;
 use parity_scale_codec::Encode;
+use sp_arithmetic::traits::SaturatedConversion;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Hash};
 use sp_std::vec::Vec;
@@ -16,13 +17,19 @@ mod old {
 	use cfg_types::{domain_address::DomainAddress, tokens::FilterCurrency};
 	use frame_support::{pallet_prelude::*, storage_alias};
 	use frame_system::pallet_prelude::*;
-	use hex::FromHex;
 	use pallet_transfer_allowlist::AllowanceDetails;
 	use sp_core::H256;
 	use staging_xcm::v3;
 
 	#[derive(
-		Clone, RuntimeDebugNoBound, Encode, Decode, Eq, PartialEq, MaxEncodedLen, TypeInfo,
+		Clone,
+		RuntimeDebugNoBound,
+		Encode,
+		parity_scale_codec::Decode,
+		Eq,
+		PartialEq,
+		MaxEncodedLen,
+		TypeInfo,
 	)]
 	pub enum RestrictedTransferLocation {
 		Local(AccountId),
@@ -42,7 +49,7 @@ mod old {
 		OptionQuery,
 	>;
 
-	pub fn location_v3_created_by_apps(_account_id: &AccountId) -> v3::Location {
+	pub fn location_v3_created_by_apps(account_id: AccountId) -> v3::Location {
 		// Ref: https://github.com/centrifuge/apps/blob/b59bdd34561a4ccd90e0d803c14a3729fc2f3a6d/centrifuge-app/src/utils/usePermissions.tsx#L386
 		// for account_id == "4dTeMxuPJCK7zQGhFcgCivSJqBs9Wo2SuMSQeYCCuVJ9xrE2"
 		v3::Location::new(
@@ -51,11 +58,7 @@ mod old {
 				v3::Junction::Parachain(1000), // AssetHub
 				v3::Junction::AccountId32 {
 					network: None,
-					id: <[u8; 32]>::from_hex(
-						// Address used by Anemoy to withdraw in AssetHub
-						"10c03288a534d77418e3c19e745dfbc952423e179e1e3baa89e287092fc7802f",
-					)
-					.expect("keep in the array"),
+					id: account_id.into(),
 				},
 			),
 		)
@@ -64,64 +67,40 @@ mod old {
 
 const LOG_PREFIX: &str = "MigrateRestrictedTransferLocation:";
 
-fn migrate_location_key(account_id: &AccountId, hash: H256) -> Option<RestrictedTransferLocation> {
-	let old_location = old::location_v3_created_by_apps(account_id);
-	if BlakeTwo256::hash(&old_location.encode()) == hash {
-		match v4::Location::try_from(old_location) {
-			Ok(location) => {
-				log::info!("{LOG_PREFIX} Hash: '{hash}' migrated!");
-				let new_restricted_location = RestrictedTransferLocation::Xcm(location);
-
-				Some(new_restricted_location)
-			}
-			Err(_) => {
-				log::error!("{LOG_PREFIX} Non isometric location v3 -> v4");
-				None
-			}
-		}
-	} else {
-		log::error!("{LOG_PREFIX} Hash can not be recovered");
-		None
-	}
-}
-
-pub struct MigrateRestrictedTransferLocation<T>(sp_std::marker::PhantomData<T>);
-impl<T> OnRuntimeUpgrade for MigrateRestrictedTransferLocation<T>
+pub struct MigrateRestrictedTransferLocation<T, AccountMap>(
+	sp_std::marker::PhantomData<(T, AccountMap)>,
+);
+impl<T, AccountMap> OnRuntimeUpgrade for MigrateRestrictedTransferLocation<T, AccountMap>
 where
 	T: pallet_transfer_allowlist::Config<
 		AccountId = AccountId,
 		CurrencyId = FilterCurrency,
 		Location = RestrictedTransferLocation,
 	>,
+	AccountMap: Get<Vec<(AccountId, AccountId)>>,
 {
 	fn on_runtime_upgrade() -> Weight {
 		log::info!("{LOG_PREFIX} Check keys to migrate...");
 
-		let mut weight = Weight::zero();
+		let mut weight = T::DbWeight::get().reads(
+			old::AccountCurrencyTransferAllowance::<T>::iter_keys()
+				.count()
+				.saturated_into(),
+		);
 
-		let key_translations = old::AccountCurrencyTransferAllowance::<T>::iter_keys()
-			.filter_map(|(account_id, currency_id, old_restricted_location)| {
-				weight.saturating_accrue(T::DbWeight::get().reads(1));
-				match old_restricted_location {
-					old::RestrictedTransferLocation::Xcm(hash) => {
-						migrate_location_key(&account_id, hash).map(|new_restricted_location| {
-							(
-								(account_id.clone(), currency_id, old_restricted_location),
-								(account_id, currency_id, new_restricted_location),
-							)
-						})
-					}
-					_ => None,
-				}
-			})
-			.collect::<Vec<_>>();
+		let key_translations = Self::get_key_translations();
 
-		for (old_key, new_key) in key_translations {
-			log::info!("{LOG_PREFIX} Remove {old_key:?} and add {new_key:?}");
-
-			let value = old::AccountCurrencyTransferAllowance::<T>::get(&old_key);
+		for (acc, currency, old_location, maybe_new_location) in key_translations {
+			let old_key = (&acc, &currency, &old_location);
+			log::info!("{LOG_PREFIX} Removing old key {old_key:?}");
+			let value = old::AccountCurrencyTransferAllowance::<T>::get(old_key);
 			old::AccountCurrencyTransferAllowance::<T>::remove(old_key);
-			AccountCurrencyTransferAllowance::<T>::set(new_key, value);
+
+			if let Some(new_location) = maybe_new_location {
+				let new_key = (&acc, &currency, &new_location);
+				log::info!("{LOG_PREFIX} Adding new key {new_key:?}");
+				AccountCurrencyTransferAllowance::<T>::set(new_key, value);
+			}
 
 			weight.saturating_accrue(T::DbWeight::get().writes(2));
 		}
@@ -131,11 +110,100 @@ where
 
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
-		Ok(Vec::new())
+		let key_translations = Self::get_key_translations();
+		assert!(
+			key_translations
+				.iter()
+				.all(|(_, _, _, new_location)| new_location.is_some()),
+			"At least one XCM location could not be translated"
+		);
+
+		let count: u64 = old::AccountCurrencyTransferAllowance::<T>::iter_keys()
+			.count()
+			.saturated_into();
+
+		log::info!("{LOG_PREFIX} Pre checks done!");
+		Ok(count.encode())
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(_pre_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+	fn post_upgrade(pre_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		let count_pre: u64 = parity_scale_codec::Decode::decode(&mut pre_state.as_slice())
+			.expect("pre_upgrade provides a valid state; qed");
+		let count_post: u64 = AccountCurrencyTransferAllowance::<T>::iter_keys()
+			.count()
+			.saturated_into();
+		assert_eq!(count_pre, count_post, "Number of keys in AccountCurrencyTransferAllowance changed during migration: pre {count_pre} vs post {count_post}");
+
+		log::info!("{LOG_PREFIX} Post checks done!");
 		Ok(())
+	}
+}
+
+impl<T, AccountMap> MigrateRestrictedTransferLocation<T, AccountMap>
+where
+	T: pallet_transfer_allowlist::Config<
+		AccountId = AccountId,
+		CurrencyId = FilterCurrency,
+		Location = RestrictedTransferLocation,
+	>,
+	AccountMap: Get<Vec<(AccountId, AccountId)>>,
+{
+	fn migrate_location_key(
+		account_id: AccountId,
+		hash: H256,
+	) -> Option<RestrictedTransferLocation> {
+		let old_location = old::location_v3_created_by_apps(account_id);
+		if BlakeTwo256::hash(&old_location.encode()) == hash {
+			match v4::Location::try_from(old_location) {
+				Ok(location) => {
+					log::info!("{LOG_PREFIX} Hash: '{hash}' migrated!");
+					let new_restricted_location = RestrictedTransferLocation::Xcm(location);
+
+					Some(new_restricted_location)
+				}
+				Err(_) => {
+					log::error!("{LOG_PREFIX} Non isometric location v3 -> v4");
+					None
+				}
+			}
+		} else {
+			log::error!("{LOG_PREFIX} Hash can not be recovered");
+			None
+		}
+	}
+
+	fn get_key_translations() -> Vec<(
+		AccountId,
+		FilterCurrency,
+		old::RestrictedTransferLocation,
+		Option<RestrictedTransferLocation>,
+	)> {
+		let accounts = AccountMap::get();
+
+		old::AccountCurrencyTransferAllowance::<T>::iter_keys()
+			.filter_map(|(account_id, currency_id, old_restricted_location)| {
+				match (accounts.iter().find(|(key, _)| key == &account_id), old_restricted_location.clone()) {
+					(Some((_, transfer_address)), old::RestrictedTransferLocation::Xcm(hash)) => Some((
+						account_id.clone(),
+						currency_id,
+						old_restricted_location,
+						Self::migrate_location_key(transfer_address.clone(), hash),
+					)),
+					(None, old::RestrictedTransferLocation::Xcm(_)) => {
+						log::warn!("{LOG_PREFIX} Account {account_id:?} missing in AccountMap despite old XCM location storage");
+						Some((
+							account_id.clone(),
+							currency_id,
+							old_restricted_location,
+							// Leads to storage entry removal
+							// TODO: Discuss whether we are fine with removing such storage entries or whether we want to keep the old undecodable ones or maybe just use same account id per default instead of removing?
+							None,
+						))
+					}
+					_ => None,
+				}
+			})
+			.collect::<Vec<_>>()
 	}
 }

--- a/runtime/common/src/migrations/restricted_location.rs
+++ b/runtime/common/src/migrations/restricted_location.rs
@@ -8,6 +8,7 @@ use pallet_transfer_allowlist::AccountCurrencyTransferAllowance;
 use parity_scale_codec::Encode;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Hash};
+use sp_std::vec::Vec;
 use staging_xcm::v4;
 
 mod old {
@@ -25,7 +26,7 @@ mod old {
 	)]
 	pub enum RestrictedTransferLocation {
 		Local(AccountId),
-		XCM(H256),
+		Xcm(H256),
 		Address(DomainAddress),
 	}
 
@@ -69,7 +70,7 @@ fn migrate_location_key(account_id: &AccountId, hash: H256) -> Option<Restricted
 		match v4::Location::try_from(old_location) {
 			Ok(location) => {
 				log::info!("{LOG_PREFIX} Hash: '{hash}' migrated!");
-				let new_restricted_location = RestrictedTransferLocation::XCM(location);
+				let new_restricted_location = RestrictedTransferLocation::Xcm(location);
 
 				Some(new_restricted_location)
 			}
@@ -102,7 +103,7 @@ where
 			.filter_map(|(account_id, currency_id, old_restricted_location)| {
 				weight.saturating_accrue(T::DbWeight::get().reads(1));
 				match old_restricted_location {
-					old::RestrictedTransferLocation::XCM(hash) => {
+					old::RestrictedTransferLocation::Xcm(hash) => {
 						migrate_location_key(&account_id, hash).map(|new_restricted_location| {
 							(
 								(account_id.clone(), currency_id, old_restricted_location),
@@ -129,12 +130,12 @@ where
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
 		Ok(Vec::new())
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(_pre_state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+	fn post_upgrade(_pre_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
 		Ok(())
 	}
 }

--- a/runtime/common/src/transfer_filter.rs
+++ b/runtime/common/src/transfer_filter.rs
@@ -22,9 +22,8 @@ use pallet_restricted_tokens::TransferDetails;
 use pallet_restricted_xtokens::TransferEffects;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
-use sp_core::Hasher;
 use sp_runtime::{
-	traits::{BlakeTwo256, Convert, DispatchInfoOf, SignedExtension, StaticLookup},
+	traits::{Convert, DispatchInfoOf, SignedExtension, StaticLookup},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	DispatchError, DispatchResult, TokenError,
 };
@@ -49,12 +48,12 @@ impl<
 			amalgamate_allowance(
 				T::allowance(
 					sender.clone(),
-					RestrictedTransferLocation::XCM(BlakeTwo256::hash(&destination.encode())),
+					RestrictedTransferLocation::XCM(destination.clone()),
 					FilterCurrency::Specific(currency),
 				),
 				T::allowance(
 					sender,
-					RestrictedTransferLocation::XCM(BlakeTwo256::hash(&destination.encode())),
+					RestrictedTransferLocation::XCM(destination),
 					FilterCurrency::All,
 				),
 			)

--- a/runtime/common/src/transfer_filter.rs
+++ b/runtime/common/src/transfer_filter.rs
@@ -27,8 +27,11 @@ use sp_runtime::{
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	DispatchError, DispatchResult, TokenError,
 };
-use sp_std::vec::Vec;
-use staging_xcm::v4::{Asset, Location};
+use sp_std::{boxed::Box, vec::Vec};
+use staging_xcm::{
+	v4::{Asset, Location},
+	VersionedLocation,
+};
 
 pub struct PreXcmTransfer<T, C>(sp_std::marker::PhantomData<(T, C)>);
 
@@ -44,16 +47,16 @@ impl<
 	type Result = DispatchResult;
 
 	fn check(t: TransferEffects<AccountId, CurrencyId, Balance>) -> Self::Result {
-		let currency_based_check = |sender: AccountId, destination: Location, currency| {
+		let currency_based_check = |sender: AccountId, destination: VersionedLocation, currency| {
 			amalgamate_allowance(
 				T::allowance(
 					sender.clone(),
-					RestrictedTransferLocation::Xcm(destination.clone()),
+					RestrictedTransferLocation::Xcm(Box::new(destination.clone())),
 					FilterCurrency::Specific(currency),
 				),
 				T::allowance(
 					sender,
-					RestrictedTransferLocation::Xcm(destination),
+					RestrictedTransferLocation::Xcm(Box::new(destination)),
 					FilterCurrency::All,
 				),
 			)

--- a/runtime/common/src/transfer_filter.rs
+++ b/runtime/common/src/transfer_filter.rs
@@ -48,12 +48,12 @@ impl<
 			amalgamate_allowance(
 				T::allowance(
 					sender.clone(),
-					RestrictedTransferLocation::XCM(destination.clone()),
+					RestrictedTransferLocation::Xcm(destination.clone()),
 					FilterCurrency::Specific(currency),
 				),
 				T::allowance(
 					sender,
-					RestrictedTransferLocation::XCM(destination),
+					RestrictedTransferLocation::Xcm(destination),
 					FilterCurrency::All,
 				),
 			)

--- a/runtime/development/Cargo.toml
+++ b/runtime/development/Cargo.toml
@@ -12,7 +12,7 @@ documentation.workspace = true
 [dependencies]
 getrandom = { workspace = true }
 hex = { workspace = true }
-hex-literal = { workspace = true, optional = true }
+hex-literal = { workspace = true }
 log = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
@@ -266,7 +266,6 @@ std = [
 
 runtime-benchmarks = [
   # Enabling optional
-  "hex-literal",
   "frame-system-benchmarking/runtime-benchmarks",
   "frame-benchmarking/runtime-benchmarks",
   "cumulus-pallet-session-benchmarking/runtime-benchmarks",

--- a/runtime/development/src/migrations.rs
+++ b/runtime/development/src/migrations.rs
@@ -10,10 +10,15 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+use cfg_primitives::AccountId;
 use sp_core::parameter_types;
+use sp_std::{vec, vec::Vec};
+
 parameter_types! {
 	pub const CollatorReward: cfg_primitives::Balance = cfg_primitives::constants::CFG;
 	pub const AnnualTreasuryInflationPercent: u32 = 3;
+	pub AccountMap: Vec<(AccountId, AccountId)> = vec![];
+
 }
 
 // Number of identities on Dev and Demo Chain on 30.05.2024 was both 0
@@ -52,6 +57,10 @@ pub type UpgradeDevelopment1047 = (
 		crate::Runtime,
 		CollatorReward,
 		AnnualTreasuryInflationPercent,
+	>,
+	runtime_common::migrations::restricted_location::MigrateRestrictedTransferLocation<
+		crate::Runtime,
+		AccountMap,
 	>,
 	runtime_common::migrations::loans::AddWithLinearPricing<crate::Runtime>,
 	runtime_common::migrations::hold_reason::MigrateTransferAllowListHolds<

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -6700,7 +6700,7 @@ mod centrifuge {
 		}
 
 		fn allowed_xcm_location() -> RestrictedTransferLocation {
-			RestrictedTransferLocation::Xcm(BlakeTwo256::hash(&xcm_location().encode()))
+			RestrictedTransferLocation::Xcm(xcm_location())
 		}
 
 		fn add_allowance<T: Runtime>(
@@ -7220,18 +7220,15 @@ mod centrifuge {
 					pallet_transfer_allowlist::Pallet::<T>::add_transfer_allowance(
 						RawOrigin::Signed(Keyring::Alice.into()).into(),
 						FilterCurrency::Specific(USDC),
-						RestrictedTransferLocation::Xcm(BlakeTwo256::hash(
-							&Location::new(
-								1,
-								[
-									Parachain(T::FudgeHandle::SIBLING_ID),
-									Junction::AccountId32 {
-										id: Keyring::Alice.into(),
-										network: None,
-									}
-								]
-							)
-							.encode()
+						RestrictedTransferLocation::Xcm(Location::new(
+							1,
+							[
+								Parachain(T::FudgeHandle::SIBLING_ID),
+								Junction::AccountId32 {
+									id: Keyring::Alice.into(),
+									network: None,
+								}
+							]
 						))
 					)
 				);

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -6700,7 +6700,7 @@ mod centrifuge {
 		}
 
 		fn allowed_xcm_location() -> RestrictedTransferLocation {
-			RestrictedTransferLocation::XCM(BlakeTwo256::hash(&xcm_location().encode()))
+			RestrictedTransferLocation::Xcm(BlakeTwo256::hash(&xcm_location().encode()))
 		}
 
 		fn add_allowance<T: Runtime>(
@@ -7220,7 +7220,7 @@ mod centrifuge {
 					pallet_transfer_allowlist::Pallet::<T>::add_transfer_allowance(
 						RawOrigin::Signed(Keyring::Alice.into()).into(),
 						FilterCurrency::Specific(USDC),
-						RestrictedTransferLocation::XCM(BlakeTwo256::hash(
+						RestrictedTransferLocation::Xcm(BlakeTwo256::hash(
 							&Location::new(
 								1,
 								[

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -6690,17 +6690,17 @@ mod centrifuge {
 		const TRANSFER_AMOUNT: u128 = 10;
 
 		fn xcm_location() -> VersionedLocation {
-			VersionedLocation::v4::new(
+			VersionedLocation::V4(Location::new(
 				1,
 				AccountId32 {
 					id: Keyring::Alice.into(),
 					network: None,
 				},
-			)
+			))
 		}
 
 		fn allowed_xcm_location() -> RestrictedTransferLocation {
-			RestrictedTransferLocation::Xcm(xcm_location())
+			RestrictedTransferLocation::Xcm(Box::new(xcm_location()))
 		}
 
 		fn add_allowance<T: Runtime>(
@@ -7220,16 +7220,18 @@ mod centrifuge {
 					pallet_transfer_allowlist::Pallet::<T>::add_transfer_allowance(
 						RawOrigin::Signed(Keyring::Alice.into()).into(),
 						FilterCurrency::Specific(USDC),
-						RestrictedTransferLocation::Xcm(VersionedLocation::v4::new(
-							1,
-							[
-								Parachain(T::FudgeHandle::SIBLING_ID),
-								Junction::AccountId32 {
-									id: Keyring::Alice.into(),
-									network: None,
-								}
-							]
-						))
+						RestrictedTransferLocation::Xcm(Box::new(VersionedLocation::V4(
+							Location::new(
+								1,
+								[
+									Parachain(T::FudgeHandle::SIBLING_ID),
+									Junction::AccountId32 {
+										id: Keyring::Alice.into(),
+										network: None,
+									}
+								]
+							)
+						)))
 					)
 				);
 

--- a/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/generic/cases/liquidity_pools.rs
@@ -6689,8 +6689,8 @@ mod centrifuge {
 
 		const TRANSFER_AMOUNT: u128 = 10;
 
-		fn xcm_location() -> Location {
-			Location::new(
+		fn xcm_location() -> VersionedLocation {
+			VersionedLocation::v4::new(
 				1,
 				AccountId32 {
 					id: Keyring::Alice.into(),
@@ -7220,7 +7220,7 @@ mod centrifuge {
 					pallet_transfer_allowlist::Pallet::<T>::add_transfer_allowance(
 						RawOrigin::Signed(Keyring::Alice.into()).into(),
 						FilterCurrency::Specific(USDC),
-						RestrictedTransferLocation::Xcm(Location::new(
+						RestrictedTransferLocation::Xcm(VersionedLocation::v4::new(
 							1,
 							[
 								Parachain(T::FudgeHandle::SIBLING_ID),

--- a/scripts/runtime_benchmarks.sh
+++ b/scripts/runtime_benchmarks.sh
@@ -41,7 +41,7 @@ echo "Benchmarking pallets for runtime ${runtime}..."
 if [[ $runtime == "development" ]];
 then
   runtime_path="runtime/development"
-  chain="development-local"
+  chain="development"
 elif [[ $runtime == "centrifuge" ]];
 then
   runtime_path="runtime/centrifuge"


### PR DESCRIPTION
# Description

Modify how RestrictedTransferLocation stores XCM information and do the consequent migration. Based on this https://github.com/centrifuge/centrifuge-chain/pull/1833#discussion_r1604512221


