### PR TITLE
refactor: enable ITs for centrifuge + dev runtimes

### DIFF
--- a/runtime/integration-tests/src/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/cases/liquidity_pools.rs
@@ -156,7 +156,9 @@ mod utils {
 							token_name: BoundedVec::<
 								u8,
 								<T as pallet_pool_system::Config>::StringLimit,
-							>::try_from("A highly advanced tranche".as_bytes().to_vec())
+							>::try_from(
+								"A highly advanced tranche".as_bytes().to_vec()
+							)
 							.expect("Can create BoundedVec for token name"),
 							token_symbol: BoundedVec::<
 								u8,

--- a/runtime/integration-tests/src/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/cases/liquidity_pools.rs
@@ -156,9 +156,7 @@ mod utils {
 							token_name: BoundedVec::<
 								u8,
 								<T as pallet_pool_system::Config>::StringLimit,
-							>::try_from(
-								"A highly advanced tranche".as_bytes().to_vec()
-							)
+							>::try_from("A highly advanced tranche".as_bytes().to_vec())
 							.expect("Can create BoundedVec for token name"),
 							token_symbol: BoundedVec::<
 								u8,
@@ -695,7 +693,7 @@ mod foreign_investments {
 	mod same_currencies {
 		use super::*;
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn increase_deposit_request<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -747,7 +745,7 @@ mod foreign_investments {
 			});
 		}
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn decrease_deposit_request<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -837,7 +835,7 @@ mod foreign_investments {
 			});
 		}
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn cancel_deposit_request<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -937,7 +935,7 @@ mod foreign_investments {
 			});
 		}
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn collect_deposit_request<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -1078,7 +1076,7 @@ mod foreign_investments {
 			});
 		}
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn collect_investment<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -1301,7 +1299,7 @@ mod foreign_investments {
 			});
 		}
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn increase_redeem_request<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -1354,7 +1352,7 @@ mod foreign_investments {
 			});
 		}
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn cancel_redeem_request<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -1449,7 +1447,7 @@ mod foreign_investments {
 			});
 		}
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn collect_redeem_request<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -1631,7 +1629,7 @@ mod foreign_investments {
 			mod should_throw_requires_collect {
 				use super::*;
 
-				#[test_runtimes([development])]
+				#[test_runtimes([centrifuge, development])]
 				fn invest_requires_collect<T: Runtime + FudgeSupport>() {
 					let mut env = FudgeEnv::<T>::from_parachain_storage(
 						Genesis::default()
@@ -1711,7 +1709,7 @@ mod foreign_investments {
 					});
 				}
 
-				#[test_runtimes([development])]
+				#[test_runtimes([centrifuge, development])]
 				fn redeem_requires_collect<T: Runtime + FudgeSupport>() {
 					let mut env = FudgeEnv::<T>::from_parachain_storage(
 						Genesis::default()
@@ -1802,7 +1800,7 @@ mod foreign_investments {
 			mod payment_payout_currency {
 				use super::*;
 
-				#[test_runtimes([development])]
+				#[test_runtimes([centrifuge, development])]
 				fn redeem_payout_currency_not_found<T: Runtime + FudgeSupport>() {
 					let mut env = FudgeEnv::<T>::from_parachain_storage(
 						Genesis::default()
@@ -1862,7 +1860,7 @@ mod foreign_investments {
 	mod mismatching_currencies {
 		use super::*;
 
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn collect_foreign_investment_for<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -1975,7 +1973,7 @@ mod foreign_investments {
 
 		/// Invest, fulfill swap foreign->pool, cancel, fulfill swap
 		/// pool->foreign
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn cancel_unprocessed_investment<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()
@@ -2121,7 +2119,7 @@ mod foreign_investments {
 
 		/// Invest, fulfill swap foreign->pool, process 50% of investment,
 		/// cancel, swap back pool->foreign of remaining unprocessed investment
-		#[test_runtimes([development])]
+		#[test_runtimes([centrifuge, development])]
 		fn cancel_partially_processed_investment<T: Runtime + FudgeSupport>() {
 			let mut env = FudgeEnv::<T>::from_parachain_storage(
 				Genesis::default()

--- a/runtime/integration-tests/src/cases/lp/investments.rs
+++ b/runtime/integration-tests/src/cases/lp/investments.rs
@@ -155,7 +155,7 @@ mod with_pool_currency {
 	use super::{utils, *};
 	use crate::cases::lp::utils as lp_utils;
 
-	#[test_runtimes([development])]
+	#[test_runtimes([centrifuge, development])]
 	fn currency_invest<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -189,7 +189,7 @@ mod with_pool_currency {
 		});
 	}
 
-	#[test_runtimes([development])]
+	#[test_runtimes([centrifuge, development])]
 	fn currency_collect<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -257,7 +257,7 @@ mod with_pool_currency {
 		});
 	}
 
-	#[test_runtimes([development])]
+	#[test_runtimes([centrifuge, development])]
 	fn invest_cancel_full<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -335,7 +335,7 @@ mod with_foreign_currency {
 		POOL_A,
 	};
 
-	#[test_runtimes([development])]
+	#[test_runtimes([centrifuge, development])]
 	fn invest_cancel_full_before_swap<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		env.state_mut(|evm| {
@@ -393,7 +393,7 @@ mod with_foreign_currency {
 		});
 	}
 
-	#[test_runtimes([development])]
+	#[test_runtimes([centrifuge, development])]
 	fn invest_cancel_full_after_swap<T: Runtime>() {
 		let mut env = setup_full::<T>();
 
@@ -486,7 +486,7 @@ mod with_foreign_currency {
 		});
 	}
 
-	#[test_runtimes([development])]
+	#[test_runtimes([centrifuge, development])]
 	fn invest_cancel_full_after_swap_partially<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		let part = Quantity::checked_from_rational(1, 2).unwrap();
@@ -589,7 +589,7 @@ mod with_foreign_currency {
 		});
 	}
 
-	#[test_runtimes([development])]
+	#[test_runtimes([centrifuge, development])]
 	fn invest_cancel_full_after_swap_partially_inter_epoch_close<T: Runtime>() {
 		let mut env = setup_full::<T>();
 		let part = Quantity::checked_from_rational(1, 3).unwrap();

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -38,7 +38,7 @@ use crate::{
 	},
 };
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn add_currency<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|_| {});
 
@@ -127,7 +127,7 @@ fn add_currency<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn add_pool<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|_| {});
 	const POOL: PoolId = 1;
@@ -172,7 +172,7 @@ fn add_pool<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn hook_address<T: Runtime>() {
 	let env = super::setup::<T, _>(|_| {});
 	env.state(|evm| {
@@ -185,7 +185,7 @@ fn hook_address<T: Runtime>() {
 	})
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn add_tranche<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|evm| {
 		super::setup_currencies(evm);
@@ -267,7 +267,7 @@ fn add_tranche<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn allow_investment_currency<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|evm| {
 		super::setup_currencies(evm);
@@ -319,7 +319,7 @@ fn allow_investment_currency<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn disallow_investment_currency<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|evm| {
 		super::setup_currencies(evm);
@@ -372,7 +372,7 @@ fn disallow_investment_currency<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn update_member<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|evm| {
 		super::setup_currencies(evm);
@@ -456,7 +456,7 @@ fn update_member<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn update_tranche_token_metadata<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|evm| {
 		super::setup_currencies(evm);
@@ -551,7 +551,7 @@ fn update_tranche_token_metadata<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn update_tranche_token_price<T: Runtime>() {
 	let mut env = super::setup::<T, _>(|evm| {
 		super::setup_currencies(evm);

--- a/runtime/integration-tests/src/cases/lp/transfers.rs
+++ b/runtime/integration-tests/src/cases/lp/transfers.rs
@@ -144,7 +144,7 @@ mod utils {
 	}
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn transfer_tokens_from_local<T: Runtime>() {
 	let mut env = super::setup_full::<T>();
 	utils::prepare_hold_usdc_local::<T>(&mut env);
@@ -173,7 +173,7 @@ fn transfer_tokens_from_local<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn transfer_tranche_tokens_from_local<T: Runtime>() {
 	let mut env = super::setup_full::<T>();
 
@@ -235,7 +235,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 	let mut env = super::setup_full::<T>();
 	utils::prepare_hold_tt_domain::<T>(&mut env);
@@ -313,7 +313,7 @@ fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 	});
 }
 
-#[test_runtimes([development])]
+#[test_runtimes([centrifuge, development])]
 fn transfer_tranche_tokens_domain_to_local<T: Runtime>() {
 	let mut env = super::setup_full::<T>();
 	utils::prepare_hold_tt_domain::<T>(&mut env);


### PR DESCRIPTION
# Description

Reverts previous convenience change of running ITs solely for Development runtime. Since LPs are not expected to be used on Altair for now, we save time by running them solely on Centrifuge and Development runtimes

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
