### PR TITLE
fix: allow root to propose and remove fees

### DIFF
--- a/pallets/pool-fees/src/lib.rs
+++ b/pallets/pool-fees/src/lib.rs
@@ -327,16 +327,18 @@ pub mod pallet {
 			bucket: PoolFeeBucket,
 			fee: PoolFeeInfoOf<T>,
 		) -> DispatchResult {
-			let who = ensure_signed(origin)?;
+			let who = ensure_signed_or_root(origin)?;
 
 			ensure!(
 				T::PoolReserve::pool_exists(pool_id),
 				Error::<T>::PoolNotFound
 			);
-			ensure!(
-				T::IsPoolAdmin::check((who, pool_id)),
-				Error::<T>::NotPoolAdmin
-			);
+			if let Some(signer) = who {
+				ensure!(
+					T::IsPoolAdmin::check((signer, pool_id)),
+					Error::<T>::NotPoolAdmin
+				);
+			}
 
 			let fee_id = Self::generate_fee_id()?;
 			T::ChangeGuard::note(
@@ -385,11 +387,16 @@ pub mod pallet {
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::remove_fee(T::MaxPoolFeesPerBucket::get()))]
 		pub fn remove_fee(origin: OriginFor<T>, fee_id: T::FeeId) -> DispatchResult {
-			let who = ensure_signed(origin)?;
+			let who = ensure_signed_or_root(origin)?;
 
 			let fee = Self::get_active_fee(fee_id)?;
+			//
 			ensure!(
-				matches!(fee.editor, PoolFeeEditor::Account(account) if account == who),
+				match (fee.editor, who) {
+					(PoolFeeEditor::Account(editor), Some(signer)) => editor == signer,
+					(PoolFeeEditor::Root, None) => true,
+					_ => false,
+				},
 				Error::<T>::UnauthorizedEdit
 			);
 			Self::do_remove_fee(fee_id)?;

--- a/pallets/pool-fees/src/mock.rs
+++ b/pallets/pool-fees/src/mock.rs
@@ -219,6 +219,16 @@ pub fn default_fixed_fee() -> PoolFeeInfoOf<Runtime> {
 	})
 }
 
+pub fn root_editor_fee() -> PoolFeeInfoOf<Runtime> {
+	PoolFeeInfoOf::<Runtime> {
+		destination: DESTINATION,
+		editor: PoolFeeEditor::Root,
+		fee_type: PoolFeeType::Fixed {
+			limit: PoolFeeAmount::ShareOfPortfolioValuation(Rate::saturating_from_rational(1, 10)),
+		},
+	}
+}
+
 pub fn default_chargeable_fee() -> PoolFeeInfoOf<Runtime> {
 	new_fee(PoolFeeType::ChargedUpTo {
 		limit: PoolFeeAmount::AmountPerSecond(1),


### PR DESCRIPTION
# Description

Fixes https://github.com/centrifuge/centrifuge-chain/issues/1847

## Changes and Descriptions

* Feat: Allow `root` origin for proposing fees
* Fix: Allow `root` origin for removing fees if fee editor is configured as `Root`

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
