### PR TITLE
Chore: Make min epoch time in dev smaller

### DIFF
--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1099,7 +1099,7 @@ parameter_types! {
 	};
 
 	// Defaults for pool parameters
-	pub const DefaultMinEpochTime: u64 = 5 * SECONDS_PER_MINUTE; // 5 minutes
+	pub const DefaultMinEpochTime: u64 = 1; // 1 Second
 	pub const DefaultMaxNAVAge: u64 = 1 * SECONDS_PER_MINUTE; // 1 minute
 
 	// Runtime-defined constraints for pool parameters


### PR DESCRIPTION
# Description
`DefaultMinEpochTime` was 5 minutes beforehand. Which made creating pools in dev annoying, as you need to wait 5 minutes to bring in investments. Now, this is all possible in 2 blocks. 


## Changes and Descriptions
* Change runtime configuration to allow closing multiple epochs per block
*  Change runtime configuration to have a minimum default epoch time of 0 

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
