### PR TITLE
Fix: LP integration tests compilation issue 

### DIFF
--- a/runtime/integration-tests/src/generic/utils/evm.rs
+++ b/runtime/integration-tests/src/generic/utils/evm.rs
@@ -60,6 +60,16 @@ impl ContractInfo {
 	}
 }
 
+fn is_sol_directory(dir_entry: &std::fs::DirEntry) -> bool {
+	dir_entry
+		.path()
+		.parent()
+		.expect(ESSENTIAL)
+		.extension()
+		.map(|s| s.to_str().expect(ESSENTIAL))
+		== Some("sol")
+}
+
 fn traversal(path: impl AsRef<Path>, files: &mut Vec<PathBuf>) {
 	for path in fs::read_dir(path).expect("Submodules directory must exist for integration-tests") {
 		if let Ok(dir_entry) = path.as_ref() {
@@ -77,7 +87,9 @@ fn traversal(path: impl AsRef<Path>, files: &mut Vec<PathBuf>) {
 				.map(|meta| meta.is_file())
 				.unwrap_or(false)
 			{
-				files.push(dir_entry.path())
+				if is_sol_directory(dir_entry) {
+					files.push(dir_entry.path())
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Description

Fix CI on `main`

There is a `build-info` folder artifact in the solidity tree folders. That artifact also contain `.json` files that the evm loader process understands as a solidity json, when it's not.
