### PR TITLE
Refactor: Transform `TrancheCurrency` type in a tuple

### DIFF
--- a/libs/mocks/src/pools.rs
+++ b/libs/mocks/src/pools.rs
@@ -25,7 +25,6 @@ pub mod pallet {
 		type Balance;
 		type BalanceRatio;
 		type CurrencyId;
-		type TrancheCurrency;
 	}
 
 	#[pallet::pallet]
@@ -65,21 +64,28 @@ pub mod pallet {
 
 		pub fn mock_info(
 			f: impl Fn(
-					T::TrancheCurrency,
+					(T::PoolId, T::TrancheId),
 				) -> Result<
-					InvestmentInfo<T::AccountId, T::CurrencyId, T::TrancheCurrency>,
+					InvestmentInfo<T::AccountId, T::CurrencyId, (T::PoolId, T::TrancheId)>,
 					DispatchError,
 				> + 'static,
 		) {
 			register_call!(f);
 		}
 
-		pub fn mock_balance(f: impl Fn(T::TrancheCurrency, &T::AccountId) -> T::Balance + 'static) {
+		pub fn mock_balance(
+			f: impl Fn((T::PoolId, T::TrancheId), &T::AccountId) -> T::Balance + 'static,
+		) {
 			register_call!(move |(a, b)| f(a, b));
 		}
 
 		pub fn mock_transfer(
-			f: impl Fn(T::TrancheCurrency, &T::AccountId, &T::AccountId, T::Balance) -> DispatchResult
+			f: impl Fn(
+					(T::PoolId, T::TrancheId),
+					&T::AccountId,
+					&T::AccountId,
+					T::Balance,
+				) -> DispatchResult
 				+ 'static,
 		) {
 			register_call!(move |(a, b, c, d)| f(a, b, c, d));
@@ -93,21 +99,21 @@ pub mod pallet {
 
 		#[allow(non_snake_case)]
 		pub fn mock_InvestmentAccountant_deposit(
-			f: impl Fn(&T::AccountId, T::TrancheCurrency, T::Balance) -> DispatchResult + 'static,
+			f: impl Fn(&T::AccountId, (T::PoolId, T::TrancheId), T::Balance) -> DispatchResult + 'static,
 		) {
 			register_call!(move |(a, b, c)| f(a, b, c));
 		}
 
 		#[allow(non_snake_case)]
 		pub fn mock_InvestmentAccountant_withdraw(
-			f: impl Fn(&T::AccountId, T::TrancheCurrency, T::Balance) -> DispatchResult + 'static,
+			f: impl Fn(&T::AccountId, (T::PoolId, T::TrancheId), T::Balance) -> DispatchResult + 'static,
 		) {
 			register_call!(move |(a, b, c)| f(a, b, c));
 		}
 
 		#[cfg(feature = "runtime-benchmarks")]
 		pub fn mock_bench_default_investment_id(
-			f: impl Fn(T::PoolId) -> T::TrancheCurrency + 'static,
+			f: impl Fn(T::PoolId) -> (T::PoolId, T::TrancheId) + 'static,
 		) {
 			register_call!(f);
 		}
@@ -138,7 +144,7 @@ pub mod pallet {
 	impl<T: Config> InvestmentAccountant<T::AccountId> for Pallet<T> {
 		type Amount = T::Balance;
 		type Error = DispatchError;
-		type InvestmentId = T::TrancheCurrency;
+		type InvestmentId = (T::PoolId, T::TrancheId);
 		type InvestmentInfo = InvestmentInfo<T::AccountId, T::CurrencyId, Self::InvestmentId>;
 
 		fn info(a: Self::InvestmentId) -> Result<Self::InvestmentInfo, DispatchError> {
@@ -211,7 +217,7 @@ pub mod pallet {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	impl<T: Config> cfg_traits::benchmarking::InvestmentIdBenchmarkHelper for Pallet<T> {
-		type InvestmentId = T::TrancheCurrency;
+		type InvestmentId = (T::PoolId, T::TrancheId);
 		type PoolId = T::PoolId;
 
 		fn bench_default_investment_id(a: Self::PoolId) -> Self::InvestmentId {

--- a/libs/primitives/src/lib.rs
+++ b/libs/primitives/src/lib.rs
@@ -124,6 +124,9 @@ pub mod types {
 	/// A representation of a tranche identifier
 	pub type TrancheId = [u8; 16];
 
+	/// A representation of an investment
+	pub type InvestmentId = (PoolId, TrancheId);
+
 	/// A representation of a tranche weight, used to weight
 	/// importance of a tranche
 	#[derive(Encode, Decode, Copy, Debug, Default, Clone, PartialEq, Eq, TypeInfo, CompactAs)]

--- a/libs/traits/src/investments.rs
+++ b/libs/traits/src/investments.rs
@@ -23,6 +23,20 @@ pub trait TrancheCurrency<PoolId, TrancheId> {
 	fn of_tranche(&self) -> TrancheId;
 }
 
+impl<PoolId: Clone, TrancheId: Clone> TrancheCurrency<PoolId, TrancheId> for (PoolId, TrancheId) {
+	fn generate(pool_id: PoolId, tranche_id: TrancheId) -> Self {
+		(pool_id, tranche_id)
+	}
+
+	fn of_pool(&self) -> PoolId {
+		self.0.clone()
+	}
+
+	fn of_tranche(&self) -> TrancheId {
+		self.1.clone()
+	}
+}
+
 /// A trait, when implemented allows to invest into
 /// investment classes
 pub trait Investment<AccountId> {

--- a/libs/types/src/tokens.rs
+++ b/libs/types/src/tokens.rs
@@ -16,7 +16,7 @@ use cfg_primitives::{
 	types::{PoolId, TrancheId},
 	Balance,
 };
-use cfg_traits::{investments::TrancheCurrency as TrancheCurrencyT, HasLocalAssetRepresentation};
+use cfg_traits::HasLocalAssetRepresentation;
 use orml_traits::asset_registry;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
@@ -118,6 +118,12 @@ impl TryFrom<CurrencyId> for LocalAssetId {
 		} else {
 			Err(())
 		}
+	}
+}
+
+impl From<(PoolId, TrancheId)> for CurrencyId {
+	fn from((pool_id, tranche_id): (PoolId, TrancheId)) -> Self {
+		CurrencyId::Tranche(pool_id, tranche_id)
 	}
 }
 
@@ -227,55 +233,6 @@ where
 			index: value.into(),
 			_phantom: Default::default(),
 		}
-	}
-}
-
-/// A Currency that is solely used by tranches.
-///
-/// We distinguish here between the enum variant CurrencyId::Tranche(PoolId,
-/// TranchId) in order to be able to have a clear separation of concerns. This
-/// enables us to use the `TrancheCurrency` type separately where solely this
-/// enum variant would be relevant. Most notably, in the `struct Tranche`.
-#[derive(
-	Clone,
-	Copy,
-	PartialOrd,
-	Ord,
-	PartialEq,
-	Eq,
-	Debug,
-	Encode,
-	Decode,
-	TypeInfo,
-	MaxEncodedLen,
-	Serialize,
-	Deserialize,
-)]
-pub struct TrancheCurrency {
-	pub pool_id: PoolId,
-	pub tranche_id: TrancheId,
-}
-
-impl From<TrancheCurrency> for CurrencyId {
-	fn from(x: TrancheCurrency) -> Self {
-		CurrencyId::Tranche(x.pool_id, x.tranche_id)
-	}
-}
-
-impl TrancheCurrencyT<PoolId, TrancheId> for TrancheCurrency {
-	fn generate(pool_id: PoolId, tranche_id: TrancheId) -> Self {
-		Self {
-			pool_id,
-			tranche_id,
-		}
-	}
-
-	fn of_pool(&self) -> PoolId {
-		self.pool_id
-	}
-
-	fn of_tranche(&self) -> TrancheId {
-		self.tranche_id
 	}
 }
 

--- a/pallets/foreign-investments/src/mock.rs
+++ b/pallets/foreign-investments/src/mock.rs
@@ -1,8 +1,5 @@
-use cfg_traits::investments::TrancheCurrency;
 use cfg_types::investments::{ExecutedForeignCollect, ExecutedForeignDecreaseInvest};
 use frame_support::derive_impl;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use scale_info::TypeInfo;
 use sp_runtime::FixedU128;
 
 use crate::{pallet as pallet_foreign_investments, FulfilledSwapHook, SwapId};
@@ -14,25 +11,6 @@ pub type PoolId = u64;
 pub type OrderId = u64;
 pub type CurrencyId = u8;
 pub type Ratio = FixedU128;
-
-#[derive(
-	Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
-)]
-pub struct InvestmentId(pub PoolId, pub TrancheId);
-
-impl TrancheCurrency<PoolId, TrancheId> for InvestmentId {
-	fn generate(pool_id: PoolId, tranche_id: TrancheId) -> Self {
-		Self(pool_id, tranche_id)
-	}
-
-	fn of_pool(&self) -> PoolId {
-		self.0
-	}
-
-	fn of_tranche(&self) -> TrancheId {
-		self.1
-	}
-}
 
 frame_support::construct_runtime!(
 	pub enum Runtime {
@@ -56,7 +34,7 @@ impl frame_system::Config for Runtime {
 impl cfg_mocks::investment::pallet::Config for Runtime {
 	type Amount = Balance;
 	type CurrencyId = CurrencyId;
-	type InvestmentId = InvestmentId;
+	type InvestmentId = (PoolId, TrancheId);
 	type TrancheAmount = Balance;
 }
 
@@ -70,19 +48,19 @@ impl cfg_mocks::token_swaps::pallet::Config for Runtime {
 
 type Hook1 = cfg_mocks::status_notification::pallet::Instance1;
 impl cfg_mocks::status_notification::pallet::Config<Hook1> for Runtime {
-	type Id = (AccountId, InvestmentId);
+	type Id = (AccountId, (PoolId, TrancheId));
 	type Status = ExecutedForeignDecreaseInvest<Balance, CurrencyId>;
 }
 
 type Hook2 = cfg_mocks::status_notification::pallet::Instance2;
 impl cfg_mocks::status_notification::pallet::Config<Hook2> for Runtime {
-	type Id = (AccountId, InvestmentId);
+	type Id = (AccountId, (PoolId, TrancheId));
 	type Status = ExecutedForeignCollect<Balance, Balance, Balance, CurrencyId>;
 }
 
 type Hook3 = cfg_mocks::status_notification::pallet::Instance3;
 impl cfg_mocks::status_notification::pallet::Config<Hook3> for Runtime {
-	type Id = (AccountId, InvestmentId);
+	type Id = (AccountId, (PoolId, TrancheId));
 	type Status = ExecutedForeignCollect<Balance, Balance, Balance, CurrencyId>;
 }
 
@@ -91,7 +69,6 @@ impl cfg_mocks::pools::pallet::Config for Runtime {
 	type BalanceRatio = Ratio;
 	type CurrencyId = CurrencyId;
 	type PoolId = PoolId;
-	type TrancheCurrency = InvestmentId;
 	type TrancheId = TrancheId;
 }
 
@@ -111,7 +88,7 @@ impl pallet_foreign_investments::Config for Runtime {
 	type DecreasedForeignInvestOrderHook = MockDecreaseInvestHook;
 	type ForeignBalance = Balance;
 	type Investment = MockInvestment;
-	type InvestmentId = InvestmentId;
+	type InvestmentId = (PoolId, TrancheId);
 	type PoolBalance = Balance;
 	type PoolInspect = MockPools;
 	type RuntimeEvent = RuntimeEvent;

--- a/pallets/foreign-investments/src/tests.rs
+++ b/pallets/foreign-investments/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 const USER: AccountId = 1;
-const INVESTMENT_ID: InvestmentId = InvestmentId(42, 23);
+const INVESTMENT_ID: (PoolId, TrancheId) = (42, 23);
 const FOREIGN_CURR: CurrencyId = 5;
 const POOL_CURR: CurrencyId = 10;
 const STABLE_RATIO: Balance = 10; // Means: 1 foreign curr is 10 pool curr

--- a/pallets/investments/src/benchmarking.rs
+++ b/pallets/investments/src/benchmarking.rs
@@ -39,7 +39,7 @@ where
 
 		#[cfg(test)]
 		crate::mock::MockAccountant::mock_bench_default_investment_id(|_| {
-			crate::mock::InvestmentId::default()
+			cfg_primitives::InvestmentId::default()
 		});
 
 		T::Accountant::bench_create_funded_pool(pool_id, &pool_admin);

--- a/pallets/investments/src/mock.rs
+++ b/pallets/investments/src/mock.rs
@@ -35,9 +35,6 @@ use frame_support::{
 	},
 };
 use orml_traits::GetByKey;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use scale_info::TypeInfo;
-use serde::{Deserialize, Serialize};
 use sp_arithmetic::{FixedPointNumber, Perquintill};
 use sp_io::TestExternalities;
 use sp_runtime::{traits::AccountIdConversion, BuildStorage, DispatchError, DispatchResult};
@@ -111,7 +108,6 @@ impl cfg_mocks::pallet_mock_pools::Config for Runtime {
 	type BalanceRatio = Quantity;
 	type CurrencyId = CurrencyId;
 	type PoolId = PoolId;
-	type TrancheCurrency = InvestmentId;
 	type TrancheId = TrancheId;
 }
 
@@ -153,51 +149,6 @@ impl<T> PreConditions<T> for Always {
 	}
 }
 
-// TODO: This struct should be temporarily needed only
-//       We should add the possibility to use subsets of the
-//       global CurrencyId enum
-#[derive(
-	Copy,
-	Clone,
-	Encode,
-	Decode,
-	PartialEq,
-	Debug,
-	Ord,
-	PartialOrd,
-	Eq,
-	TypeInfo,
-	Serialize,
-	Deserialize,
-	MaxEncodedLen,
-)]
-pub enum InvestmentId {
-	PoolTranche {
-		pool_id: PoolId,
-		tranche_id: TrancheId,
-	},
-}
-
-impl Default for InvestmentId {
-	fn default() -> Self {
-		Self::PoolTranche {
-			pool_id: Default::default(),
-			tranche_id: Default::default(),
-		}
-	}
-}
-
-impl From<InvestmentId> for CurrencyId {
-	fn from(val: InvestmentId) -> Self {
-		match val {
-			InvestmentId::PoolTranche {
-				pool_id,
-				tranche_id,
-			} => CurrencyId::Tranche(pool_id, tranche_id),
-		}
-	}
-}
-
 // Test externalities builder
 //
 // This type is mainly used for mocking storage in tests. It is the type alias
@@ -226,21 +177,13 @@ pub const TRANCHE_ID_1: [u8; 16] = [1u8; 16];
 pub const OWNER_START_BALANCE: u128 = 100_000_000 * CURRENCY;
 
 /// The investment-id for investing into pool 0 and tranche 0
-pub const INVESTMENT_0_0: InvestmentId = InvestmentId::PoolTranche {
-	pool_id: POOL_ID,
-	tranche_id: TRANCHE_ID_0,
-};
+pub const INVESTMENT_0_0: InvestmentId = (POOL_ID, TRANCHE_ID_0);
+
 /// The investment-id for investing into pool 0 and tranche 1
-pub const INVESTMENT_0_1: InvestmentId = InvestmentId::PoolTranche {
-	pool_id: POOL_ID,
-	tranche_id: TRANCHE_ID_1,
-};
+pub const INVESTMENT_0_1: InvestmentId = (POOL_ID, TRANCHE_ID_1);
 
 /// An unknown investment id -> i.e. a not yet created pool
-pub const UNKNOWN_INVESTMENT: InvestmentId = InvestmentId::PoolTranche {
-	pool_id: 1,
-	tranche_id: TRANCHE_ID_0,
-};
+pub const UNKNOWN_INVESTMENT: InvestmentId = (1, TRANCHE_ID_0);
 
 /// The currency id for the AUSD token
 pub const AUSD_CURRENCY_ID: CurrencyId = CurrencyId::ForeignAsset(1);

--- a/pallets/liquidity-pools/src/inbound.rs
+++ b/pallets/liquidity-pools/src/inbound.rs
@@ -205,7 +205,7 @@ where
 		// Transfer tranche tokens from `DomainLocator` account of
 		// origination domain
 		T::Tokens::transfer(
-			invest_id.clone().into(),
+			invest_id.into(),
 			&sending_domain.domain().into_account(),
 			&investor,
 			amount,
@@ -244,13 +244,13 @@ where
 
 		T::ForeignInvestment::decrease_foreign_redemption(
 			&investor,
-			invest_id.clone(),
+			invest_id,
 			tranche_tokens_payout,
 			payout_currency,
 		)?;
 
 		T::Tokens::transfer(
-			invest_id.clone().into(),
+			invest_id.into(),
 			&investor,
 			&destination.domain().into_account(),
 			tranche_tokens_payout,
@@ -263,11 +263,7 @@ where
 			investor: investor.clone().into(),
 			currency: currency_u128,
 			tranche_tokens_payout: tranche_tokens_payout.into(),
-			remaining_redeem_amount: T::ForeignInvestment::redemption(
-				&investor,
-				invest_id.clone(),
-			)?
-			.into(),
+			remaining_redeem_amount: T::ForeignInvestment::redemption(&investor, invest_id)?.into(),
 		};
 
 		T::OutboundQueue::submit(T::TreasuryAccount::get(), destination.domain(), message)?;

--- a/pallets/liquidity-pools/src/inbound.rs
+++ b/pallets/liquidity-pools/src/inbound.rs
@@ -117,7 +117,7 @@ where
 		currency_index: GeneralCurrencyIndexOf<T>,
 		amount: <T as Config>::Balance,
 	) -> DispatchResult {
-		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
+		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let payment_currency = Self::try_get_currency_id(currency_index)?;
 
 		// Mint additional amount of payment currency
@@ -149,7 +149,7 @@ where
 		currency_index: GeneralCurrencyIndexOf<T>,
 		amount: <T as Config>::Balance,
 	) -> DispatchResult {
-		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
+		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let payout_currency = Self::try_get_currency_id(currency_index)?;
 
 		T::ForeignInvestment::decrease_foreign_investment(
@@ -177,7 +177,7 @@ where
 		investor: T::AccountId,
 		currency_index: GeneralCurrencyIndexOf<T>,
 	) -> DispatchResult {
-		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
+		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let amount = T::ForeignInvestment::investment(&investor, invest_id)?;
 
 		Self::handle_decrease_invest_order(pool_id, tranche_id, investor, currency_index, amount)
@@ -199,7 +199,7 @@ where
 		currency_index: GeneralCurrencyIndexOf<T>,
 		sending_domain: DomainAddress,
 	) -> DispatchResult {
-		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
+		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let payout_currency = Self::try_get_currency_id(currency_index)?;
 
 		// Transfer tranche tokens from `DomainLocator` account of
@@ -238,7 +238,7 @@ where
 		currency_index: GeneralCurrencyIndexOf<T>,
 		destination: DomainAddress,
 	) -> DispatchResult {
-		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
+		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let currency_u128 = currency_index.index;
 		let payout_currency = Self::try_get_currency_id(currency_index)?;
 
@@ -287,7 +287,7 @@ where
 		currency_index: GeneralCurrencyIndexOf<T>,
 		destination: DomainAddress,
 	) -> DispatchResult {
-		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
+		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let amount = T::ForeignInvestment::redemption(&investor, invest_id)?;
 
 		Self::handle_decrease_redeem_order(
@@ -317,7 +317,7 @@ where
 		investor: T::AccountId,
 		currency_index: GeneralCurrencyIndexOf<T>,
 	) -> DispatchResult {
-		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
+		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let payment_currency = Self::try_get_currency_id(currency_index)?;
 
 		// NOTE: Dispatch of `ExecutedCollectInvest` is handled by
@@ -344,7 +344,7 @@ where
 		investor: T::AccountId,
 		currency_index: GeneralCurrencyIndexOf<T>,
 	) -> DispatchResult {
-		let invest_id: T::TrancheCurrency = Self::derive_invest_id(pool_id, tranche_id)?;
+		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let payout_currency = Self::try_get_currency_id(currency_index)?;
 
 		T::ForeignInvestment::collect_foreign_redemption(&investor, invest_id, payout_currency)?;

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -104,8 +104,8 @@ pub type GeneralCurrencyIndexOf<T> =
 #[frame_support::pallet]
 pub mod pallet {
 	use cfg_traits::{
-		investments::{ForeignInvestment, TrancheCurrency},
-		CurrencyInspect, Permissions, PoolInspect, Seconds, TimeAsSecs, TrancheTokenPrice,
+		investments::ForeignInvestment, CurrencyInspect, Permissions, PoolInspect, Seconds,
+		TimeAsSecs, TrancheTokenPrice,
 	};
 	use cfg_types::{
 		permissions::{PermissionScope, PoolRole, Role},
@@ -204,11 +204,6 @@ pub mod pallet {
 		type Tokens: Mutate<Self::AccountId>
 			+ Inspect<Self::AccountId, AssetId = Self::CurrencyId, Balance = Self::Balance>;
 
-		/// The currency type of investments.
-		type TrancheCurrency: TrancheCurrency<Self::PoolId, Self::TrancheId>
-			+ Into<Self::CurrencyId>
-			+ Clone;
-
 		/// Enables investing and redeeming into investment classes with foreign
 		/// currencies.
 		type ForeignInvestment: ForeignInvestment<
@@ -217,7 +212,7 @@ pub mod pallet {
 			TrancheAmount = Self::Balance,
 			CurrencyId = Self::CurrencyId,
 			Error = DispatchError,
-			InvestmentId = <Self as Config>::TrancheCurrency,
+			InvestmentId = (Self::PoolId, Self::TrancheId),
 		>;
 
 		/// The source of truth for the transferability of assets via the
@@ -239,7 +234,8 @@ pub mod pallet {
 			+ TryInto<GeneralCurrencyIndexOf<Self>, Error = DispatchError>
 			+ TryFrom<GeneralCurrencyIndexOf<Self>, Error = DispatchError>
 			// Enables checking whether currency is tranche token
-			+ CurrencyInspect<CurrencyId = Self::CurrencyId>;
+			+ CurrencyInspect<CurrencyId = Self::CurrencyId>
+			+ From<(Self::PoolId, Self::TrancheId)>;
 
 		/// The converter from a DomainAddress to a Substrate AccountId.
 		type DomainAddressToAccountId: Convert<DomainAddress, Self::AccountId>;
@@ -900,7 +896,7 @@ pub mod pallet {
 		pub fn derive_invest_id(
 			pool_id: T::PoolId,
 			tranche_id: T::TrancheId,
-		) -> Result<<T as pallet::Config>::TrancheCurrency, DispatchError> {
+		) -> Result<(T::PoolId, T::TrancheId), DispatchError> {
 			ensure!(
 				T::PoolInspect::pool_exists(pool_id),
 				Error::<T>::PoolNotFound
@@ -910,7 +906,7 @@ pub mod pallet {
 				Error::<T>::TrancheNotFound
 			);
 
-			Ok(TrancheCurrency::generate(pool_id, tranche_id))
+			Ok((pool_id, tranche_id))
 		}
 
 		/// Performs multiple checks for the provided currency and returns its

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -552,11 +552,7 @@ pub mod pallet {
 			// Ensure pool and tranche exist and derive invest id
 			let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 
-			T::PreTransferFilter::check((
-				who.clone(),
-				domain_address.clone(),
-				invest_id.clone().into(),
-			))?;
+			T::PreTransferFilter::check((who.clone(), domain_address.clone(), invest_id.into()))?;
 
 			// Transfer to the domain account for bookkeeping
 			T::Tokens::transfer(

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -5,7 +5,7 @@ use cfg_types::{
 	permissions::PermissionScope,
 	tokens::{
 		AssetMetadata, AssetStringLimit, CrossChainTransferability, CurrencyId, CustomMetadata,
-		LocalAssetId, TrancheCurrency,
+		LocalAssetId,
 	},
 };
 use frame_support::{derive_impl, traits::PalletInfo as _};
@@ -87,7 +87,6 @@ impl cfg_mocks::pools::pallet::Config for Runtime {
 	type BalanceRatio = Ratio;
 	type CurrencyId = CurrencyId;
 	type PoolId = PoolId;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 }
 
@@ -101,7 +100,7 @@ impl cfg_mocks::asset_registry::pallet::Config for Runtime {
 impl cfg_mocks::foreign_investment::pallet::Config for Runtime {
 	type Amount = Balance;
 	type CurrencyId = CurrencyId;
-	type InvestmentId = TrancheCurrency;
+	type InvestmentId = (PoolId, TrancheId);
 	type TrancheAmount = Balance;
 }
 
@@ -177,7 +176,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Time;
 	type Tokens = Tokens;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 	type TrancheTokenPrice = Pools;
 	type TreasuryAccount = TreasuryAccount;

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -44,10 +44,7 @@ pub const DECIMALS: u8 = 6;
 pub const TRANCHE_CURRENCY: CurrencyId = CurrencyId::Tranche(POOL_ID, TRANCHE_ID);
 pub const TRANCHE_TOKEN_PRICE: Ratio = Ratio::from_rational(10, 1);
 pub const MARKET_RATIO: Ratio = Ratio::from_rational(2, 1);
-pub const INVESTMENT_ID: TrancheCurrency = TrancheCurrency {
-	pool_id: POOL_ID,
-	tranche_id: TRANCHE_ID,
-};
+pub const INVESTMENT_ID: (PoolId, TrancheId) = (POOL_ID, TRANCHE_ID);
 
 frame_support::construct_runtime!(
 	pub enum Runtime {

--- a/pallets/loans/src/tests/mock.rs
+++ b/pallets/loans/src/tests/mock.rs
@@ -17,7 +17,7 @@ use cfg_mocks::{
 	pallet_mock_change_guard, pallet_mock_data, pallet_mock_permissions, pallet_mock_pools,
 };
 use cfg_traits::Millis;
-use cfg_types::{permissions::PermissionScope, tokens::TrancheCurrency};
+use cfg_types::permissions::PermissionScope;
 use frame_support::{
 	derive_impl,
 	traits::{
@@ -168,7 +168,6 @@ impl pallet_mock_pools::Config for Runtime {
 	type BalanceRatio = Quantity;
 	type CurrencyId = CurrencyId;
 	type PoolId = PoolId;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 }
 

--- a/pallets/pool-fees/src/mock.rs
+++ b/pallets/pool-fees/src/mock.rs
@@ -21,7 +21,6 @@ use cfg_types::{
 	fixed_point::{Rate, Ratio},
 	permissions::PermissionScope,
 	pools::{PayableFeeAmount, PoolFeeAmount, PoolFeeEditor, PoolFeeType},
-	tokens::TrancheCurrency,
 };
 use frame_support::{
 	assert_ok, derive_impl, parameter_types,
@@ -98,7 +97,6 @@ impl pallet_mock_pools::Config for Runtime {
 	type BalanceRatio = Ratio;
 	type CurrencyId = CurrencyId;
 	type PoolId = PoolId;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 }
 

--- a/pallets/pool-registry/src/benchmarking.rs
+++ b/pallets/pool-registry/src/benchmarking.rs
@@ -13,13 +13,8 @@
 
 //! Module provides benchmarking for Loan Pallet
 use cfg_primitives::PoolEpochId;
-use cfg_traits::{
-	benchmarking::PoolFeesBenchmarkHelper, fee::PoolFeeBucket, investments::TrancheCurrency as _,
-};
-use cfg_types::{
-	pools::TrancheMetadata,
-	tokens::{CurrencyId, TrancheCurrency},
-};
+use cfg_traits::{benchmarking::PoolFeesBenchmarkHelper, fee::PoolFeeBucket};
+use cfg_types::{pools::TrancheMetadata, tokens::CurrencyId};
 use frame_benchmarking::benchmarks;
 use frame_support::traits::fungibles::Inspect;
 use frame_system::RawOrigin;
@@ -61,7 +56,7 @@ benchmarks! {
 		<PoolId = u64,
 			  TrancheId = [u8; 16],
 			  Balance = u128,
-			  CurrencyId = CurrencyId> + pallet_investments::Config<InvestmentId = TrancheCurrency, Amount = u128>,
+			  CurrencyId = CurrencyId> + pallet_investments::Config<InvestmentId = (u64, [u8; 16]), Amount = u128>,
 		T: pallet_pool_system::Config<PoolId = u64,
 			  TrancheId = [u8; 16],
 			  Balance = u128,
@@ -136,7 +131,7 @@ benchmarks! {
 		let amount = MAX_RESERVE / 2;
 		let investor = create_investor::<T>(0, TRANCHE, Some(amount))?;
 		let locator = get_tranche_id::<T>(TRANCHE);
-		pallet_investments::Pallet::<T>::update_redeem_order(RawOrigin::Signed(investor.clone()).into(), TrancheCurrency::generate(POOL, locator), amount)?;
+		pallet_investments::Pallet::<T>::update_redeem_order(RawOrigin::Signed(investor.clone()).into(), (POOL, locator), amount)?;
 
 
 		let changes = PoolChanges {
@@ -202,12 +197,12 @@ benchmarks! {
 		let investor = create_investor::<T>(0, TRANCHE, Some(1))?;
 		let locator = get_tranche_id::<T>(TRANCHE);
 		// Submit redemption order so the update isn't immediately executed
-		pallet_investments::Pallet::<T>::update_redeem_order(RawOrigin::Signed(investor.clone()).into(), TrancheCurrency::generate(POOL, locator), 1)?;
+		pallet_investments::Pallet::<T>::update_redeem_order(RawOrigin::Signed(investor.clone()).into(), (POOL, locator), 1)?;
 
 		update_pool::<T>(changes.clone())?;
 
 		// Withdraw redeem order so the update can be executed after that
-		pallet_investments::Pallet::<T>::update_redeem_order(RawOrigin::Signed(investor.clone()).into(), TrancheCurrency::generate(POOL, locator), 0)?;
+		pallet_investments::Pallet::<T>::update_redeem_order(RawOrigin::Signed(investor.clone()).into(), (POOL, locator), 0)?;
 	}: execute_update(RawOrigin::Signed(admin), POOL)
 	verify {
 		let pool = get_pool::<T>();

--- a/pallets/pool-registry/src/lib.rs
+++ b/pallets/pool-registry/src/lib.rs
@@ -20,7 +20,6 @@
 
 use cfg_traits::{
 	fee::{PoolFeeBucket, PoolFeesInspect},
-	investments::TrancheCurrency,
 	AssetMetadataOf, Permissions, PoolMutate, PoolWriteOffPolicyMutate, UpdateState,
 };
 use cfg_types::{
@@ -121,19 +120,9 @@ pub mod pallet {
 
 		type ModifyWriteOffPolicy: PoolWriteOffPolicyMutate<Self::PoolId>;
 
-		/// The currency type of investments.
-		type TrancheCurrency: TrancheCurrency<Self::PoolId, Self::TrancheId>
-			+ Into<Self::CurrencyId>;
+		type CurrencyId: Parameter + Copy + From<(Self::PoolId, Self::TrancheId)>;
 
-		type CurrencyId: Parameter + Copy;
-
-		type TrancheId: Member
-			+ Parameter
-			+ Default
-			+ Copy
-			+ MaxEncodedLen
-			+ TypeInfo
-			+ From<[u8; 16]>;
+		type TrancheId: Member + Parameter + Default + Copy + MaxEncodedLen + TypeInfo;
 
 		/// The origin permitted to create pools
 		type PoolCreateOrigin: EnsureOrigin<Self::RuntimeOrigin>;
@@ -450,7 +439,7 @@ pub mod pallet {
 			pool_id: Self::PoolId,
 			tranche_id: Self::TrancheId,
 		) -> Result<Self::AssetMetadata, DispatchError> {
-			let currency_id = T::TrancheCurrency::generate(pool_id, tranche_id).into();
+			let currency_id = (pool_id, tranche_id).into();
 			T::AssetRegistry::metadata(&currency_id)
 				.ok_or(Error::<T>::MetadataForCurrencyNotFound.into())
 		}
@@ -460,7 +449,7 @@ pub mod pallet {
 			tranche: Self::TrancheId,
 			metadata: Self::AssetMetadata,
 		) -> DispatchResult {
-			let currency_id = T::TrancheCurrency::generate(pool_id, tranche).into();
+			let currency_id = (pool_id, tranche).into();
 			T::AssetRegistry::register_asset(Some(currency_id), metadata)
 		}
 
@@ -474,7 +463,7 @@ pub mod pallet {
 			location: Option<Option<VersionedLocation>>,
 			additional: Option<Self::CustomMetadata>,
 		) -> DispatchResult {
-			let currency_id = T::TrancheCurrency::generate(pool_id, tranche).into();
+			let currency_id = (pool_id, tranche).into();
 			T::AssetRegistry::update_asset(
 				currency_id,
 				decimals,

--- a/pallets/pool-registry/src/mock.rs
+++ b/pallets/pool-registry/src/mock.rs
@@ -26,7 +26,7 @@ use cfg_traits::{
 use cfg_types::{
 	fixed_point::{Quantity, Rate},
 	permissions::{PermissionScope, Role},
-	tokens::{CurrencyId, CustomMetadata, TrancheCurrency},
+	tokens::{CurrencyId, CustomMetadata},
 };
 use frame_support::{
 	derive_impl,
@@ -164,7 +164,7 @@ impl pallet_pool_system::Config for Test {
 	type StringLimit = StringLimit;
 	type Time = Timestamp;
 	type Tokens = OrmlTokens;
-	type TrancheCurrency = TrancheCurrency;
+	type TrancheCurrency = (PoolId, TrancheId);
 	type TrancheId = TrancheId;
 	type TrancheWeight = TrancheWeight;
 	type UpdateGuard = UpdateGuard;
@@ -316,7 +316,6 @@ impl Config for Test {
 	type PoolFeesInspect = MockPoolFeesInspect;
 	type PoolId = u64;
 	type RuntimeEvent = RuntimeEvent;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 	type WeightInfo = ();
 }
@@ -349,7 +348,7 @@ impl orml_tokens::Config for Test {
 pub struct NoopCollectHook;
 impl cfg_traits::StatusNotificationHook for NoopCollectHook {
 	type Error = DispatchError;
-	type Id = (AccountId, TrancheCurrency);
+	type Id = (AccountId, (PoolId, TrancheId));
 	type Status = cfg_types::investments::CollectedAmount<Balance, Balance>;
 
 	fn notify_status_change(_id: Self::Id, _status: Self::Status) -> DispatchResult {
@@ -365,7 +364,7 @@ impl pallet_investments::Config for Test {
 	type BalanceRatio = Quantity;
 	type CollectedInvestmentHook = NoopCollectHook;
 	type CollectedRedemptionHook = NoopCollectHook;
-	type InvestmentId = TrancheCurrency;
+	type InvestmentId = (PoolId, TrancheId);
 	type MaxOutstandingCollects = MaxOutstandingCollects;
 	type PreConditions = Always;
 	type RuntimeEvent = RuntimeEvent;
@@ -411,7 +410,7 @@ impl PoolUpdateGuard for UpdateGuard {
 	type Moment = Seconds;
 	type PoolDetails = PoolDetails<
 		CurrencyId,
-		TrancheCurrency,
+		(PoolId, TrancheId),
 		u32,
 		Balance,
 		Rate,

--- a/pallets/pool-system/src/benchmarking.rs
+++ b/pallets/pool-system/src/benchmarking.rs
@@ -16,12 +16,11 @@ use cfg_primitives::PoolEpochId;
 use cfg_traits::{
 	benchmarking::PoolFeesBenchmarkHelper,
 	fee::{PoolFeeBucket, PoolFeesInspect},
-	investments::TrancheCurrency as _,
 	UpdateState,
 };
 use cfg_types::{
 	pools::{PoolFeeInfo, TrancheMetadata},
-	tokens::{CurrencyId, CustomMetadata, TrancheCurrency},
+	tokens::{CurrencyId, CustomMetadata},
 };
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::Currency;
@@ -54,7 +53,7 @@ benchmarks! {
 			  Balance = u128,
 			  CurrencyId = CurrencyId,
 			  EpochId = PoolEpochId>
-			+ pallet_investments::Config<InvestmentId = TrancheCurrency, Amount = u128>,
+			+ pallet_investments::Config<InvestmentId = (u64, T::TrancheId), Amount = u128>,
 		<T as pallet_investments::Config>::Tokens: Inspect<T::AccountId, AssetId = CurrencyId, Balance = u128>,
 		T::AccountId: EncodeLike<<T as frame_system::Config>::AccountId>,
 		<<T as frame_system::Config>::Lookup as sp_runtime::traits::StaticLookup>::Source:
@@ -109,7 +108,7 @@ benchmarks! {
 		let investment = MAX_RESERVE * 2;
 		let investor = create_investor::<T>(0, TRANCHE, None)?;
 		let origin = RawOrigin::Signed(investor.clone()).into();
-		pallet_investments::Pallet::<T>::update_invest_order(origin, TrancheCurrency::generate(POOL, get_tranche_id::<T>(TRANCHE)), investment)?;
+		pallet_investments::Pallet::<T>::update_invest_order(origin, (POOL, get_tranche_id::<T>(TRANCHE)), investment)?;
 	}: close_epoch(RawOrigin::Signed(admin.clone()), POOL)
 	verify {
 		assert_eq!(get_pool::<T>().epoch.last_executed, 0);
@@ -129,7 +128,7 @@ benchmarks! {
 		let investment = MAX_RESERVE / 2;
 		let investor = create_investor::<T>(0, TRANCHE, None)?;
 		let origin = RawOrigin::Signed(investor.clone()).into();
-		pallet_investments::Pallet::<T>::update_invest_order(origin, TrancheCurrency::generate(POOL, get_tranche_id::<T>(TRANCHE)), investment)?;
+		pallet_investments::Pallet::<T>::update_invest_order(origin, (POOL, get_tranche_id::<T>(TRANCHE)), investment)?;
 	}: close_epoch(RawOrigin::Signed(admin.clone()), POOL)
 	verify {
 		assert_eq!(get_pool::<T>().epoch.last_executed, 1);
@@ -149,7 +148,7 @@ benchmarks! {
 		let investment = MAX_RESERVE * 2;
 		let investor = create_investor::<T>(0, TRANCHE, None)?;
 		let origin = RawOrigin::Signed(investor.clone()).into();
-		pallet_investments::Pallet::<T>::update_invest_order(origin, TrancheCurrency::generate(POOL, get_tranche_id::<T>(TRANCHE)), investment)?;
+		pallet_investments::Pallet::<T>::update_invest_order(origin, (POOL, get_tranche_id::<T>(TRANCHE)), investment)?;
 
 		let admin_origin = RawOrigin::Signed(admin.clone()).into();
 		Pallet::<T>::close_epoch(admin_origin, POOL)?;
@@ -180,7 +179,7 @@ benchmarks! {
 		let investment = MAX_RESERVE * 2;
 		let investor = create_investor::<T>(0, TRANCHE, None)?;
 		let origin = RawOrigin::Signed(investor.clone()).into();
-		pallet_investments::Pallet::<T>::update_invest_order(origin, TrancheCurrency::generate(POOL, get_tranche_id::<T>(TRANCHE)), investment)?;
+		pallet_investments::Pallet::<T>::update_invest_order(origin, (POOL, get_tranche_id::<T>(TRANCHE)), investment)?;
 
 		let admin_origin = RawOrigin::Signed(admin.clone()).into();
 		Pallet::<T>::close_epoch(admin_origin, POOL)?;

--- a/pallets/pool-system/src/tests/mod.rs
+++ b/pallets/pool-system/src/tests/mod.rs
@@ -11,15 +11,12 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::{constants::SECONDS_PER_YEAR, Balance};
-use cfg_traits::{
-	fee::PoolFeeBucket, investments::TrancheCurrency as TrancheCurrencyT, PoolMutate, PoolNAV,
-	TrancheTokenPrice,
-};
+use cfg_traits::{fee::PoolFeeBucket, PoolMutate, PoolNAV, TrancheTokenPrice};
 use cfg_types::{
 	epoch::EpochState,
 	fixed_point::Rate,
 	pools::TrancheMetadata,
-	tokens::{CrossChainTransferability, CurrencyId, CustomMetadata, TrancheCurrency},
+	tokens::{CrossChainTransferability, CurrencyId, CustomMetadata},
 };
 use frame_support::{assert_err, assert_noop, assert_ok};
 use orml_traits::asset_registry::{AssetMetadata, Inspect};
@@ -151,7 +148,7 @@ pub mod util {
 			// forcing to call `execute_epoch()` later.
 			Investments::update_invest_order(
 				RuntimeOrigin::signed(0),
-				TrancheCurrency::generate(0, SeniorTrancheId::get()),
+				(0, SeniorTrancheId::get()),
 				500 * CURRENCY,
 			)
 			.unwrap();
@@ -269,19 +266,19 @@ fn core_constraints_currency_available_cant_cover_redemptions() {
 fn pool_constraints_pool_reserve_above_max_reserve() {
 	new_test_ext().execute_with(|| {
 		let tranche_a = Tranche {
-			currency: TrancheCurrency::generate(0, [0u8; 16]),
+			currency: (0, [0u8; 16]),
 			..Default::default()
 		};
 		let tranche_b = Tranche {
-			currency: TrancheCurrency::generate(0, [1u8; 16]),
+			currency: (0, [1u8; 16]),
 			..Default::default()
 		};
 		let tranche_c = Tranche {
-			currency: TrancheCurrency::generate(0, [2u8; 16]),
+			currency: (0, [2u8; 16]),
 			..Default::default()
 		};
 		let tranche_d = Tranche {
-			currency: TrancheCurrency::generate(0, [3u8; 16]),
+			currency: (0, [3u8; 16]),
 			..Default::default()
 		};
 		let tranches = Tranches::new(0, vec![tranche_a, tranche_b, tranche_c, tranche_d]).unwrap();
@@ -454,7 +451,7 @@ fn pool_constraints_pass() {
 				min_risk_buffer: Perquintill::from_float(0.2),
 			},
 			seniority: 3,
-			currency: TrancheCurrency::generate(0, [3u8; 16]),
+			currency: (0, [3u8; 16]),
 			..Default::default()
 		};
 		let tranche_b = Tranche {
@@ -463,7 +460,7 @@ fn pool_constraints_pass() {
 				min_risk_buffer: Perquintill::from_float(0.1),
 			},
 			seniority: 2,
-			currency: TrancheCurrency::generate(0, [2u8; 16]),
+			currency: (0, [2u8; 16]),
 			..Default::default()
 		};
 		let tranche_c = Tranche {
@@ -472,13 +469,13 @@ fn pool_constraints_pass() {
 				min_risk_buffer: Perquintill::from_float(0.05),
 			},
 			seniority: 1,
-			currency: TrancheCurrency::generate(0, [1u8; 16]),
+			currency: (0, [1u8; 16]),
 			..Default::default()
 		};
 		let tranche_d = Tranche {
 			tranche_type: TrancheType::Residual,
 			seniority: 0,
-			currency: TrancheCurrency::generate(0, [0u8; 16]),
+			currency: (0, [0u8; 16]),
 			..Default::default()
 		};
 		let tranches = Tranches::new(0, vec![tranche_d, tranche_c, tranche_b, tranche_a]).unwrap();
@@ -601,12 +598,12 @@ fn epoch() {
 		));
 		assert_ok!(Investments::update_invest_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			500 * CURRENCY
 		));
 		assert_ok!(Investments::update_invest_order(
 			RuntimeOrigin::signed(1),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 			500 * CURRENCY
 		));
 
@@ -648,11 +645,11 @@ fn epoch() {
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_investments(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 		));
 		assert_ok!(Investments::collect_investments(
 			RuntimeOrigin::signed(1),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 		));
 
 		let pool = PoolSystem::pool(0).unwrap();
@@ -753,7 +750,7 @@ fn epoch() {
 		next_block();
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(1),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 			250 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
@@ -838,12 +835,12 @@ fn submission_period() {
 		));
 		assert_ok!(Investments::update_invest_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			500 * CURRENCY
 		));
 		assert_ok!(Investments::update_invest_order(
 			RuntimeOrigin::signed(1),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 			500 * CURRENCY
 		));
 
@@ -860,13 +857,13 @@ fn submission_period() {
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_investments(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 		));
 
 		// Attempt to redeem everything
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			500 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
@@ -1047,7 +1044,7 @@ fn execute_info_removed_after_epoch_execute() {
 		// Attempt to redeem everything
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			500 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
@@ -1106,14 +1103,14 @@ fn pool_updates_should_be_constrained() {
 
 		assert_ok!(Investments::update_invest_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			100 * CURRENCY
 		));
 		test_nav_update(0, 0, START_DATE + DefaultMaxNAVAge::get() + 1);
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_investments(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 		));
 
 		let initial_pool = &crate::Pool::<Runtime>::try_get(pool_id).unwrap();
@@ -1147,7 +1144,7 @@ fn pool_updates_should_be_constrained() {
 
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			100 * CURRENCY
 		));
 
@@ -1667,7 +1664,7 @@ fn triger_challange_period_with_zero_solution() {
 		// Attempt to redeem everything
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			500 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
@@ -1761,7 +1758,7 @@ fn min_challenge_time_is_respected() {
 		// Attempt to redeem everything
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			500 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
@@ -1857,14 +1854,14 @@ fn only_zero_solution_is_accepted_max_reserve_violated() {
 		// Attempt to invest above reserve
 		assert_ok!(Investments::update_invest_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			1 * CURRENCY
 		));
 
 		// Attempt to invest above reserve
 		assert_ok!(Investments::update_invest_order(
 			RuntimeOrigin::signed(1),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 			1 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
@@ -2059,17 +2056,17 @@ fn only_zero_solution_is_accepted_when_risk_buff_violated_else() {
 		// Redeem so that we are exactly at 10 percent risk buffer
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			88_888_888_888_888_888_799
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 		));
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			1 * CURRENCY
 		));
 
@@ -2919,7 +2916,7 @@ mod pool_fees {
 			// Attempt to redeem everything
 			assert_ok!(Investments::update_redeem_order(
 				RuntimeOrigin::signed(0),
-				TrancheCurrency::generate(DEFAULT_POOL_ID, JuniorTrancheId::get()),
+				(DEFAULT_POOL_ID, JuniorTrancheId::get()),
 				INVESTMENT_AMOUNT
 			));
 			assert_ok!(PoolSystem::close_epoch(
@@ -3049,7 +3046,7 @@ mod pool_fees {
 			// Closing should update fee nav by disbursements because reserve is sufficient
 			assert_ok!(Investments::update_redeem_order(
 				RuntimeOrigin::signed(0),
-				TrancheCurrency::generate(DEFAULT_POOL_ID, JuniorTrancheId::get()),
+				(DEFAULT_POOL_ID, JuniorTrancheId::get()),
 				INVESTMENT_AMOUNT
 			));
 			next_block();
@@ -3266,12 +3263,12 @@ mod pool_fees {
 			// Redeem all junior and senior tranche tokens to require manual epoch execution
 			assert_ok!(Investments::update_redeem_order(
 				RuntimeOrigin::signed(0),
-				TrancheCurrency::generate(DEFAULT_POOL_ID, JuniorTrancheId::get()),
+				(DEFAULT_POOL_ID, JuniorTrancheId::get()),
 				INVESTMENT_AMOUNT
 			));
 			assert_ok!(Investments::update_redeem_order(
 				RuntimeOrigin::signed(1),
-				TrancheCurrency::generate(DEFAULT_POOL_ID, SeniorTrancheId::get()),
+				(DEFAULT_POOL_ID, SeniorTrancheId::get()),
 				INVESTMENT_AMOUNT
 			));
 
@@ -3384,12 +3381,12 @@ mod pool_fees {
 			// Reinvest to check for fulfillment later
 			assert_ok!(Investments::update_invest_order(
 				RuntimeOrigin::signed(0),
-				TrancheCurrency::generate(DEFAULT_POOL_ID, JuniorTrancheId::get()),
+				(DEFAULT_POOL_ID, JuniorTrancheId::get()),
 				INVESTMENT_AMOUNT
 			));
 			assert_ok!(Investments::update_redeem_order(
 				RuntimeOrigin::signed(0),
-				TrancheCurrency::generate(DEFAULT_POOL_ID, JuniorTrancheId::get()),
+				(DEFAULT_POOL_ID, JuniorTrancheId::get()),
 				INVESTMENT_AMOUNT
 			));
 
@@ -3456,7 +3453,7 @@ mod pool_fees {
 			assert_eq!(
 				pallet_investments::InvestOrders::<Runtime>::get(
 					0,
-					TrancheCurrency::generate(DEFAULT_POOL_ID, JuniorTrancheId::get())
+					(DEFAULT_POOL_ID, JuniorTrancheId::get())
 				)
 				.expect("InvestOrders should not be fulfilled due to reserve drain from pool fees")
 				.amount(),
@@ -3465,7 +3462,7 @@ mod pool_fees {
 			assert_eq!(
 				pallet_investments::RedeemOrders::<Runtime>::get(
 					0,
-					TrancheCurrency::generate(DEFAULT_POOL_ID, JuniorTrancheId::get())
+					(DEFAULT_POOL_ID, JuniorTrancheId::get())
 				)
 				.expect("RedeemOrder should not be fulfilled due to reserve drain from pool fees")
 				.amount(),

--- a/pallets/pool-system/src/tests/ratios.rs
+++ b/pallets/pool-system/src/tests/ratios.rs
@@ -62,13 +62,13 @@ fn ensure_ratios_are_distributed_correctly_2_tranches() {
 		// Attempt to redeem 40%
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 			200 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 		));
 
 		let new_residual_ratio = Perquintill::from_rational(5u64, 8u64);
@@ -88,13 +88,13 @@ fn ensure_ratios_are_distributed_correctly_2_tranches() {
 		// Attempt to redeem everything
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 			300 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 		));
 
 		let new_residual_ratio = Perquintill::one();
@@ -172,13 +172,13 @@ fn ensure_ratios_are_distributed_correctly_1_tranche() {
 		// Attempt to redeem 40%
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			200 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 		));
 
 		// Ensure ratio is 100
@@ -194,13 +194,13 @@ fn ensure_ratios_are_distributed_correctly_1_tranche() {
 		// Attempt to redeem everything
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			300 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 		));
 
 		// Ensure ratio is 0
@@ -284,13 +284,13 @@ fn ensure_ratios_are_distributed_correctly_3_tranches() {
 
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			250 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 		));
 
 		let check_ratios = [
@@ -312,13 +312,13 @@ fn ensure_ratios_are_distributed_correctly_3_tranches() {
 
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SecondSeniorTrancheId::get()),
+			(0, SecondSeniorTrancheId::get()),
 			250 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SecondSeniorTrancheId::get()),
+			(0, SecondSeniorTrancheId::get()),
 		));
 
 		let check_ratios = [
@@ -361,35 +361,35 @@ fn ensure_ratios_are_distributed_correctly_3_tranches() {
 		// Redeem everything
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SecondSeniorTrancheId::get()),
+			(0, SecondSeniorTrancheId::get()),
 			250 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SecondSeniorTrancheId::get()),
+			(0, SecondSeniorTrancheId::get()),
 		));
 
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 			500 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, SeniorTrancheId::get()),
+			(0, SeniorTrancheId::get()),
 		));
 
 		assert_ok!(Investments::update_redeem_order(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 			500 * CURRENCY
 		));
 		assert_ok!(PoolSystem::close_epoch(pool_owner_origin.clone(), 0));
 		assert_ok!(Investments::collect_redemptions(
 			RuntimeOrigin::signed(0),
-			TrancheCurrency::generate(0, JuniorTrancheId::get()),
+			(0, JuniorTrancheId::get()),
 		));
 
 		// Ensure ratios are 0

--- a/pallets/pool-system/src/tranches.rs
+++ b/pallets/pool-system/src/tranches.rs
@@ -1458,15 +1458,13 @@ fn finalize_combine<R, T, W>(
 #[cfg(test)]
 pub mod test {
 	use cfg_primitives::{Balance, PoolId, TrancheId, TrancheWeight};
-	use cfg_types::{
-		fixed_point::{FixedPointNumberExtension, Quantity, Rate},
-		tokens::TrancheCurrency,
-	};
+	use cfg_types::fixed_point::{FixedPointNumberExtension, Quantity, Rate};
 
 	use super::*;
 	use crate::mock::MaxTranches;
 
 	type BalanceRatio = Quantity;
+	type TrancheCurrency = (PoolId, TrancheId);
 	type TTrancheType = TrancheType<Rate>;
 	type TTranche = Tranche<Balance, Rate, TrancheWeight, TrancheCurrency>;
 	type TTranches =
@@ -1525,7 +1523,7 @@ pub mod test {
 			Self {
 				tranche_type: TrancheType::Residual,
 				seniority: 1,
-				currency: TrancheCurrency::generate(0, [0u8; 16]),
+				currency: (0, [0u8; 16]),
 				debt: Zero::zero(),
 				reserve: Zero::zero(),
 				loss: Zero::zero(),
@@ -1540,7 +1538,7 @@ pub mod test {
 	impl Default for EpochExecutionTranche<Balance, Quantity, TrancheWeight, TrancheCurrency> {
 		fn default() -> Self {
 			Self {
-				currency: TrancheCurrency::generate(0, [0u8; 16]),
+				currency: (0, [0u8; 16]),
 				supply: 0,
 				price: Quantity::one(),
 				invest: 0,
@@ -1560,7 +1558,7 @@ pub mod test {
 		TTranche {
 			tranche_type: TrancheType::Residual,
 			seniority: seniority,
-			currency: TrancheCurrency::generate(DEFAULT_POOL_ID, [id; 16]),
+			currency: (DEFAULT_POOL_ID, [id; 16]),
 			debt,
 			reserve,
 			loss: 0,
@@ -1601,7 +1599,7 @@ pub mod test {
 				min_risk_buffer,
 			},
 			seniority: seniority,
-			currency: TrancheCurrency::generate(DEFAULT_POOL_ID, [id; 16]),
+			currency: (DEFAULT_POOL_ID, [id; 16]),
 			debt,
 			reserve,
 			loss: 0,
@@ -1843,15 +1841,15 @@ pub mod test {
 			let tranches = default_tranches();
 			assert_eq!(
 				tranches.tranche_currency(TrancheLoc::Index(0)),
-				Some(TrancheCurrency::generate(DEFAULT_POOL_ID, [0u8; 16]))
+				Some((DEFAULT_POOL_ID, [0u8; 16]))
 			);
 			assert_eq!(
 				tranches.tranche_currency(TrancheLoc::Index(1)),
-				Some(TrancheCurrency::generate(DEFAULT_POOL_ID, [1u8; 16]))
+				Some((DEFAULT_POOL_ID, [1u8; 16]))
 			);
 			assert_eq!(
 				tranches.tranche_currency(TrancheLoc::Index(2)),
-				Some(TrancheCurrency::generate(DEFAULT_POOL_ID, [2u8; 16]))
+				Some((DEFAULT_POOL_ID, [2u8; 16]))
 			);
 			assert_eq!(tranches.tranche_currency(TrancheLoc::Index(3)), None);
 		}
@@ -2008,16 +2006,13 @@ pub mod test {
 					reserve: 0,
 					loss: 0,
 					seniority: 5,
-					currency: TrancheCurrency { .. },
+					currency: _,
 					last_updated_interest: SECS_PER_YEAR,
 					..
 				} if b == min_risk_buffer && int_per_sec == ir => true,
 				_ => false,
 			});
-			assert_eq!(
-				new_tranche.currency,
-				TrancheCurrency::generate(DEFAULT_POOL_ID, tranche_id)
-			);
+			assert_eq!(new_tranche.currency, (DEFAULT_POOL_ID, tranche_id));
 			assert_eq!(new_tranche.ratio, Perquintill::zero());
 
 			// Create tranche with implicit seniority (through index)

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -24,13 +24,13 @@ use cfg_primitives::{
 	liquidity_pools::GeneralCurrencyPrefix,
 	types::{
 		AccountId, Address, AuraId, Balance, BlockNumber, CollectionId, Hash, Hashing, Header,
-		IBalance, ItemId, LoanId, Nonce, OrderId, OutboundMessageNonce, PalletIndex, PoolEpochId,
-		PoolFeeId, PoolId, Signature, TrancheId, TrancheWeight,
+		IBalance, InvestmentId, ItemId, LoanId, Nonce, OrderId, OutboundMessageNonce, PalletIndex,
+		PoolEpochId, PoolFeeId, PoolId, Signature, TrancheId, TrancheWeight,
 	},
 };
 use cfg_traits::{
-	investments::{OrderManager, TrancheCurrency as _},
-	Millis, Permissions as PermissionsT, PoolUpdateGuard, PreConditions, Seconds,
+	investments::OrderManager, Millis, Permissions as PermissionsT, PoolUpdateGuard, PreConditions,
+	Seconds,
 };
 use cfg_types::{
 	fee_keys::{Fee, FeeKey},
@@ -42,8 +42,7 @@ use cfg_types::{
 	pools::PoolNav,
 	time::TimeProvider,
 	tokens::{
-		AssetStringLimit, CurrencyId, CustomMetadata, FilterCurrency, LocalAssetId,
-		StakingCurrency, TrancheCurrency,
+		AssetStringLimit, CurrencyId, CustomMetadata, FilterCurrency, LocalAssetId, StakingCurrency,
 	},
 };
 use constants::currency::*;
@@ -1534,7 +1533,7 @@ impl pallet_pool_system::Config for Runtime {
 	type StringLimit = AssetStringLimit;
 	type Time = Timestamp;
 	type Tokens = Tokens;
-	type TrancheCurrency = TrancheCurrency;
+	type TrancheCurrency = InvestmentId;
 	type TrancheId = TrancheId;
 	type TrancheWeight = TrancheWeight;
 	type UpdateGuard = UpdateGuard;
@@ -1555,7 +1554,6 @@ impl pallet_pool_registry::Config for Runtime {
 	type PoolFeesInspect = PoolFees;
 	type PoolId = PoolId;
 	type RuntimeEvent = RuntimeEvent;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 	type WeightInfo = weights::pallet_pool_registry::WeightInfo<Runtime>;
 }
@@ -1602,7 +1600,7 @@ impl PoolUpdateGuard for UpdateGuard {
 	type Moment = Seconds;
 	type PoolDetails = PoolDetails<
 		CurrencyId,
-		TrancheCurrency,
+		InvestmentId,
 		u32,
 		Balance,
 		Rate,
@@ -1644,7 +1642,7 @@ impl PoolUpdateGuard for UpdateGuard {
 			.ids_non_residual_top()
 			.iter()
 			.map(|tranche_id| {
-				let investment_id = TrancheCurrency::generate(pool_id, *tranche_id);
+				let investment_id = (pool_id, *tranche_id);
 				Investments::redeem_orders(investment_id).amount
 			})
 			.fold(Balance::zero(), |acc, redemption| {
@@ -1668,7 +1666,7 @@ impl pallet_investments::Config for Runtime {
 	type BalanceRatio = Quantity;
 	type CollectedInvestmentHook = pallet_foreign_investments::CollectedInvestmentHook<Runtime>;
 	type CollectedRedemptionHook = pallet_foreign_investments::CollectedRedemptionHook<Runtime>;
-	type InvestmentId = TrancheCurrency;
+	type InvestmentId = InvestmentId;
 	type MaxOutstandingCollects = MaxOutstandingCollects;
 	type PreConditions = IsTrancheInvestor<Permissions, Timestamp>;
 	type RuntimeEvent = RuntimeEvent;
@@ -1682,35 +1680,29 @@ pub struct IsTrancheInvestor<P, T>(PhantomData<(P, T)>);
 impl<
 		P: PermissionsT<AccountId, Scope = PermissionScope<PoolId, CurrencyId>, Role = Role>,
 		T: UnixTime,
-	> PreConditions<OrderType<AccountId, TrancheCurrency, Balance>> for IsTrancheInvestor<P, T>
+	> PreConditions<OrderType<AccountId, InvestmentId, Balance>> for IsTrancheInvestor<P, T>
 {
 	type Result = DispatchResult;
 
-	fn check(order: OrderType<AccountId, TrancheCurrency, Balance>) -> Self::Result {
+	fn check(order: OrderType<AccountId, InvestmentId, Balance>) -> Self::Result {
 		let is_tranche_investor = match order {
 			OrderType::Investment {
 				who,
-				investment_id: tranche,
+				investment_id: (pool_id, tranche_id),
 				..
 			} => P::has(
-				PermissionScope::Pool(tranche.of_pool()),
+				PermissionScope::Pool(pool_id),
 				who,
-				Role::PoolRole(PoolRole::TrancheInvestor(
-					tranche.of_tranche(),
-					T::now().as_secs(),
-				)),
+				Role::PoolRole(PoolRole::TrancheInvestor(tranche_id, T::now().as_secs())),
 			),
 			OrderType::Redemption {
 				who,
-				investment_id: tranche,
+				investment_id: (pool_id, tranche_id),
 				..
 			} => P::has(
-				PermissionScope::Pool(tranche.of_pool()),
+				PermissionScope::Pool(pool_id),
 				who,
-				Role::PoolRole(PoolRole::TrancheInvestor(
-					tranche.of_tranche(),
-					T::now().as_secs(),
-				)),
+				Role::PoolRole(PoolRole::TrancheInvestor(tranche_id, T::now().as_secs())),
 			),
 		};
 
@@ -1785,7 +1777,7 @@ impl pallet_foreign_investments::Config for Runtime {
 	type DecreasedForeignInvestOrderHook = DecreasedForeignInvestOrderHook<Runtime>;
 	type ForeignBalance = Balance;
 	type Investment = Investments;
-	type InvestmentId = TrancheCurrency;
+	type InvestmentId = InvestmentId;
 	type PoolBalance = Balance;
 	type PoolInspect = PoolSystem;
 	type RuntimeEvent = RuntimeEvent;
@@ -1817,7 +1809,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 	type TrancheTokenPrice = PoolSystem;
 	type TreasuryAccount = TreasuryAccount;
@@ -2496,8 +2487,8 @@ impl_runtime_apis! {
 	}
 
 	// Investment Runtime APIs
-	impl runtime_common::apis::InvestmentsApi<Block, AccountId, TrancheCurrency, InvestmentPortfolio<Balance, CurrencyId>> for Runtime {
-		fn investment_portfolio(account_id: AccountId) -> Vec<(TrancheCurrency, InvestmentPortfolio<Balance, CurrencyId>)> {
+	impl runtime_common::apis::InvestmentsApi<Block, AccountId, InvestmentId, InvestmentPortfolio<Balance, CurrencyId>> for Runtime {
+		fn investment_portfolio(account_id: AccountId) -> Vec<(InvestmentId, InvestmentPortfolio<Balance, CurrencyId>)> {
 			runtime_common::investment_portfolios::get_account_portfolio::<Runtime>(account_id).unwrap_or_default()
 		}
 	}

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -24,13 +24,13 @@ use cfg_primitives::{
 	liquidity_pools::GeneralCurrencyPrefix,
 	types::{
 		AccountId, Address, AuraId, Balance, BlockNumber, CollectionId, Hash, Hashing, Header,
-		IBalance, ItemId, LoanId, Nonce, OrderId, OutboundMessageNonce, PalletIndex, PoolEpochId,
-		PoolFeeId, PoolId, Signature, TrancheId, TrancheWeight,
+		IBalance, InvestmentId, ItemId, LoanId, Nonce, OrderId, OutboundMessageNonce, PalletIndex,
+		PoolEpochId, PoolFeeId, PoolId, Signature, TrancheId, TrancheWeight,
 	},
 };
 use cfg_traits::{
-	investments::{OrderManager, TrancheCurrency as _},
-	Millis, Permissions as PermissionsT, PoolUpdateGuard, PreConditions, Seconds,
+	investments::OrderManager, Millis, Permissions as PermissionsT, PoolUpdateGuard, PreConditions,
+	Seconds,
 };
 use cfg_types::{
 	fee_keys::{Fee, FeeKey},
@@ -44,8 +44,7 @@ use cfg_types::{
 	pools::PoolNav,
 	time::TimeProvider,
 	tokens::{
-		AssetStringLimit, CurrencyId, CustomMetadata, FilterCurrency, LocalAssetId,
-		StakingCurrency, TrancheCurrency,
+		AssetStringLimit, CurrencyId, CustomMetadata, FilterCurrency, LocalAssetId, StakingCurrency,
 	},
 };
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
@@ -1414,7 +1413,7 @@ impl PoolUpdateGuard for UpdateGuard {
 	type Moment = Seconds;
 	type PoolDetails = PoolDetails<
 		CurrencyId,
-		TrancheCurrency,
+		InvestmentId,
 		u32,
 		Balance,
 		Rate,
@@ -1456,7 +1455,7 @@ impl PoolUpdateGuard for UpdateGuard {
 			.ids_non_residual_top()
 			.iter()
 			.map(|tranche_id| {
-				let investment_id = TrancheCurrency::generate(pool_id, *tranche_id);
+				let investment_id = (pool_id, *tranche_id);
 				Investments::redeem_orders(investment_id).amount
 			})
 			.fold(Balance::zero(), |acc, redemption| {
@@ -1485,7 +1484,6 @@ impl pallet_pool_registry::Config for Runtime {
 	type PoolFeesInspect = PoolFees;
 	type PoolId = PoolId;
 	type RuntimeEvent = RuntimeEvent;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 	type WeightInfo = weights::pallet_pool_registry::WeightInfo<Runtime>;
 }
@@ -1524,7 +1522,7 @@ impl pallet_pool_system::Config for Runtime {
 	type StringLimit = AssetStringLimit;
 	type Time = Timestamp;
 	type Tokens = Tokens;
-	type TrancheCurrency = TrancheCurrency;
+	type TrancheCurrency = InvestmentId;
 	type TrancheId = TrancheId;
 	type TrancheWeight = TrancheWeight;
 	type UpdateGuard = UpdateGuard;
@@ -1633,35 +1631,29 @@ pub struct IsTrancheInvestor<P, T>(PhantomData<(P, T)>);
 impl<
 		P: PermissionsT<AccountId, Scope = PermissionScope<PoolId, CurrencyId>, Role = Role>,
 		T: UnixTime,
-	> PreConditions<OrderType<AccountId, TrancheCurrency, Balance>> for IsTrancheInvestor<P, T>
+	> PreConditions<OrderType<AccountId, InvestmentId, Balance>> for IsTrancheInvestor<P, T>
 {
 	type Result = DispatchResult;
 
-	fn check(order: OrderType<AccountId, TrancheCurrency, Balance>) -> Self::Result {
+	fn check(order: OrderType<AccountId, InvestmentId, Balance>) -> Self::Result {
 		let is_tranche_investor = match order {
 			OrderType::Investment {
 				who,
-				investment_id: tranche,
+				investment_id: (pool_id, tranche_id),
 				..
 			} => P::has(
-				PermissionScope::Pool(tranche.of_pool()),
+				PermissionScope::Pool(pool_id),
 				who,
-				Role::PoolRole(PoolRole::TrancheInvestor(
-					tranche.of_tranche(),
-					T::now().as_secs(),
-				)),
+				Role::PoolRole(PoolRole::TrancheInvestor(tranche_id, T::now().as_secs())),
 			),
 			OrderType::Redemption {
 				who,
-				investment_id: tranche,
+				investment_id: (pool_id, tranche_id),
 				..
 			} => P::has(
-				PermissionScope::Pool(tranche.of_pool()),
+				PermissionScope::Pool(pool_id),
 				who,
-				Role::PoolRole(PoolRole::TrancheInvestor(
-					tranche.of_tranche(),
-					T::now().as_secs(),
-				)),
+				Role::PoolRole(PoolRole::TrancheInvestor(tranche_id, T::now().as_secs())),
 			),
 		};
 
@@ -1684,7 +1676,7 @@ impl pallet_investments::Config for Runtime {
 	type BalanceRatio = Quantity;
 	type CollectedInvestmentHook = pallet_foreign_investments::CollectedInvestmentHook<Runtime>;
 	type CollectedRedemptionHook = pallet_foreign_investments::CollectedRedemptionHook<Runtime>;
-	type InvestmentId = TrancheCurrency;
+	type InvestmentId = InvestmentId;
 	type MaxOutstandingCollects = MaxOutstandingCollects;
 	type PreConditions = IsTrancheInvestor<Permissions, Timestamp>;
 	type RuntimeEvent = RuntimeEvent;
@@ -1864,7 +1856,7 @@ impl pallet_foreign_investments::Config for Runtime {
 	type DecreasedForeignInvestOrderHook = DecreasedForeignInvestOrderHook<Runtime>;
 	type ForeignBalance = Balance;
 	type Investment = Investments;
-	type InvestmentId = TrancheCurrency;
+	type InvestmentId = InvestmentId;
 	type PoolBalance = Balance;
 	type PoolInspect = PoolSystem;
 	type RuntimeEvent = RuntimeEvent;
@@ -1897,7 +1889,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Time = Timestamp;
 	type Tokens = Tokens;
-	type TrancheCurrency = TrancheCurrency;
 	type TrancheId = TrancheId;
 	type TrancheTokenPrice = PoolSystem;
 	type TreasuryAccount = TreasuryAccount;
@@ -2434,8 +2425,8 @@ impl_runtime_apis! {
 	}
 
 	// Investment Runtime APIs
-	impl runtime_common::apis::InvestmentsApi<Block, AccountId, TrancheCurrency, InvestmentPortfolio<Balance, CurrencyId>> for Runtime {
-		fn investment_portfolio(account_id: AccountId) -> Vec<(TrancheCurrency, InvestmentPortfolio<Balance, CurrencyId>)> {
+	impl runtime_common::apis::InvestmentsApi<Block, AccountId, InvestmentId, InvestmentPortfolio<Balance, CurrencyId>> for Runtime {
+		fn investment_portfolio(account_id: AccountId) -> Vec<(InvestmentId, InvestmentPortfolio<Balance, CurrencyId>)> {
 			runtime_common::investment_portfolios::get_account_portfolio::<Runtime>(account_id).unwrap_or_default()
 		}
 	}

--- a/runtime/integration-tests/src/cases/investments.rs
+++ b/runtime/integration-tests/src/cases/investments.rs
@@ -1,10 +1,6 @@
 use cfg_primitives::{AccountId, Balance, PoolId};
-use cfg_traits::{investments::TrancheCurrency as _, Seconds};
-use cfg_types::{
-	investments::InvestmentPortfolio,
-	permissions::PoolRole,
-	tokens::{CurrencyId, TrancheCurrency},
-};
+use cfg_traits::Seconds;
+use cfg_types::{investments::InvestmentPortfolio, permissions::PoolRole, tokens::CurrencyId};
 use frame_support::traits::fungibles::MutateHold;
 use runtime_common::apis::{
 	runtime_decl_for_investments_api::InvestmentsApiV1, runtime_decl_for_pools_api::PoolsApiV1,
@@ -66,7 +62,7 @@ fn investment_portfolio_single_tranche<T: Runtime>() {
 	let mut env = common::initialize_state_for_investments::<RuntimeEnv<T>, T>();
 
 	let tranche_id = env.parachain_state(|| T::Api::tranche_id(POOL_A, 0).unwrap());
-	let invest_id = TrancheCurrency::generate(POOL_A, tranche_id);
+	let invest_id = (POOL_A, tranche_id);
 
 	let mut investment_portfolio =
 		env.parachain_state(|| T::Api::investment_portfolio(INVESTOR.id()));

--- a/runtime/integration-tests/src/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/cases/liquidity_pools.rs
@@ -1,10 +1,9 @@
 use cfg_primitives::{
-	currency_decimals, parachains, AccountId, Balance, OrderId, PoolId, TrancheId,
+	currency_decimals, parachains, AccountId, Balance, InvestmentId, OrderId, PoolId, TrancheId,
 };
 use cfg_traits::{
-	investments::{OrderManager, TrancheCurrency},
-	liquidity_pools::InboundQueue,
-	IdentityCurrencyConversion, Permissions, PoolInspect, PoolMutate, Seconds,
+	investments::OrderManager, liquidity_pools::InboundQueue, IdentityCurrencyConversion,
+	Permissions, PoolInspect, PoolMutate, Seconds,
 };
 use cfg_types::{
 	domain_address::{Domain, DomainAddress},
@@ -347,16 +346,12 @@ mod utils {
 	pub fn investment_id<T: Runtime + FudgeSupport>(
 		pool_id: u64,
 		tranche_id: TrancheId,
-	) -> cfg_types::tokens::TrancheCurrency {
-		<T as pallet_liquidity_pools::Config>::TrancheCurrency::generate(pool_id, tranche_id)
+	) -> InvestmentId {
+		(pool_id, tranche_id)
 	}
 
-	pub fn default_investment_id<T: Runtime + FudgeSupport>() -> cfg_types::tokens::TrancheCurrency
-	{
-		<T as pallet_liquidity_pools::Config>::TrancheCurrency::generate(
-			POOL_ID,
-			default_tranche_id::<T>(POOL_ID),
-		)
+	pub fn default_investment_id<T: Runtime + FudgeSupport>() -> InvestmentId {
+		(POOL_ID, default_tranche_id::<T>(POOL_ID))
 	}
 
 	pub fn default_order_id<T: Runtime + FudgeSupport>(investor: &AccountId) -> OrderId {

--- a/runtime/integration-tests/src/cases/lp/investments.rs
+++ b/runtime/integration-tests/src/cases/lp/investments.rs
@@ -30,8 +30,8 @@ use crate::{
 const DEFAULT_INVESTMENT_AMOUNT: Balance = 100 * DECIMALS_6;
 
 mod utils {
-	use cfg_primitives::{AccountId, Balance};
-	use cfg_traits::{investments::TrancheCurrency, HasLocalAssetRepresentation};
+	use cfg_primitives::{AccountId, Balance, InvestmentId, PoolId, TrancheId};
+	use cfg_traits::HasLocalAssetRepresentation;
 	use ethabi::Token;
 	use pallet_foreign_investments::Action;
 	use pallet_liquidity_pools::{GeneralCurrencyIndexOf, GeneralCurrencyIndexType};
@@ -62,10 +62,10 @@ mod utils {
 	}
 
 	pub fn investment_id<T: pallet_pool_system::Config>(
-		pool: T::PoolId,
-		tranche: T::TrancheId,
-	) -> <T as pallet_pool_system::Config>::TrancheCurrency {
-		<T as pallet_pool_system::Config>::TrancheCurrency::generate(pool, tranche)
+		pool: PoolId,
+		tranche: TrancheId,
+	) -> InvestmentId {
+		(pool, tranche)
 	}
 
 	// TODO: CHANGE EVM TO BE ENVIRONMENTAL AND MAKE TRAIT NON SELF BUT RATHER GET

--- a/runtime/integration-tests/src/config.rs
+++ b/runtime/integration-tests/src/config.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
 use cfg_primitives::{
-	AccountId, Address, AuraId, Balance, CollectionId, Header, IBalance, ItemId, LoanId, Nonce,
-	OrderId, PoolId, Signature, TrancheId,
+	AccountId, Address, AuraId, Balance, CollectionId, Header, IBalance, InvestmentId, ItemId,
+	LoanId, Nonce, OrderId, PoolId, Signature, TrancheId,
 };
 use cfg_traits::Millis;
 use cfg_types::{
@@ -11,7 +11,7 @@ use cfg_types::{
 	locations::RestrictedTransferLocation,
 	oracles::OracleKey,
 	permissions::{PermissionScope, Role},
-	tokens::{AssetStringLimit, CurrencyId, CustomMetadata, FilterCurrency, TrancheCurrency},
+	tokens::{AssetStringLimit, CurrencyId, CustomMetadata, FilterCurrency},
 };
 use fp_evm::PrecompileSet;
 use fp_self_contained::{SelfContainedCall, UncheckedExtrinsic};
@@ -72,22 +72,20 @@ pub trait Runtime:
 		TrancheId = TrancheId,
 		BalanceRatio = Quantity,
 		MaxTranches = Self::MaxTranchesExt,
-		TrancheCurrency = TrancheCurrency,
+		TrancheCurrency = InvestmentId,
 	> + pallet_balances::Config<Balance = Balance>
 	+ pallet_pool_registry::Config<
 		CurrencyId = CurrencyId,
 		PoolId = PoolId,
+		TrancheId = TrancheId,
 		InterestRate = Rate,
 		Balance = Balance,
 		MaxTranches = Self::MaxTranchesExt,
 		ModifyPool = pallet_pool_system::Pallet<Self>,
 		ModifyWriteOffPolicy = pallet_loans::Pallet<Self>,
 	> + pallet_permissions::Config<Role = Role, Scope = PermissionScope<PoolId, CurrencyId>>
-	+ pallet_investments::Config<
-		InvestmentId = <Self as pallet_pool_system::Config>::TrancheCurrency,
-		Amount = Balance,
-		BalanceRatio = Ratio,
-	> + pallet_loans::Config<
+	+ pallet_investments::Config<InvestmentId = InvestmentId, Amount = Balance, BalanceRatio = Ratio>
+	+ pallet_loans::Config<
 		Balance = Balance,
 		PoolId = PoolId,
 		LoanId = LoanId,
@@ -136,7 +134,6 @@ pub trait Runtime:
 		Balance = Balance,
 		PoolId = PoolId,
 		TrancheId = TrancheId,
-		TrancheCurrency = TrancheCurrency,
 		BalanceRatio = Ratio,
 	> + pallet_liquidity_pools_gateway::Config<Router = DomainRouter<Self>, Message = Message>
 	+ pallet_xcm_transactor::Config<CurrencyId = CurrencyId>
@@ -154,7 +151,7 @@ pub trait Runtime:
 		ForeignBalance = Balance,
 		PoolBalance = Balance,
 		TrancheBalance = Balance,
-		InvestmentId = TrancheCurrency,
+		InvestmentId = InvestmentId,
 		CurrencyId = CurrencyId,
 	> + pallet_preimage::Config
 	+ pallet_collective::Config<CouncilCollective, Proposal = Self::RuntimeCallExt>
@@ -323,7 +320,7 @@ pub trait Runtime:
 		> + apis::runtime_decl_for_investments_api::InvestmentsApiV1<
 			Self::BlockExt,
 			AccountId,
-			TrancheCurrency,
+			InvestmentId,
 			InvestmentPortfolio<Balance, CurrencyId>,
 		> + apis::runtime_decl_for_account_conversion_api::AccountConversionApiV1<
 			Self::BlockExt,

--- a/runtime/integration-tests/src/utils/mod.rs
+++ b/runtime/integration-tests/src/utils/mod.rs
@@ -22,12 +22,8 @@ pub mod tokens;
 pub mod xcm;
 
 use cfg_primitives::{AccountId, Balance, CollectionId, ItemId, PoolId, TrancheId};
-use cfg_traits::{investments::TrancheCurrency as _, Seconds, TimeAsSecs};
-use cfg_types::{
-	fixed_point::Ratio,
-	oracles::OracleKey,
-	tokens::{CurrencyId, TrancheCurrency},
-};
+use cfg_traits::{Seconds, TimeAsSecs};
+use cfg_types::{fixed_point::Ratio, oracles::OracleKey, tokens::CurrencyId};
 use frame_system::RawOrigin;
 use pallet_oracle_collection::types::CollectionInfo;
 use runtime_common::oracle::Feeder;
@@ -187,7 +183,7 @@ pub fn invest<T: Runtime>(
 ) {
 	pallet_investments::Pallet::<T>::update_invest_order(
 		RawOrigin::Signed(investor).into(),
-		TrancheCurrency::generate(pool_id, tranche_id),
+		(pool_id, tranche_id),
 		amount,
 	)
 	.unwrap();
@@ -201,7 +197,7 @@ pub fn redeem<T: Runtime>(
 ) {
 	pallet_investments::Pallet::<T>::update_redeem_order(
 		RawOrigin::Signed(investor).into(),
-		TrancheCurrency::generate(pool_id, tranche_id),
+		(pool_id, tranche_id),
 		amount,
 	)
 	.unwrap();
@@ -214,7 +210,7 @@ pub fn collect_investments<T: Runtime>(
 ) {
 	pallet_investments::Pallet::<T>::collect_investments(
 		RawOrigin::Signed(investor).into(),
-		TrancheCurrency::generate(pool_id, tranche_id),
+		(pool_id, tranche_id),
 	)
 	.unwrap();
 }
@@ -226,7 +222,7 @@ pub fn collect_redemptions<T: Runtime>(
 ) {
 	pallet_investments::Pallet::<T>::collect_redemptions(
 		RawOrigin::Signed(investor).into(),
-		TrancheCurrency::generate(pool_id, tranche_id),
+		(pool_id, tranche_id),
 	)
 	.unwrap();
 }


### PR DESCRIPTION
# Description

Remove the TrancheCurrency type & trait, which represent exact tuple behavior, and use a tuple directly.

## Why this change?
- Less knowledge layers
- Easier to create mocks in pallets that need this type. Previously, either you imported the `TrancheCurrency` type (which is a centrifuge domain type), or you created your own by adding boilerplate in the tests. But your own implementation doesn't work well with the `CurrencyId` type used everywhere, which needs a conversion.
- This change is a step to clean all domain dependencies from our pallets and unitary tests, and get close to the ideal here: https://github.com/centrifuge/centrifuge-chain/issues/1380

### This change comes in two parts:

- Part 1 (this PR): 
  - Refactor to use a tuple instead of `TrancheCurrency` type which is fully removed. 
  - The tuple still implements the `TrancheCurrency` trait which is still used by 2 pallets: `pallet-pool-system` and `pallet-foreign-investments`
- Part 2 (new PR over `lpv2` branch): 
  - We clean `pallet-foreign-investments` from the usage of `TrancheCurrency` in this branch to avoid git conflicts later. 
  - Finishing some refactors required to `pallet-pool-system` to remove unused generics from this change.
  - Remove the `TrancheCurrency` trait.