### PR TITLE
Fix: `pallet-pool-system` - Ratio Calculation

### DIFF
--- a/pallets/pool-system/src/lib.rs
+++ b/pallets/pool-system/src/lib.rs
@@ -1255,16 +1255,13 @@ pub mod pallet {
 							//       implementation defaults to 100% if the denominator is zero
 							let ratio = if total_assets.is_zero() {
 								Perquintill::zero()
+							} else if current_tranche < num_tranches {
+								Perquintill::from_rational(
+									tranche.supply.ensure_add(invest)?.ensure_sub(redeem)?,
+									total_assets,
+								)
 							} else {
-								if current_tranche < num_tranches {
-									Perquintill::from_rational(
-										tranche.supply.ensure_add(invest)?.ensure_sub(redeem)?,
-										total_assets,
-									)
-								} else {
-									Perquintill::one()
-										.ensure_sub(sum_non_residual_tranche_ratios)?
-								}
+								Perquintill::one().ensure_sub(sum_non_residual_tranche_ratios)?
 							};
 
 							sum_non_residual_tranche_ratios.ensure_add_assign(ratio)?;

--- a/pallets/pool-system/src/mock.rs
+++ b/pallets/pool-system/src/mock.rs
@@ -506,6 +506,7 @@ fn create_tranche_id(pool: u64, tranche: u64) -> [u8; 16] {
 parameter_types! {
 	pub JuniorTrancheId: [u8; 16] = create_tranche_id(0, 0);
 	pub SeniorTrancheId: [u8; 16] = create_tranche_id(0, 1);
+	pub SecondSeniorTrancheId: [u8; 16] = create_tranche_id(0, 2);
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/pool-system/src/mock.rs
+++ b/pallets/pool-system/src/mock.rs
@@ -27,9 +27,7 @@ use cfg_types::{
 	tokens::{CurrencyId, CustomMetadata, TrancheCurrency},
 };
 use frame_support::{
-	assert_ok, derive_impl,
-	dispatch::RawOrigin,
-	parameter_types,
+	assert_ok, derive_impl, parameter_types,
 	traits::{Contains, EnsureOriginWithArg, Hooks, PalletInfoAccess, SortedMembers},
 	Blake2_128, PalletId, StorageHasher,
 };

--- a/pallets/pool-system/src/mock.rs
+++ b/pallets/pool-system/src/mock.rs
@@ -26,6 +26,8 @@ use cfg_types::{
 	time::TimeProvider,
 	tokens::{CurrencyId, CustomMetadata, TrancheCurrency},
 };
+#[cfg(feature = "runtime-benchmarks")]
+use frame_support::dispatch::RawOrigin;
 use frame_support::{
 	assert_ok, derive_impl, parameter_types,
 	traits::{Contains, EnsureOriginWithArg, Hooks, PalletInfoAccess, SortedMembers},

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -75,7 +75,7 @@ pub mod util {
 					TrancheInput {
 						tranche_type: TrancheType::NonResidual {
 							interest_rate_per_sec: Rate::default(),
-							min_risk_buffer: Perquintill::default(),
+							min_risk_buffer: Perquintill::from_percent(50),
 						},
 						seniority: None,
 						metadata: TrancheMetadata {
@@ -85,7 +85,7 @@ pub mod util {
 					},
 				],
 				AUSD_CURRENCY_ID,
-				0,
+				10_000 * CURRENCY,
 				vec![],
 			)
 			.unwrap();
@@ -97,7 +97,7 @@ pub mod util {
 			// forcing to call `execute_epoch()` later.
 			Investments::update_invest_order(
 				RuntimeOrigin::signed(0),
-				TrancheCurrency::generate(0, JuniorTrancheId::get()),
+				TrancheCurrency::generate(0, SeniorTrancheId::get()),
 				500 * CURRENCY,
 			)
 			.unwrap();

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -58,32 +58,86 @@ pub mod util {
 	pub mod default_pool {
 		use super::*;
 
+		pub fn one_tranche_input() -> Vec<TrancheInput<Rate, StringLimit>> {
+			vec![TrancheInput {
+				tranche_type: TrancheType::Residual,
+				seniority: None,
+				metadata: TrancheMetadata {
+					token_name: BoundedVec::default(),
+					token_symbol: BoundedVec::default(),
+				},
+			}]
+		}
+
+		pub fn three_tranche_input() -> Vec<TrancheInput<Rate, StringLimit>> {
+			vec![
+				TrancheInput {
+					tranche_type: TrancheType::Residual,
+					seniority: None,
+					metadata: TrancheMetadata {
+						token_name: BoundedVec::default(),
+						token_symbol: BoundedVec::default(),
+					},
+				},
+				TrancheInput {
+					tranche_type: TrancheType::NonResidual {
+						interest_rate_per_sec: Rate::default(),
+						min_risk_buffer: Perquintill::from_percent(50),
+					},
+					seniority: None,
+					metadata: TrancheMetadata {
+						token_name: BoundedVec::default(),
+						token_symbol: BoundedVec::default(),
+					},
+				},
+				TrancheInput {
+					tranche_type: TrancheType::NonResidual {
+						interest_rate_per_sec: Rate::default(),
+						min_risk_buffer: Perquintill::from_percent(50),
+					},
+					seniority: None,
+					metadata: TrancheMetadata {
+						token_name: BoundedVec::default(),
+						token_symbol: BoundedVec::default(),
+					},
+				},
+			]
+		}
+
+		pub fn two_tranche_input() -> Vec<TrancheInput<Rate, StringLimit>> {
+			vec![
+				TrancheInput {
+					tranche_type: TrancheType::Residual,
+					seniority: None,
+					metadata: TrancheMetadata {
+						token_name: BoundedVec::default(),
+						token_symbol: BoundedVec::default(),
+					},
+				},
+				TrancheInput {
+					tranche_type: TrancheType::NonResidual {
+						interest_rate_per_sec: Rate::default(),
+						min_risk_buffer: Perquintill::from_percent(50),
+					},
+					seniority: None,
+					metadata: TrancheMetadata {
+						token_name: BoundedVec::default(),
+						token_symbol: BoundedVec::default(),
+					},
+				},
+			]
+		}
+
 		pub fn create() {
+			create_with_tranche_input(two_tranche_input())
+		}
+
+		pub fn create_with_tranche_input(input: Vec<TrancheInput<Rate, StringLimit>>) {
 			PoolSystem::create(
 				DEFAULT_POOL_OWNER,
 				DEFAULT_POOL_OWNER,
 				DEFAULT_POOL_ID,
-				vec![
-					TrancheInput {
-						tranche_type: TrancheType::Residual,
-						seniority: None,
-						metadata: TrancheMetadata {
-							token_name: BoundedVec::default(),
-							token_symbol: BoundedVec::default(),
-						},
-					},
-					TrancheInput {
-						tranche_type: TrancheType::NonResidual {
-							interest_rate_per_sec: Rate::default(),
-							min_risk_buffer: Perquintill::from_percent(50),
-						},
-						seniority: None,
-						metadata: TrancheMetadata {
-							token_name: BoundedVec::default(),
-							token_symbol: BoundedVec::default(),
-						},
-					},
-				],
+				input,
 				AUSD_CURRENCY_ID,
 				10_000 * CURRENCY,
 				vec![],

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -42,6 +42,8 @@ use crate::{
 	UnhealthyState,
 };
 
+mod ratios;
+
 const AUSD_CURRENCY_ID: CurrencyId = CurrencyId::ForeignAsset(1);
 
 pub mod util {

--- a/pallets/pool-system/src/tests/ratios.rs
+++ b/pallets/pool-system/src/tests/ratios.rs
@@ -296,6 +296,7 @@ fn ensure_ratios_are_distributed_correctly_3_tranches() {
 		let check_ratios = [
 			Perquintill::from_rational(1u64, 5),
 			Perquintill::from_rational(2u64, 5),
+			Perquintill::from_rational(2u64, 5),
 		];
 
 		// Ensure ratios are 100

--- a/pallets/pool-system/src/tests/ratios.rs
+++ b/pallets/pool-system/src/tests/ratios.rs
@@ -1,0 +1,163 @@
+use sp_arithmetic::traits::EnsureSub;
+
+// Copyright 2021 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+use super::*;
+
+#[test]
+fn ensure_ratios_are_distributed_correctly() {
+	new_test_ext().execute_with(|| {
+		let pool_owner = DEFAULT_POOL_OWNER;
+		let pool_owner_origin = RuntimeOrigin::signed(pool_owner);
+
+		// Initialize pool with initial investments
+		let senior_interest_rate = Rate::saturating_from_rational(10, 100)
+			/ Rate::saturating_from_integer(SECONDS_PER_YEAR)
+			+ One::one();
+
+		assert_ok!(PoolSystem::create(
+			pool_owner.clone(),
+			pool_owner.clone(),
+			0,
+			vec![
+				TrancheInput {
+					tranche_type: TrancheType::Residual,
+					seniority: None,
+					metadata: TrancheMetadata {
+						token_name: BoundedVec::default(),
+						token_symbol: BoundedVec::default(),
+					}
+				},
+				TrancheInput {
+					tranche_type: TrancheType::NonResidual {
+						interest_rate_per_sec: senior_interest_rate,
+						min_risk_buffer: Perquintill::from_percent(10),
+					},
+					seniority: None,
+					metadata: TrancheMetadata {
+						token_name: BoundedVec::default(),
+						token_symbol: BoundedVec::default(),
+					}
+				},
+			],
+			AUSD_CURRENCY_ID,
+			10_000 * CURRENCY,
+			vec![],
+		));
+
+		/// Assert ratios are all zero
+		crate::Pool::<Runtime>::get(0)
+			.unwrap()
+			.tranches
+			.residual_top_slice()
+			.iter()
+			.for_each(|tranche| {
+				assert_eq!(tranche.ratio, Perquintill::from_percent(0));
+			});
+
+		// Force min_epoch_time to 0 without using update
+		// as this breaks the runtime-defined pool
+		// parameter bounds and update will not allow this.
+		crate::Pool::<Runtime>::try_mutate(0, |maybe_pool| -> Result<(), ()> {
+			maybe_pool.as_mut().unwrap().parameters.min_epoch_time = 0;
+			maybe_pool.as_mut().unwrap().parameters.max_nav_age = u64::MAX;
+			Ok(())
+		})
+		.unwrap();
+
+		invest_close_and_collect(
+			0,
+			vec![
+				(0, JuniorTrancheId::get(), 500 * CURRENCY),
+				(0, SeniorTrancheId::get(), 500 * CURRENCY),
+			],
+		);
+
+		// Ensure ratios are 50/50
+		crate::Pool::<Runtime>::get(0)
+			.unwrap()
+			.tranches
+			.residual_top_slice()
+			.iter()
+			.for_each(|tranche| {
+				assert_eq!(tranche.ratio, Perquintill::from_percent(50));
+			});
+
+		// Attempt to redeem half
+		assert_ok!(Investments::update_redeem_order(
+			RuntimeOrigin::signed(0),
+			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			200 * CURRENCY
+		));
+		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
+		assert_ok!(Investments::collect_redemptions(
+			RuntimeOrigin::signed(0),
+			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+		));
+
+		let new_residual_ratio = Perquintill::from_rational(5u64, 8u64);
+		let mut next_ratio = new_residual_ratio;
+
+		// Ensure ratios are 500/800 and 300/800
+		crate::Pool::<Runtime>::get(0)
+			.unwrap()
+			.tranches
+			.residual_top_slice()
+			.iter()
+			.for_each(|tranche| {
+				assert_eq!(tranche.ratio, next_ratio);
+				next_ratio = Perquintill::one().ensure_sub(next_ratio).unwrap();
+			});
+
+		// Attempt to redeem everything
+		assert_ok!(Investments::update_redeem_order(
+			RuntimeOrigin::signed(0),
+			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			300 * CURRENCY
+		));
+		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
+		assert_ok!(Investments::collect_redemptions(
+			RuntimeOrigin::signed(0),
+			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+		));
+
+		let new_residual_ratio = Perquintill::one();
+		let mut next_ratio = new_residual_ratio;
+
+		// Ensure ratios are 100/0
+		crate::Pool::<Runtime>::get(0)
+			.unwrap()
+			.tranches
+			.residual_top_slice()
+			.iter()
+			.for_each(|tranche| {
+				assert_eq!(tranche.ratio, next_ratio);
+				next_ratio = Perquintill::one().ensure_sub(next_ratio).unwrap();
+			});
+
+		/// Ensure ratio goes up again
+		invest_close_and_collect(0, vec![(0, SeniorTrancheId::get(), 300 * CURRENCY)]);
+		let new_residual_ratio = Perquintill::from_rational(5u64, 8u64);
+		let mut next_ratio = new_residual_ratio;
+
+		// Ensure ratios are 500/800 and 300/800
+		crate::Pool::<Runtime>::get(0)
+			.unwrap()
+			.tranches
+			.residual_top_slice()
+			.iter()
+			.for_each(|tranche| {
+				assert_eq!(tranche.ratio, next_ratio);
+				next_ratio = Perquintill::one().ensure_sub(next_ratio).unwrap();
+			});
+	});
+}

--- a/pallets/pool-system/src/tests/ratios.rs
+++ b/pallets/pool-system/src/tests/ratios.rs
@@ -1,5 +1,3 @@
-use sp_arithmetic::traits::EnsureSub;
-
 // Copyright 2021 Centrifuge Foundation (centrifuge.io).
 //
 // This file is part of the Centrifuge chain project.
@@ -11,6 +9,8 @@ use sp_arithmetic::traits::EnsureSub;
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
+use sp_arithmetic::traits::EnsureSub;
+
 use super::*;
 
 #[test]
@@ -19,42 +19,9 @@ fn ensure_ratios_are_distributed_correctly() {
 		let pool_owner = DEFAULT_POOL_OWNER;
 		let pool_owner_origin = RuntimeOrigin::signed(pool_owner);
 
-		// Initialize pool with initial investments
-		let senior_interest_rate = Rate::saturating_from_rational(10, 100)
-			/ Rate::saturating_from_integer(SECONDS_PER_YEAR)
-			+ One::one();
+		util::default_pool::create();
 
-		assert_ok!(PoolSystem::create(
-			pool_owner.clone(),
-			pool_owner.clone(),
-			0,
-			vec![
-				TrancheInput {
-					tranche_type: TrancheType::Residual,
-					seniority: None,
-					metadata: TrancheMetadata {
-						token_name: BoundedVec::default(),
-						token_symbol: BoundedVec::default(),
-					}
-				},
-				TrancheInput {
-					tranche_type: TrancheType::NonResidual {
-						interest_rate_per_sec: senior_interest_rate,
-						min_risk_buffer: Perquintill::from_percent(10),
-					},
-					seniority: None,
-					metadata: TrancheMetadata {
-						token_name: BoundedVec::default(),
-						token_symbol: BoundedVec::default(),
-					}
-				},
-			],
-			AUSD_CURRENCY_ID,
-			10_000 * CURRENCY,
-			vec![],
-		));
-
-		/// Assert ratios are all zero
+		// Assert ratios are all zero
 		crate::Pool::<Runtime>::get(0)
 			.unwrap()
 			.tranches
@@ -67,7 +34,7 @@ fn ensure_ratios_are_distributed_correctly() {
 		// Force min_epoch_time to 0 without using update
 		// as this breaks the runtime-defined pool
 		// parameter bounds and update will not allow this.
-		crate::Pool::<Runtime>::try_mutate(0, |maybe_pool| -> Result<(), ()> {
+		Pool::<Runtime>::try_mutate(0, |maybe_pool| -> Result<(), ()> {
 			maybe_pool.as_mut().unwrap().parameters.min_epoch_time = 0;
 			maybe_pool.as_mut().unwrap().parameters.max_nav_age = u64::MAX;
 			Ok(())
@@ -83,7 +50,7 @@ fn ensure_ratios_are_distributed_correctly() {
 		);
 
 		// Ensure ratios are 50/50
-		crate::Pool::<Runtime>::get(0)
+		Pool::<Runtime>::get(0)
 			.unwrap()
 			.tranches
 			.residual_top_slice()
@@ -92,7 +59,7 @@ fn ensure_ratios_are_distributed_correctly() {
 				assert_eq!(tranche.ratio, Perquintill::from_percent(50));
 			});
 
-		// Attempt to redeem half
+		// Attempt to redeem 40%
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
 			TrancheCurrency::generate(0, SeniorTrancheId::get()),
@@ -108,7 +75,7 @@ fn ensure_ratios_are_distributed_correctly() {
 		let mut next_ratio = new_residual_ratio;
 
 		// Ensure ratios are 500/800 and 300/800
-		crate::Pool::<Runtime>::get(0)
+		Pool::<Runtime>::get(0)
 			.unwrap()
 			.tranches
 			.residual_top_slice()
@@ -134,7 +101,7 @@ fn ensure_ratios_are_distributed_correctly() {
 		let mut next_ratio = new_residual_ratio;
 
 		// Ensure ratios are 100/0
-		crate::Pool::<Runtime>::get(0)
+		Pool::<Runtime>::get(0)
 			.unwrap()
 			.tranches
 			.residual_top_slice()
@@ -144,13 +111,13 @@ fn ensure_ratios_are_distributed_correctly() {
 				next_ratio = Perquintill::one().ensure_sub(next_ratio).unwrap();
 			});
 
-		/// Ensure ratio goes up again
+		// Ensure ratio goes up again
 		invest_close_and_collect(0, vec![(0, SeniorTrancheId::get(), 300 * CURRENCY)]);
 		let new_residual_ratio = Perquintill::from_rational(5u64, 8u64);
 		let mut next_ratio = new_residual_ratio;
 
 		// Ensure ratios are 500/800 and 300/800
-		crate::Pool::<Runtime>::get(0)
+		Pool::<Runtime>::get(0)
 			.unwrap()
 			.tranches
 			.residual_top_slice()

--- a/pallets/pool-system/src/tranches.rs
+++ b/pallets/pool-system/src/tranches.rs
@@ -1352,7 +1352,11 @@ where
 		.map(|tranche_value| {
 			remaining_subordinate_value =
 				remaining_subordinate_value.saturating_sub(*tranche_value);
-			Perquintill::from_rational(remaining_subordinate_value, pool_value)
+			if pool_value.is_zero() {
+				Perquintill::zero()
+			} else {
+				Perquintill::from_rational(remaining_subordinate_value, pool_value)
+			}
 		})
 		.collect::<Vec<Perquintill>>();
 

--- a/pallets/pool-system/src/tranches.rs
+++ b/pallets/pool-system/src/tranches.rs
@@ -1347,12 +1347,13 @@ where
 	// previous more senior tranche - this tranche value.
 	let mut remaining_subordinate_value = pool_value;
 	let mut risk_buffers: Vec<Perquintill> = tranche_values
-		.iter()
+		.into_iter()
 		.rev()
 		.map(|tranche_value| {
-			remaining_subordinate_value =
-				remaining_subordinate_value.saturating_sub(*tranche_value);
-			if pool_value.is_zero() {
+			remaining_subordinate_value = remaining_subordinate_value.saturating_sub(tranche_value);
+			if tranche_value.is_zero() {
+				Perquintill::one()
+			} else if pool_value.is_zero() {
 				Perquintill::zero()
 			} else {
 				Perquintill::from_rational(remaining_subordinate_value, pool_value)


### PR DESCRIPTION
# Description
The current ratio calculation has the following bug. The logic assumes that `Sum(tranche.supply) = total_assets`, but as the residual tranche does only receive its variable interest after the ratio calculation, this is not true. 

In order to fix this, the following change does give the automatically all the remaining ratio to the residual tranche.
## Changes and Descriptions
* Adds a test to ensure ratios are actually adapting accordingly
* Changes ratio calculation during `fn do_execute_epoch`

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
