### PR TITLE
LP: Add Unitary Tests for update_member()

### DIFF
--- a/pallets/liquidity-pools/src/tests.rs
+++ b/pallets/liquidity-pools/src/tests.rs
@@ -1,5 +1,5 @@
 use cfg_primitives::{PoolId, TrancheId};
-use cfg_traits::{liquidity_pools::InboundQueue, Millis};
+use cfg_traits::{liquidity_pools::InboundQueue, Millis, Seconds};
 use cfg_types::{
 	domain_address::DomainAddress,
 	permissions::{PermissionScope, PoolRole, Role},
@@ -25,13 +25,14 @@ const CHAIN_ID: u64 = 1;
 const ALICE: AccountId = AccountId::new([0; 32]);
 const CONTRACT_ACCOUNT: [u8; 20] = [1; 20];
 const CONTRACT_ACCOUNT_ID: AccountId = AccountId::new([1; 32]);
-const EVM_ADDRESS: DomainAddress = DomainAddress::EVM(CHAIN_ID, CONTRACT_ACCOUNT);
+const EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::EVM(CHAIN_ID, CONTRACT_ACCOUNT);
 const AMOUNT: Balance = 100;
 const CURRENCY_ID: CurrencyId = CurrencyId::ForeignAsset(1);
 const POOL_CURRENCY_ID: CurrencyId = CurrencyId::LocalAsset(LocalAssetId(1));
 const POOL_ID: PoolId = 1;
 const TRANCHE_ID: TrancheId = [1; 16];
-const NOW: Millis = 0;
+const NOW: Millis = 10000;
+const NOW_SECS: Seconds = 10;
 const NAME: &[u8] = b"Token name";
 const SYMBOL: &[u8] = b"Token symbol";
 const DECIMALS: u8 = 6;
@@ -97,13 +98,13 @@ mod transfer {
 			Tokens::mint_into(CURRENCY_ID, &ALICE, AMOUNT).unwrap();
 			Gateway::mock_submit(|sender, destination, msg| {
 				assert_eq!(sender, ALICE);
-				assert_eq!(destination, EVM_ADDRESS.domain());
+				assert_eq!(destination, EVM_DOMAIN_ADDRESS.domain());
 				assert_eq!(
 					msg,
 					Message::Transfer {
 						currency: util::currency_index(CURRENCY_ID),
 						sender: ALICE.into(),
-						receiver: EVM_ADDRESS.address(),
+						receiver: EVM_DOMAIN_ADDRESS.address(),
 						amount: AMOUNT
 					}
 				);
@@ -113,7 +114,7 @@ mod transfer {
 			assert_ok!(LiquidityPools::transfer(
 				RuntimeOrigin::signed(ALICE),
 				CurrencyId::ForeignAsset(1),
-				EVM_ADDRESS,
+				EVM_DOMAIN_ADDRESS,
 				AMOUNT
 			));
 
@@ -131,7 +132,7 @@ mod transfer {
 					LiquidityPools::transfer(
 						RuntimeOrigin::signed(ALICE),
 						CURRENCY_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						0
 					),
 					Error::<Runtime>::InvalidTransferAmount,
@@ -146,7 +147,7 @@ mod transfer {
 					LiquidityPools::transfer(
 						RuntimeOrigin::signed(ALICE),
 						CurrencyId::Tranche(42, [0; 16]),
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					Error::<Runtime>::InvalidTransferCurrency,
@@ -163,7 +164,7 @@ mod transfer {
 					LiquidityPools::transfer(
 						RuntimeOrigin::signed(ALICE),
 						CURRENCY_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					Error::<Runtime>::AssetNotFound,
@@ -180,7 +181,7 @@ mod transfer {
 					LiquidityPools::transfer(
 						RuntimeOrigin::signed(ALICE),
 						CurrencyId::Native,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					TokenError::Unsupported,
@@ -197,7 +198,7 @@ mod transfer {
 					LiquidityPools::transfer(
 						RuntimeOrigin::signed(ALICE),
 						CURRENCY_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					Error::<Runtime>::AssetNotLiquidityPoolsTransferable,
@@ -214,7 +215,7 @@ mod transfer {
 					LiquidityPools::transfer(
 						RuntimeOrigin::signed(ALICE),
 						CURRENCY_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					Error::<Runtime>::AssetNotLiquidityPoolsWrappedToken
@@ -249,7 +250,7 @@ mod transfer {
 					LiquidityPools::transfer(
 						RuntimeOrigin::signed(ALICE),
 						CURRENCY_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					DispatchError::Other("Err"),
@@ -267,7 +268,7 @@ mod transfer {
 					LiquidityPools::transfer(
 						RuntimeOrigin::signed(ALICE),
 						CURRENCY_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					Error::<Runtime>::BalanceTooLow
@@ -290,7 +291,7 @@ mod transfer_tranche_tokens {
 				assert!(matches!(scope, PermissionScope::Pool(POOL_ID)));
 				assert!(matches!(
 					role,
-					Role::PoolRole(PoolRole::TrancheInvestor(TRANCHE_ID, NOW))
+					Role::PoolRole(PoolRole::TrancheInvestor(TRANCHE_ID, NOW_SECS))
 				));
 				true
 			});
@@ -300,15 +301,15 @@ mod transfer_tranche_tokens {
 			Tokens::mint_into(TRANCHE_CURRENCY, &ALICE, AMOUNT).unwrap();
 			Gateway::mock_submit(|sender, destination, msg| {
 				assert_eq!(sender, ALICE);
-				assert_eq!(destination, EVM_ADDRESS.domain());
+				assert_eq!(destination, EVM_DOMAIN_ADDRESS.domain());
 				assert_eq!(
 					msg,
 					Message::TransferTrancheTokens {
 						pool_id: POOL_ID,
 						tranche_id: TRANCHE_ID,
 						sender: ALICE.into(),
-						domain: EVM_ADDRESS.domain().into(),
-						receiver: EVM_ADDRESS.address(),
+						domain: EVM_DOMAIN_ADDRESS.domain().into(),
+						receiver: EVM_DOMAIN_ADDRESS.address(),
 						amount: AMOUNT
 					}
 				);
@@ -319,11 +320,11 @@ mod transfer_tranche_tokens {
 				RuntimeOrigin::signed(ALICE),
 				POOL_ID,
 				TRANCHE_ID,
-				EVM_ADDRESS,
+				EVM_DOMAIN_ADDRESS,
 				AMOUNT
 			));
 
-			let destination = EVM_ADDRESS.domain().into_account();
+			let destination = EVM_DOMAIN_ADDRESS.domain().into_account();
 			assert_eq!(Tokens::balance(TRANCHE_CURRENCY, &ALICE), 0);
 			assert_eq!(Tokens::balance(TRANCHE_CURRENCY, &destination), AMOUNT);
 		})
@@ -340,7 +341,7 @@ mod transfer_tranche_tokens {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						0
 					),
 					Error::<Runtime>::InvalidTransferAmount,
@@ -360,7 +361,7 @@ mod transfer_tranche_tokens {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					Error::<Runtime>::UnauthorizedTransfer,
@@ -381,7 +382,7 @@ mod transfer_tranche_tokens {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					Error::<Runtime>::PoolNotFound,
@@ -403,7 +404,7 @@ mod transfer_tranche_tokens {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					Error::<Runtime>::TrancheNotFound,
@@ -426,7 +427,7 @@ mod transfer_tranche_tokens {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS,
+						EVM_DOMAIN_ADDRESS,
 						AMOUNT
 					),
 					DispatchError::Other("Err"),
@@ -451,7 +452,7 @@ mod add_pool {
 			Pools::mock_pool_exists(|_| true);
 			Gateway::mock_submit(|sender, destination, msg| {
 				assert_eq!(sender, ALICE);
-				assert_eq!(destination, EVM_ADDRESS.domain());
+				assert_eq!(destination, EVM_DOMAIN_ADDRESS.domain());
 				assert_eq!(msg, Message::AddPool { pool_id: POOL_ID });
 				Ok(())
 			});
@@ -459,7 +460,7 @@ mod add_pool {
 			assert_ok!(LiquidityPools::add_pool(
 				RuntimeOrigin::signed(ALICE),
 				POOL_ID,
-				EVM_ADDRESS.domain(),
+				EVM_DOMAIN_ADDRESS.domain(),
 			));
 		})
 	}
@@ -476,7 +477,7 @@ mod add_pool {
 					LiquidityPools::add_pool(
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::PoolNotFound
 				);
@@ -493,7 +494,7 @@ mod add_pool {
 					LiquidityPools::add_pool(
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::NotPoolAdmin
 				);
@@ -519,7 +520,7 @@ mod add_tranche {
 			AssetRegistry::mock_metadata(|_| Some(util::default_metadata()));
 			Gateway::mock_submit(|sender, destination, msg| {
 				assert_eq!(sender, ALICE);
-				assert_eq!(destination, EVM_ADDRESS.domain());
+				assert_eq!(destination, EVM_DOMAIN_ADDRESS.domain());
 				assert_eq!(
 					msg,
 					Message::AddTranche {
@@ -538,7 +539,7 @@ mod add_tranche {
 				RuntimeOrigin::signed(ALICE),
 				POOL_ID,
 				TRANCHE_ID,
-				EVM_ADDRESS.domain(),
+				EVM_DOMAIN_ADDRESS.domain(),
 			));
 		})
 	}
@@ -556,7 +557,7 @@ mod add_tranche {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::NotPoolAdmin
 				);
@@ -574,7 +575,7 @@ mod add_tranche {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::PoolNotFound
 				);
@@ -593,7 +594,7 @@ mod add_tranche {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::TrancheNotFound,
 				);
@@ -613,7 +614,7 @@ mod add_tranche {
 						RuntimeOrigin::signed(ALICE),
 						POOL_ID,
 						TRANCHE_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::TrancheMetadataNotFound,
 				);
@@ -638,7 +639,7 @@ mod update_token_price {
 			AssetRegistry::mock_metadata(|_| Some(util::wrapped_transferable_metadata()));
 			Gateway::mock_submit(|sender, destination, msg| {
 				assert_eq!(sender, ALICE);
-				assert_eq!(destination, EVM_ADDRESS.domain());
+				assert_eq!(destination, EVM_DOMAIN_ADDRESS.domain());
 				assert_eq!(
 					msg,
 					Message::UpdateTrancheTokenPrice {
@@ -659,7 +660,7 @@ mod update_token_price {
 				POOL_ID,
 				TRANCHE_ID,
 				CURRENCY_ID,
-				EVM_ADDRESS.domain(),
+				EVM_DOMAIN_ADDRESS.domain(),
 			));
 		})
 	}
@@ -678,7 +679,7 @@ mod update_token_price {
 						POOL_ID,
 						TRANCHE_ID,
 						CURRENCY_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::MissingTranchePrice,
 				);
@@ -697,7 +698,7 @@ mod update_token_price {
 						POOL_ID,
 						TRANCHE_ID,
 						CURRENCY_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::PoolNotFound,
 				);
@@ -717,7 +718,7 @@ mod update_token_price {
 						POOL_ID,
 						TRANCHE_ID,
 						CURRENCY_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					DispatchError::Other("")
 				);
@@ -738,7 +739,7 @@ mod update_token_price {
 						POOL_ID,
 						TRANCHE_ID,
 						CURRENCY_ID,
-						EVM_ADDRESS.domain(),
+						EVM_DOMAIN_ADDRESS.domain(),
 					),
 					Error::<Runtime>::AssetNotLiquidityPoolsTransferable,
 				);
@@ -747,13 +748,144 @@ mod update_token_price {
 	}
 }
 
+mod update_member {
+	use super::*;
+
+	const VALID_UNTIL_SECS: Seconds = NOW_SECS + 1;
+
+	#[test]
+	fn success() {
+		System::externalities().execute_with(|| {
+			Pools::mock_pool_exists(|_| true);
+			Pools::mock_tranche_exists(|_, _| true);
+			Time::mock_now(|| NOW);
+			DomainAddressToAccountId::mock_convert(|_| CONTRACT_ACCOUNT_ID);
+			Permissions::mock_has(move |scope, who, role| {
+				assert_eq!(who, CONTRACT_ACCOUNT_ID);
+				assert!(matches!(scope, PermissionScope::Pool(POOL_ID)));
+				assert!(matches!(
+					role,
+					Role::PoolRole(PoolRole::TrancheInvestor(TRANCHE_ID, VALID_UNTIL_SECS))
+				));
+				true
+			});
+			Gateway::mock_submit(|sender, destination, msg| {
+				assert_eq!(sender, ALICE);
+				assert_eq!(destination, EVM_DOMAIN_ADDRESS.domain());
+				assert_eq!(
+					msg,
+					Message::UpdateMember {
+						pool_id: POOL_ID,
+						tranche_id: TRANCHE_ID,
+						valid_until: VALID_UNTIL_SECS,
+						member: EVM_DOMAIN_ADDRESS.address(),
+					}
+				);
+				Ok(())
+			});
+
+			assert_ok!(LiquidityPools::update_member(
+				RuntimeOrigin::signed(ALICE),
+				POOL_ID,
+				TRANCHE_ID,
+				EVM_DOMAIN_ADDRESS,
+				VALID_UNTIL_SECS,
+			));
+		})
+	}
+
+	mod erroring_out {
+		use super::*;
+
+		#[test]
+		fn with_wrong_pool() {
+			System::externalities().execute_with(|| {
+				Pools::mock_pool_exists(|_| false);
+
+				assert_noop!(
+					LiquidityPools::update_member(
+						RuntimeOrigin::signed(ALICE),
+						POOL_ID,
+						TRANCHE_ID,
+						EVM_DOMAIN_ADDRESS,
+						VALID_UNTIL_SECS,
+					),
+					Error::<Runtime>::PoolNotFound,
+				);
+			})
+		}
+
+		#[test]
+		fn with_wrong_tranche() {
+			System::externalities().execute_with(|| {
+				Pools::mock_pool_exists(|_| true);
+				Pools::mock_tranche_exists(|_, _| false);
+
+				assert_noop!(
+					LiquidityPools::update_member(
+						RuntimeOrigin::signed(ALICE),
+						POOL_ID,
+						TRANCHE_ID,
+						EVM_DOMAIN_ADDRESS,
+						VALID_UNTIL_SECS,
+					),
+					Error::<Runtime>::TrancheNotFound,
+				);
+			})
+		}
+
+		#[test]
+		fn with_wrong_time() {
+			System::externalities().execute_with(|| {
+				Pools::mock_pool_exists(|_| true);
+				Pools::mock_tranche_exists(|_, _| true);
+				Time::mock_now(|| VALID_UNTIL_SECS * 1000);
+
+				assert_noop!(
+					LiquidityPools::update_member(
+						RuntimeOrigin::signed(ALICE),
+						POOL_ID,
+						TRANCHE_ID,
+						EVM_DOMAIN_ADDRESS,
+						VALID_UNTIL_SECS,
+					),
+					Error::<Runtime>::InvalidTrancheInvestorValidity,
+				);
+			})
+		}
+
+		#[test]
+		fn with_wrong_permissions() {
+			System::externalities().execute_with(|| {
+				Pools::mock_pool_exists(|_| true);
+				Pools::mock_tranche_exists(|_, _| true);
+				Time::mock_now(|| NOW);
+				DomainAddressToAccountId::mock_convert(|_| CONTRACT_ACCOUNT_ID);
+				Permissions::mock_has(|_, _, _| false);
+
+				assert_noop!(
+					LiquidityPools::update_member(
+						RuntimeOrigin::signed(ALICE),
+						POOL_ID,
+						TRANCHE_ID,
+						EVM_DOMAIN_ADDRESS,
+						VALID_UNTIL_SECS,
+					),
+					Error::<Runtime>::InvestorDomainAddressNotAMember,
+				);
+			})
+		}
+	}
+}
+
 #[test]
-fn receiving_output_message() {
+fn receiving_invalid_message() {
 	System::externalities().execute_with(|| {
+		// Add pool is an outbound message, not valid to be received
 		let msg = Message::AddPool { pool_id: 123 };
 
 		assert_noop!(
-			LiquidityPools::submit(EVM_ADDRESS, msg),
+			LiquidityPools::submit(EVM_DOMAIN_ADDRESS, msg),
 			Error::<Runtime>::InvalidIncomingMessage,
 		);
 	})

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -18,7 +18,7 @@ use cfg_types::{
 	tokens::{CrossChainTransferability, CurrencyId, CustomMetadata},
 };
 use ethabi::{ethereum_types::H160, Token, Uint};
-use frame_support::{assert_noop, assert_ok, traits::OriginTrait};
+use frame_support::{assert_ok, traits::OriginTrait};
 use frame_system::pallet_prelude::OriginFor;
 use pallet_liquidity_pools::GeneralCurrencyIndexOf;
 use runtime_common::account_conversion::AccountConverter;
@@ -387,18 +387,6 @@ fn update_member<T: Runtime>() {
 			AccountConverter::convert_evm_address(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.into()),
 			POOL_A,
 			PoolRole::TrancheInvestor(pool_a_tranche_1_id::<T>(), SECONDS_PER_YEAR),
-		);
-
-		// Address given MUST match derived allowlisted address for that domain
-		assert_noop!(
-			pallet_liquidity_pools::Pallet::<T>::update_member(
-				Keyring::Bob.as_origin(),
-				POOL_A,
-				pool_a_tranche_1_id::<T>(),
-				DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, Keyring::Alice.into()),
-				SECONDS_PER_YEAR,
-			),
-			pallet_liquidity_pools::Error::<T>::InvestorDomainAddressNotAMember
 		);
 
 		assert_ok!(pallet_liquidity_pools::Pallet::<T>::update_member(


### PR DESCRIPTION
# Description

Add UTs to `update_member()` and remove unitary testing from integration tests related to it.

@wischli I've done over `main` because it should not conflict with the current lpv2 work. Maybe just a minor import.