### PR TITLE
ci: disable checks for drafts

### DIFF
--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
 jobs:
   test-n-lint:
+    if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 90
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest-8-cores
@@ -41,12 +42,13 @@ jobs:
           RUSTC_WRAPPER: "sccache"
 
   benchmark-check:
+    if: ${{ !github.event.pull_request.draft }}
     # timeout-minutes: 90 # <- Not needed as ubunt-latest is free of charge
     name: bench-check-${{ matrix.runtime }}
     runs-on: ubuntu-latest #-4-cores
     strategy:
       matrix:
-        runtime: [ altair, centrifuge ]
+        runtime: [ centrifuge ]
     steps:
       - name: Check out code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #4.1.4


### PR DESCRIPTION
# Description

Goal: Reduce CI overload

* Disables CI checks on draft PRs
* Removes `altair` runtime from benchmark checks

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
