### PR TITLE
development: Add Anchors V2 to PodOperation proxy

### DIFF
--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -678,6 +678,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				c,
 				RuntimeCall::Uniques(..)
 					| RuntimeCall::Anchor(..)
+					| RuntimeCall::AnchorsV2(..)
 					| RuntimeCall::Utility(pallet_utility::Call::batch_all { .. })
 			),
 			// This type of proxy is used only for authenticating with the centrifuge POD,


### PR DESCRIPTION
# Description

Adds access to the Anchors V2 calls to the `PodOperation` proxy type.

