### PR TITLE
Loans: multi cashflows fix external loan

### DIFF
--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -59,11 +59,10 @@ pub mod util;
 
 mod weights;
 
-#[cfg(test)]
-mod tests;
-
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+#[cfg(test)]
+mod tests;
 
 pub use pallet::*;
 pub use weights::WeightInfo;
@@ -1260,7 +1259,7 @@ pub mod pallet {
 			ActiveLoans::<T>::get(pool_id)
 				.into_iter()
 				.find(|(id, _)| *id == loan_id)
-				.map(|(_, loan)| loan.expected_cashflows(pool_id))
+				.map(|(_, loan)| loan.expected_cashflows())
 				.ok_or(Error::<T>::LoanNotActiveOrNotFound)?
 		}
 	}

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -1260,7 +1260,7 @@ pub mod pallet {
 			ActiveLoans::<T>::get(pool_id)
 				.into_iter()
 				.find(|(id, _)| *id == loan_id)
-				.map(|(_, loan)| loan.expected_cashflows())
+				.map(|(_, loan)| loan.expected_cashflows(pool_id))
 				.ok_or(Error::<T>::LoanNotActiveOrNotFound)?
 		}
 	}

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -630,7 +630,7 @@ mod cashflow {
 	}
 
 	#[test]
-	fn computed_correctly() {
+	fn computed_correctly_interal_pricing() {
 		new_test_ext().execute_with(|| {
 			let loan_id = create_cashflow_loan();
 

--- a/pallets/loans/src/tests/borrow_loan.rs
+++ b/pallets/loans/src/tests/borrow_loan.rs
@@ -615,24 +615,24 @@ fn increase_debt_does_not_withdraw() {
 mod cashflow {
 	use super::*;
 
-	fn create_cashflow_loan() -> LoanId {
-		util::create_loan(LoanInfo {
-			schedule: RepaymentSchedule {
-				maturity: Maturity::Fixed {
-					date: (now() + YEAR).as_secs(),
-					extension: 0,
-				},
-				interest_payments: InterestPayments::Monthly(1),
-				pay_down_schedule: PayDownSchedule::None,
+	fn monthly_schedule() -> RepaymentSchedule {
+		RepaymentSchedule {
+			maturity: Maturity::Fixed {
+				date: (now() + YEAR).as_secs(),
+				extension: 0,
 			},
-			..util::base_internal_loan()
-		})
+			interest_payments: InterestPayments::Monthly(1),
+			pay_down_schedule: PayDownSchedule::None,
+		}
 	}
 
 	#[test]
-	fn computed_correctly_interal_pricing() {
+	fn computed_correctly_internal_pricing() {
 		new_test_ext().execute_with(|| {
-			let loan_id = create_cashflow_loan();
+			let loan_id = util::create_loan(LoanInfo {
+				schedule: monthly_schedule(),
+				..util::base_internal_loan()
+			});
 
 			config_mocks(COLLATERAL_VALUE / 2);
 			assert_ok!(Loans::borrow(
@@ -690,9 +690,75 @@ mod cashflow {
 	}
 
 	#[test]
+	fn computed_correctly_external_pricing() {
+		new_test_ext().execute_with(|| {
+			let loan_id = util::create_loan(LoanInfo {
+				schedule: monthly_schedule(),
+				..util::base_external_loan()
+			});
+
+			let amount = ExternalAmount::new(QUANTITY / 2.into(), PRICE_VALUE);
+			config_mocks(amount.balance().unwrap());
+
+			assert_ok!(Loans::borrow(
+				RuntimeOrigin::signed(BORROWER),
+				POOL_A,
+				loan_id,
+				PrincipalInput::External(amount.clone())
+			));
+
+			let loan = util::get_loan(loan_id);
+
+			let total_principal = amount.balance().unwrap();
+			dbg!(total_principal);
+			let acc_interest_rate_per_year = checked_pow(
+				util::default_interest_rate().per_sec().unwrap(),
+				SECONDS_PER_YEAR as usize,
+			)
+			.unwrap();
+
+			let outstanding_notional = util::current_extenal_pricing(loan_id)
+				.outstanding_notional_principal()
+				.unwrap();
+
+			let total_interest = acc_interest_rate_per_year.saturating_mul_int(total_principal)
+				- outstanding_notional;
+
+			// The -1 comes from a precission issue when computing cashflows.
+			let principal = (total_principal - 1) / 12;
+			let interest = total_interest / 12;
+
+			assert_eq!(
+				loan.expected_cashflows()
+					.unwrap()
+					.into_iter()
+					.map(|payment| (payment.when, payment.principal, payment.interest))
+					.collect::<Vec<_>>(),
+				vec![
+					(last_secs_from_ymd(1970, 2, 1), principal, interest),
+					(last_secs_from_ymd(1970, 3, 1), principal, interest),
+					(last_secs_from_ymd(1970, 4, 1), principal, interest),
+					(last_secs_from_ymd(1970, 5, 1), principal, interest),
+					(last_secs_from_ymd(1970, 6, 1), principal, interest),
+					(last_secs_from_ymd(1970, 7, 1), principal, interest),
+					(last_secs_from_ymd(1970, 8, 1), principal, interest),
+					(last_secs_from_ymd(1970, 9, 1), principal, interest),
+					(last_secs_from_ymd(1970, 10, 1), principal, interest),
+					(last_secs_from_ymd(1970, 11, 1), principal, interest),
+					(last_secs_from_ymd(1970, 12, 1), principal, interest),
+					(last_secs_from_ymd(1971, 1, 1), principal, interest),
+				]
+			);
+		});
+	}
+
+	#[test]
 	fn borrow_twice_same_month() {
 		new_test_ext().execute_with(|| {
-			let loan_id = create_cashflow_loan();
+			let loan_id = util::create_loan(LoanInfo {
+				schedule: monthly_schedule(),
+				..util::base_internal_loan()
+			});
 
 			config_mocks(COLLATERAL_VALUE / 2);
 			assert_ok!(Loans::borrow(
@@ -720,7 +786,10 @@ mod cashflow {
 	#[test]
 	fn payment_overdue() {
 		new_test_ext().execute_with(|| {
-			let loan_id = create_cashflow_loan();
+			let loan_id = util::create_loan(LoanInfo {
+				schedule: monthly_schedule(),
+				..util::base_internal_loan()
+			});
 
 			config_mocks(COLLATERAL_VALUE / 2);
 			assert_ok!(Loans::borrow(
@@ -767,7 +836,10 @@ mod cashflow {
 	#[test]
 	fn allow_borrow_again_after_repay_overdue_amount() {
 		new_test_ext().execute_with(|| {
-			let loan_id = create_cashflow_loan();
+			let loan_id = util::create_loan(LoanInfo {
+				schedule: monthly_schedule(),
+				..util::base_internal_loan()
+			});
 
 			config_mocks(COLLATERAL_VALUE / 2);
 			assert_ok!(Loans::borrow(

--- a/pallets/loans/src/tests/mod.rs
+++ b/pallets/loans/src/tests/mod.rs
@@ -16,7 +16,10 @@ use super::{
 		input::{PrincipalInput, RepaidInput},
 		loans::{ActiveLoan, ActiveLoanInfo, LoanInfo},
 		pricing::{
-			external::{ExternalAmount, ExternalPricing, MaxBorrowAmount as ExtMaxBorrowAmount},
+			external::{
+				ExternalActivePricing, ExternalAmount, ExternalPricing,
+				MaxBorrowAmount as ExtMaxBorrowAmount,
+			},
 			internal::{InternalPricing, MaxBorrowAmount as IntMaxBorrowAmount},
 			ActivePricing, Pricing,
 		},

--- a/pallets/loans/src/tests/util.rs
+++ b/pallets/loans/src/tests/util.rs
@@ -27,6 +27,13 @@ pub fn current_loan_debt(loan_id: LoanId) -> Balance {
 	}
 }
 
+pub fn current_extenal_pricing(loan_id: LoanId) -> ExternalActivePricing<Runtime> {
+	match get_loan(loan_id).pricing() {
+		ActivePricing::Internal(_) => panic!("expected external pricing"),
+		ActivePricing::External(pricing) => pricing.clone(),
+	}
+}
+
 pub fn borrower(loan_id: LoanId) -> AccountId {
 	match CreatedLoan::<Runtime>::get(POOL_A, loan_id) {
 		Some(created_loan) => *created_loan.borrower(),


### PR DESCRIPTION
# Description

External pricing loan with correct cashflow computation.

For computing interest of:
- internal loans: we use `debt - principal`
- external loans: we use `debt - notional`

From the cashflow perspective, we can emulate the `debt` at maturity given the `interest` and `principal` parameters given to the `expected_cashflows()`. Nevertheless, in the case of external loans, the principal used for computing the debt is different from the value substracted to the debt to obtain the interest. We need to pass a new parameter to `expected_cashflows()`. Called `principal_base`, which is the unaltered principal. It maps to `principal` for internal pricing and `notional` for external pricing.
