### PR TITLE
LPv2: Batch message logic (r2)

### DIFF
--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -16,6 +16,26 @@
 use parity_scale_codec::Encode;
 use sp_std::cmp::min;
 
+pub struct BufferReader<'a>(pub &'a [u8]);
+
+impl<'a> BufferReader<'a> {
+	pub fn read_bytes(&mut self, bytes: usize) -> Option<&[u8]> {
+		if self.0.len() < bytes {
+			return None;
+		}
+
+		let (consumed, remaining) = self.0.split_at(bytes);
+		self.0 = remaining;
+		Some(consumed)
+	}
+
+	pub fn read_array<const N: usize>(&mut self) -> Option<&[u8; N]> {
+		let (consumed, remaining) = self.0.split_first_chunk::<N>()?;
+		self.0 = remaining;
+		Some(consumed)
+	}
+}
+
 /// Build a fixed-size array using as many elements from `src` as possible
 /// without overflowing and ensuring that the array is 0 padded in the case
 /// where `src.len()` is smaller than S.

--- a/pallets/liquidity-pools-gateway/axelar-gateway-precompile/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/axelar-gateway-precompile/src/lib.rs
@@ -287,7 +287,7 @@ where
 				exit_status: ExitError::Other("account bytes mismatch for domain".into()),
 			})?;
 
-		match pallet_liquidity_pools_gateway::Pallet::<T>::process_msg(
+		match pallet_liquidity_pools_gateway::Pallet::<T>::receive_message(
 			pallet_liquidity_pools_gateway::GatewayOrigin::Domain(domain_address).into(),
 			msg,
 		)

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -38,7 +38,7 @@ use cfg_traits::{
 };
 use cfg_types::domain_address::{Domain, DomainAddress};
 use frame_support::{dispatch::DispatchResult, pallet_prelude::*, PalletError};
-use frame_system::pallet_prelude::OriginFor;
+use frame_system::pallet_prelude::{ensure_signed, OriginFor};
 use message::GatewayMessage;
 use orml_traits::GetByKey;
 pub use pallet::*;
@@ -208,6 +208,13 @@ pub mod pallet {
 	pub type DomainHookAddress<T: Config> =
 		StorageMap<_, Blake2_128Concat, Domain, [u8; 20], OptionQuery>;
 
+	/// Stores a packed message, not ready yet to be enqueue.
+	/// Lifetime handled by `start_pack_messages()` and `end_pack_messages()`
+	/// extrinsics.
+	#[pallet::storage]
+	pub(crate) type PackedMessage<T: Config> =
+		StorageMap<_, Blake2_128Concat, (T::AccountId, Domain), T::Message>;
+
 	#[pallet::error]
 	pub enum Error<T> {
 		/// Router initialization failed.
@@ -218,9 +225,6 @@ pub mod pallet {
 
 		/// The domain is not supported.
 		DomainNotSupported,
-
-		/// Message decoding error.
-		MessageDecodingFailed,
 
 		/// Instance was already added to the domain.
 		InstanceAlreadyAdded,
@@ -246,6 +250,14 @@ pub mod pallet {
 		/// Decoding that is essential and this error
 		/// signals malforming of the wrapping information.
 		RelayerMessageDecodingFailed { reason: RelayerMessageDecodingError },
+
+		/// Emitted when you call `start_pack_messages()` but that was already
+		/// called. You should finalize the message with `end_pack_messages()`
+		MessagePackingAlreadyStarted,
+
+		/// Emitted when you can `end_pack_messages()` but the packing process
+		/// was not started by `start_pack_messages()`.
+		MessagePackingNotStarted,
 	}
 
 	#[pallet::call]
@@ -356,16 +368,14 @@ pub mod pallet {
 		}
 
 		/// Process an inbound message.
-		#[pallet::weight(T::WeightInfo::process_msg())]
+		#[pallet::weight(T::WeightInfo::receive_message())]
 		#[pallet::call_index(5)]
-		pub fn process_msg(
+		pub fn receive_message(
 			origin: OriginFor<T>,
 			msg: BoundedVec<u8, T::MaxIncomingMessageSize>,
 		) -> DispatchResult {
-			let (domain_address, incoming_msg) = match T::LocalEVMOrigin::ensure_origin(origin)? {
-				GatewayOrigin::Domain(domain_address) => {
-					Pallet::<T>::validate(domain_address, msg)?
-				}
+			let (origin_address, incoming_msg) = match T::LocalEVMOrigin::ensure_origin(origin)? {
+				GatewayOrigin::Domain(domain_address) => (domain_address, msg),
 				GatewayOrigin::AxelarRelay(domain_address) => {
 					// Every axelar relay address has a separate storage
 					ensure!(
@@ -376,88 +386,58 @@ pub mod pallet {
 					// Every axelar relay will prepend the (sourceChain,
 					// sourceAddress) from actual origination chain to the
 					// message bytes, with a length identifier
-					let slice_ref = &mut msg.as_slice();
-					let length_source_chain: usize = Pallet::<T>::try_range(
-						slice_ref,
-						BYTES_U32,
-						Error::<T>::from(MalformedSourceChainLength),
-						|be_bytes_u32| {
-							let mut bytes = [0u8; BYTES_U32];
-							// NOTE: This can NEVER panic as the `try_range` logic ensures the given
-							// bytes have the right length. I.e. 4 in this case
-							bytes.copy_from_slice(be_bytes_u32);
+					let mut input = cfg_utils::BufferReader(msg.as_slice());
 
-							u32::from_be_bytes(bytes).try_into().map_err(|_| {
-								DispatchError::Other("Expect: usize in wasm is always ge u32")
-							})
-						},
-					)?;
+					let length_source_chain = match input.read_array::<BYTES_U32>() {
+						Some(bytes) => u32::from_be_bytes(*bytes),
+						None => Err(Error::<T>::from(MalformedSourceChainLength))?,
+					};
 
-					let source_chain = Pallet::<T>::try_range(
-						slice_ref,
-						length_source_chain,
-						Error::<T>::from(MalformedSourceChain),
-						|source_chain| Ok(source_chain.to_vec()),
-					)?;
+					let source_chain = match input.read_bytes(length_source_chain as usize) {
+						Some(bytes) => bytes.to_vec(),
+						None => Err(Error::<T>::from(MalformedSourceChain))?,
+					};
 
-					let length_source_address: usize = Pallet::<T>::try_range(
-						slice_ref,
-						BYTES_U32,
-						Error::<T>::from(MalformedSourceAddressLength),
-						|be_bytes_u32| {
-							let mut bytes = [0u8; BYTES_U32];
-							// NOTE: This can NEVER panic as the `try_range` logic ensures the given
-							// bytes have the right length. I.e. 4 in this case
-							bytes.copy_from_slice(be_bytes_u32);
+					let length_source_address = match input.read_array::<BYTES_U32>() {
+						Some(bytes) => u32::from_be_bytes(*bytes),
+						None => Err(Error::<T>::from(MalformedSourceAddressLength))?,
+					};
 
-							u32::from_be_bytes(bytes).try_into().map_err(|_| {
-								DispatchError::Other("Expect: usize in wasm is always ge u32")
-							})
-						},
-					)?;
-
-					let source_address = Pallet::<T>::try_range(
-						slice_ref,
-						length_source_address,
-						Error::<T>::from(MalformedSourceAddress),
-						|source_address| {
+					let source_address = match input.read_bytes(length_source_address as usize) {
+						Some(bytes) => {
 							// NOTE: Axelar simply provides the hexadecimal string of an EVM
-							//       address as the `sourceAddress` argument. Solidity does on the
-							//       other side recognize the hex-encoding and encode the hex bytes
-							//       to utf-8 bytes.
+							//       address as the `sourceAddress` argument. Solidity does on
+							// the       other side recognize the hex-encoding and
+							// encode the hex bytes       to utf-8 bytes.
 							//
 							//       Hence, we are reverting this process here.
-							let source_address =
-								cfg_utils::decode_var_source::<BYTES_ACCOUNT_20>(source_address)
-									.ok_or(Error::<T>::from(MalformedSourceAddress))?;
+							cfg_utils::decode_var_source::<BYTES_ACCOUNT_20>(bytes)
+								.ok_or(Error::<T>::from(MalformedSourceAddress))?
+								.to_vec()
+						}
+						None => Err(Error::<T>::from(MalformedSourceAddress))?,
+					};
 
-							Ok(source_address.to_vec())
-						},
-					)?;
-
-					let origin_msg = Pallet::<T>::try_range(
-						slice_ref,
-						slice_ref.len(),
-						Error::<T>::from(MalformedMessage),
-						|msg| {
-							BoundedVec::try_from(msg.to_vec()).map_err(|_| {
-								DispatchError::Other(
-									"Remaining bytes smaller vector in the first place. qed.",
-								)
-							})
-						},
-					)?;
-
-					let origin_domain =
-						T::OriginRecovery::try_convert((source_chain, source_address))?;
-
-					Pallet::<T>::validate(origin_domain, origin_msg)?
+					(
+						T::OriginRecovery::try_convert((source_chain, source_address))?,
+						BoundedVec::try_from(input.0.to_vec())
+							.map_err(|_| Error::<T>::from(MalformedMessage))?,
+					)
 				}
 			};
 
+			if let DomainAddress::Centrifuge(_) = origin_address {
+				return Err(Error::<T>::InvalidMessageOrigin.into());
+			}
+
+			ensure!(
+				Allowlist::<T>::contains_key(origin_address.domain(), origin_address.clone()),
+				Error::<T>::UnknownInstance,
+			);
+
 			let gateway_message = GatewayMessage::<T::AccountId, T::Message>::Inbound {
-				domain_address,
-				message: incoming_msg,
+				domain_address: origin_address,
+				message: T::Message::deserialize(&incoming_msg)?,
 			};
 
 			T::MessageQueue::submit(gateway_message)
@@ -485,46 +465,48 @@ pub mod pallet {
 
 			Ok(())
 		}
+
+		/// Start packing messages in a single message instead of enqueue
+		/// messages.
+		/// The message will be enqueued once `end_pack_messages()` is called.
+		#[pallet::weight(T::WeightInfo::start_pack_messages())]
+		#[pallet::call_index(9)]
+		pub fn start_pack_messages(origin: OriginFor<T>, destination: Domain) -> DispatchResult {
+			let sender = ensure_signed(origin)?;
+
+			PackedMessage::<T>::mutate((&sender, &destination), |msg| match msg {
+				Some(_) => Err(Error::<T>::MessagePackingAlreadyStarted.into()),
+				None => {
+					*msg = Some(T::Message::empty());
+					Ok(())
+				}
+			})
+		}
+
+		/// End packing messages.
+		/// If exists any packed message it will be enqueued.
+		#[pallet::weight(T::WeightInfo::end_pack_messages())]
+		#[pallet::call_index(10)]
+		pub fn end_pack_messages(origin: OriginFor<T>, destination: Domain) -> DispatchResult {
+			let sender = ensure_signed(origin)?;
+
+			match PackedMessage::<T>::take((&sender, &destination)) {
+				Some(msg) if msg.unpack().is_empty() => Ok(()), //No-op
+				Some(message) => {
+					let gateway_message = GatewayMessage::<T::AccountId, T::Message>::Outbound {
+						sender: T::Sender::get(),
+						destination,
+						message,
+					};
+
+					T::MessageQueue::submit(gateway_message)
+				}
+				None => Err(Error::<T>::MessagePackingNotStarted.into()),
+			}
+		}
 	}
 
 	impl<T: Config> Pallet<T> {
-		pub(crate) fn try_range<'a, D, F>(
-			slice: &mut &'a [u8],
-			next_steps: usize,
-			error: Error<T>,
-			transformer: F,
-		) -> Result<D, DispatchError>
-		where
-			F: Fn(&'a [u8]) -> Result<D, DispatchError>,
-		{
-			ensure!(slice.len() >= next_steps, error);
-
-			let (input, new_slice) = slice.split_at(next_steps);
-			let res = transformer(input)?;
-			*slice = new_slice;
-
-			Ok(res)
-		}
-
-		fn validate(
-			address: DomainAddress,
-			msg: BoundedVec<u8, T::MaxIncomingMessageSize>,
-		) -> Result<(DomainAddress, T::Message), DispatchError> {
-			if let DomainAddress::Centrifuge(_) = address {
-				return Err(Error::<T>::InvalidMessageOrigin.into());
-			}
-
-			ensure!(
-				Allowlist::<T>::contains_key(address.domain(), address.clone()),
-				Error::<T>::UnknownInstance,
-			);
-
-			let incoming_msg = T::Message::deserialize(msg.as_slice())
-				.map_err(|_| Error::<T>::MessageDecodingFailed)?;
-
-			Ok((address, incoming_msg))
-		}
-
 		/// Sends the message to the `InboundMessageHandler`.
 		fn process_inbound_message(
 			domain_address: DomainAddress,
@@ -533,10 +515,17 @@ pub mod pallet {
 			let weight = Weight::from_parts(0, T::Message::max_encoded_len() as u64)
 				.saturating_add(LP_DEFENSIVE_WEIGHT);
 
-			match T::InboundMessageHandler::handle(domain_address, message) {
-				Ok(_) => (Ok(()), weight),
-				Err(e) => (Err(e), weight),
+			let mut count = 0;
+			for submessage in message.unpack() {
+				count += 1;
+
+				if let Err(e) = T::InboundMessageHandler::handle(domain_address.clone(), submessage)
+				{
+					return (Err(e), weight.saturating_mul(count));
+				}
 			}
+
+			(Ok(()), weight.saturating_mul(count))
 		}
 
 		/// Retrieves the router stored for the provided domain, sends the
@@ -547,55 +536,29 @@ pub mod pallet {
 			domain: Domain,
 			message: T::Message,
 		) -> (DispatchResult, Weight) {
-			let mut weight = T::DbWeight::get().reads(1);
+			let read_weight = T::DbWeight::get().reads(1);
 
-			let router = match DomainRouters::<T>::get(domain) {
-				Some(r) => r,
-				None => return (Err(Error::<T>::RouterNotFound.into()), weight),
+			let Some(router) = DomainRouters::<T>::get(domain) else {
+				return (Err(Error::<T>::RouterNotFound.into()), read_weight);
 			};
 
-			match router.send(sender.clone(), message.serialize()) {
-				Ok(dispatch_info) => Self::update_total_post_dispatch_info_weight(
-					&mut weight,
-					dispatch_info.actual_weight,
-				),
-				Err(e) => {
-					Self::update_total_post_dispatch_info_weight(
-						&mut weight,
-						e.post_info.actual_weight,
-					);
+			let serialized = message.serialize();
+			let serialized_len = serialized.len() as u64;
 
-					return (Err(e.error), weight);
-				}
-			}
+			// TODO: do we really need to return the weights in send() if later we use the
+			// defensive ones?
+			let (result, router_weight) = match router.send(sender, serialized) {
+				Ok(dispatch_info) => (Ok(()), dispatch_info.actual_weight),
+				Err(e) => (Err(e.error), e.post_info.actual_weight),
+			};
 
-			(Ok(()), weight)
-		}
-
-		/// Updates the provided `PostDispatchInfo` with the weight required to
-		/// process an outbound message.
-		pub(crate) fn update_total_post_dispatch_info_weight(
-			weight: &mut Weight,
-			router_call_weight: Option<Weight>,
-		) {
-			let router_call_weight =
-				Self::get_outbound_message_processing_weight(router_call_weight);
-
-			*weight = weight.saturating_add(router_call_weight);
-		}
-
-		/// Calculates the weight used by a router when processing an outbound
-		/// message.
-		fn get_outbound_message_processing_weight(router_call_weight: Option<Weight>) -> Weight {
-			let pov_weight: u64 = (Domain::max_encoded_len()
-				+ T::AccountId::max_encoded_len()
-				+ T::Message::max_encoded_len())
-			.try_into()
-			.expect("can calculate outbound message POV weight");
-
-			router_call_weight
-				.unwrap_or(Weight::from_parts(LP_DEFENSIVE_WEIGHT_REF_TIME, 0))
-				.saturating_add(Weight::from_parts(0, pov_weight))
+			(
+				result,
+				router_weight
+					.unwrap_or(Weight::from_parts(LP_DEFENSIVE_WEIGHT_REF_TIME, 0))
+					.saturating_add(read_weight)
+					.saturating_add(Weight::from_parts(0, serialized_len)),
+			)
 		}
 	}
 
@@ -611,7 +574,7 @@ pub mod pallet {
 		type Sender = T::AccountId;
 
 		fn handle(
-			_sender: Self::Sender,
+			from: Self::Sender,
 			destination: Self::Destination,
 			message: Self::Message,
 		) -> DispatchResult {
@@ -620,13 +583,27 @@ pub mod pallet {
 				Error::<T>::DomainNotSupported
 			);
 
-			let gateway_message = GatewayMessage::<T::AccountId, T::Message>::Outbound {
-				sender: T::Sender::get(),
-				destination,
-				message,
-			};
+			ensure!(
+				DomainRouters::<T>::contains_key(destination.clone()),
+				Error::<T>::RouterNotFound
+			);
 
-			T::MessageQueue::submit(gateway_message)
+			match PackedMessage::<T>::get((&from, &destination)) {
+				Some(packed) => {
+					PackedMessage::<T>::insert((from, destination), packed.pack(message)?);
+					Ok(())
+				}
+				None => {
+					// Ok, we use the gateway sender.
+					let gateway_message = GatewayMessage::<T::AccountId, T::Message>::Outbound {
+						sender: T::Sender::get(),
+						destination,
+						message,
+					};
+
+					T::MessageQueue::submit(gateway_message)
+				}
+			}
 		}
 	}
 

--- a/pallets/liquidity-pools-gateway/src/weights.rs
+++ b/pallets/liquidity-pools-gateway/src/weights.rs
@@ -18,9 +18,11 @@ pub trait WeightInfo {
 	fn remove_instance() -> Weight;
 	fn add_relayer() -> Weight;
 	fn remove_relayer() -> Weight;
-	fn process_msg() -> Weight;
+	fn receive_message() -> Weight;
 	fn process_outbound_message() -> Weight;
 	fn process_failed_outbound_message() -> Weight;
+	fn start_pack_messages() -> Weight;
+	fn end_pack_messages() -> Weight;
 }
 
 // NOTE: We use temporary weights here. `execute_epoch` is by far our heaviest
@@ -84,7 +86,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}
 
-	fn process_msg() -> Weight {
+	fn receive_message() -> Weight {
 		// NOTE: Defensive hardcoded weight taken from pool_system::execute_epoch. Will
 		// be replaced with real benchmark soon.
 		//
@@ -121,5 +123,27 @@ impl WeightInfo for () {
 		Weight::from_parts(30_117_000, 5991)
 			.saturating_add(RocksDbWeight::get().reads(2))
 			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+
+	fn start_pack_messages() -> Weight {
+		// TODO: BENCHMARK CORRECTLY
+		//
+		// NOTE: Reasonable weight taken from `PoolSystem::set_max_reserve`
+		//       This one has one read and one write for sure and possible one
+		//       read for `AdminOrigin`
+		Weight::from_parts(30_117_000, 5991)
+			.saturating_add(RocksDbWeight::get().reads(1))
+			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+
+	fn end_pack_messages() -> Weight {
+		// TODO: BENCHMARK CORRECTLY
+		//
+		// NOTE: Reasonable weight taken from `PoolSystem::set_max_reserve`
+		//       This one has one read and one write for sure and possible one
+		//       read for `AdminOrigin`
+		Weight::from_parts(30_117_000, 5991)
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(2))
 	}
 }

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -339,6 +339,9 @@ pub mod pallet {
 		NotPoolAdmin,
 		/// The domain hook address could not be found.
 		DomainHookAddressNotFound,
+		/// This pallet does not expect to receive direclty a batch message,
+		/// instead it expects several calls to it with different messages.
+		UnsupportedBatchMessage,
 	}
 
 	#[pallet::call]
@@ -1029,6 +1032,7 @@ pub mod pallet {
 					currency.into(),
 					sender,
 				),
+				Message::Batch(_) => Err(Error::<T>::UnsupportedBatchMessage.into()),
 				_ => Err(Error::<T>::InvalidIncomingMessage.into()),
 			}?;
 

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -529,9 +529,19 @@ pub enum Message<BatchContent = BatchMessages> {
 	},
 }
 
-impl Message {
+impl LPEncoding for Message {
+	const MAX_PACKED_MESSAGES: u32 = MAX_BATCH_MESSAGES;
+
+	fn serialize(&self) -> Vec<u8> {
+		gmpf::to_vec(self).unwrap_or_default()
+	}
+
+	fn deserialize(data: &[u8]) -> Result<Self, DispatchError> {
+		gmpf::from_slice(data).map_err(|_| DispatchError::Other("LP Deserialization issue"))
+	}
+
 	/// Compose this message with a new one
-	pub fn pack(&self, other: Self) -> Result<Self, DispatchError> {
+	fn pack(&self, other: Self) -> Result<Self, DispatchError> {
 		Ok(match self.clone() {
 			Message::Batch(content) => {
 				let mut content = content.clone();
@@ -543,21 +553,15 @@ impl Message {
 	}
 
 	/// Decompose the message into a list of messages
-	pub fn unpack(&self) -> Vec<Self> {
+	fn unpack(&self) -> Vec<Self> {
 		match self {
 			Message::Batch(content) => content.clone().into_iter().collect(),
 			message => vec![message.clone()],
 		}
 	}
-}
 
-impl LPEncoding for Message {
-	fn serialize(&self) -> Vec<u8> {
-		gmpf::to_vec(self).unwrap_or_default()
-	}
-
-	fn deserialize(data: &[u8]) -> Result<Self, DispatchError> {
-		gmpf::from_slice(data).map_err(|_| DispatchError::Other("LP Deserialization issue"))
+	fn empty() -> Message {
+		Message::Batch(BatchMessages::default())
 	}
 }
 


### PR DESCRIPTION
# Description

This PR overrides the previous https://github.com/centrifuge/centrifuge-chain/pull/1923, in a simplified version

### Responsibilities
- `pallet-liquidity-pools-gateway` knows to batch/unbatch but doesn't know what a `Batch` message is. To handle this, the `LPMessage` trait allows pack/unpack methods.
- `pallet-liquidity-pools` will never send or receive a batch. The gateway is responsible for the batching process.

### Details
Batching is handled by two extrinsic: 
  - `Gateway::start_pack_messages(sender, destination)`:  When calling this, any submitted messages from LP, that match the `sender` & `destination` will be packed. _NOTE: We need to index also by destination domain because the destination information is not inside the message. So, we can never bundle two messages with two different destinations._
  - `Gateway::end_pack_messages(sender, destination)`: When calling this, the batch is finally submitted. If this is not called, no message is sent. If the batch reaches the limit size, it will dispatch an error.
  
Later, the user can call `pallet_utility::batch(calls)`, and any message sent between `start_pack` and `end_pack` will be bundled in the batch.

### Changes
- Added `Gateway::start_pack_messages()` and `Gateway::end_pack_messages()` to allow creating batches.
- Renamed `process_msg()` to `receive_message()`.
- Removed `try_range` for header message deserialization and use a `BufferReader`.
