### PR TITLE
IT: Panic if event is not found in the expected blocks

### DIFF
--- a/runtime/integration-tests/src/generic/cases/routers.rs
+++ b/runtime/integration-tests/src/generic/cases/routers.rs
@@ -140,12 +140,9 @@ fn check_submission<T: Runtime>(mut env: impl Env<T>, domain_router: DomainRoute
 	});
 
 	env.pass(Blocks::UntilEvent {
-		event: expected_event.clone().into(),
+		event: expected_event.into(),
 		limit: 3,
 	});
-
-	env.check_event(expected_event)
-		.expect("expected OutboundMessageExecutionSuccess event");
 }
 
 #[test_runtimes(all)]

--- a/runtime/integration-tests/src/generic/cases/routers.rs
+++ b/runtime/integration-tests/src/generic/cases/routers.rs
@@ -76,14 +76,8 @@ fn environment_for_evm<T: Runtime + FudgeSupport>() -> FudgeEnv<T> {
 	env.parachain_state_mut(|| {
 		pallet_evm::AccountCodes::<T>::insert(AXELAR_CONTRACT_ADDRESS, AXELAR_CONTRACT_CODE);
 
-		utils::evm::mint_balance_into_derived_account::<T>(
-			AXELAR_CONTRACT_ADDRESS,
-			cfg(1_000_000_000),
-		);
-		utils::evm::mint_balance_into_derived_account::<T>(
-			get_gateway_h160_account::<T>(),
-			cfg(1_000_000),
-		);
+		utils::evm::mint_balance_into_derived_account::<T>(AXELAR_CONTRACT_ADDRESS, cfg(1));
+		utils::evm::mint_balance_into_derived_account::<T>(get_gateway_h160_account::<T>(), cfg(1));
 	});
 
 	env

--- a/runtime/integration-tests/src/generic/env.rs
+++ b/runtime/integration-tests/src/generic/env.rs
@@ -111,13 +111,21 @@ pub trait Env<T: Runtime>: Default {
 			)
 		});
 
+		let mut found_event = false;
 		for i in blocks.range_for(current, slot) {
 			self.__priv_build_block(i);
 
 			if let Blocks::UntilEvent { event, .. } = blocks.clone() {
 				if self.check_event(event).is_some() {
+					found_event = true;
 					break;
 				}
+			}
+		}
+
+		if let Blocks::UntilEvent { event, limit } = blocks.clone() {
+			if !found_event {
+				panic!("Event {event:?} was not found producing {limit} blocks");
 			}
 		}
 	}


### PR DESCRIPTION
# Description

The current behavior for `env.pass(Blocks::UntilEvent{event, limit})` evolve the chain a maximum blocks of `limit` looking for the event. Nevertheless if the event is not found nothing happens. 

That means that later, we need to ensure that the event is found. We can avoid that if we panic if the event is not found during `pass()` method.
