### PR TITLE
fix: add remark call to borrow proxy

### DIFF
--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -644,7 +644,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::TokenMux(pallet_token_mux::Call::match_swap {..}) |
 					// Borrowers should be able to (un)charge fees as part of the borrow flow
 					RuntimeCall::PoolFees(pallet_pool_fees::Call::charge_fee { .. }) |
-					RuntimeCall::PoolFees(pallet_pool_fees::Call::uncharge_fee { .. })
+					RuntimeCall::PoolFees(pallet_pool_fees::Call::uncharge_fee { .. }) |
+					RuntimeCall::Remarks(pallet_remarks::Call::remark { .. })
 				) | ProxyType::PodOperation.filter(c)
 			}
 			ProxyType::Invest => matches!(

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -737,7 +737,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::TokenMux(pallet_token_mux::Call::match_swap {..}) |
 					// Borrowers should be able to (un)charge fees as part of the borrow flow
 					RuntimeCall::PoolFees(pallet_pool_fees::Call::charge_fee { .. }) |
-					RuntimeCall::PoolFees(pallet_pool_fees::Call::uncharge_fee { .. })
+					RuntimeCall::PoolFees(pallet_pool_fees::Call::uncharge_fee { .. }) |
+					RuntimeCall::Remarks(pallet_remarks::Call::remark { .. })
 				) | ProxyType::PodOperation.filter(c)
 			}
 			ProxyType::Invest => matches!(

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -649,7 +649,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::TokenMux(pallet_token_mux::Call::match_swap {..}) |
 					// Borrowers should be able to (un)charge fees as part of the borrow flow
 					RuntimeCall::PoolFees(pallet_pool_fees::Call::charge_fee { .. }) |
-					RuntimeCall::PoolFees(pallet_pool_fees::Call::uncharge_fee { .. })
+					RuntimeCall::PoolFees(pallet_pool_fees::Call::uncharge_fee { .. }) |
+					RuntimeCall::Remarks(pallet_remarks::Call::remark { .. })
 				) | ProxyType::PodOperation.filter(c)
 			}
 			ProxyType::Invest => matches!(


### PR DESCRIPTION
# Description
Needed for apps


## Changes and Descriptions
* Adds `pallet_remarks::Call::remark` to the allowed calls for `ProxyType::Borrow`

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
