### PR TITLE
CI enhancements

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Build and push centrifugeio/centrifuge-chain
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 #v5.3.0
         with:
+          provenance: false # Solves untagged containers getting into the GH registry https://github.com/docker/build-push-action/issues/894
           context: .
           file: ./docker/centrifuge-chain/Dockerfile
           build-args: |
@@ -111,14 +112,14 @@ jobs:
           short-description: ${{ github.event.repository.description }}
           enable-url-completion: true
 
-      - name: Update GitHub release
-        if: github.event_name == 'release' && github.event.action == 'released' && matrix.target == 'release'
-        uses: softprops/action-gh-release@v1
-        with:
-          append_body: true
-          body: |
-            **Docker tags (${{ env.NOW }}):**
-               ${{ steps.meta.outputs.tags }}
+      # - name: Update GitHub release
+      #   if: github.event_name == 'release' && github.event.action == 'released' && matrix.target == 'release'
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     append_body: true
+      #     body: |
+      #       **Docker tags (${{ env.NOW }}):**
+      #          ${{ steps.meta.outputs.tags }}
 
       - if: failure()
         name: Check available space after build failed

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -18,14 +18,13 @@ jobs:
     # Benchmark (with cache hit)
     # ubuntu-latest 50 min
     # ubuntu-latest-4-cores 34 min
-    runs-on:  ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-4-cores
     strategy:
       matrix:
-        target: [build-runtime]
-        package: [altair-runtime, centrifuge-runtime, development-runtime]
-    name: ${{ matrix.target }}-${{ matrix.package }}
+        chain: [ altair, centrifuge, development ]
+    name: build-runtime-${{ matrix.chain }}
     steps:
-    # PREP
+      # PREP
       - name: Check out code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #4.1.4
 
@@ -42,22 +41,12 @@ jobs:
             ./target/srtool
           cache-directories: ./runtime
 
-    # BUILD
-      - name: Run srtool # https://docs.substrate.io/reference/command-line-tools/srtool/
-        run: >
-          docker run --rm  --user root --platform=linux/amd64
-          -e PACKAGE=${{ matrix.package }} -v /home/runner/.cargo:/cargo-home  
-          -v ${{ github.workspace }}:/build paritytech/srtool:1.75.0-0.14.0
-          /srtool/build --app
-
-      # Alternative way of running SRTool that allows for "script-like" execution,
-      # extremely useful to debug:
-
+      # Use this to debug what's going on inside the srtool container
       # - name: Run Docker SRTool
       #   uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 #v3
       #   with:
       #     image: paritytech/srtool:${{ matrix.rust_version }}
-      #     options: --user root -v /home/runner/.cargo:/cargo-home -v ${{ github.workspace }}:/build -e BUILD_OPTS=${{ env.BUILD_OPTS || ''}} -e PACKAGE=${{ matrix.package }}
+      #     options: --user root -v /home/runner/.cargo:/cargo-home -v ${{ github.workspace }}:/build -e BUILD_OPTS=${{ env.BUILD_OPTS || ''}} -e PACKAGE=${{ matrix.chain }}-runtime
       #     run: |
       #       echo "---- Env VARS ----"
       #       echo "BUILD_OPT=${BUILD_OPT}"
@@ -66,13 +55,60 @@ jobs:
       #       ls -la /cargo-home/
       #       du -sh /cargo-home/*
       #       echo "---- RUNNING BUILD ----"
-      #       /srtool/build --save
+      #       /srtool/build --app --json -cM   
+      
+      
+      # Build and setup env vars:
+      - name: Run srtool # https://docs.substrate.io/reference/command-line-tools/srtool/
+        id: srtool_build
+        shell: bash
+        run: |
+          ##"RUNNING SRTOOL"
+          echo ::group::Docker run srtool build ${{ inputs.chain }}
+          CMD="docker run --rm  --user root --platform=linux/amd64
+          -e PROFILE=release -e PACKAGE=${{ matrix.chain }}-runtime -e BUILD_OPTS="--features=on-chain-release-build" 
+          -v /home/runner/.cargo:/cargo-home -v ${{ github.workspace }}:/build 
+          paritytech/srtool:1.77.0-0.15.0 /srtool/build --app --json -cM"
+          echo ::debug::build::docker_run $CMD
+          echo ::endgroup
+          # here we keep streaming the progress and fetch the last line for the json result
+          stdbuf -oL $CMD | {
+            while IFS= read -r line
+            do
+              echo ║ $line
+              JSON="$line"
+            done
+            echo "json=$JSON" >> $GITHUB_OUTPUT
 
-      - name: Upload srtool report
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
-        with:
-          name: srtool-wasm-report.txt
-          path: ./${{ matrix.package }}-srtool-wasm-report.json
+            PROP=`echo $JSON | jq -r .runtimes.compact.prop`
+            echo "proposal_hash=$PROP" >> $GITHUB_OUTPUT
+  
+            WASM=`echo $JSON | jq -r .runtimes.compact.wasm`
+            echo "wasm=$WASM" >> $GITHUB_OUTPUT
+  
+            Z_WASM=`echo $JSON | jq -r .runtimes.compressed.wasm`
+            echo "wasm_compressed=$Z_WASM" >> $GITHUB_OUTPUT
+  
+            IPFS=`echo $JSON | jq -r .runtimes.compact.ipfs`
+            echo "ipfs=$IPFS" >> $GITHUB_OUTPUT
+          }
+             
+      - name: Summary
+        run: |
+          ## Summary and JSON output
+          echo "::group::Summary"
+          echo "- version: ${{ steps.srtool_build.outputs.version }}"
+          echo "- info: ${{ steps.srtool_build.outputs.info }}"
+          echo "- prop: ${{ steps.srtool_build.outputs.proposal_hash }}"
+          echo "- runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+          echo "::endgroup"
+
+          echo "::group::JSON output"
+          PRETTY_JSON=$(echo '${{ steps.srtool_build.outputs.json }}' | jq .)
+          echo '${{ steps.srtool_build.outputs.json }}' | jq . > "${{ matrix.chain }}-srtool-digest.json"
+          echo "JSON Output:"
+          cat "${{ matrix.chain }}-srtool-digest.json"
+          echo "::endgroup"
 
       - id: 'auth'
         if: github.event_name != 'pull_request'
@@ -89,8 +125,29 @@ jobs:
         if: ${{ steps.auth.outcome == 'success' }}
         shell: bash
         run: |
-          runtime_name=$(echo "${{ matrix.package }}" | sed -e "s/-runtime$//" )
-          filename=$(echo "${{ matrix.package }}" | sed -e 's/-/_/g' )
+          ## Publish WASM and JSON summary
+          echo '${{ steps.srtool_build.outputs.json }}' | jq . > "${{ matrix.chain }}-srtool-digest.json"
           gsutil cp \
-            ./runtime/${runtime_name}/target/srtool/release/wbuild/${{ matrix.package }}/${filename}.compact.compressed.wasm \
-            gs://centrifuge-wasm-repo/${runtime_name}/${runtime_name}-$(git rev-parse --short HEAD).wasm
+            "${{ steps.srtool_build.outputs.wasm }}" \
+            "gs://centrifuge-wasm-repo/${{ matrix.chain }}/${{ matrix.chain }}-$(git rev-parse --short HEAD).wasm"
+          gsutil cp \
+            "${{ matrix.chain }}-srtool-digest.json" \
+            "gs://centrifuge-wasm-repo/${{ matrix.chain }}/${{ matrix.chain }}-$(git rev-parse --short HEAD)-srtool-digest.json"
+
+      - name: Upload WASM to release tag ${{ github.ref_name }}
+        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # @v1
+        if: github.event_name == 'release'
+        # https://github.com/ncipollo/release-action
+        with:
+          tag: ${{ github.ref_name }}
+          commit: ${{ github.sha }}
+          artifacts: "${{ steps.srtool_build.outputs.wasm }}, ${{ matrix.chain }}-srtool-digest.json"
+          replacesArtifacts: true
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          # updateOnlyUnreleased: true # When allowUpdates is enabled, this will fail the action if the release it is updating is not a draft or a prerelease.
+          

--- a/.github/workflows/delete_untagged.yml
+++ b/.github/workflows/delete_untagged.yml
@@ -1,0 +1,45 @@
+name: Delete untagged
+on:
+  workflow_dispatch:
+jobs:
+  delete_untagged:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # id-token: write
+    steps:
+      - name: Delete untagged ghcr
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v3
+        with:
+          # Personal access token (PAT) used to fetch the repository. The PAT is configured
+          # with the local git config, which enables your scripts to run authenticated git
+          # commands. The post-job step removes the PAT.
+          # needs delete:packages permissions
+          # required: true
+          # [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Repository name or  name with owner
+          # Delete only from repository name
+          # Default: ${{ github.repository }}
+          repository: 'centrifuge-chain'
+          # 'The repository owner name'
+          # Default: ${{ github.repository_owner }}
+          # repository_owner: ''
+          # 'The package names'
+          # Delete only from comma separated package names
+          # required: false
+          package_name: 'centrifuge-chain'
+          # Delete only package versions without tag
+          # required: false
+          # Default: true
+          # choices: true, false
+          untagged_only: true
+          # Except untagged multiplatform packages from deletion
+          # only for untagged_only=true
+          # needs docker installed
+          except_untagged_multiplatform: false
+          # the owner type
+          # required: true
+          # choices: org, user
+          owner_type: 'org'

--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
 jobs:
   test-n-lint:
+    timeout-minutes: 90
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest-8-cores
     strategy:
@@ -40,6 +41,7 @@ jobs:
           RUSTC_WRAPPER: "sccache"
 
   benchmark-check:
+    # timeout-minutes: 90 # <- Not needed as ubunt-latest is free of charge
     name: bench-check-${{ matrix.runtime }}
     runs-on: ubuntu-latest #-4-cores
     strategy:


### PR DESCRIPTION
# Description

Pipeline enhancements

    Limit sanity_checks to 90m to avoid consuming minutes on stuck jobs
    Modify wasm build to output srtool information
    Upload artifacts when creating a release (wasm and json summary)
    Upload json summary to GCP bucket too
    Add a manual workflow to delete extra containers from GH registry (verified working)
    Remove updating the release with the docker tag as appended comment (preferred to do manually)
