### PR TITLE
Lpv2: ignore failing tests

### DIFF
--- a/runtime/integration-tests/src/cases/lp/investments.rs
+++ b/runtime/integration-tests/src/cases/lp/investments.rs
@@ -155,8 +155,7 @@ mod with_pool_currency {
 	use super::{utils, *};
 	use crate::cases::lp::utils as lp_utils;
 
-	// TODO(@william): Fix
-	// #[test_runtimes([development])]
+	#[test_runtimes([development], ignore = "solidity mismatch")]
 	fn currency_invest<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -190,8 +189,7 @@ mod with_pool_currency {
 		});
 	}
 
-	// TODO(@william): Fix
-	// #[test_runtimes([development])]
+	#[test_runtimes([development], ignore = "solidity mismatch")]
 	fn currency_collect<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -259,8 +257,7 @@ mod with_pool_currency {
 		});
 	}
 
-	// TODO(@william): Fix
-	// #[test_runtimes([development])]
+	#[test_runtimes([development], ignore = "solidity mismatch")]
 	fn invest_cancel_full<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -338,8 +335,7 @@ mod with_foreign_currency {
 		POOL_A,
 	};
 
-	// TODO(@william): Fix
-	// #[test_runtimes([development])]
+	#[test_runtimes([development], ignore = "solidity mismatch")]
 	fn invest_cancel_full_before_swap<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -397,8 +393,7 @@ mod with_foreign_currency {
 		});
 	}
 
-	// TODO(@william): Fix
-	// #[test_runtimes([development])]
+	#[test_runtimes([development], ignore = "solidity mismatch")]
 	fn invest_cancel_full_after_swap<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -489,8 +484,7 @@ mod with_foreign_currency {
 		});
 	}
 
-	// TODO(@william): Fix
-	// #[test_runtimes([development])]
+	#[test_runtimes([development], ignore = "solidity mismatch")]
 	fn invest_cancel_full_after_swap_partially<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		let part = Quantity::checked_from_rational(1, 2).unwrap();
@@ -594,8 +588,7 @@ mod with_foreign_currency {
 		});
 	}
 
-	// TODO(@william): Fix
-	// #[test_runtimes([development])]
+	#[test_runtimes([development], ignore = "solidity mismatch")]
 	fn invest_cancel_full_after_swap_partially_inter_epoch_close<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		let part = Quantity::checked_from_rational(1, 3).unwrap();

--- a/runtime/integration-tests/src/cases/lp/transfers.rs
+++ b/runtime/integration-tests/src/cases/lp/transfers.rs
@@ -132,7 +132,7 @@ mod utils {
 	}
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([development], ignore = "solidity mismatch")]
 fn transfer_tokens_from_local<T: Runtime>() {
 	let mut env = super::setup_full::<T>();
 	utils::prepare_hold_usdc_local::<T>(&mut env);
@@ -223,8 +223,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 	});
 }
 
-// TODO(@william): Fix
-// #[test_runtimes([development])]
+#[test_runtimes([development], ignore = "solidity mismatch")]
 fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 	let mut env = super::setup_full::<T>();
 	utils::prepare_hold_tt_domain::<T>(&mut env);
@@ -297,8 +296,7 @@ fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 	});
 }
 
-// TODO(@william): Fix
-// #[test_runtimes([development])]
+#[test_runtimes([development], ignore = "solidity mismatch")]
 fn transfer_tranche_tokens_domain_to_local<T: Runtime>() {
 	let mut env = super::setup_full::<T>();
 	utils::prepare_hold_tt_domain::<T>(&mut env);


### PR DESCRIPTION
# Description

We want to mark them as `ignore` not to forget them later when they work again
