### PR TITLE
feat: add domain hook storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8293,6 +8293,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "rand",
+ "runtime-common",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8290,6 +8290,7 @@ dependencies = [
  "frame-system",
  "hex",
  "hex-literal",
+ "orml-traits",
  "pallet-balances",
  "parity-scale-codec",
  "rand",

--- a/libs/mocks/src/outbound_queue.rs
+++ b/libs/mocks/src/outbound_queue.rs
@@ -1,8 +1,9 @@
 #[frame_support::pallet(dev_mode)]
 pub mod pallet {
-	use cfg_traits::liquidity_pools::{DomainHook, OutboundQueue};
+	use cfg_traits::liquidity_pools::OutboundQueue;
 	use frame_support::pallet_prelude::*;
 	use mock_builder::{execute_call, register_call};
+	use orml_traits::GetByKey;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -28,8 +29,8 @@ pub mod pallet {
 			register_call!(move |(a, b, c)| f(a, b, c));
 		}
 
-		pub fn mock_get_address(f: impl Fn(T::Destination) -> Option<T::Sender> + 'static) {
-			register_call!(move |a| f(a));
+		pub fn mock_get(f: impl Fn(&T::Destination) -> Option<T::Sender> + 'static) {
+			register_call!(f);
 		}
 	}
 
@@ -43,11 +44,8 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> DomainHook for Pallet<T> {
-		type AccountId = T::Sender;
-		type Domain = T::Destination;
-
-		fn get_address(a: Self::Domain) -> Option<Self::AccountId> {
+	impl<T: Config> GetByKey<T::Destination, Option<T::Sender>> for Pallet<T> {
+		fn get(a: &T::Destination) -> Option<T::Sender> {
 			execute_call!(a)
 		}
 	}

--- a/libs/mocks/src/outbound_queue.rs
+++ b/libs/mocks/src/outbound_queue.rs
@@ -25,7 +25,7 @@ pub mod pallet {
 			register_call!(move |(a, b, c)| f(a, b, c));
 		}
 
-		pub fn mock_get(f: impl Fn(&T::Destination) -> Option<T::Sender> + 'static) {
+		pub fn mock_get(f: impl Fn(&T::Destination) -> Option<[u8; 20]> + 'static) {
 			register_call!(f);
 		}
 	}
@@ -40,8 +40,8 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> GetByKey<T::Destination, Option<T::Sender>> for Pallet<T> {
-		fn get(a: &T::Destination) -> Option<T::Sender> {
+	impl<T: Config> GetByKey<T::Destination, Option<[u8; 20]>> for Pallet<T> {
+		fn get(a: &T::Destination) -> Option<[u8; 20]> {
 			execute_call!(a)
 		}
 	}

--- a/libs/mocks/src/outbound_queue.rs
+++ b/libs/mocks/src/outbound_queue.rs
@@ -7,8 +7,8 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		type Sender: Parameter;
-		type Destination: Parameter;
+		type Sender;
+		type Destination;
 		type Message;
 	}
 
@@ -17,10 +17,6 @@ pub mod pallet {
 
 	#[pallet::storage]
 	type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
-
-	#[pallet::storage]
-	type DomainAddressHook<T: Config> =
-		StorageMap<_, _, <T as Config>::Destination, <T as Config>::Sender>;
 
 	impl<T: Config> Pallet<T> {
 		pub fn mock_submit(

--- a/libs/mocks/src/outbound_queue.rs
+++ b/libs/mocks/src/outbound_queue.rs
@@ -1,13 +1,13 @@
 #[frame_support::pallet(dev_mode)]
 pub mod pallet {
-	use cfg_traits::liquidity_pools::OutboundQueue;
+	use cfg_traits::liquidity_pools::{DomainHook, OutboundQueue};
 	use frame_support::pallet_prelude::*;
 	use mock_builder::{execute_call, register_call};
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		type Sender;
-		type Destination;
+		type Sender: Parameter;
+		type Destination: Parameter;
 		type Message;
 	}
 
@@ -17,11 +17,19 @@ pub mod pallet {
 	#[pallet::storage]
 	type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
 
+	#[pallet::storage]
+	type DomainAddressHook<T: Config> =
+		StorageMap<_, _, <T as Config>::Destination, <T as Config>::Sender>;
+
 	impl<T: Config> Pallet<T> {
 		pub fn mock_submit(
 			f: impl Fn(T::Sender, T::Destination, T::Message) -> DispatchResult + 'static,
 		) {
 			register_call!(move |(a, b, c)| f(a, b, c));
+		}
+
+		pub fn mock_get_address(f: impl Fn(T::Destination) -> Option<T::Sender> + 'static) {
+			register_call!(move |a| f(a));
 		}
 	}
 
@@ -32,6 +40,15 @@ pub mod pallet {
 
 		fn submit(a: Self::Sender, b: Self::Destination, c: Self::Message) -> DispatchResult {
 			execute_call!((a, b, c))
+		}
+	}
+
+	impl<T: Config> DomainHook for Pallet<T> {
+		type AccountId = T::Sender;
+		type Domain = T::Destination;
+
+		fn get_address(a: Self::Domain) -> Option<Self::AccountId> {
+			execute_call!(a)
 		}
 	}
 }

--- a/libs/traits/src/liquidity_pools.rs
+++ b/libs/traits/src/liquidity_pools.rs
@@ -88,3 +88,14 @@ pub trait InboundQueue {
 	/// Submit a message to the inbound queue.
 	fn submit(sender: Self::Sender, msg: Self::Message) -> DispatchResult;
 }
+
+/// Trait to query the domain hook address
+pub trait DomainHook {
+	/// The domain type for the input
+	type Domain;
+
+	/// The account address type for the response
+	type AccountId;
+
+	fn get_address(domain: Self::Domain) -> Option<Self::AccountId>;
+}

--- a/libs/traits/src/liquidity_pools.rs
+++ b/libs/traits/src/liquidity_pools.rs
@@ -88,14 +88,3 @@ pub trait InboundQueue {
 	/// Submit a message to the inbound queue.
 	fn submit(sender: Self::Sender, msg: Self::Message) -> DispatchResult;
 }
-
-/// Trait to query the domain hook address
-pub trait DomainHook {
-	/// The domain type for the input
-	type Domain;
-
-	/// The account address type for the response
-	type AccountId;
-
-	fn get_address(domain: Self::Domain) -> Option<Self::AccountId>;
-}

--- a/libs/types/src/consts.rs
+++ b/libs/types/src/consts.rs
@@ -19,12 +19,3 @@ pub mod rewards {
 	/// assigned to any member of the only group in block rewards.
 	pub const DEFAULT_COLLATOR_STAKE: Balance = CFG;
 }
-
-pub mod liquidity_pools {
-	/// The account id of the solidity restriction manager interface required
-	/// for the `hook` param of the `AddTranche` LP message.
-	///
-	/// NOTE: Temporarily hardcoded.
-	pub const SOLIDITY_RESTRICTION_MANAGER_ADDRESS: [u8; 32] =
-		hex_literal::hex!("193356f6df34af00288f98bbb34d6ec98512ed32000000000000000045564d00");
-}

--- a/pallets/liquidity-pools-gateway/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/Cargo.toml
@@ -36,6 +36,7 @@ cfg-primitives = { workspace = true, default-features = true }
 hex-literal = { workspace = true }
 pallet-balances = { workspace = true, default-features = true }
 rand = { workspace = true, default-features = true }
+runtime-common = { workspace = true, default-features = true }
 sp-io = { workspace = true, default-features = true }
 
 [features]

--- a/pallets/liquidity-pools-gateway/Cargo.toml
+++ b/pallets/liquidity-pools-gateway/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 hex = { workspace = true }
+orml-traits = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
@@ -48,6 +49,7 @@ std = [
   "frame-support/std",
   "frame-system/std",
   "frame-benchmarking/std",
+  "orml-traits/std",
   "sp-std/std",
   "sp-core/std",
   "sp-runtime/std",

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -29,9 +29,7 @@
 use core::fmt::Debug;
 
 use cfg_traits::{
-	liquidity_pools::{
-		DomainHook, InboundQueue, LPEncoding, OutboundQueue, Router as DomainRouter,
-	},
+	liquidity_pools::{InboundQueue, LPEncoding, OutboundQueue, Router as DomainRouter},
 	TryConvert,
 };
 use cfg_types::domain_address::{Domain, DomainAddress};
@@ -40,6 +38,7 @@ use frame_system::{
 	ensure_signed,
 	pallet_prelude::{BlockNumberFor, OriginFor},
 };
+use orml_traits::GetByKey;
 pub use pallet::*;
 use parity_scale_codec::{EncodeLike, FullCodec};
 use sp_runtime::traits::{AtLeast32BitUnsigned, EnsureAdd, EnsureAddAssign, One};
@@ -863,11 +862,8 @@ pub mod pallet {
 	}
 }
 
-impl<T: Config> DomainHook for Pallet<T> {
-	type AccountId = T::AccountId;
-	type Domain = Domain;
-
-	fn get_address(domain: Domain) -> Option<T::AccountId> {
+impl<T: Config> GetByKey<Domain, Option<T::AccountId>> for Pallet<T> {
+	fn get(domain: &Domain) -> Option<T::AccountId> {
 		DomainHookAddress::<T>::get(domain)
 	}
 }

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -209,7 +209,7 @@ pub mod pallet {
 		/// The domain hook address was initialized or updated.
 		DomainHookAddressSet {
 			domain: Domain,
-			hook_address: T::AccountId,
+			hook_address: [u8; 20],
 		},
 	}
 
@@ -271,7 +271,7 @@ pub mod pallet {
 	/// NOTE: Must only be changeable via root or `AdminOrigin`.
 	#[pallet::storage]
 	pub type DomainHookAddress<T: Config> =
-		StorageMap<_, Blake2_128Concat, Domain, T::AccountId, OptionQuery>;
+		StorageMap<_, Blake2_128Concat, Domain, [u8; 20], OptionQuery>;
 
 	#[pallet::error]
 	pub enum Error<T> {
@@ -625,13 +625,12 @@ pub mod pallet {
 		pub fn set_domain_hook_address(
 			origin: OriginFor<T>,
 			domain: Domain,
-			hook_address: T::AccountId,
+			hook_address: [u8; 20],
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
 			ensure!(domain != Domain::Centrifuge, Error::<T>::DomainNotSupported);
-
-			DomainHookAddress::<T>::insert(domain.clone(), hook_address.clone());
+			DomainHookAddress::<T>::insert(domain.clone(), hook_address);
 
 			Self::deposit_event(Event::DomainHookAddressSet {
 				domain,
@@ -862,8 +861,8 @@ pub mod pallet {
 	}
 }
 
-impl<T: Config> GetByKey<Domain, Option<T::AccountId>> for Pallet<T> {
-	fn get(domain: &Domain) -> Option<T::AccountId> {
+impl<T: Config> GetByKey<Domain, Option<[u8; 20]>> for Pallet<T> {
+	fn get(domain: &Domain) -> Option<[u8; 20]> {
 		DomainHookAddress::<T>::get(domain)
 	}
 }

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -3,7 +3,7 @@ use cfg_primitives::OutboundMessageNonce;
 use cfg_traits::liquidity_pools::test_util::Message;
 use cfg_types::domain_address::DomainAddress;
 use frame_support::derive_impl;
-use frame_system::EnsureRoot;
+use runtime_common::origin::EnsureAccountOrRoot;
 use sp_core::{crypto::AccountId32, H256};
 use sp_runtime::traits::IdentityLookup;
 
@@ -15,6 +15,8 @@ pub const SOURCE_CHAIN_EVM_ID: u64 = 1;
 
 pub const LENGTH_SOURCE_ADDRESS: usize = 20;
 pub const SOURCE_ADDRESS: [u8; LENGTH_SOURCE_ADDRESS] = [0u8; LENGTH_SOURCE_ADDRESS];
+
+pub const LP_ADMIN_ACCOUNT: AccountId32 = AccountId32::new([u8::MAX; 32]);
 
 frame_support::construct_runtime!(
 	pub enum Runtime {
@@ -48,10 +50,11 @@ impl cfg_mocks::converter::pallet::Config for Runtime {
 frame_support::parameter_types! {
 	pub Sender: AccountId32 = AccountId32::from(H256::from_low_u64_be(1).to_fixed_bytes());
 	pub const MaxIncomingMessageSize: u32 = 1024;
+	pub const LpAdminAccount: AccountId32 = LP_ADMIN_ACCOUNT;
 }
 
 impl pallet_liquidity_pools_gateway::Config for Runtime {
-	type AdminOrigin = EnsureRoot<AccountId32>;
+	type AdminOrigin = EnsureAccountOrRoot<LpAdminAccount>;
 	type InboundQueue = MockLiquidityPools;
 	type LocalEVMOrigin = EnsureLocal;
 	type MaxIncomingMessageSize = MaxIncomingMessageSize;

--- a/pallets/liquidity-pools-gateway/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/src/tests.rs
@@ -28,6 +28,10 @@ mod utils {
 		[0u8; 32].into()
 	}
 
+	pub fn get_test_hook_bytes() -> [u8; 20] {
+		[10u8; 20]
+	}
+
 	pub fn event_exists<E: Into<MockEvent>>(e: E) {
 		let e: MockEvent = e.into();
 		assert!(frame_system::Pallet::<Runtime>::events()
@@ -1229,12 +1233,11 @@ mod set_domain_hook {
 	fn success_with_root() {
 		new_test_ext().execute_with(|| {
 			let domain = Domain::EVM(0);
-			let address = get_test_account_id();
 
 			assert_ok!(LiquidityPoolsGateway::set_domain_hook_address(
 				RuntimeOrigin::root(),
 				domain,
-				address
+				get_test_hook_bytes()
 			));
 		});
 	}
@@ -1243,12 +1246,11 @@ mod set_domain_hook {
 	fn success_with_lp_admin_account() {
 		new_test_ext().execute_with(|| {
 			let domain = Domain::EVM(0);
-			let address = get_test_account_id();
 
 			assert_ok!(LiquidityPoolsGateway::set_domain_hook_address(
 				RuntimeOrigin::signed(LP_ADMIN_ACCOUNT),
 				domain,
-				address
+				get_test_hook_bytes()
 			));
 		});
 	}
@@ -1257,13 +1259,12 @@ mod set_domain_hook {
 	fn failure_bad_origin() {
 		new_test_ext().execute_with(|| {
 			let domain = Domain::EVM(0);
-			let address = get_test_account_id();
 
 			assert_noop!(
 				LiquidityPoolsGateway::set_domain_hook_address(
 					RuntimeOrigin::signed(AccountId32::new([0u8; 32])),
 					domain,
-					address
+					get_test_hook_bytes()
 				),
 				BadOrigin
 			);
@@ -1274,13 +1275,12 @@ mod set_domain_hook {
 	fn failure_centrifuge_domain() {
 		new_test_ext().execute_with(|| {
 			let domain = Domain::Centrifuge;
-			let address = get_test_account_id();
 
 			assert_noop!(
 				LiquidityPoolsGateway::set_domain_hook_address(
 					RuntimeOrigin::root(),
 					domain,
-					address
+					get_test_hook_bytes()
 				),
 				Error::<Runtime>::DomainNotSupported
 			);

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -42,7 +42,7 @@
 use core::convert::TryFrom;
 
 use cfg_traits::{
-	liquidity_pools::{DomainHook, InboundQueue, OutboundQueue},
+	liquidity_pools::{InboundQueue, OutboundQueue},
 	swaps::TokenSwaps,
 	PreConditions,
 };
@@ -58,7 +58,10 @@ use frame_support::{
 	},
 	transactional,
 };
-use orml_traits::asset_registry::{self, Inspect as _};
+use orml_traits::{
+	asset_registry::{self, Inspect as _},
+	GetByKey,
+};
 pub use pallet::*;
 use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, Convert, EnsureMul},
@@ -253,7 +256,7 @@ pub mod pallet {
 		/// The type for processing outgoing messages and retrieving the domain
 		/// hook address.
 		type OutboundQueue: OutboundQueue<Sender = Self::AccountId, Message = Message, Destination = Domain>
-			+ DomainHook<Domain = Domain, AccountId = Self::AccountId>;
+			+ GetByKey<Domain, Option<Self::AccountId>>;
 
 		/// The prefix for currencies added via the LiquidityPools feature.
 		#[pallet::constant]
@@ -408,7 +411,7 @@ pub mod pallet {
 				.ok_or(Error::<T>::TrancheMetadataNotFound)?;
 			let token_name = vec_to_fixed_array(metadata.name);
 			let token_symbol = vec_to_fixed_array(metadata.symbol);
-			let hook = <T::OutboundQueue as DomainHook>::get_address(domain.clone())
+			let hook = T::OutboundQueue::get(&domain)
 				.ok_or(Error::<T>::DomainHookAddressNotFound)?
 				.into();
 

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -30,6 +30,7 @@ pub const ALICE_EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::EVM(42, ALICE
 pub const CENTRIFUGE_DOMAIN_ADDRESS: DomainAddress = DomainAddress::Centrifuge(ALICE_32);
 pub const CONTRACT_ACCOUNT: [u8; 20] = [1; 20];
 pub const CONTRACT_ACCOUNT_ID: AccountId = AccountId::new([1; 32]);
+pub const DOMAIN_HOOK_ADDRESS: [u8; 20] = [10u8; 20];
 pub const EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::EVM(CHAIN_ID, CONTRACT_ACCOUNT);
 pub const AMOUNT: Balance = 100;
 pub const CURRENCY_ID: CurrencyId = CurrencyId::ForeignAsset(1);

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -157,11 +157,9 @@ impl orml_tokens::Config for Runtime {
 frame_support::parameter_types! {
 	pub CurrencyPrefix: [u8; 12] = [1; 12];
 	pub TreasuryAccount: AccountId = [2; 32].into();
-	pub AddTrancheHookAddress: [u8; 32] = [3; 32];
 }
 
 impl pallet_liquidity_pools::Config for Runtime {
-	type AddTrancheHookAddress = AddTrancheHookAddress;
 	type AssetRegistry = AssetRegistry;
 	type Balance = Balance;
 	type BalanceRatio = Ratio;

--- a/pallets/liquidity-pools/src/tests.rs
+++ b/pallets/liquidity-pools/src/tests.rs
@@ -429,7 +429,10 @@ mod add_tranche {
 	use super::*;
 
 	fn config_mocks() {
-		let hook = [1u8; 32];
+		let mut hook = [0; 32];
+		hook[0..20].copy_from_slice(&DOMAIN_HOOK_ADDRESS);
+		hook[20..28].copy_from_slice(&1u64.to_be_bytes());
+		hook[28..31].copy_from_slice(b"EVM");
 
 		Permissions::mock_has(move |scope, who, role| {
 			assert_eq!(who, ALICE);
@@ -442,7 +445,11 @@ mod add_tranche {
 		AssetRegistry::mock_metadata(|_| Some(util::default_metadata()));
 		Gateway::mock_get(move |domain| {
 			assert_eq!(domain, &EVM_DOMAIN_ADDRESS.domain());
-			Some(hook.into())
+			Some(DOMAIN_HOOK_ADDRESS)
+		});
+		DomainAddressToAccountId::mock_convert(move |domain| {
+			assert_eq!(domain, DomainAddress::EVM(CHAIN_ID, DOMAIN_HOOK_ADDRESS));
+			hook.clone().into()
 		});
 		Gateway::mock_submit(move |sender, destination, msg| {
 			assert_eq!(sender, ALICE);

--- a/pallets/liquidity-pools/src/tests.rs
+++ b/pallets/liquidity-pools/src/tests.rs
@@ -440,8 +440,8 @@ mod add_tranche {
 		Pools::mock_pool_exists(|_| true);
 		Pools::mock_tranche_exists(|_, _| true);
 		AssetRegistry::mock_metadata(|_| Some(util::default_metadata()));
-		Gateway::mock_get_address(move |domain| {
-			assert_eq!(domain, EVM_DOMAIN_ADDRESS.domain());
+		Gateway::mock_get(move |domain| {
+			assert_eq!(domain, &EVM_DOMAIN_ADDRESS.domain());
 			Some(hook.into())
 		});
 		Gateway::mock_submit(move |sender, destination, msg| {
@@ -557,7 +557,7 @@ mod add_tranche {
 				Pools::mock_pool_exists(|_| true);
 				Pools::mock_tranche_exists(|_, _| true);
 				AssetRegistry::mock_metadata(|_| Some(util::default_metadata()));
-				Gateway::mock_get_address(|_| None);
+				Gateway::mock_get(|_| None);
 
 				assert_noop!(
 					LiquidityPools::add_tranche(

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1784,11 +1784,9 @@ impl pallet_foreign_investments::Config for Runtime {
 
 parameter_types! {
 	pub LiquidityPoolsPalletIndex: PalletIndex = <LiquidityPools as PalletInfoAccess>::index() as u8;
-	pub const AddTrancheHookAddress: [u8; 32] = cfg_types::consts::liquidity_pools::SOLIDITY_RESTRICTION_MANAGER_ADDRESS;
 }
 
 impl pallet_liquidity_pools::Config for Runtime {
-	type AddTrancheHookAddress = AddTrancheHookAddress;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
 	type BalanceRatio = Ratio;

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1864,11 +1864,9 @@ impl pallet_foreign_investments::Config for Runtime {
 parameter_types! {
 	// To be used if we want to register a particular asset in the chain spec, when running the chain locally.
 	pub LiquidityPoolsPalletIndex: PalletIndex = <LiquidityPools as PalletInfoAccess>::index() as u8;
-	pub const AddTrancheHookAddress: [u8; 32] = cfg_types::consts::liquidity_pools::SOLIDITY_RESTRICTION_MANAGER_ADDRESS;
 }
 
 impl pallet_liquidity_pools::Config for Runtime {
-	type AddTrancheHookAddress = AddTrancheHookAddress;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
 	type BalanceRatio = Ratio;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1884,11 +1884,9 @@ impl pallet_foreign_investments::Config for Runtime {
 parameter_types! {
 	// To be used if we want to register a particular asset in the chain spec, when running the chain locally.
 	pub LiquidityPoolsPalletIndex: PalletIndex = <LiquidityPools as PalletInfoAccess>::index() as u8;
-	pub const AddTrancheHookAddress: [u8; 32] = cfg_types::consts::liquidity_pools::SOLIDITY_RESTRICTION_MANAGER_ADDRESS;
 }
 
 impl pallet_liquidity_pools::Config for Runtime {
-	type AddTrancheHookAddress = AddTrancheHookAddress;
 	type AssetRegistry = OrmlAssetRegistry;
 	type Balance = Balance;
 	type BalanceRatio = Ratio;

--- a/runtime/integration-tests/src/cases/lp/mod.rs
+++ b/runtime/integration-tests/src/cases/lp/mod.rs
@@ -101,6 +101,11 @@ pub const DOMAIN_EVM: u8 = 1;
 /// Represents Centrifuge Chain id which is 0
 pub const CENTRIFUGE_CHAIN_ID: u8 = 0;
 
+/// The address of the local restriction manager contract required for
+/// `AddTranche` message
+pub const LOCAL_RESTRICTION_MANAGER_ADDRESS: [u8; 32] =
+	hex_literal::hex!("193356f6df34af00288f98bbb34d6ec98512ed32000000000000000045564d00");
+
 pub mod contracts {
 	pub const ROOT: &str = "Root";
 	pub const ESCROW: &str = "Escrow";

--- a/runtime/integration-tests/src/cases/lp/mod.rs
+++ b/runtime/integration-tests/src/cases/lp/mod.rs
@@ -103,8 +103,8 @@ pub const CENTRIFUGE_CHAIN_ID: u8 = 0;
 
 /// The address of the local restriction manager contract required for
 /// `AddTranche` message
-pub const LOCAL_RESTRICTION_MANAGER_ADDRESS: [u8; 32] =
-	hex_literal::hex!("193356f6df34af00288f98bbb34d6ec98512ed32000000000000000045564d00");
+pub const LOCAL_RESTRICTION_MANAGER_ADDRESS: [u8; 20] =
+	hex_literal::hex!("193356f6df34af00288f98bbb34d6ec98512ed32");
 
 pub mod contracts {
 	pub const ROOT: &str = "Root";

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -20,7 +20,6 @@ use cfg_types::{
 use ethabi::{ethereum_types::H160, Token, Uint};
 use frame_support::{assert_ok, traits::OriginTrait};
 use frame_system::pallet_prelude::OriginFor;
-use pallet_evm::AddressMapping;
 use pallet_liquidity_pools::GeneralCurrencyIndexOf;
 use runtime_common::account_conversion::AccountConverter;
 use sp_runtime::FixedPointNumber;
@@ -177,9 +176,8 @@ fn add_pool<T: Runtime>() {
 fn hook_address<T: Runtime>() {
 	let env = super::setup::<T, _>(|_| {});
 	env.state(|evm| {
-		let solidity =
-			T::AddressMapping::into_account_id(evm.deployed(names::RESTRICTION_MANAGER).address());
-		let rust: AccountId = LOCAL_RESTRICTION_MANAGER_ADDRESS.into();
+		let solidity = evm.deployed(names::RESTRICTION_MANAGER).address();
+		let rust = LOCAL_RESTRICTION_MANAGER_ADDRESS.into();
 		assert_eq!(
 			solidity, rust,
 			"Hook address changed, please change our stored value (right) to the new address (left)"

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -18,10 +18,7 @@ use cfg_types::{
 	tokens::{CrossChainTransferability, CurrencyId, CustomMetadata},
 };
 use ethabi::{ethereum_types::H160, Token, Uint};
-use frame_support::{
-	assert_ok,
-	traits::{Get, OriginTrait},
-};
+use frame_support::{assert_ok, traits::OriginTrait};
 use frame_system::pallet_prelude::OriginFor;
 use pallet_evm::AddressMapping;
 use pallet_liquidity_pools::GeneralCurrencyIndexOf;
@@ -32,7 +29,7 @@ use crate::{
 	cases::lp::{
 		names, utils,
 		utils::{pool_a_tranche_1_id, Decoder},
-		LocalUSDC, EVM_DOMAIN_CHAIN_ID, POOL_A, USDC,
+		LocalUSDC, EVM_DOMAIN_CHAIN_ID, LOCAL_RESTRICTION_MANAGER_ADDRESS, POOL_A, USDC,
 	},
 	config::Runtime,
 	env::{EnvEvmExtension, EvmEnv},
@@ -182,8 +179,7 @@ fn hook_address<T: Runtime>() {
 	env.state(|evm| {
 		let solidity =
 			T::AddressMapping::into_account_id(evm.deployed(names::RESTRICTION_MANAGER).address());
-		let rust: AccountId =
-			<T as pallet_liquidity_pools::Config>::AddTrancheHookAddress::get().into();
+		let rust: AccountId = LOCAL_RESTRICTION_MANAGER_ADDRESS.into();
 		assert_eq!(
 			solidity, rust,
 			"Hook address changed, please change our stored value (right) to the new address (left)"
@@ -462,7 +458,7 @@ fn update_member<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development], ignore = "solidity mismatch")]
+#[test_runtimes([development])]
 fn update_tranche_token_metadata<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|evm| {
 		super::setup_currencies(evm);

--- a/runtime/integration-tests/src/cases/lp/setup_lp.rs
+++ b/runtime/integration-tests/src/cases/lp/setup_lp.rs
@@ -111,6 +111,14 @@ pub fn setup<T: Runtime, F: FnOnce(&mut <RuntimeEnv<T> as EnvEvmExtension<T>>::E
 			SourceConverter::new(EVM_DOMAIN),
 		));
 
+		assert_ok!(
+			pallet_liquidity_pools_gateway::Pallet::<T>::set_domain_hook_address(
+				RawOrigin::Root.into(),
+				Domain::EVM(EVM_DOMAIN_CHAIN_ID),
+				LOCAL_RESTRICTION_MANAGER_ADDRESS.into(),
+			)
+		);
+
 		additional(evm);
 	});
 


### PR DESCRIPTION
# Description

* Replaces hardcoded `AddTrancheHookAddress` with `DomainHookAddress` storage because it is different for every domain
  * @mustermeiszer recommended adding the storage to the gateway instead of the LP pallet
* Extends gateway tests by also checking LP Admin account origin

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
