### PR TITLE
Feat: decrease debt

### DIFF
--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -355,6 +355,12 @@ pub mod pallet {
 			loan_id: T::LoanId,
 			amount: PrincipalInput<T>,
 		},
+		/// Debt of a loan has been decreased
+		DebtDecreased {
+			pool_id: T::PoolId,
+			loan_id: T::LoanId,
+			amount: RepaidInput<T>,
+		},
 	}
 
 	#[pallet::error]
@@ -883,6 +889,34 @@ pub mod pallet {
 			let _count = Self::borrow_action(&who, pool_id, loan_id, &amount, false)?;
 
 			Self::deposit_event(Event::<T>::DebtIncreased {
+				pool_id,
+				loan_id,
+				amount,
+			});
+
+			Ok(())
+		}
+
+		/// Decrease debt for a loan. Similar to [`Pallet::repay()`] but
+		/// without transferring from the pool.
+		///
+		/// The origin must be the borrower of the loan.
+		/// The decrease debt action should fulfill the repay restrictions
+		/// configured at [`types::LoanRestrictions`]. The portfolio valuation
+		/// of the pool is updated to reflect the new present value of the loan.
+		#[pallet::weight(T::WeightInfo::increase_debt(T::MaxActiveLoansPerPool::get()))]
+		#[pallet::call_index(14)]
+		pub fn decrease_debt(
+			origin: OriginFor<T>,
+			pool_id: T::PoolId,
+			loan_id: T::LoanId,
+			amount: RepaidInput<T>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			let (amount, _count) = Self::repay_action(&who, pool_id, loan_id, &amount, false)?;
+
+			Self::deposit_event(Event::<T>::DebtDecreased {
 				pool_id,
 				loan_id,
 				amount,

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -601,9 +601,22 @@ fn increase_debt_does_not_withdraw() {
 		let loan_id = util::create_loan(loan);
 
 		let amount = ExternalAmount::new(QUANTITY, PRICE_VALUE);
-		config_mocks(amount.balance().unwrap());
+		MockPrices::mock_get(|id, pool_id| {
+			assert_eq!(*pool_id, POOL_A);
+			match *id {
+				REGISTER_PRICE_ID => Ok((PRICE_VALUE, BLOCK_TIME_MS)),
+				_ => Err(PRICE_ID_NO_FOUND),
+			}
+		});
+		MockPrices::mock_register_id(|id, pool_id| {
+			assert_eq!(*pool_id, POOL_A);
+			match *id {
+				REGISTER_PRICE_ID => Ok(()),
+				_ => Err(PRICE_ID_NO_FOUND),
+			}
+		});
 
-		assert_ok!(Loans::borrow(
+		assert_ok!(Loans::increase_debt(
 			RuntimeOrigin::signed(BORROWER),
 			POOL_A,
 			loan_id,


### PR DESCRIPTION
# Description
Allows issuers to decrease the debt of any loan without actually repaying to the pool. Mostly useful for ensuring offchain cash is reflected accurately. This is basically an expense in most cases, should be covered by fees, but is a good increase of flexibility.

NOTE:
* The deployed capital ratio of the tranches will decrease during the next epoch close but until then the tranches expect to generate the same revenue as of before - i.e. with a higher deployed capital ratio

## Changes and Descriptions
* adds  extrinsic `fn decrease_debt(..)` - same as `fn repay(..)` but without moving tokens to the pool

# Checklist:
- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
