### PR TITLE
ci: re-enable submodule pulling

### DIFF
--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #4.1.4
+        with:
+          submodules: 'recursive'
 
       - name: Prep build
         uses: ./.github/actions/prep-ubuntu
@@ -50,6 +52,7 @@ jobs:
           cache: enabled
           GWIP: ${{ secrets.GWIP_SCCACHE }}
           GSA: ${{ secrets.GSA_SCCACHE }}
+          submodules: 'recursive'
 
       # Required for integration tests evm interaction
       - name: Install Foundry

--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #4.1.4
+        with:
+          submodules: 'recursive'
 
       - name: Prep build
         uses: ./.github/actions/prep-ubuntu
@@ -26,7 +28,10 @@ jobs:
           # Cache needs Google credentials:
           GWIP: ${{ secrets.GWIP_SCCACHE }}
           GSA: ${{ secrets.GSA_SCCACHE }}
-          submodules: 'recursive'
+
+      # Required for integration tests evm interaction
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Runing cargo ${{ matrix.target }}
         run: ./ci/run-check.sh
@@ -52,11 +57,7 @@ jobs:
           cache: enabled
           GWIP: ${{ secrets.GWIP_SCCACHE }}
           GSA: ${{ secrets.GSA_SCCACHE }}
-          submodules: 'recursive'
 
-      # Required for integration tests evm interaction
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Runing cargo ${{ matrix.target }}
         run: ./ci/run-check.sh


### PR DESCRIPTION
# Description

* Fixes over aggressive reversion of changes in https://github.com/centrifuge/centrifuge-chain/pull/1822 in commit https://github.com/centrifuge/centrifuge-chain/pull/1822/commits/5d4acff282cd93edf60de02913ad0603ee9c1cda
* Enables submodule pulling in CI such that LP integration test build should work

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
