### PR TITLE
Refactor: Unify DomainAddress and account conversions

### DIFF
--- a/libs/types/src/domain_address.rs
+++ b/libs/types/src/domain_address.rs
@@ -10,88 +10,99 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_utils::vec_to_fixed_array;
 use frame_support::pallet_prelude::RuntimeDebug;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
-use sp_runtime::traits::AccountIdConversion;
+use sp_runtime::{traits::AccountIdConversion, TypeId};
 
 use crate::EVMChainId;
 
+const MAX_ADDRESS_SIZE: usize = 32;
+pub type LocalAddress = [u8; 32];
+pub type EthAddress = [u8; 20];
+
+pub fn local_to_eth_address(address: LocalAddress) -> EthAddress {
+	*address
+		.split_first_chunk::<20>()
+		.expect("always fit, qed")
+		.0
+}
+
+pub fn evm_to_local_address(chain_id: u64, address: EthAddress) -> LocalAddress {
+	// We use a custom encoding here rather than relying on
+	// `AccountIdConversion` for a couple of reasons:
+	// 1. We have very few bytes to spare, so choosing our own fields is nice
+	// 2. AccountIdConversion puts the tag first, which can unbalance the storage
+	//    trees if users create many H160-derived accounts. We put the tag last
+	//    here.
+	let tag = b"EVM";
+	let mut bytes = [0; 32];
+	bytes[0..20].copy_from_slice(&address);
+	bytes[20..28].copy_from_slice(&chain_id.to_be_bytes());
+	bytes[28..31].copy_from_slice(tag);
+	bytes
+}
+
 /// A Domain is a chain or network we can send a message to.
-#[derive(Encode, Decode, Clone, Eq, MaxEncodedLen, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, Copy, Eq, MaxEncodedLen, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum Domain {
-	/// Referring to the Centrifuge Parachain. Will be used for handling
-	/// incoming messages.
-	///
-	/// NOTE: messages CAN NOT be sent directly from the Centrifuge chain to the
-	/// Centrifuge chain itself.
-	Centrifuge,
+	/// Referring to the Local Parachain.
+	Local,
 	/// An EVM domain, identified by its EVM Chain Id
-	EVM(EVMChainId),
+	Evm(EVMChainId),
+}
+
+impl TypeId for Domain {
+	const TYPE_ID: [u8; 4] = crate::ids::DOMAIN_ID;
 }
 
 impl Domain {
 	pub fn into_account<AccountId: Encode + Decode>(&self) -> AccountId {
-		DomainLocator {
-			domain: self.clone(),
-		}
-		.into_account_truncating()
+		self.into_account_truncating()
 	}
-}
-
-#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
-pub struct DomainLocator<Domain> {
-	pub domain: Domain,
 }
 
 #[derive(Encode, Decode, Clone, Eq, MaxEncodedLen, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum DomainAddress {
-	/// A Centrifuge-Chain based account address, 32-bytes long
-	Centrifuge([u8; 32]),
-	/// An EVM chain address, 20-bytes long
-	EVM(EVMChainId, [u8; 20]),
+	/// A local based account address
+	Local(LocalAddress),
+	/// An EVM chain address
+	Evm(EVMChainId, EthAddress),
+}
+
+impl TypeId for DomainAddress {
+	const TYPE_ID: [u8; 4] = crate::ids::DOMAIN_ADDRESS_ID;
 }
 
 impl Default for DomainAddress {
 	fn default() -> Self {
-		DomainAddress::Centrifuge([0; 32])
-	}
-}
-
-impl DomainAddress {
-	pub fn evm(chain_id: EVMChainId, address: [u8; 20]) -> Self {
-		Self::EVM(chain_id, address)
-	}
-
-	pub fn centrifuge(address: [u8; 32]) -> Self {
-		Self::Centrifuge(address)
-	}
-}
-
-impl From<(EVMChainId, [u8; 20])> for DomainAddress {
-	fn from((chain_id, address): (EVMChainId, [u8; 20])) -> Self {
-		Self::evm(chain_id, address)
+		DomainAddress::Local(LocalAddress::default())
 	}
 }
 
 impl From<DomainAddress> for Domain {
 	fn from(x: DomainAddress) -> Self {
 		match x {
-			DomainAddress::Centrifuge(_) => Domain::Centrifuge,
-			DomainAddress::EVM(chain_id, _) => Domain::EVM(chain_id),
+			DomainAddress::Local(_) => Domain::Local,
+			DomainAddress::Evm(chain_id, _) => Domain::Evm(chain_id),
 		}
 	}
 }
 
 impl DomainAddress {
-	/// Get the address in a 32-byte long representation.
-	/// For EVM addresses, append 12 zeros.
-	pub fn address(&self) -> [u8; 32] {
-		match self.clone() {
-			Self::Centrifuge(x) => x,
-			Self::EVM(_, x) => vec_to_fixed_array(x),
+	pub fn new(domain: Domain, address: [u8; MAX_ADDRESS_SIZE]) -> Self {
+		match domain {
+			Domain::Local => DomainAddress::Local(LocalAddress::from(address)),
+			Domain::Evm(chain_id) => DomainAddress::Evm(chain_id, local_to_eth_address(address)),
 		}
+	}
+
+	pub fn from_local(address: impl Into<LocalAddress>) -> DomainAddress {
+		DomainAddress::Local(address.into())
+	}
+
+	pub fn from_evm(chain_id: EVMChainId, address: impl Into<EthAddress>) -> DomainAddress {
+		DomainAddress::Evm(chain_id, address.into())
 	}
 
 	pub fn domain(&self) -> Domain {
@@ -99,24 +110,20 @@ impl DomainAddress {
 	}
 }
 
-#[cfg(test)]
-mod tests {
-	use parity_scale_codec::{Decode, Encode};
-
-	use super::*;
-
-	#[test]
-	fn test_domain_encode_decode() {
-		test_domain_identity(Domain::Centrifuge);
-		test_domain_identity(Domain::EVM(1284));
-		test_domain_identity(Domain::EVM(1));
+impl DomainAddress {
+	pub fn as_local<Address: From<LocalAddress>>(&self) -> Address {
+		match self.clone() {
+			Self::Local(x) => x,
+			Self::Evm(chain_id, x) => evm_to_local_address(chain_id, x),
+		}
+		.into()
 	}
 
-	/// Test that (decode . encode) results in the original value
-	fn test_domain_identity(domain: Domain) {
-		let encoded = domain.encode();
-		let decoded = Domain::decode(&mut encoded.as_slice()).unwrap();
-
-		assert_eq!(domain, decoded);
+	pub fn as_eth<Address: From<EthAddress>>(&self) -> Address {
+		match self.clone() {
+			Self::Local(x) => local_to_eth_address(x),
+			Self::Evm(_, x) => x,
+		}
+		.into()
 	}
 }

--- a/libs/types/src/ids.rs
+++ b/libs/types/src/ids.rs
@@ -15,10 +15,7 @@
 use frame_support::PalletId;
 use sp_runtime::TypeId;
 
-use crate::{
-	domain_address::{DomainAddress, DomainLocator},
-	investments::InvestmentAccount,
-};
+use crate::investments::InvestmentAccount;
 
 // The TypeId impl we derive pool-accounts from
 impl<InvestmentId> TypeId for InvestmentAccount<InvestmentId> {
@@ -45,10 +42,5 @@ pub const CHAIN_BRIDGE_NATIVE_TOKEN_ID: [u8; 4] = *b"xCFG";
 /// The identifier of the group eligible to receive block rewards.
 pub const COLLATOR_GROUP_ID: u32 = 1;
 
-impl TypeId for DomainAddress {
-	const TYPE_ID: [u8; 4] = *b"dadr";
-}
-
-impl<Domain> TypeId for DomainLocator<Domain> {
-	const TYPE_ID: [u8; 4] = *b"domn";
-}
+pub const DOMAIN_ID: [u8; 4] = *b"dadr";
+pub const DOMAIN_ADDRESS_ID: [u8; 4] = *b"domn";

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -28,13 +28,13 @@ use cfg_primitives::{
 	SAFE_XCM_VERSION,
 };
 use cfg_types::{
+	domain_address::DomainAddress,
 	fee_keys::FeeKey,
 	tokens::{usdc, AssetMetadata, CrossChainTransferability, CurrencyId, CustomMetadata},
 };
 use cfg_utils::vec_to_fixed_array;
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
-use runtime_common::account_conversion::AccountConverter;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, Properties};
 use serde::{Deserialize, Serialize};
@@ -271,8 +271,8 @@ fn centrifuge_genesis(
 	let chain_id: u32 = id.into();
 
 	endowed_accounts.extend(endowed_evm_accounts.into_iter().map(|(addr, id)| {
-		let chain_id = id.unwrap_or_else(|| chain_id.into());
-		AccountConverter::convert_evm_address(chain_id, addr)
+		let chain_id = id.unwrap_or(chain_id.into());
+		DomainAddress::from_evm(chain_id, addr).as_local()
 	}));
 
 	let num_endowed_accounts = endowed_accounts.len();
@@ -371,8 +371,8 @@ fn altair_genesis(
 	let chain_id: u32 = id.into();
 
 	endowed_accounts.extend(endowed_evm_accounts.into_iter().map(|(addr, id)| {
-		let chain_id = id.unwrap_or_else(|| chain_id.into());
-		AccountConverter::convert_evm_address(chain_id, addr)
+		let chain_id = id.unwrap_or(chain_id.into());
+		DomainAddress::from_evm(chain_id, addr).as_local()
 	}));
 
 	let num_endowed_accounts = endowed_accounts.len();
@@ -472,8 +472,8 @@ fn development_genesis(
 	let chain_id: u32 = id.into();
 
 	endowed_accounts.extend(endowed_evm_accounts.into_iter().map(|(addr, id)| {
-		let chain_id = id.unwrap_or_else(|| chain_id.into());
-		AccountConverter::convert_evm_address(chain_id, addr)
+		let chain_id = id.unwrap_or(chain_id.into());
+		DomainAddress::from_evm(chain_id, addr).as_local()
 	}));
 
 	let num_endowed_accounts = endowed_accounts.len();

--- a/pallets/axelar-router/src/lib.rs
+++ b/pallets/axelar-router/src/lib.rs
@@ -238,7 +238,7 @@ pub mod pallet {
 
 					T::Receiver::receive(
 						AxelarId::Evm(chain_id).into(),
-						DomainAddress::EVM(chain_id, source_address_bytes),
+						DomainAddress::Evm(chain_id, source_address_bytes),
 						payload.to_vec(),
 					)
 				}
@@ -324,7 +324,7 @@ pub mod pallet {
 
 			match config.domain {
 				DomainConfig::Evm(evm_config) => {
-					let sender_evm_address = H160::from_slice(&origin.address()[0..20]);
+					let sender_eth_address = origin.as_eth::<H160>();
 
 					let message = wrap_into_axelar_msg(
 						message,
@@ -334,7 +334,7 @@ pub mod pallet {
 					.map_err(DispatchError::Other)?;
 
 					T::Transactor::call(
-						sender_evm_address,
+						sender_eth_address,
 						evm_config.target_contract_address,
 						message.as_slice(),
 						evm_config.fee_values.value,

--- a/pallets/axelar-router/src/tests.rs
+++ b/pallets/axelar-router/src/tests.rs
@@ -9,7 +9,7 @@ const LP_CONTRACT_ADDRESS: H160 = H160::repeat_byte(1);
 const AXELAR_CONTRACT_ADDRESS: H160 = H160::repeat_byte(2);
 const SOURCE_ADDRESS: H160 = H160::repeat_byte(3);
 const AXELAR_CONTRACT_HASH: H256 = H256::repeat_byte(42);
-const SENDER: DomainAddress = DomainAddress::Centrifuge([0; 32]);
+const SENDER: DomainAddress = DomainAddress::Local([0; 32]);
 const MESSAGE: &[u8] = &[1, 2, 3];
 const FEE_VALUE: U256 = U256::zero();
 const GAS_LIMIT: U256 = U256::one();
@@ -91,7 +91,7 @@ mod send {
 			correct_configuration();
 
 			Transactor::mock_call(move |from, to, data, value, gas_price, gas_limit| {
-				assert_eq!(from, H160::from_slice(&SENDER.address()[0..20]));
+				assert_eq!(from, SENDER.as_eth());
 				assert_eq!(to, AXELAR_CONTRACT_ADDRESS);
 				assert_eq!(data, &wrap_message(MESSAGE.to_vec()));
 				assert_eq!(value, FEE_VALUE);
@@ -143,7 +143,7 @@ mod receive {
 
 			Receiver::mock_receive(|middleware, origin, message| {
 				assert_eq!(middleware, Middleware(AxelarId::Evm(CHAIN_ID)));
-				assert_eq!(origin, DomainAddress::EVM(CHAIN_ID, SOURCE_ADDRESS.0));
+				assert_eq!(origin, DomainAddress::Evm(CHAIN_ID, SOURCE_ADDRESS.0));
 				assert_eq!(&message, MESSAGE);
 				Ok(())
 			});

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -200,7 +200,7 @@ pub mod pallet {
 			T::AdminOrigin::ensure_origin(origin)?;
 
 			ensure!(
-				instance.domain() != Domain::Centrifuge,
+				instance.domain() != Domain::Local,
 				Error::<T>::DomainNotSupported
 			);
 
@@ -244,7 +244,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let GatewayOrigin::Domain(origin_address) = T::LocalEVMOrigin::ensure_origin(origin)?;
 
-			if let DomainAddress::Centrifuge(_) = origin_address {
+			if let DomainAddress::Local(_) = origin_address {
 				return Err(Error::<T>::InvalidMessageOrigin.into());
 			}
 
@@ -263,7 +263,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
-			ensure!(domain != Domain::Centrifuge, Error::<T>::DomainNotSupported);
+			ensure!(domain != Domain::Local, Error::<T>::DomainNotSupported);
 			DomainHookAddress::<T>::insert(domain.clone(), hook_address);
 
 			Self::deposit_event(Event::DomainHookAddressSet {
@@ -377,10 +377,7 @@ pub mod pallet {
 			destination: Self::Destination,
 			message: Self::Message,
 		) -> DispatchResult {
-			ensure!(
-				destination != Domain::Centrifuge,
-				Error::<T>::DomainNotSupported
-			);
+			ensure!(destination != Domain::Local, Error::<T>::DomainNotSupported);
 
 			PackedMessage::<T>::mutate((&from, destination.clone()), |batch| match batch {
 				Some(batch) => batch.pack_with(message),

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -264,7 +264,7 @@ pub mod pallet {
 			T::AdminOrigin::ensure_origin(origin)?;
 
 			ensure!(domain != Domain::Local, Error::<T>::DomainNotSupported);
-			DomainHookAddress::<T>::insert(domain.clone(), hook_address);
+			DomainHookAddress::<T>::insert(domain, hook_address);
 
 			Self::deposit_event(Event::DomainHookAddressSet {
 				domain,
@@ -379,7 +379,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			ensure!(destination != Domain::Local, Error::<T>::DomainNotSupported);
 
-			PackedMessage::<T>::mutate((&from, destination.clone()), |batch| match batch {
+			PackedMessage::<T>::mutate((&from, destination), |batch| match batch {
 				Some(batch) => batch.pack_with(message),
 				None => Self::queue_message(destination, message),
 			})

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -5,7 +5,7 @@ use frame_support::{derive_impl, weights::constants::RocksDbWeight};
 use frame_system::EnsureRoot;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
-use sp_core::{crypto::AccountId32, H256};
+use sp_core::crypto::AccountId32;
 use sp_runtime::{traits::IdentityLookup, DispatchError, DispatchResult};
 
 use crate::{pallet as pallet_liquidity_pools_gateway, EnsureLocal, GatewayMessage};
@@ -115,7 +115,7 @@ impl cfg_mocks::router_message::pallet::Config for Runtime {
 }
 
 frame_support::parameter_types! {
-	pub Sender: DomainAddress = DomainAddress::Centrifuge(AccountId32::from(H256::from_low_u64_be(1).to_fixed_bytes()).into());
+	pub Sender: DomainAddress = DomainAddress::Local([1; 32]);
 	pub const MaxIncomingMessageSize: u32 = 1024;
 	pub const LpAdminAccount: AccountId32 = LP_ADMIN_ACCOUNT;
 }

--- a/pallets/liquidity-pools-gateway/src/origin.rs
+++ b/pallets/liquidity-pools-gateway/src/origin.rs
@@ -14,8 +14,6 @@ use cfg_types::domain_address::DomainAddress;
 use frame_support::traits::EnsureOrigin;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
-#[cfg(feature = "runtime-benchmarks")]
-use sp_core::H160;
 use sp_runtime::RuntimeDebug;
 
 #[derive(Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
@@ -34,9 +32,6 @@ impl<O: Into<Result<GatewayOrigin, O>> + From<GatewayOrigin>> EnsureOrigin<O> fo
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_successful_origin() -> Result<O, ()> {
-		Ok(O::from(GatewayOrigin::Domain(DomainAddress::EVM(
-			1,
-			H160::from_low_u64_be(1).into(),
-		))))
+		unimplemented!()
 	}
 }

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -93,11 +93,13 @@ pub use message::Message;
 pub mod hooks;
 mod inbound;
 
+/*
 #[cfg(test)]
 mod mock;
 
 #[cfg(test)]
 mod tests;
+*/
 
 pub type GeneralCurrencyIndexType = u128;
 

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -1020,7 +1020,7 @@ pub mod pallet {
 			ensure_root(origin)?;
 
 			ensure!(
-				matches!(domain_address.domain(), Domain::EVM(_)),
+				matches!(domain_address.domain(), Domain::Evm(_)),
 				Error::<T>::InvalidDomain
 			);
 
@@ -1030,7 +1030,7 @@ pub mod pallet {
 				Message::RecoverAssets {
 					contract: incorrect_contract,
 					asset,
-					recipient: T::DomainAddressToAccountId::convert(domain_address).into(),
+					recipient: domain_address.as_local(),
 					amount: amount.into(),
 				},
 			)?;

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -43,7 +43,7 @@ use core::convert::TryFrom;
 
 use cfg_traits::{liquidity_pools::OutboundMessageHandler, swaps::TokenSwaps, PreConditions};
 use cfg_types::{
-	domain_address::{Domain, DomainAddress},
+	domain_address::{Domain, DomainAddress, EthAddress, LocalAddress},
 	tokens::GeneralCurrencyIndex,
 };
 use cfg_utils::vec_to_fixed_array;
@@ -60,7 +60,7 @@ use orml_traits::{
 };
 pub use pallet::*;
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Convert, EnsureMul},
+	traits::{AtLeast32BitUnsigned, EnsureMul},
 	FixedPointNumber, SaturatedConversion,
 };
 use sp_std::{convert::TryInto, vec};
@@ -240,12 +240,6 @@ pub mod pallet {
 			+ CurrencyInspect<CurrencyId = Self::CurrencyId>
 			+ From<(Self::PoolId, Self::TrancheId)>;
 
-		/// The converter from a DomainAddress to a Substrate AccountId.
-		type DomainAddressToAccountId: Convert<DomainAddress, Self::AccountId>;
-
-		/// The converter from a Domain and a 32 byte array to DomainAddress.
-		type DomainAccountToDomainAddress: Convert<(Domain, [u8; 32]), DomainAddress>;
-
 		/// The type for processing outgoing messages and retrieving the domain
 		/// hook address.
 		type OutboundMessageHandler: OutboundMessageHandler<
@@ -354,7 +348,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T>
 	where
-		<T as frame_system::Config>::AccountId: From<[u8; 32]> + Into<[u8; 32]>,
+		T::AccountId: From<LocalAddress> + Into<LocalAddress>,
 	{
 		/// Add a pool to a given domain.
 		///
@@ -425,12 +419,10 @@ pub mod pallet {
 			let hook_bytes = T::OutboundMessageHandler::get(&domain)
 				.ok_or(Error::<T>::DomainHookAddressNotFound)?;
 			let evm_chain_id = match domain {
-				Domain::EVM(id) => Ok(id),
+				Domain::Evm(id) => Ok(id),
 				_ => Err(Error::<T>::InvalidDomain),
 			}?;
-			let hook =
-				T::DomainAddressToAccountId::convert(DomainAddress::EVM(evm_chain_id, hook_bytes))
-					.into();
+			let hook = DomainAddress::Evm(evm_chain_id, hook_bytes).as_local();
 
 			// Send the message to the domain
 			T::OutboundMessageHandler::handle(
@@ -478,7 +470,7 @@ pub mod pallet {
 			// Check that the registered asset location matches the destination
 			let (chain_id, ..) = Self::try_get_wrapped_token(&currency_id)?;
 			ensure!(
-				Domain::EVM(chain_id) == destination,
+				Domain::Evm(chain_id) == destination,
 				Error::<T>::InvalidDomain
 			);
 
@@ -530,7 +522,7 @@ pub mod pallet {
 			ensure!(
 				T::Permission::has(
 					PermissionScope::Pool(pool_id),
-					T::DomainAddressToAccountId::convert(domain_address.clone()),
+					domain_address.as_local(),
 					Role::PoolRole(PoolRole::TrancheInvestor(tranche_id, valid_until))
 				),
 				Error::<T>::InvestorDomainAddressNotAMember
@@ -543,7 +535,7 @@ pub mod pallet {
 					pool_id: pool_id.into(),
 					tranche_id: tranche_id.into(),
 					update: UpdateRestrictionMessage::UpdateMember {
-						member: domain_address.address(),
+						member: domain_address.as_local(),
 						valid_until,
 					},
 				},
@@ -570,11 +562,7 @@ pub mod pallet {
 			let who = ensure_signed(origin.clone())?;
 
 			ensure!(!amount.is_zero(), Error::<T>::InvalidTransferAmount);
-			Self::validate_investor_can_transfer(
-				T::DomainAddressToAccountId::convert(domain_address.clone()),
-				pool_id,
-				tranche_id,
-			)?;
+			Self::validate_investor_can_transfer(domain_address.as_local(), pool_id, tranche_id)?;
 
 			// Ensure pool and tranche exist and derive invest id
 			let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
@@ -598,7 +586,7 @@ pub mod pallet {
 					tranche_id: tranche_id.into(),
 					amount: amount.into(),
 					domain: domain_address.domain().into(),
-					receiver: domain_address.address(),
+					receiver: domain_address.as_local(),
 				},
 			)?;
 
@@ -631,7 +619,7 @@ pub mod pallet {
 			// Check that the registered asset location matches the destination
 			let (chain_id, ..) = Self::try_get_wrapped_token(&currency_id)?;
 			ensure!(
-				Domain::EVM(chain_id) == receiver.domain(),
+				Domain::Evm(chain_id) == receiver.domain(),
 				Error::<T>::InvalidDomain
 			);
 
@@ -669,7 +657,7 @@ pub mod pallet {
 				Message::TransferAssets {
 					amount: amount.into(),
 					currency,
-					receiver: receiver.address(),
+					receiver: receiver.as_local(),
 				},
 			)?;
 
@@ -691,7 +679,7 @@ pub mod pallet {
 
 			T::OutboundMessageHandler::handle(
 				who,
-				Domain::EVM(chain_id),
+				Domain::Evm(chain_id),
 				Message::AddAsset {
 					currency,
 					evm_address,
@@ -729,7 +717,7 @@ pub mod pallet {
 
 			T::OutboundMessageHandler::handle(
 				who,
-				Domain::EVM(chain_id),
+				Domain::Evm(chain_id),
 				Message::AllowAsset {
 					pool_id: pool_id.into(),
 					currency,
@@ -754,7 +742,7 @@ pub mod pallet {
 
 			T::OutboundMessageHandler::handle(
 				T::TreasuryAccount::get(),
-				Domain::EVM(evm_chain_id),
+				Domain::Evm(evm_chain_id),
 				Message::ScheduleUpgrade { contract },
 			)
 		}
@@ -773,7 +761,7 @@ pub mod pallet {
 
 			T::OutboundMessageHandler::handle(
 				T::TreasuryAccount::get(),
-				Domain::EVM(evm_chain_id),
+				Domain::Evm(evm_chain_id),
 				Message::CancelUpgrade { contract },
 			)
 		}
@@ -837,7 +825,7 @@ pub mod pallet {
 
 			T::OutboundMessageHandler::handle(
 				who,
-				Domain::EVM(chain_id),
+				Domain::Evm(chain_id),
 				Message::DisallowAsset {
 					pool_id: pool_id.into(),
 					currency,
@@ -863,7 +851,6 @@ pub mod pallet {
 			domain_address: DomainAddress,
 		) -> DispatchResult {
 			let who = ensure_signed(origin.clone())?;
-			let local_address = T::DomainAddressToAccountId::convert(domain_address.clone());
 
 			ensure!(
 				T::PoolInspect::pool_exists(pool_id),
@@ -883,7 +870,7 @@ pub mod pallet {
 				Error::<T>::NotPoolAdmin
 			);
 			Self::validate_investor_status(
-				local_address.clone(),
+				domain_address.as_local(),
 				pool_id,
 				tranche_id,
 				T::Time::now(),
@@ -897,7 +884,7 @@ pub mod pallet {
 					pool_id: pool_id.into(),
 					tranche_id: tranche_id.into(),
 					update: UpdateRestrictionMessage::Freeze {
-						address: domain_address.address(),
+						address: domain_address.as_local(),
 					},
 				},
 			)?;
@@ -921,7 +908,6 @@ pub mod pallet {
 			domain_address: DomainAddress,
 		) -> DispatchResult {
 			let who = ensure_signed(origin.clone())?;
-			let local_address = T::DomainAddressToAccountId::convert(domain_address.clone());
 
 			ensure!(
 				T::PoolInspect::pool_exists(pool_id),
@@ -941,7 +927,7 @@ pub mod pallet {
 				Error::<T>::NotPoolAdmin
 			);
 			Self::validate_investor_status(
-				local_address.clone(),
+				domain_address.as_local(),
 				pool_id,
 				tranche_id,
 				T::Time::now(),
@@ -955,7 +941,7 @@ pub mod pallet {
 					pool_id: pool_id.into(),
 					tranche_id: tranche_id.into(),
 					update: UpdateRestrictionMessage::Unfreeze {
-						address: domain_address.address(),
+						address: domain_address.as_local(),
 					},
 				},
 			)?;
@@ -996,11 +982,10 @@ pub mod pallet {
 			);
 
 			let evm_chain_id = match domain {
-				Domain::EVM(id) => Ok(id),
+				Domain::Evm(id) => Ok(id),
 				_ => Err(Error::<T>::InvalidDomain),
 			}?;
-			let hook_32 =
-				T::DomainAddressToAccountId::convert(DomainAddress::EVM(evm_chain_id, hook)).into();
+			let hook_32 = DomainAddress::Evm(evm_chain_id, hook).as_local();
 
 			T::OutboundMessageHandler::handle(
 				who,
@@ -1054,7 +1039,10 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> Pallet<T> {
+	impl<T: Config> Pallet<T>
+	where
+		T::AccountId: From<LocalAddress> + Into<LocalAddress>,
+	{
 		/// Returns the `u128` general index of a currency as the concatenation
 		/// of the configured `GeneralCurrencyPrefix` and its local currency
 		/// identifier.
@@ -1096,7 +1084,7 @@ pub mod pallet {
 		/// Requires the currency to be registered in the `AssetRegistry`.
 		pub fn try_get_wrapped_token(
 			currency_id: &T::CurrencyId,
-		) -> Result<(EVMChainId, [u8; 20]), DispatchError> {
+		) -> Result<(EVMChainId, EthAddress), DispatchError> {
 			let meta = T::AssetRegistry::metadata(currency_id).ok_or(Error::<T>::AssetNotFound)?;
 			ensure!(
 				meta.additional.transferability.includes_liquidity_pools(),
@@ -1165,11 +1153,6 @@ pub mod pallet {
 			Ok((currency, chain_id))
 		}
 
-		fn domain_account_to_account_id(domain_account: (Domain, [u8; 32])) -> T::AccountId {
-			let domain_address = T::DomainAccountToDomainAddress::convert(domain_account);
-			T::DomainAddressToAccountId::convert(domain_address)
-		}
-
 		/// Checks whether the given address has investor permissions with at
 		/// least the given validity timestamp. Moreover, checks whether the
 		/// investor is frozen or not.
@@ -1231,7 +1214,7 @@ pub mod pallet {
 
 	impl<T: Config> InboundMessageHandler for Pallet<T>
 	where
-		<T as frame_system::Config>::AccountId: From<[u8; 32]> + Into<[u8; 32]>,
+		T::AccountId: From<LocalAddress> + Into<LocalAddress>,
 	{
 		type Message = Message;
 		type Sender = DomainAddress;
@@ -1261,7 +1244,7 @@ pub mod pallet {
 					pool_id.into(),
 					tranche_id.into(),
 					sender.domain(),
-					T::DomainAccountToDomainAddress::convert((domain.try_into()?, receiver)),
+					DomainAddress::new(domain.try_into()?, receiver),
 					amount.into(),
 				),
 				Message::DepositRequest {
@@ -1273,7 +1256,7 @@ pub mod pallet {
 				} => Self::handle_deposit_request(
 					pool_id.into(),
 					tranche_id.into(),
-					Self::domain_account_to_account_id((sender.domain(), investor)),
+					DomainAddress::new(sender.domain(), investor).as_local(),
 					currency.into(),
 					amount.into(),
 				),
@@ -1286,7 +1269,7 @@ pub mod pallet {
 				} => Self::handle_redeem_request(
 					pool_id.into(),
 					tranche_id.into(),
-					Self::domain_account_to_account_id((sender.domain(), investor)),
+					DomainAddress::new(sender.domain(), investor).as_local(),
 					amount.into(),
 					currency.into(),
 					sender,
@@ -1299,7 +1282,7 @@ pub mod pallet {
 				} => Self::handle_cancel_deposit_request(
 					pool_id.into(),
 					tranche_id.into(),
-					Self::domain_account_to_account_id((sender.domain(), investor)),
+					DomainAddress::new(sender.domain(), investor).as_local(),
 					currency.into(),
 				),
 				Message::CancelRedeemRequest {
@@ -1310,7 +1293,7 @@ pub mod pallet {
 				} => Self::handle_cancel_redeem_request(
 					pool_id.into(),
 					tranche_id.into(),
-					Self::domain_account_to_account_id((sender.domain(), investor)),
+					DomainAddress::new(sender.domain(), investor).as_local(),
 					currency.into(),
 					sender,
 				),

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -93,13 +93,11 @@ pub use message::Message;
 pub mod hooks;
 mod inbound;
 
-/*
 #[cfg(test)]
 mod mock;
 
 #[cfg(test)]
 mod tests;
-*/
 
 pub type GeneralCurrencyIndexType = u128;
 

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -740,7 +740,7 @@ mod tests {
 	}
 
 	#[test]
-	fn transfer_tranche_tokens_to_moonbeam() {
+	fn transfer_tranche_tokens_to_chain() {
 		let domain_address = DomainAddress::Evm(1284, default_address_20());
 
 		test_encode_decode_identity(
@@ -751,7 +751,7 @@ mod tests {
 				receiver: domain_address.as_local(),
 				amount: AMOUNT,
 			},
-			"120000000000000001811acd5b3f17c06841c7e41e9e04cb1b0100000000000005041231231231231231231231231231231231231231000000000000000000000000000000000052b7d2dcc80cd2e4000000"
+            "120000000000000001811acd5b3f17c06841c7e41e9e04cb1b0100000000000005041231231231231231231231231231231231231231000000000000050445564d00000000000052b7d2dcc80cd2e4000000"
 		);
 	}
 

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -55,8 +55,8 @@ pub struct SerializableDomain(u8, u64);
 impl From<Domain> for SerializableDomain {
 	fn from(domain: Domain) -> Self {
 		match domain {
-			Domain::Centrifuge => Self(0, 0),
-			Domain::EVM(chain_id) => Self(1, chain_id),
+			Domain::Local => Self(0, 0),
+			Domain::Evm(chain_id) => Self(1, chain_id),
 		}
 	}
 }
@@ -66,8 +66,8 @@ impl TryInto<Domain> for SerializableDomain {
 
 	fn try_into(self) -> Result<Domain, DispatchError> {
 		match self.0 {
-			0 => Ok(Domain::Centrifuge),
-			1 => Ok(Domain::EVM(self.1)),
+			0 => Ok(Domain::Local),
+			1 => Ok(Domain::Evm(self.1)),
 			_ => Err(DispatchError::Other("Unknown domain")),
 		}
 	}
@@ -624,22 +624,22 @@ mod tests {
 	fn encoding_domain() {
 		// The Centrifuge substrate chain
 		assert_eq!(
-			hex::encode(gmpf::to_vec(&SerializableDomain::from(Domain::Centrifuge)).unwrap()),
+			hex::encode(gmpf::to_vec(&SerializableDomain::from(Domain::Local)).unwrap()),
 			"000000000000000000"
 		);
 		// Ethereum MainNet
 		assert_eq!(
-			hex::encode(gmpf::to_vec(&SerializableDomain::from(Domain::EVM(1))).unwrap()),
+			hex::encode(gmpf::to_vec(&SerializableDomain::from(Domain::Evm(1))).unwrap()),
 			"010000000000000001"
 		);
 		// Moonbeam EVM chain
 		assert_eq!(
-			hex::encode(gmpf::to_vec(&SerializableDomain::from(Domain::EVM(1284))).unwrap()),
+			hex::encode(gmpf::to_vec(&SerializableDomain::from(Domain::Evm(1284))).unwrap()),
 			"010000000000000504"
 		);
 		// Avalanche Chain
 		assert_eq!(
-			hex::encode(gmpf::to_vec(&SerializableDomain::from(Domain::EVM(43114))).unwrap()),
+			hex::encode(gmpf::to_vec(&SerializableDomain::from(Domain::Evm(43114))).unwrap()),
 			"01000000000000a86a"
 		);
 	}
@@ -741,14 +741,14 @@ mod tests {
 
 	#[test]
 	fn transfer_tranche_tokens_to_moonbeam() {
-		let domain_address = DomainAddress::EVM(1284, default_address_20());
+		let domain_address = DomainAddress::Evm(1284, default_address_20());
 
 		test_encode_decode_identity(
 			Message::TransferTrancheTokens {
 				pool_id: 1,
 				tranche_id: default_tranche_id(),
 				domain: domain_address.domain().into(),
-				receiver: domain_address.address(),
+				receiver: domain_address.as_local(),
 				amount: AMOUNT,
 			},
 			"120000000000000001811acd5b3f17c06841c7e41e9e04cb1b0100000000000005041231231231231231231231231231231231231231000000000000000000000000000000000052b7d2dcc80cd2e4000000"
@@ -761,7 +761,7 @@ mod tests {
 			Message::TransferTrancheTokens {
 				pool_id: 1,
 				tranche_id: default_tranche_id(),
-				domain: Domain::Centrifuge.into(),
+				domain: Domain::Local.into(),
 				receiver: default_address_32(),
 				amount: AMOUNT,
 			},

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -1,7 +1,7 @@
 use cfg_primitives::{PoolId, TrancheId};
 use cfg_traits::{Millis, Seconds};
 use cfg_types::{
-	domain_address::{Domain, DomainAddress, EthAddress, LocalAddress},
+	domain_address::{Domain, DomainAddress},
 	permissions::PermissionScope,
 	tokens::{
 		AssetMetadata, AssetStringLimit, CrossChainTransferability, CurrencyId, CustomMetadata,
@@ -29,9 +29,7 @@ pub const ALICE_ETH: [u8; 20] = [2; 20];
 pub const ALICE_EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::Evm(42, ALICE_ETH);
 pub const LOCAL_DOMAIN_ADDRESS: DomainAddress = DomainAddress::Local(ALICE_32);
 pub const CONTRACT_ACCOUNT: [u8; 20] = [1; 20];
-pub const CONTRACT_ACCOUNT_ID: AccountId = AccountId::new([1; 32]);
 pub const DOMAIN_HOOK_ADDRESS_20: [u8; 20] = [10u8; 20];
-pub const DOMAIN_HOOK_ADDRESS_32: [u8; 32] = [10u8; 32];
 pub const EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::Evm(CHAIN_ID, CONTRACT_ACCOUNT);
 pub const EVM_DOMAIN: Domain = Domain::Evm(CHAIN_ID);
 pub const AMOUNT: Balance = 100;

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -68,8 +68,6 @@ frame_support::construct_runtime!(
 		AssetRegistry: cfg_mocks::asset_registry::pallet,
 		ForeignInvestment: cfg_mocks::foreign_investment::pallet,
 		Gateway: cfg_mocks::pallet_mock_liquidity_pools_gateway,
-		DomainAddressToAccountId: cfg_mocks::converter::pallet::<Instance1>,
-		DomainAccountToDomainAddress: cfg_mocks::converter::pallet::<Instance2>,
 		TransferFilter: cfg_mocks::pre_conditions::pallet,
 		MarketRatio: cfg_mocks::token_swaps::pallet,
 		Tokens: orml_tokens,
@@ -119,16 +117,6 @@ impl cfg_mocks::pallet_mock_liquidity_pools_gateway::Config for Runtime {
 	type Message = crate::Message;
 }
 
-impl cfg_mocks::converter::pallet::Config<cfg_mocks::converter::pallet::Instance1> for Runtime {
-	type From = DomainAddress;
-	type To = AccountId;
-}
-
-impl cfg_mocks::converter::pallet::Config<cfg_mocks::converter::pallet::Instance2> for Runtime {
-	type From = (Domain, [u8; 32]);
-	type To = DomainAddress;
-}
-
 impl cfg_mocks::pre_conditions::pallet::Config for Runtime {
 	type Conditions = (AccountId, DomainAddress, CurrencyId);
 	type Result = DispatchResult;
@@ -172,8 +160,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Balance = Balance;
 	type BalanceRatio = Ratio;
 	type CurrencyId = CurrencyId;
-	type DomainAccountToDomainAddress = DomainAccountToDomainAddress;
-	type DomainAddressToAccountId = DomainAddressToAccountId;
 	type ForeignInvestment = ForeignInvestment;
 	type GeneralCurrencyPrefix = CurrencyPrefix;
 	type MarketRatio = MarketRatio;

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -1,7 +1,7 @@
 use cfg_primitives::{PoolId, TrancheId};
 use cfg_traits::{Millis, Seconds};
 use cfg_types::{
-	domain_address::{Domain, DomainAddress},
+	domain_address::{Domain, DomainAddress, EthAddress, LocalAddress},
 	permissions::PermissionScope,
 	tokens::{
 		AssetMetadata, AssetStringLimit, CrossChainTransferability, CurrencyId, CustomMetadata,
@@ -26,24 +26,14 @@ pub const CHAIN_ID: u64 = 1;
 pub const ALICE_32: [u8; 32] = [2; 32];
 pub const ALICE: AccountId = AccountId::new(ALICE_32);
 pub const ALICE_ETH: [u8; 20] = [2; 20];
-pub const ALICE_EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::EVM(CHAIN_ID, ALICE_ETH);
-// TODO(future): Can be removed after domain conversion refactor
-pub const ALICE_EVM_LOCAL_ACCOUNT: AccountId = {
-	let mut arr = [0u8; 32];
-	let mut i = 0;
-	while i < 20 {
-		arr[i] = ALICE_ETH[i];
-		i += 1;
-	}
-	AccountId::new(arr)
-};
-pub const CENTRIFUGE_DOMAIN_ADDRESS: DomainAddress = DomainAddress::Centrifuge(ALICE_32);
+pub const ALICE_EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::Evm(42, ALICE_ETH);
+pub const LOCAL_DOMAIN_ADDRESS: DomainAddress = DomainAddress::Local(ALICE_32);
 pub const CONTRACT_ACCOUNT: [u8; 20] = [1; 20];
 pub const CONTRACT_ACCOUNT_ID: AccountId = AccountId::new([1; 32]);
 pub const DOMAIN_HOOK_ADDRESS_20: [u8; 20] = [10u8; 20];
 pub const DOMAIN_HOOK_ADDRESS_32: [u8; 32] = [10u8; 32];
-pub const EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::EVM(CHAIN_ID, CONTRACT_ACCOUNT);
-pub const EVM_DOMAIN: Domain = Domain::EVM(CHAIN_ID);
+pub const EVM_DOMAIN_ADDRESS: DomainAddress = DomainAddress::Evm(CHAIN_ID, CONTRACT_ACCOUNT);
+pub const EVM_DOMAIN: Domain = Domain::Evm(CHAIN_ID);
 pub const AMOUNT: Balance = 100;
 pub const CURRENCY_ID: CurrencyId = CurrencyId::ForeignAsset(1);
 pub const POOL_CURRENCY_ID: CurrencyId = CurrencyId::LocalAsset(LocalAssetId(1));

--- a/pallets/liquidity-pools/src/tests.rs
+++ b/pallets/liquidity-pools/src/tests.rs
@@ -13,7 +13,7 @@ use sp_runtime::{traits::Saturating, DispatchError, TokenError};
 
 use crate::{mock::*, Error, Message, UpdateRestrictionMessage};
 
-//mod inbound;
+mod inbound;
 
 mod transfer {
 	use super::*;
@@ -1418,7 +1418,7 @@ mod freeze {
 	use super::*;
 	use crate::message::UpdateRestrictionMessage;
 
-	fn config_mocks(receiver: DomainAddress) {
+	fn config_mocks() {
 		Time::mock_now(|| NOW);
 		Permissions::mock_has(move |scope, who, role| {
 			assert!(matches!(scope, PermissionScope::Pool(POOL_ID)));
@@ -1464,7 +1464,7 @@ mod freeze {
 	#[test]
 	fn success() {
 		System::externalities().execute_with(|| {
-			config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+			config_mocks();
 
 			assert_ok!(LiquidityPools::freeze_investor(
 				RuntimeOrigin::signed(ALICE),
@@ -1510,7 +1510,7 @@ mod freeze {
 		#[test]
 		fn with_pool_dne() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Pools::mock_pool_exists(|_| false);
 
 				assert_noop!(
@@ -1528,7 +1528,7 @@ mod freeze {
 		#[test]
 		fn with_tranche_dne() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Pools::mock_tranche_exists(|_, _| false);
 
 				assert_noop!(
@@ -1546,7 +1546,7 @@ mod freeze {
 		#[test]
 		fn with_origin_not_admin() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Permissions::mock_has(|_, _, _| false);
 
 				assert_noop!(
@@ -1564,7 +1564,7 @@ mod freeze {
 		#[test]
 		fn with_investor_not_member() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Permissions::mock_has(move |scope, who, role| {
 					assert!(matches!(scope, PermissionScope::Pool(POOL_ID)));
 					match role {
@@ -1591,7 +1591,7 @@ mod freeze {
 		#[test]
 		fn with_investor_frozen() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Permissions::mock_has(move |scope, who, role| {
 					assert!(matches!(scope, PermissionScope::Pool(POOL_ID)));
 					match role {
@@ -1634,7 +1634,7 @@ mod unfreeze {
 	use super::*;
 	use crate::message::UpdateRestrictionMessage;
 
-	fn config_mocks(receiver: DomainAddress) {
+	fn config_mocks() {
 		Time::mock_now(|| NOW);
 		Permissions::mock_has(move |scope, who, role| {
 			assert!(matches!(scope, PermissionScope::Pool(POOL_ID)));
@@ -1680,7 +1680,7 @@ mod unfreeze {
 	#[test]
 	fn success() {
 		System::externalities().execute_with(|| {
-			config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+			config_mocks();
 
 			assert_ok!(LiquidityPools::unfreeze_investor(
 				RuntimeOrigin::signed(ALICE),
@@ -1726,7 +1726,7 @@ mod unfreeze {
 		#[test]
 		fn with_pool_dne() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Pools::mock_pool_exists(|_| false);
 
 				assert_noop!(
@@ -1744,7 +1744,7 @@ mod unfreeze {
 		#[test]
 		fn with_tranche_dne() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Pools::mock_tranche_exists(|_, _| false);
 
 				assert_noop!(
@@ -1762,7 +1762,7 @@ mod unfreeze {
 		#[test]
 		fn with_origin_not_admin() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Permissions::mock_has(|_, _, _| false);
 
 				assert_noop!(
@@ -1780,7 +1780,7 @@ mod unfreeze {
 		#[test]
 		fn with_investor_not_member() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Permissions::mock_has(move |scope, who, role| {
 					assert!(matches!(scope, PermissionScope::Pool(POOL_ID)));
 					match role {
@@ -1807,7 +1807,7 @@ mod unfreeze {
 		#[test]
 		fn with_investor_unfrozen() {
 			System::externalities().execute_with(|| {
-				config_mocks(ALICE_EVM_DOMAIN_ADDRESS);
+				config_mocks();
 				Permissions::mock_has(move |_, _, _| true);
 
 				assert_noop!(

--- a/pallets/liquidity-pools/src/tests.rs
+++ b/pallets/liquidity-pools/src/tests.rs
@@ -1,6 +1,6 @@
 use cfg_traits::Seconds;
 use cfg_types::{
-	domain_address::DomainAddress,
+	domain_address::{Domain, DomainAddress},
 	permissions::{PermissionScope, PoolRole, Role},
 	tokens::CurrencyId,
 };
@@ -1990,17 +1990,16 @@ mod recover_assets {
 	const ASSET: [u8; 32] = [43; 32];
 
 	fn config_mocks() {
-		DomainAddressToAccountId::mock_convert(move |_| ALICE_EVM_LOCAL_ACCOUNT);
 		Permissions::mock_has(|_, _, _| false);
 		Gateway::mock_handle(|sender, destination, msg| {
 			assert_eq!(sender, TreasuryAccount::get());
-			assert_eq!(destination, EVM_DOMAIN);
+			assert_eq!(destination, Domain::Evm(42));
 			assert_eq!(
 				msg,
 				Message::RecoverAssets {
 					contract: CONTRACT,
 					asset: ASSET,
-					recipient: ALICE_EVM_LOCAL_ACCOUNT.into(),
+					recipient: ALICE_EVM_DOMAIN_ADDRESS.as_local(),
 					amount: sp_core::U256::from(AMOUNT).into(),
 				}
 			);
@@ -2070,7 +2069,7 @@ mod recover_assets {
 				assert_noop!(
 					LiquidityPools::recover_assets(
 						RuntimeOrigin::root(),
-						DomainAddress::Centrifuge(ALICE.into()),
+						DomainAddress::Local(ALICE.into()),
 						CONTRACT,
 						ASSET,
 						AMOUNT.into(),

--- a/pallets/liquidity-pools/src/tests/inbound.rs
+++ b/pallets/liquidity-pools/src/tests/inbound.rs
@@ -1,6 +1,6 @@
 use cfg_traits::liquidity_pools::InboundMessageHandler;
 use cfg_types::{
-	domain_address::{Domain, DomainAddress},
+	domain_address::DomainAddress,
 	permissions::{PermissionScope, PoolRole, Role},
 };
 use frame_support::{

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -1737,8 +1737,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Balance = Balance;
 	type BalanceRatio = Ratio;
 	type CurrencyId = CurrencyId;
-	type DomainAccountToDomainAddress = AccountConverter;
-	type DomainAddressToAccountId = AccountConverter;
 	type ForeignInvestment = ForeignInvestments;
 	type GeneralCurrencyPrefix = GeneralCurrencyPrefix;
 	type MarketRatio = OrderBook;
@@ -1758,7 +1756,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 
 parameter_types! {
 	pub const MaxIncomingMessageSize: u32 = 1024;
-	pub Sender: DomainAddress = gateway::get_gateway_account::<Runtime>();
+	pub Sender: DomainAddress = gateway::get_gateway_domain_address::<Runtime>();
 }
 
 impl pallet_liquidity_pools_gateway::Config for Runtime {

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -1820,8 +1820,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Balance = Balance;
 	type BalanceRatio = Ratio;
 	type CurrencyId = CurrencyId;
-	type DomainAccountToDomainAddress = AccountConverter;
-	type DomainAddressToAccountId = AccountConverter;
 	type ForeignInvestment = ForeignInvestments;
 	type GeneralCurrencyPrefix = GeneralCurrencyPrefix;
 	type MarketRatio = OrderBook;
@@ -1841,7 +1839,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 
 parameter_types! {
 	pub const MaxIncomingMessageSize: u32 = 1024;
-	pub Sender: DomainAddress = gateway::get_gateway_account::<Runtime>();
+	pub Sender: DomainAddress = gateway::get_gateway_domain_address::<Runtime>();
 }
 
 parameter_types! {

--- a/runtime/common/src/account_conversion.rs
+++ b/runtime/common/src/account_conversion.rs
@@ -11,10 +11,9 @@
 // GNU General Public License for more details.
 
 use cfg_primitives::AccountId;
-use cfg_types::domain_address::{Domain, DomainAddress};
+use cfg_types::domain_address::DomainAddress;
 use pallet_evm::AddressMapping;
 use sp_core::{Get, H160};
-use sp_runtime::traits::Convert;
 use staging_xcm::v4::{Junction::AccountKey20, Location, NetworkId::Ethereum};
 use staging_xcm_executor::traits::ConvertLocation;
 
@@ -23,22 +22,6 @@ use staging_xcm_executor::traits::ConvertLocation;
 pub struct AccountConverter;
 
 impl AccountConverter {
-	/// Converts an EVM address from a given chain into a local AccountId
-	pub fn convert_evm_address(chain_id: u64, address: [u8; 20]) -> AccountId {
-		// We use a custom encoding here rather than relying on
-		// `AccountIdConversion` for a couple of reasons:
-		// 1. We have very few bytes to spare, so choosing our own fields is nice
-		// 2. AccountIdConversion puts the tag first, which can unbalance the storage
-		//    trees if users create many H160-derived accounts. We put the tag last
-		//    here.
-		let tag = b"EVM";
-		let mut bytes = [0; 32];
-		bytes[0..20].copy_from_slice(&address);
-		bytes[20..28].copy_from_slice(&chain_id.to_be_bytes());
-		bytes[28..31].copy_from_slice(tag);
-		AccountId::new(bytes)
-	}
-
 	pub fn location_to_account<XcmConverter: ConvertLocation<AccountId>>(
 		location: Location,
 	) -> Option<AccountId> {
@@ -54,7 +37,7 @@ impl AccountConverter {
 							network: Some(Ethereum { chain_id }),
 							key,
 						}],
-					) => Some(Self::convert_evm_address(*chain_id, *key)),
+					) => Some(DomainAddress::from_evm(*chain_id, *key).as_local()),
 					_ => None,
 				}
 			}
@@ -63,34 +46,7 @@ impl AccountConverter {
 
 	pub fn evm_address_to_account<R: pallet_evm_chain_id::Config>(address: H160) -> AccountId {
 		let chain_id = pallet_evm_chain_id::Pallet::<R>::get();
-		Self::convert_evm_address(chain_id, address.0)
-	}
-
-	pub fn domain_account_to_account(domain: Domain, account_id: AccountId) -> AccountId {
-		let domain_address = Self::convert((domain, account_id.into()));
-		Self::convert(domain_address)
-	}
-}
-
-impl Convert<DomainAddress, AccountId> for AccountConverter {
-	fn convert(domain_address: DomainAddress) -> AccountId {
-		match domain_address {
-			DomainAddress::Centrifuge(addr) => AccountId::new(addr),
-			DomainAddress::EVM(chain_id, addr) => Self::convert_evm_address(chain_id, addr),
-		}
-	}
-}
-
-impl Convert<(Domain, [u8; 32]), DomainAddress> for AccountConverter {
-	fn convert((domain, account): (Domain, [u8; 32])) -> DomainAddress {
-		match domain {
-			Domain::Centrifuge => DomainAddress::Centrifuge(account),
-			Domain::EVM(chain_id) => {
-				let mut bytes20 = [0; 20];
-				bytes20.copy_from_slice(&account[..20]);
-				DomainAddress::EVM(chain_id, bytes20)
-			}
-		}
+		DomainAddress::from_evm(chain_id, address.0).as_local()
 	}
 }
 
@@ -103,37 +59,4 @@ impl<R: pallet_evm_chain_id::Config> AddressMapping<AccountId> for RuntimeAccoun
 	fn into_account_id(address: H160) -> AccountId {
 		AccountConverter::evm_address_to_account::<R>(address)
 	}
-}
-
-#[cfg(test)]
-mod tests {
-	use hex_literal::hex;
-
-	use super::*;
-
-	#[test]
-	fn domain_evm_conversion() {
-		let address = [0x42; 20];
-		let chain_id = 0xDADB0D;
-		let domain_address = DomainAddress::EVM(chain_id, address);
-		let account: AccountId = AccountConverter::convert(domain_address);
-		let expected = AccountId::new(hex![
-			"42424242424242424242424242424242424242420000000000DADB0D45564d00"
-		]);
-		assert_eq!(account, expected);
-	}
-
-	#[test]
-	fn domain_native_conversion() {
-		// Native conversion is an identity function
-		let address = [0x42; 32];
-		let expected = AccountId::new(address);
-		let domain_address = DomainAddress::Centrifuge(address);
-		let account: AccountId = AccountConverter::convert(domain_address);
-		assert_eq!(account, expected);
-	}
-
-	// Note: We don't test the EVM pallet conversion here since it
-	// requires storage to be set up etc. It shares conversion with
-	// domain EVM conversion which is tested above.
 }

--- a/runtime/common/src/routing.rs
+++ b/runtime/common/src/routing.rs
@@ -32,7 +32,7 @@ impl From<AxelarId> for RouterId {
 impl From<RouterId> for Domain {
 	fn from(router_id: RouterId) -> Self {
 		match router_id {
-			RouterId::Axelar(AxelarId::Evm(chain_id)) => Domain::EVM(chain_id),
+			RouterId::Axelar(AxelarId::Evm(chain_id)) => Domain::Evm(chain_id),
 		}
 	}
 }
@@ -40,8 +40,8 @@ impl From<RouterId> for Domain {
 impl RouterSupport<Domain> for RouterId {
 	fn for_domain(domain: Domain) -> Vec<Self> {
 		match domain {
-			Domain::EVM(chain_id) => vec![RouterId::Axelar(AxelarId::Evm(chain_id))],
-			Domain::Centrifuge => vec![],
+			Domain::Evm(chain_id) => vec![RouterId::Axelar(AxelarId::Evm(chain_id))],
+			Domain::Local => vec![],
 		}
 	}
 }

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -1842,8 +1842,6 @@ impl pallet_liquidity_pools::Config for Runtime {
 	type Balance = Balance;
 	type BalanceRatio = Ratio;
 	type CurrencyId = CurrencyId;
-	type DomainAccountToDomainAddress = AccountConverter;
-	type DomainAddressToAccountId = AccountConverter;
 	type ForeignInvestment = ForeignInvestments;
 	type GeneralCurrencyPrefix = GeneralCurrencyPrefix;
 	type MarketRatio = OrderBook;
@@ -1863,7 +1861,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 
 parameter_types! {
 	pub const MaxIncomingMessageSize: u32 = 1024;
-	pub Sender: DomainAddress = gateway::get_gateway_account::<Runtime>();
+	pub Sender: DomainAddress = gateway::get_gateway_domain_address::<Runtime>();
 }
 
 impl pallet_liquidity_pools_gateway::Config for Runtime {

--- a/runtime/integration-tests/src/cases/example.rs
+++ b/runtime/integration-tests/src/cases/example.rs
@@ -13,7 +13,7 @@ use crate::{
 	utils::{accounts::Keyring, genesis::Genesis},
 };
 
-#[test_runtimes([development, altair, centrifuge])]
+#[test_runtimes([development, altair, centrifuge], ignore = "uncomment to run the example")]
 fn transfer_balance<T: Runtime>() {
 	const TRANSFER: Balance = 1000 * CFG;
 	const FOR_FEES: Balance = 1 * CFG;
@@ -68,7 +68,7 @@ fn transfer_balance<T: Runtime>() {
 }
 
 // Identical to `transfer_balance()` test but using fudge.
-#[test_runtimes([development, altair, centrifuge])]
+#[test_runtimes([development, altair, centrifuge], ignore = "uncomment to run the example")]
 fn fudge_transfer_balance<T: Runtime + FudgeSupport>() {
 	const TRANSFER: Balance = 1000 * CFG;
 	const FOR_FEES: Balance = 1 * CFG;
@@ -127,7 +127,7 @@ fn fudge_transfer_balance<T: Runtime + FudgeSupport>() {
 	});
 }
 
-#[test_runtimes(all)]
+#[test_runtimes(all, ignore = "uncomment to run the example")]
 fn call_api<T: Runtime>() {
 	let env = RuntimeEnv::<T>::default();
 
@@ -141,7 +141,7 @@ fn call_api<T: Runtime>() {
 	})
 }
 
-#[test_runtimes(all)]
+#[test_runtimes(all, ignore = "uncomment to run the example")]
 fn fudge_call_api<T: Runtime + FudgeSupport>() {
 	let env = FudgeEnv::<T>::default();
 
@@ -158,7 +158,7 @@ fn fudge_call_api<T: Runtime + FudgeSupport>() {
 	})
 }
 
-#[test_runtimes(all)]
+#[test_runtimes(all, ignore = "uncomment to run the example")]
 fn pass_time_one_block<T: Runtime>() {
 	let mut env = RuntimeEnv::<T>::default();
 

--- a/runtime/integration-tests/src/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/cases/liquidity_pools.rs
@@ -28,13 +28,10 @@ use pallet_liquidity_pools::Message;
 use pallet_liquidity_pools_gateway::message::GatewayMessage;
 use pallet_liquidity_pools_gateway_queue::MessageNonceStore;
 use pallet_pool_system::tranches::{TrancheInput, TrancheLoc, TrancheType};
-use runtime_common::{
-	account_conversion::AccountConverter, foreign_investments::IdentityPoolCurrencyConverter,
-	xcm::general_key,
-};
+use runtime_common::{foreign_investments::IdentityPoolCurrencyConverter, xcm::general_key};
 use sp_core::Get;
 use sp_runtime::{
-	traits::{AccountIdConversion, Convert, EnsureAdd, One, Zero},
+	traits::{AccountIdConversion, EnsureAdd, One, Zero},
 	BoundedVec, DispatchError, FixedPointNumber, Perquintill, SaturatedConversion,
 };
 use staging_xcm::{
@@ -72,11 +69,11 @@ pub const POOL_ID: PoolId = 42;
 pub const MOONBEAM_EVM_CHAIN_ID: u64 = 1284;
 pub const DEFAULT_EVM_ADDRESS_MOONBEAM: [u8; 20] = [99; 20];
 pub const DEFAULT_VALIDITY: Seconds = 2555583502;
-pub const DOMAIN_MOONBEAM: Domain = Domain::EVM(MOONBEAM_EVM_CHAIN_ID);
+pub const DOMAIN_MOONBEAM: Domain = Domain::Evm(MOONBEAM_EVM_CHAIN_ID);
 pub const DEFAULT_DOMAIN_ADDRESS_MOONBEAM: DomainAddress =
-	DomainAddress::EVM(MOONBEAM_EVM_CHAIN_ID, DEFAULT_EVM_ADDRESS_MOONBEAM);
+	DomainAddress::Evm(MOONBEAM_EVM_CHAIN_ID, DEFAULT_EVM_ADDRESS_MOONBEAM);
 pub const DEFAULT_OTHER_DOMAIN_ADDRESS: DomainAddress =
-	DomainAddress::EVM(MOONBEAM_EVM_CHAIN_ID, [0; 20]);
+	DomainAddress::Evm(MOONBEAM_EVM_CHAIN_ID, [0; 20]);
 
 pub type LiquidityPoolMessage = Message;
 
@@ -280,10 +277,7 @@ pub mod utils {
 
 			assert_ok!(orml_tokens::Pallet::<T>::set_balance(
 				<T as frame_system::Config>::RuntimeOrigin::root(),
-				AccountId::from(
-					<T as pallet_liquidity_pools_gateway::Config>::Sender::get().address()
-				)
-				.into(),
+				T::Sender::get().as_local::<AccountId>().into(),
 				GLMR_CURRENCY_ID,
 				DEFAULT_BALANCE_GLMR,
 				0,
@@ -509,7 +503,7 @@ pub mod utils {
 		assert_eq!(
 			orml_tokens::Pallet::<T>::balance(
 				default_investment_id::<T>().into(),
-				&AccountConverter::convert(DEFAULT_OTHER_DOMAIN_ADDRESS)
+				&DEFAULT_OTHER_DOMAIN_ADDRESS.as_local(),
 			),
 			0
 		);
@@ -683,8 +677,8 @@ mod foreign_investments {
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
 				let amount = 10 * decimals(12);
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let currency_id = AUSD_CURRENCY_ID;
 				let currency_decimals = currency_decimals::AUSD;
 
@@ -731,8 +725,8 @@ mod foreign_investments {
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
 				let invest_amount: u128 = 10 * decimals(12);
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let currency_id: CurrencyId = AUSD_CURRENCY_ID;
 				let currency_decimals = currency_decimals::AUSD;
 
@@ -821,8 +815,8 @@ mod foreign_investments {
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
 				let invest_amount = 10 * decimals(12);
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let currency_id = AUSD_CURRENCY_ID;
 				let currency_decimals = currency_decimals::AUSD;
 
@@ -921,8 +915,8 @@ mod foreign_investments {
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
 				let amount = 10 * decimals(12);
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let currency_id = AUSD_CURRENCY_ID;
 				let currency_decimals = currency_decimals::AUSD;
 				let sending_domain_locator =
@@ -1029,7 +1023,7 @@ mod foreign_investments {
 
 				let nonce = MessageNonceStore::<T>::get();
 
-				let sender = <T as pallet_liquidity_pools_gateway::Config>::Sender::get();
+				let sender = T::Sender::get();
 
 				// Clearing of foreign InvestState should be dispatched
 				assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
@@ -1067,8 +1061,8 @@ mod foreign_investments {
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
 				let invest_amount = 10 * decimals(12);
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let currency_id = AUSD_CURRENCY_ID;
 				let currency_decimals = currency_decimals::AUSD;
 				let sending_domain_locator =
@@ -1304,8 +1298,8 @@ mod foreign_investments {
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
 				let amount = 10 * decimals(12);
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let currency_id = AUSD_CURRENCY_ID;
 				let currency_decimals = currency_decimals::AUSD;
 
@@ -1357,8 +1351,8 @@ mod foreign_investments {
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
 				let redeem_amount = 10 * decimals(12);
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let currency_id = AUSD_CURRENCY_ID;
 				let currency_decimals = currency_decimals::AUSD;
 				let sending_domain_locator =
@@ -1452,8 +1446,8 @@ mod foreign_investments {
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
 				let redeem_amount = 10 * decimals(12);
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let currency_id = AUSD_CURRENCY_ID;
 				let currency_decimals = currency_decimals::AUSD;
 				let pool_account = pallet_pool_system::pool_types::PoolLocator { pool_id }
@@ -1645,10 +1639,8 @@ mod foreign_investments {
 					env.parachain_state_mut(|| {
 						let pool_id = POOL_ID;
 						let amount: u128 = 10 * decimals(12);
-						let investor = AccountConverter::domain_account_to_account(
-							DOMAIN_MOONBEAM,
-							Keyring::Bob.id(),
-						);
+						let investor: AccountId =
+							DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 						let currency_id: CurrencyId = AUSD_CURRENCY_ID;
 						let currency_decimals = currency_decimals::AUSD;
 						create_currency_pool::<T>(pool_id, currency_id, currency_decimals.into());
@@ -1725,10 +1717,8 @@ mod foreign_investments {
 					env.parachain_state_mut(|| {
 						let pool_id = POOL_ID;
 						let amount: u128 = 10 * decimals(12);
-						let investor = AccountConverter::domain_account_to_account(
-							DOMAIN_MOONBEAM,
-							Keyring::Bob.id(),
-						);
+						let investor: AccountId =
+							DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 						let currency_id: CurrencyId = AUSD_CURRENCY_ID;
 						let currency_decimals = currency_decimals::AUSD;
 						create_currency_pool::<T>(pool_id, currency_id, currency_decimals.into());
@@ -1815,10 +1805,8 @@ mod foreign_investments {
 
 					env.parachain_state_mut(|| {
 						let pool_id = POOL_ID;
-						let investor = AccountConverter::domain_account_to_account(
-							DOMAIN_MOONBEAM,
-							Keyring::Bob.id(),
-						);
+						let investor: AccountId =
+							DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 						let pool_currency = AUSD_CURRENCY_ID;
 						let currency_decimals = currency_decimals::AUSD;
 						let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
@@ -1877,8 +1865,8 @@ mod foreign_investments {
 
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 				let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 				let pool_currency_decimals = currency_decimals::AUSD;
@@ -1999,8 +1987,8 @@ mod foreign_investments {
 
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let trader: AccountId = Keyring::Alice.into();
 				let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 				let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
@@ -2147,8 +2135,8 @@ mod foreign_investments {
 
 			env.parachain_state_mut(|| {
 				let pool_id = POOL_ID;
-				let investor =
-					AccountConverter::domain_account_to_account(DOMAIN_MOONBEAM, Keyring::Bob.id());
+				let investor: AccountId =
+					DomainAddress::new(DOMAIN_MOONBEAM, Keyring::Bob.into()).as_local();
 				let pool_currency: CurrencyId = AUSD_CURRENCY_ID;
 				let foreign_currency: CurrencyId = USDT_CURRENCY_ID;
 				let pool_currency_decimals = currency_decimals::AUSD;

--- a/runtime/integration-tests/src/cases/liquidity_pools_gateway_queue.rs
+++ b/runtime/integration-tests/src/cases/liquidity_pools_gateway_queue.rs
@@ -25,7 +25,7 @@ fn inbound<T: Runtime + FudgeSupport>() {
 	let expected_event = env.parachain_state_mut(|| {
 		let nonce = <T as pallet_liquidity_pools_gateway_queue::Config>::MessageNonce::one();
 		let message = GatewayMessage::Inbound {
-			domain_address: DomainAddress::EVM(1, [2; 20]),
+			domain_address: DomainAddress::Evm(1, [2; 20]),
 			message: Message::Invalid,
 		};
 
@@ -55,8 +55,8 @@ fn outbound<T: Runtime + FudgeSupport>() {
 	let expected_event = env.parachain_state_mut(|| {
 		let nonce = <T as pallet_liquidity_pools_gateway_queue::Config>::MessageNonce::one();
 		let message = GatewayMessage::Outbound {
-			sender: DomainAddress::Centrifuge([1; 32]),
-			destination: Domain::EVM(1),
+			sender: DomainAddress::Local([1; 32]),
+			destination: Domain::Evm(1),
 			message: Message::Invalid,
 		};
 

--- a/runtime/integration-tests/src/cases/lp/investments.rs
+++ b/runtime/integration-tests/src/cases/lp/investments.rs
@@ -78,8 +78,8 @@ mod utils {
 			"requestDeposit",
 			Some(&[
 				Token::Uint(DEFAULT_INVESTMENT_AMOUNT.into()),
-				Token::Address(who.id_eth()),
-				Token::Address(who.id_eth()),
+				Token::Address(who.in_eth()),
+				Token::Address(who.in_eth()),
 			]),
 		)
 		.unwrap();
@@ -91,7 +91,7 @@ mod utils {
 			Default::default(),
 			lp_pool,
 			"cancelDepositRequest",
-			Some(&[Token::Uint(U256::from(0)), Token::Address(who.id_eth())]),
+			Some(&[Token::Uint(U256::from(0)), Token::Address(who.in_eth())]),
 		)
 		.unwrap();
 	}
@@ -183,7 +183,7 @@ mod with_pool_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -228,10 +228,10 @@ mod with_pool_currency {
 						Keyring::TrancheInvestor(1),
 						names::POOL_C_T_1_USDC,
 						"maxDeposit",
-						Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+						Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 					))),
-					Token::Address(Keyring::TrancheInvestor(1).id_eth()),
-					Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+					Token::Address(Keyring::TrancheInvestor(1).in_eth()),
+					Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 				]),
 			)
 			.unwrap();
@@ -241,7 +241,7 @@ mod with_pool_currency {
 					Keyring::TrancheInvestor(1),
 					names::POOL_C_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 				)),
 				// Same amount as price is 1.
 				DEFAULT_INVESTMENT_AMOUNT
@@ -252,7 +252,7 @@ mod with_pool_currency {
 					Keyring::TrancheInvestor(1),
 					names::POOL_C_T_1_USDC,
 					"maxDeposit",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 				)),
 				0
 			);
@@ -287,7 +287,7 @@ mod with_pool_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -318,7 +318,7 @@ mod with_pool_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				0
@@ -370,7 +370,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -401,7 +401,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				0
@@ -450,7 +450,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -503,7 +503,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				0
@@ -549,7 +549,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -578,7 +578,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -615,7 +615,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				0
@@ -665,7 +665,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -712,7 +712,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				remaining_amount
@@ -737,7 +737,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				remaining_amount
@@ -778,7 +778,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+						Token::Address(Keyring::TrancheInvestor(1).in_eth()),
 					]),
 				)),
 				0

--- a/runtime/integration-tests/src/cases/lp/investments.rs
+++ b/runtime/integration-tests/src/cases/lp/investments.rs
@@ -78,8 +78,8 @@ mod utils {
 			"requestDeposit",
 			Some(&[
 				Token::Uint(DEFAULT_INVESTMENT_AMOUNT.into()),
-				Token::Address(who.into()),
-				Token::Address(who.into()),
+				Token::Address(who.id_eth()),
+				Token::Address(who.id_eth()),
 			]),
 		)
 		.unwrap();
@@ -91,7 +91,7 @@ mod utils {
 			Default::default(),
 			lp_pool,
 			"cancelDepositRequest",
-			Some(&[Token::Uint(U256::from(0)), Token::Address(who.into())]),
+			Some(&[Token::Uint(U256::from(0)), Token::Address(who.id_eth())]),
 		)
 		.unwrap();
 	}
@@ -183,7 +183,7 @@ mod with_pool_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -228,10 +228,10 @@ mod with_pool_currency {
 						Keyring::TrancheInvestor(1),
 						names::POOL_C_T_1_USDC,
 						"maxDeposit",
-						Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+						Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 					))),
-					Token::Address(Keyring::TrancheInvestor(1).into()),
-					Token::Address(Keyring::TrancheInvestor(1).into()),
+					Token::Address(Keyring::TrancheInvestor(1).id_eth()),
+					Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 				]),
 			)
 			.unwrap();
@@ -241,7 +241,7 @@ mod with_pool_currency {
 					Keyring::TrancheInvestor(1),
 					names::POOL_C_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 				)),
 				// Same amount as price is 1.
 				DEFAULT_INVESTMENT_AMOUNT
@@ -252,7 +252,7 @@ mod with_pool_currency {
 					Keyring::TrancheInvestor(1),
 					names::POOL_C_T_1_USDC,
 					"maxDeposit",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 				)),
 				0
 			);
@@ -287,7 +287,7 @@ mod with_pool_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -318,7 +318,7 @@ mod with_pool_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				0
@@ -370,7 +370,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -401,7 +401,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				0
@@ -450,7 +450,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -503,7 +503,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				0
@@ -549,7 +549,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -578,7 +578,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -615,7 +615,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				0
@@ -665,7 +665,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				DEFAULT_INVESTMENT_AMOUNT
@@ -712,7 +712,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				remaining_amount
@@ -737,7 +737,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				remaining_amount
@@ -778,7 +778,7 @@ mod with_foreign_currency {
 					"pendingDepositRequest",
 					Some(&[
 						Token::Uint(Uint::zero()),
-						Token::Address(Keyring::TrancheInvestor(1).into()),
+						Token::Address(Keyring::TrancheInvestor(1).id_eth()),
 					]),
 				)),
 				0

--- a/runtime/integration-tests/src/cases/lp/mod.rs
+++ b/runtime/integration-tests/src/cases/lp/mod.rs
@@ -26,7 +26,6 @@ use frame_system::pallet_prelude::OriginFor;
 use hex_literal::hex;
 use pallet_axelar_router::{AxelarConfig, DomainConfig, EvmConfig, FeeValues};
 use pallet_evm::FeeCalculator;
-use runtime_common::account_conversion::AccountConverter;
 pub use setup_lp::*;
 use sp_core::Get;
 use sp_runtime::traits::{BlakeTwo256, Hash};
@@ -86,7 +85,7 @@ pub const EVM_DOMAIN_STR: &str = "TestDomain";
 /// The test domain ChainId for the tests.
 pub const EVM_DOMAIN_CHAIN_ID: u64 = 1;
 
-pub const EVM_DOMAIN: Domain = Domain::EVM(EVM_DOMAIN_CHAIN_ID);
+pub const EVM_DOMAIN: Domain = Domain::Evm(EVM_DOMAIN_CHAIN_ID);
 
 /// Represents Solidity enum Domain.Centrifuge
 pub const DOMAIN_CENTRIFUGE: u8 = 0;

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -21,7 +21,6 @@ use ethabi::{ethereum_types::H160, Token, Uint};
 use frame_support::{assert_ok, traits::OriginTrait};
 use frame_system::pallet_prelude::OriginFor;
 use pallet_liquidity_pools::GeneralCurrencyIndexOf;
-use runtime_common::account_conversion::AccountConverter;
 use sp_runtime::FixedPointNumber;
 
 use crate::{
@@ -142,7 +141,7 @@ fn add_pool<T: Runtime>() {
 		assert_ok!(pallet_liquidity_pools::Pallet::<T>::add_pool(
 			OriginFor::<T>::signed(Keyring::Admin.into()),
 			POOL,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -163,7 +162,7 @@ fn add_pool<T: Runtime>() {
 		assert_ok!(pallet_liquidity_pools::Pallet::<T>::add_pool(
 			T::RuntimeOriginExt::signed(Keyring::Admin.into()),
 			POOL,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		utils::process_gateway_message::<T>(|_| {
@@ -213,7 +212,7 @@ fn add_tranche<T: Runtime>() {
 			OriginFor::<T>::signed(Keyring::Admin.into()),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -403,7 +402,7 @@ fn update_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		crate::utils::pool::give_role::<T>(
-			AccountConverter::convert_evm_address(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()).as_local(),
 			POOL_A,
 			PoolRole::TrancheInvestor(pool_a_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -412,7 +411,7 @@ fn update_member<T: Runtime>() {
 			Keyring::Bob.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.into()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -517,7 +516,7 @@ fn update_tranche_token_metadata<T: Runtime>() {
 				OriginFor::<T>::signed(Keyring::Alice.into()),
 				POOL_A,
 				pool_a_tranche_1_id::<T>(),
-				Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+				Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 			)
 		);
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -573,7 +572,7 @@ fn update_tranche_token_price<T: Runtime>() {
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
 			USDC.id(),
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
 
@@ -630,10 +629,7 @@ fn freeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		give_role::<T>(
-			AccountConverter::convert_evm_address(
-				EVM_DOMAIN_CHAIN_ID,
-				Keyring::TrancheInvestor(2).into(),
-			),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()).as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
 		);
@@ -641,7 +637,7 @@ fn freeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -677,10 +673,7 @@ fn unfreeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		give_role::<T>(
-			AccountConverter::convert_evm_address(
-				EVM_DOMAIN_CHAIN_ID,
-				Keyring::TrancheInvestor(2).into(),
-			),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()).as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
 		);
@@ -688,7 +681,7 @@ fn unfreeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -711,10 +704,7 @@ fn unfreeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		remove_role::<T>(
-			AccountConverter::convert_evm_address(
-				EVM_DOMAIN_CHAIN_ID,
-				Keyring::TrancheInvestor(2).into(),
-			),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()).as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
 		);
@@ -722,7 +712,7 @@ fn unfreeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -402,8 +402,7 @@ fn update_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).in_eth())
-				.as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.in_eth()).as_local(),
 			POOL_A,
 			PoolRole::TrancheInvestor(pool_a_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -390,7 +390,7 @@ fn update_member<T: Runtime>() {
 					"isMember",
 					Some(&[
 						Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-						Token::Address(Keyring::Bob.into())
+						Token::Address(Keyring::Bob.id_eth())
 					]),
 				)
 				.unwrap()
@@ -402,7 +402,8 @@ fn update_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth())
+				.as_local(),
 			POOL_A,
 			PoolRole::TrancheInvestor(pool_a_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -411,7 +412,7 @@ fn update_member<T: Runtime>() {
 			Keyring::Bob.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.id_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -427,7 +428,7 @@ fn update_member<T: Runtime>() {
 					"isMember",
 					Some(&[
 						Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-						Token::Address(Keyring::Bob.into())
+						Token::Address(Keyring::Bob.id_eth())
 					]),
 				)
 				.unwrap()
@@ -444,7 +445,7 @@ fn update_member<T: Runtime>() {
 					"isMember",
 					Some(&[
 						Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-						Token::Address(Keyring::Alice.into())
+						Token::Address(Keyring::Alice.id_eth())
 					]),
 				)
 				.unwrap()
@@ -619,7 +620,7 @@ fn freeze_member<T: Runtime>() {
 				"isFrozen",
 				Some(&[
 					Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-					Token::Address(Keyring::TrancheInvestor(2).into())
+					Token::Address(Keyring::TrancheInvestor(2).id_eth())
 				]),
 			)
 			.unwrap()
@@ -629,7 +630,8 @@ fn freeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		give_role::<T>(
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth())
+				.as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
 		);
@@ -637,7 +639,7 @@ fn freeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -651,7 +653,7 @@ fn freeze_member<T: Runtime>() {
 				"isFrozen",
 				Some(&[
 					Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-					Token::Address(Keyring::TrancheInvestor(2).into())
+					Token::Address(Keyring::TrancheInvestor(2).id_eth())
 				]),
 			)
 			.unwrap()
@@ -673,7 +675,8 @@ fn unfreeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		give_role::<T>(
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth())
+				.as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
 		);
@@ -681,7 +684,7 @@ fn unfreeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -694,7 +697,7 @@ fn unfreeze_member<T: Runtime>() {
 				"isFrozen",
 				Some(&[
 					Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-					Token::Address(Keyring::TrancheInvestor(2).into())
+					Token::Address(Keyring::TrancheInvestor(2).id_eth())
 				]),
 			)
 			.unwrap()
@@ -704,7 +707,8 @@ fn unfreeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		remove_role::<T>(
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth())
+				.as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
 		);
@@ -712,7 +716,7 @@ fn unfreeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -725,7 +729,7 @@ fn unfreeze_member<T: Runtime>() {
 				"isFrozen",
 				Some(&[
 					Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-					Token::Address(Keyring::TrancheInvestor(2).into())
+					Token::Address(Keyring::TrancheInvestor(2).id_eth())
 				]),
 			)
 			.unwrap()

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -390,7 +390,7 @@ fn update_member<T: Runtime>() {
 					"isMember",
 					Some(&[
 						Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-						Token::Address(Keyring::Bob.id_eth())
+						Token::Address(Keyring::Bob.in_eth())
 					]),
 				)
 				.unwrap()
@@ -402,7 +402,7 @@ fn update_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth())
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).in_eth())
 				.as_local(),
 			POOL_A,
 			PoolRole::TrancheInvestor(pool_a_tranche_1_id::<T>(), SECONDS_PER_YEAR),
@@ -412,7 +412,7 @@ fn update_member<T: Runtime>() {
 			Keyring::Bob.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::Bob.in_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -428,7 +428,7 @@ fn update_member<T: Runtime>() {
 					"isMember",
 					Some(&[
 						Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-						Token::Address(Keyring::Bob.id_eth())
+						Token::Address(Keyring::Bob.in_eth())
 					]),
 				)
 				.unwrap()
@@ -445,7 +445,7 @@ fn update_member<T: Runtime>() {
 					"isMember",
 					Some(&[
 						Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-						Token::Address(Keyring::Alice.id_eth())
+						Token::Address(Keyring::Alice.in_eth())
 					]),
 				)
 				.unwrap()
@@ -620,7 +620,7 @@ fn freeze_member<T: Runtime>() {
 				"isFrozen",
 				Some(&[
 					Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-					Token::Address(Keyring::TrancheInvestor(2).id_eth())
+					Token::Address(Keyring::TrancheInvestor(2).in_eth())
 				]),
 			)
 			.unwrap()
@@ -630,7 +630,7 @@ fn freeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		give_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth())
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).in_eth())
 				.as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
@@ -639,7 +639,7 @@ fn freeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).in_eth()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -653,7 +653,7 @@ fn freeze_member<T: Runtime>() {
 				"isFrozen",
 				Some(&[
 					Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-					Token::Address(Keyring::TrancheInvestor(2).id_eth())
+					Token::Address(Keyring::TrancheInvestor(2).in_eth())
 				]),
 			)
 			.unwrap()
@@ -675,7 +675,7 @@ fn unfreeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		give_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth())
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).in_eth())
 				.as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
@@ -684,7 +684,7 @@ fn unfreeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).in_eth()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -697,7 +697,7 @@ fn unfreeze_member<T: Runtime>() {
 				"isFrozen",
 				Some(&[
 					Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-					Token::Address(Keyring::TrancheInvestor(2).id_eth())
+					Token::Address(Keyring::TrancheInvestor(2).in_eth())
 				]),
 			)
 			.unwrap()
@@ -707,7 +707,7 @@ fn unfreeze_member<T: Runtime>() {
 
 	env.state_mut(|_| {
 		remove_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth())
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).in_eth())
 				.as_local(),
 			POOL_A,
 			PoolRole::FrozenTrancheInvestor(pool_a_tranche_1_id::<T>()),
@@ -716,7 +716,7 @@ fn unfreeze_member<T: Runtime>() {
 			Keyring::Admin.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(2).in_eth()),
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -729,7 +729,7 @@ fn unfreeze_member<T: Runtime>() {
 				"isFrozen",
 				Some(&[
 					Token::Address(evm.deployed(names::POOL_A_T_1).address()),
-					Token::Address(Keyring::TrancheInvestor(2).id_eth())
+					Token::Address(Keyring::TrancheInvestor(2).in_eth())
 				]),
 			)
 			.unwrap()

--- a/runtime/integration-tests/src/cases/lp/pool_management.rs
+++ b/runtime/integration-tests/src/cases/lp/pool_management.rs
@@ -831,7 +831,7 @@ fn recover_assets<T: Runtime>() {
 				Keyring::Alice,
 				names::USDC,
 				"balanceOf",
-				Some(&[Token::Address(investor.into())]),
+				Some(&[Token::Address(investor.in_eth())]),
 			)),
 			0
 		);
@@ -842,7 +842,7 @@ fn recover_assets<T: Runtime>() {
 	env.state_mut(|_| {
 		assert_ok!(pallet_liquidity_pools::Pallet::<T>::recover_assets(
 			<T as frame_system::Config>::RuntimeOrigin::root(),
-			DomainAddress::EVM(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()),
 			utils::to_fixed_array(wrong_contract.as_bytes()),
 			utils::to_fixed_array(token.as_bytes()),
 			sp_core::U256::from(amount),
@@ -866,7 +866,7 @@ fn recover_assets<T: Runtime>() {
 				Keyring::Alice,
 				names::USDC,
 				"balanceOf",
-				Some(&[Token::Address(investor.into())]),
+				Some(&[Token::Address(investor.in_eth())]),
 			)),
 			amount
 		);

--- a/runtime/integration-tests/src/cases/lp/setup_evm.rs
+++ b/runtime/integration-tests/src/cases/lp/setup_evm.rs
@@ -350,7 +350,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ADAPTER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap(); */
 	evm.call(
@@ -358,7 +358,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::LP_FACTORY,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -366,7 +366,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::TRANCHE_FACTORY,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -374,7 +374,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::RESTRICTION_MANAGER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -382,7 +382,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::TRANSFER_PROXY_FACTORY,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -390,7 +390,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ROOT,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -398,7 +398,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::INVESTMENT_MANAGER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -406,7 +406,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::POOL_MANAGER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -414,7 +414,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ESCROW,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -422,7 +422,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ROUTER_ESCROW,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -430,7 +430,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::GATEWAY,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -438,7 +438,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ROUTER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -446,7 +446,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::GAS_SERVICE,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	)
 	.unwrap();
 }
@@ -497,13 +497,13 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		contracts::ESCROW,
 		names::ESCROW,
 		Keyring::Alice,
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	);
 	evm.deploy(
 		contracts::ESCROW,
 		names::ROUTER_ESCROW,
 		Keyring::Alice,
-		Some(&[Token::Address(Keyring::Alice.into())]),
+		Some(&[Token::Address(Keyring::Alice.id_eth())]),
 	);
 	evm.deploy(
 		contracts::ROOT,
@@ -512,7 +512,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Some(&[
 			Token::Address(evm.deployed(names::ESCROW).address()),
 			Token::Uint(U256::from(48 * SECONDS_PER_HOUR)),
-			Token::Address(Keyring::Alice.into()),
+			Token::Address(Keyring::Alice.id_eth()),
 		]),
 	);
 	evm.deploy(
@@ -527,7 +527,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Keyring::Alice,
 		Some(&[
 			Token::Address(evm.deployed(names::ROOT).address()),
-			Token::Address(Keyring::Alice.into()),
+			Token::Address(Keyring::Alice.id_eth()),
 		]),
 	);
 	evm.deploy(
@@ -536,7 +536,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Keyring::Alice,
 		Some(&[
 			Token::Address(evm.deployed(names::ROOT).address()),
-			Token::Address(Keyring::Alice.into()),
+			Token::Address(Keyring::Alice.id_eth()),
 		]),
 	);
 	evm.deploy(
@@ -564,7 +564,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Keyring::Alice,
 		Some(&[
 			Token::Address(evm.deployed(names::ROOT).address()),
-			Token::Address(Keyring::Alice.into()),
+			Token::Address(Keyring::Alice.id_eth()),
 		]),
 	);
 	evm.deploy(
@@ -605,7 +605,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Keyring::Alice,
 		Some(&[
 			// Based on https://github.com/centrifuge/liquidity-pools/blob/da4e46577712c762d069670077280112ea1c8ce8/test/integration/LocalAdapter.s.sol#L12-L14
-			Token::Address(H160::from(Keyring::Admin)),
+			Token::Address(Keyring::Admin.id_eth()),
 			Token::Address(evm.deployed(names::ROOT).address()),
 			Token::Address(evm.deployed(names::GATEWAY).address()),
 		]),

--- a/runtime/integration-tests/src/cases/lp/setup_evm.rs
+++ b/runtime/integration-tests/src/cases/lp/setup_evm.rs
@@ -350,7 +350,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ADAPTER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap(); */
 	evm.call(
@@ -358,7 +358,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::LP_FACTORY,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -366,7 +366,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::TRANCHE_FACTORY,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -374,7 +374,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::RESTRICTION_MANAGER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -382,7 +382,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::TRANSFER_PROXY_FACTORY,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -390,7 +390,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ROOT,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -398,7 +398,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::INVESTMENT_MANAGER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -406,7 +406,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::POOL_MANAGER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -414,7 +414,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ESCROW,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -422,7 +422,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ROUTER_ESCROW,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -430,7 +430,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::GATEWAY,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -438,7 +438,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::ROUTER,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 	evm.call(
@@ -446,7 +446,7 @@ pub fn remove_deployer_access<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExte
 		Default::default(),
 		names::GAS_SERVICE,
 		"deny",
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	)
 	.unwrap();
 }
@@ -497,13 +497,13 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		contracts::ESCROW,
 		names::ESCROW,
 		Keyring::Alice,
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	);
 	evm.deploy(
 		contracts::ESCROW,
 		names::ROUTER_ESCROW,
 		Keyring::Alice,
-		Some(&[Token::Address(Keyring::Alice.id_eth())]),
+		Some(&[Token::Address(Keyring::Alice.in_eth())]),
 	);
 	evm.deploy(
 		contracts::ROOT,
@@ -512,7 +512,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Some(&[
 			Token::Address(evm.deployed(names::ESCROW).address()),
 			Token::Uint(U256::from(48 * SECONDS_PER_HOUR)),
-			Token::Address(Keyring::Alice.id_eth()),
+			Token::Address(Keyring::Alice.in_eth()),
 		]),
 	);
 	evm.deploy(
@@ -527,7 +527,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Keyring::Alice,
 		Some(&[
 			Token::Address(evm.deployed(names::ROOT).address()),
-			Token::Address(Keyring::Alice.id_eth()),
+			Token::Address(Keyring::Alice.in_eth()),
 		]),
 	);
 	evm.deploy(
@@ -536,7 +536,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Keyring::Alice,
 		Some(&[
 			Token::Address(evm.deployed(names::ROOT).address()),
-			Token::Address(Keyring::Alice.id_eth()),
+			Token::Address(Keyring::Alice.in_eth()),
 		]),
 	);
 	evm.deploy(
@@ -564,7 +564,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Keyring::Alice,
 		Some(&[
 			Token::Address(evm.deployed(names::ROOT).address()),
-			Token::Address(Keyring::Alice.id_eth()),
+			Token::Address(Keyring::Alice.in_eth()),
 		]),
 	);
 	evm.deploy(
@@ -605,7 +605,7 @@ pub fn deployer_script<T: Runtime>(evm: &mut <RuntimeEnv<T> as EnvEvmExtension<T
 		Keyring::Alice,
 		Some(&[
 			// Based on https://github.com/centrifuge/liquidity-pools/blob/da4e46577712c762d069670077280112ea1c8ce8/test/integration/LocalAdapter.s.sol#L12-L14
-			Token::Address(Keyring::Admin.id_eth()),
+			Token::Address(Keyring::Admin.in_eth()),
 			Token::Address(evm.deployed(names::ROOT).address()),
 			Token::Address(evm.deployed(names::GATEWAY).address()),
 		]),

--- a/runtime/integration-tests/src/cases/lp/setup_lp.rs
+++ b/runtime/integration-tests/src/cases/lp/setup_lp.rs
@@ -41,7 +41,7 @@ pub fn setup<T: Runtime, F: FnOnce(&mut <RuntimeEnv<T> as EnvEvmExtension<T>>::E
 		evm.load_contracts();
 
 		// Fund gateway sender
-		give_balance::<T>(T::Sender::get().address().into(), DEFAULT_BALANCE * CFG);
+		give_balance::<T>(T::Sender::get().as_local(), DEFAULT_BALANCE * CFG);
 
 		// Register general local pool-currency
 		register_currency::<T>(LocalUSDC, |_| {});
@@ -88,13 +88,13 @@ pub fn setup<T: Runtime, F: FnOnce(&mut <RuntimeEnv<T> as EnvEvmExtension<T>>::E
 
 		assert_ok!(pallet_liquidity_pools_gateway::Pallet::<T>::add_instance(
 			RawOrigin::Root.into(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, EVM_LP_INSTANCE)
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, EVM_LP_INSTANCE)
 		));
 
 		assert_ok!(
 			pallet_liquidity_pools_gateway::Pallet::<T>::set_domain_hook_address(
 				RawOrigin::Root.into(),
-				Domain::EVM(EVM_DOMAIN_CHAIN_ID),
+				Domain::Evm(EVM_DOMAIN_CHAIN_ID),
 				LOCAL_RESTRICTION_MANAGER_ADDRESS.into(),
 			)
 		);
@@ -228,7 +228,7 @@ pub fn setup_tranches<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			OriginFor::<T>::signed(Keyring::Admin.into()),
 			POOL_A,
 			tranche_id,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -271,7 +271,7 @@ pub fn setup_tranches<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			OriginFor::<T>::signed(Keyring::Admin.into()),
 			POOL_B,
 			tranche_id,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -314,7 +314,7 @@ pub fn setup_tranches<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			OriginFor::<T>::signed(Keyring::Admin.into()),
 			POOL_B,
 			utils::pool_b_tranche_2_id::<T>(),
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -357,7 +357,7 @@ pub fn setup_tranches<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			OriginFor::<T>::signed(Keyring::Admin.into()),
 			POOL_C,
 			tranche_id,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -403,7 +403,7 @@ pub fn setup_pools<T: Runtime>(_evm: &mut impl EvmEnv<T>) {
 	assert_ok!(pallet_liquidity_pools::Pallet::<T>::add_pool(
 		OriginFor::<T>::signed(Keyring::Admin.into()),
 		POOL_A,
-		Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+		Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 	));
 
 	utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -413,7 +413,7 @@ pub fn setup_pools<T: Runtime>(_evm: &mut impl EvmEnv<T>) {
 	assert_ok!(pallet_liquidity_pools::Pallet::<T>::add_pool(
 		OriginFor::<T>::signed(Keyring::Admin.into()),
 		POOL_B,
-		Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+		Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 	));
 
 	crate::utils::pool::create_one_tranched::<T>(Keyring::Admin.into(), POOL_C, USDC.id());
@@ -421,7 +421,7 @@ pub fn setup_pools<T: Runtime>(_evm: &mut impl EvmEnv<T>) {
 	assert_ok!(pallet_liquidity_pools::Pallet::<T>::add_pool(
 		OriginFor::<T>::signed(Keyring::Admin.into()),
 		POOL_C,
-		Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+		Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 	));
 
 	utils::process_gateway_message::<T>(utils::verify_gateway_message_success::<T>);
@@ -667,7 +667,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		);
 		// Centrifuge Chain setup: Add permissions and dispatch LP message
 		crate::utils::pool::give_role::<T>(
-			AccountConverter::convert_evm_address(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()).as_local(),
 			POOL_A,
 			PoolRole::TrancheInvestor(pool_a_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -675,7 +675,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -687,7 +687,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(pool_b_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			AccountConverter::convert_evm_address(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()).as_local(),
 			POOL_B,
 			PoolRole::TrancheInvestor(pool_b_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -695,7 +695,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_B,
 			pool_b_tranche_1_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -707,7 +707,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(pool_b_tranche_2_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			AccountConverter::convert_evm_address(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()).as_local(),
 			POOL_B,
 			PoolRole::TrancheInvestor(pool_b_tranche_2_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -715,7 +715,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_B,
 			pool_b_tranche_2_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -727,7 +727,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(utils::pool_c_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			AccountConverter::convert_evm_address(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()).as_local(),
 			POOL_C,
 			PoolRole::TrancheInvestor(utils::pool_c_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -735,7 +735,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_C,
 			utils::pool_c_tranche_1_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -930,7 +930,7 @@ pub fn setup_market_ratios<T: Runtime>() {
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
 			currency_id,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		crate::cases::liquidity_pools::utils::enable_symmetric_trading_pair::<T>(
@@ -945,7 +945,7 @@ pub fn setup_market_ratios<T: Runtime>() {
 			POOL_B,
 			pool_b_tranche_1_id::<T>(),
 			currency_id,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 		crate::cases::liquidity_pools::utils::enable_symmetric_trading_pair::<T>(
 			pallet_foreign_investments::pool_currency_of::<T>((POOL_B, pool_b_tranche_2_id::<T>()))
@@ -959,7 +959,7 @@ pub fn setup_market_ratios<T: Runtime>() {
 			POOL_B,
 			pool_b_tranche_2_id::<T>(),
 			currency_id,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 
 		crate::cases::liquidity_pools::utils::enable_symmetric_trading_pair::<T>(
@@ -974,7 +974,7 @@ pub fn setup_market_ratios<T: Runtime>() {
 			POOL_C,
 			pool_c_tranche_1_id::<T>(),
 			currency_id,
-			Domain::EVM(EVM_DOMAIN_CHAIN_ID)
+			Domain::Evm(EVM_DOMAIN_CHAIN_ID)
 		));
 	}
 }

--- a/runtime/integration-tests/src/cases/lp/setup_lp.rs
+++ b/runtime/integration-tests/src/cases/lp/setup_lp.rs
@@ -466,7 +466,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::USDC,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Alice.id_eth()),
+			Token::Address(Keyring::Alice.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -477,7 +477,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::USDC,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Bob.id_eth()),
+			Token::Address(Keyring::Bob.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -488,7 +488,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::USDC,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Charlie.id_eth()),
+			Token::Address(Keyring::Charlie.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -528,7 +528,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::FRAX,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Alice.id_eth()),
+			Token::Address(Keyring::Alice.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -539,7 +539,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::FRAX,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Bob.id_eth()),
+			Token::Address(Keyring::Bob.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -550,7 +550,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::FRAX,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Charlie.id_eth()),
+			Token::Address(Keyring::Charlie.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -590,7 +590,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::DAI,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Alice.id_eth()),
+			Token::Address(Keyring::Alice.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -601,7 +601,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::DAI,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Bob.id_eth()),
+			Token::Address(Keyring::Bob.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -612,7 +612,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::DAI,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Charlie.id_eth()),
+			Token::Address(Keyring::Charlie.in_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -667,7 +667,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		);
 		// Centrifuge Chain setup: Add permissions and dispatch LP message
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()).as_local(),
 			POOL_A,
 			PoolRole::TrancheInvestor(pool_a_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -675,7 +675,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -687,7 +687,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(pool_b_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()).as_local(),
 			POOL_B,
 			PoolRole::TrancheInvestor(pool_b_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -695,7 +695,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_B,
 			pool_b_tranche_1_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -707,7 +707,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(pool_b_tranche_2_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()).as_local(),
 			POOL_B,
 			PoolRole::TrancheInvestor(pool_b_tranche_2_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -715,7 +715,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_B,
 			pool_b_tranche_2_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -727,7 +727,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(utils::pool_c_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()).as_local(),
 			POOL_C,
 			PoolRole::TrancheInvestor(utils::pool_c_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -735,7 +735,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_C,
 			utils::pool_c_tranche_1_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.in_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -747,7 +747,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 				currency,
 				"mint",
 				Some(&[
-					Token::Address(investor.id_eth()),
+					Token::Address(investor.in_eth()),
 					Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 				]),
 			)
@@ -759,7 +759,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 						investor,
 						currency,
 						"balanceOf",
-						Some(&[Token::Address(investor.id_eth())])
+						Some(&[Token::Address(investor.in_eth())])
 					)
 					.unwrap()
 					.value

--- a/runtime/integration-tests/src/cases/lp/setup_lp.rs
+++ b/runtime/integration-tests/src/cases/lp/setup_lp.rs
@@ -466,7 +466,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::USDC,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Alice.into()),
+			Token::Address(Keyring::Alice.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -477,7 +477,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::USDC,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Bob.into()),
+			Token::Address(Keyring::Bob.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -488,7 +488,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::USDC,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Charlie.into()),
+			Token::Address(Keyring::Charlie.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -528,7 +528,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::FRAX,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Alice.into()),
+			Token::Address(Keyring::Alice.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -539,7 +539,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::FRAX,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Bob.into()),
+			Token::Address(Keyring::Bob.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -550,7 +550,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::FRAX,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Charlie.into()),
+			Token::Address(Keyring::Charlie.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -590,7 +590,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::DAI,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Alice.into()),
+			Token::Address(Keyring::Alice.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -601,7 +601,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::DAI,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Bob.into()),
+			Token::Address(Keyring::Bob.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -612,7 +612,7 @@ pub fn setup_currencies<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		names::DAI,
 		"mint",
 		Some(&[
-			Token::Address(Keyring::Charlie.into()),
+			Token::Address(Keyring::Charlie.id_eth()),
 			Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 		]),
 	)
@@ -667,7 +667,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 		);
 		// Centrifuge Chain setup: Add permissions and dispatch LP message
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()).as_local(),
 			POOL_A,
 			PoolRole::TrancheInvestor(pool_a_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -675,7 +675,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -687,7 +687,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(pool_b_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()).as_local(),
 			POOL_B,
 			PoolRole::TrancheInvestor(pool_b_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -695,7 +695,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_B,
 			pool_b_tranche_1_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -707,7 +707,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(pool_b_tranche_2_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()).as_local(),
 			POOL_B,
 			PoolRole::TrancheInvestor(pool_b_tranche_2_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -715,7 +715,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_B,
 			pool_b_tranche_2_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -727,7 +727,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			PoolRole::TrancheInvestor(utils::pool_c_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
 		crate::utils::pool::give_role::<T>(
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()).as_local(),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()).as_local(),
 			POOL_C,
 			PoolRole::TrancheInvestor(utils::pool_c_tranche_1_id::<T>(), SECONDS_PER_YEAR),
 		);
@@ -735,7 +735,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 			investor.as_origin(),
 			POOL_C,
 			utils::pool_c_tranche_1_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, investor.into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, investor.id_eth()),
 			SECONDS_PER_YEAR,
 		));
 
@@ -747,7 +747,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 				currency,
 				"mint",
 				Some(&[
-					Token::Address(investor.into()),
+					Token::Address(investor.id_eth()),
 					Token::Uint(U256::from(DEFAULT_BALANCE * DECIMALS_6)),
 				]),
 			)
@@ -759,7 +759,7 @@ pub fn setup_investors<T: Runtime>(evm: &mut impl EvmEnv<T>) {
 						investor,
 						currency,
 						"balanceOf",
-						Some(&[Token::Address(investor.into())])
+						Some(&[Token::Address(investor.id_eth())])
 					)
 					.unwrap()
 					.value

--- a/runtime/integration-tests/src/cases/lp/transfers.rs
+++ b/runtime/integration-tests/src/cases/lp/transfers.rs
@@ -78,7 +78,7 @@ mod utils {
 				OriginFor::<T>::signed(Keyring::TrancheInvestor(1).into()),
 				POOL_A,
 				pool_a_tranche_1_id::<T>(),
-				DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).into()),
+				DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).into()),
 				AMOUNT,
 			)
 			.unwrap();
@@ -157,7 +157,7 @@ fn transfer_tokens_from_local<T: Runtime>() {
 		pallet_liquidity_pools::Pallet::<T>::transfer(
 			OriginFor::<T>::signed(Keyring::Ferdie.into()),
 			USDC.id(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, Keyring::Ferdie.into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::Ferdie.into()),
 			AMOUNT,
 		)
 		.unwrap();
@@ -215,7 +215,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 			OriginFor::<T>::signed(Keyring::TrancheInvestor(1).into()),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).into()),
+			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).into()),
 			AMOUNT,
 		)
 		.unwrap();
@@ -292,7 +292,7 @@ fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 				Message::TransferTrancheTokens {
 					pool_id: POOL_A,
 					tranche_id: pool_a_tranche_1_id::<T>(),
-					domain: Domain::EVM(EVM_DOMAIN_CHAIN_ID).into(),
+					domain: Domain::Evm(EVM_DOMAIN_CHAIN_ID).into(),
 					receiver: as_h160_32bytes(Keyring::TrancheInvestor(2)),
 					amount: AMOUNT,
 				},

--- a/runtime/integration-tests/src/cases/lp/transfers.rs
+++ b/runtime/integration-tests/src/cases/lp/transfers.rs
@@ -46,7 +46,7 @@ mod utils {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 				)),
 				0
 			);
@@ -78,7 +78,7 @@ mod utils {
 				OriginFor::<T>::signed(Keyring::TrancheInvestor(1).into()),
 				POOL_A,
 				pool_a_tranche_1_id::<T>(),
-				DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).id_eth()),
+				DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).in_eth()),
 				AMOUNT,
 			)
 			.unwrap();
@@ -91,7 +91,7 @@ mod utils {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 				)),
 				AMOUNT
 			);
@@ -116,7 +116,7 @@ mod utils {
 				Keyring::Alice,
 				names::USDC,
 				"balanceOf",
-				Some(&[Token::Address(Keyring::Alice.id_eth())]),
+				Some(&[Token::Address(Keyring::Alice.in_eth())]),
 			));
 			assert!(
 				balance >= AMOUNT,
@@ -157,7 +157,7 @@ fn transfer_tokens_from_local<T: Runtime>() {
 		pallet_liquidity_pools::Pallet::<T>::transfer(
 			OriginFor::<T>::signed(Keyring::Ferdie.into()),
 			USDC.id(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::Ferdie.id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::Ferdie.in_eth()),
 			AMOUNT,
 		)
 		.unwrap();
@@ -170,7 +170,7 @@ fn transfer_tokens_from_local<T: Runtime>() {
 				Keyring::Alice,
 				names::USDC,
 				"balanceOf",
-				Some(&[Token::Address(Keyring::Ferdie.id_eth())]),
+				Some(&[Token::Address(Keyring::Ferdie.in_eth())]),
 			)),
 			AMOUNT
 		);
@@ -188,7 +188,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 				)
 				.unwrap()
 				.value,
@@ -215,7 +215,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 			OriginFor::<T>::signed(Keyring::TrancheInvestor(1).into()),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).id_eth()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).in_eth()),
 			AMOUNT,
 		)
 		.unwrap();
@@ -229,7 +229,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 				)
 				.unwrap()
 				.value,
@@ -250,7 +250,7 @@ fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 				Keyring::TrancheInvestor(1),
 				names::POOL_A_T_1,
 				"balanceOf",
-				Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+				Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 			)) >= AMOUNT,
 			"Insufficient POOL_A_T_1 funds by TrancheInvestor(1)"
 		);
@@ -309,7 +309,7 @@ fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(2).id_eth())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(2).in_eth())]),
 				)
 				.unwrap()
 				.value,
@@ -330,7 +330,7 @@ fn transfer_tranche_tokens_domain_to_local<T: Runtime>() {
 				Keyring::TrancheInvestor(1),
 				names::POOL_A_T_1,
 				"balanceOf",
-				Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
+				Some(&[Token::Address(Keyring::TrancheInvestor(1).in_eth())]),
 			)) >= AMOUNT,
 			"Insufficient POOL_A_T_1 funds by TrancheInvestor(1)"
 		);

--- a/runtime/integration-tests/src/cases/lp/transfers.rs
+++ b/runtime/integration-tests/src/cases/lp/transfers.rs
@@ -46,7 +46,7 @@ mod utils {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 				)),
 				0
 			);
@@ -78,7 +78,7 @@ mod utils {
 				OriginFor::<T>::signed(Keyring::TrancheInvestor(1).into()),
 				POOL_A,
 				pool_a_tranche_1_id::<T>(),
-				DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).into()),
+				DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).id_eth()),
 				AMOUNT,
 			)
 			.unwrap();
@@ -91,7 +91,7 @@ mod utils {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 				)),
 				AMOUNT
 			);
@@ -116,7 +116,7 @@ mod utils {
 				Keyring::Alice,
 				names::USDC,
 				"balanceOf",
-				Some(&[Token::Address(Keyring::Alice.into())]),
+				Some(&[Token::Address(Keyring::Alice.id_eth())]),
 			));
 			assert!(
 				balance >= AMOUNT,
@@ -157,7 +157,7 @@ fn transfer_tokens_from_local<T: Runtime>() {
 		pallet_liquidity_pools::Pallet::<T>::transfer(
 			OriginFor::<T>::signed(Keyring::Ferdie.into()),
 			USDC.id(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::Ferdie.into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::Ferdie.id_eth()),
 			AMOUNT,
 		)
 		.unwrap();
@@ -170,7 +170,7 @@ fn transfer_tokens_from_local<T: Runtime>() {
 				Keyring::Alice,
 				names::USDC,
 				"balanceOf",
-				Some(&[Token::Address(Keyring::Ferdie.into())]),
+				Some(&[Token::Address(Keyring::Ferdie.id_eth())]),
 			)),
 			AMOUNT
 		);
@@ -188,7 +188,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 				)
 				.unwrap()
 				.value,
@@ -215,7 +215,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 			OriginFor::<T>::signed(Keyring::TrancheInvestor(1).into()),
 			POOL_A,
 			pool_a_tranche_1_id::<T>(),
-			DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).into()),
+			DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, Keyring::TrancheInvestor(1).id_eth()),
 			AMOUNT,
 		)
 		.unwrap();
@@ -229,7 +229,7 @@ fn transfer_tranche_tokens_from_local<T: Runtime>() {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 				)
 				.unwrap()
 				.value,
@@ -250,7 +250,7 @@ fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 				Keyring::TrancheInvestor(1),
 				names::POOL_A_T_1,
 				"balanceOf",
-				Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+				Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 			)) >= AMOUNT,
 			"Insufficient POOL_A_T_1 funds by TrancheInvestor(1)"
 		);
@@ -309,7 +309,7 @@ fn transfer_tranche_tokens_domain_to_local_to_domain<T: Runtime>() {
 					Keyring::Alice,
 					names::POOL_A_T_1,
 					"balanceOf",
-					Some(&[Token::Address(Keyring::TrancheInvestor(2).into())]),
+					Some(&[Token::Address(Keyring::TrancheInvestor(2).id_eth())]),
 				)
 				.unwrap()
 				.value,
@@ -330,7 +330,7 @@ fn transfer_tranche_tokens_domain_to_local<T: Runtime>() {
 				Keyring::TrancheInvestor(1),
 				names::POOL_A_T_1,
 				"balanceOf",
-				Some(&[Token::Address(Keyring::TrancheInvestor(1).into())]),
+				Some(&[Token::Address(Keyring::TrancheInvestor(1).id_eth())]),
 			)) >= AMOUNT,
 			"Insufficient POOL_A_T_1 funds by TrancheInvestor(1)"
 		);

--- a/runtime/integration-tests/src/cases/lp/utils.rs
+++ b/runtime/integration-tests/src/cases/lp/utils.rs
@@ -36,8 +36,9 @@ use crate::{
 	utils::{accounts::Keyring, evm::receipt_ok, last_event, pool::get_tranche_ids},
 };
 
+/// Returns the local representation of a remote ethereum account
 pub fn remote_account_of<T: Runtime>(keyring: Keyring) -> <T as frame_system::Config>::AccountId {
-	DomainAddress::Evm(EVM_DOMAIN_CHAIN_ID, keyring.into()).as_local()
+	DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, keyring.id_eth()).as_local()
 }
 
 pub const REVERT_ERR: Result<CallInfo, DispatchError> =
@@ -164,7 +165,7 @@ pub fn to_fixed_array<const S: usize>(src: &[u8]) -> [u8; S] {
 
 pub fn as_h160_32bytes(who: Keyring) -> [u8; 32] {
 	let mut address = [0u8; 32];
-	address[..20].copy_from_slice(H160::from(who).as_bytes());
+	address[..20].copy_from_slice(who.id_eth().as_bytes());
 	address
 }
 

--- a/runtime/integration-tests/src/cases/lp/utils.rs
+++ b/runtime/integration-tests/src/cases/lp/utils.rs
@@ -38,7 +38,7 @@ use crate::{
 
 /// Returns the local representation of a remote ethereum account
 pub fn remote_account_of<T: Runtime>(keyring: Keyring) -> <T as frame_system::Config>::AccountId {
-	DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, keyring.id_eth()).as_local()
+	DomainAddress::from_evm(EVM_DOMAIN_CHAIN_ID, keyring.in_eth()).as_local()
 }
 
 pub const REVERT_ERR: Result<CallInfo, DispatchError> =
@@ -165,7 +165,7 @@ pub fn to_fixed_array<const S: usize>(src: &[u8]) -> [u8; S] {
 
 pub fn as_h160_32bytes(who: Keyring) -> [u8; 32] {
 	let mut address = [0u8; 32];
-	address[..20].copy_from_slice(who.id_eth().as_bytes());
+	address[..20].copy_from_slice(who.in_eth().as_bytes());
 	address
 }
 

--- a/runtime/integration-tests/src/cases/restricted_transfers.rs
+++ b/runtime/integration-tests/src/cases/restricted_transfers.rs
@@ -397,7 +397,7 @@ mod eth_address {
 		);
 
 		env.parachain_state_mut(|| {
-			let curr_contract = DomainAddress::EVM(CHAIN_ID, CONTRACT_ACCOUNT);
+			let curr_contract = DomainAddress::Evm(CHAIN_ID, CONTRACT_ACCOUNT);
 
 			assert_ok!(
 				pallet_transfer_allowlist::Pallet::<T>::add_transfer_allowance(
@@ -411,7 +411,7 @@ mod eth_address {
 				pallet_liquidity_pools::Pallet::<T>::transfer(
 					RawOrigin::Signed(Keyring::Alice.into()).into(),
 					curr.id(),
-					DomainAddress::EVM(CHAIN_ID, [2; 20]), // Not the allowed contract account
+					DomainAddress::Evm(CHAIN_ID, [2; 20]), // Not the allowed contract account
 					curr.val(TRANSFER),
 				),
 				pallet_transfer_allowlist::Error::<T>::NoAllowanceForDestination

--- a/runtime/integration-tests/src/cases/routers.rs
+++ b/runtime/integration-tests/src/cases/routers.rs
@@ -12,7 +12,7 @@ use pallet_liquidity_pools::Message;
 use pallet_liquidity_pools_gateway::message::GatewayMessage;
 use runtime_common::{
 	account_conversion::AccountConverter, evm::precompile::LP_AXELAR_GATEWAY,
-	gateway::get_gateway_h160_account,
+	gateway::get_gateway_domain_address,
 };
 use sp_core::{Get, H160, H256, U256};
 use sp_runtime::traits::{BlakeTwo256, Hash};
@@ -35,7 +35,7 @@ mod axelar_evm {
 	const CHAIN_NAME: &str = "Ethereum";
 	const INITIAL: Balance = 100;
 	const CHAIN_ID: EVMChainId = 1;
-	const TEST_DOMAIN: Domain = Domain::EVM(CHAIN_ID);
+	const TEST_DOMAIN: Domain = Domain::Evm(CHAIN_ID);
 	const AXELAR_CONTRACT_CODE: &[u8] = &[0, 0, 0];
 	const AXELAR_CONTRACT_ADDRESS: H160 = H160::repeat_byte(1);
 	const LP_CONTRACT_ADDRESS: H160 = H160::repeat_byte(2);
@@ -120,7 +120,7 @@ mod axelar_evm {
 
 			utils::evm::mint_balance_into_derived_account::<T>(AXELAR_CONTRACT_ADDRESS, cfg(1));
 			utils::evm::mint_balance_into_derived_account::<T>(
-				get_gateway_h160_account::<T>(),
+				get_gateway_domain_address::<T>().as_eth::<H160>(),
 				cfg(1),
 			);
 
@@ -171,7 +171,7 @@ mod axelar_evm {
 
 			pallet_liquidity_pools_gateway::Pallet::<T>::add_instance(
 				RawOrigin::Root.into(),
-				DomainAddress::EVM(CHAIN_ID, SOURCE_ADDRESS.0),
+				DomainAddress::Evm(CHAIN_ID, SOURCE_ADDRESS.0),
 			)
 			.unwrap();
 

--- a/runtime/integration-tests/src/envs/evm_env.rs
+++ b/runtime/integration-tests/src/envs/evm_env.rs
@@ -134,7 +134,7 @@ impl<T: Runtime> env::EvmEnv<T> for EvmEnv<T> {
 			let (base_fee, _) = <T as pallet_evm::Config>::FeeCalculator::min_gas_price();
 
 			<T as pallet_evm::Config>::Runner::create(
-				who.into(),
+				who.id_eth(),
 				init,
 				0u8.into(),
 				GAS_LIMIT,
@@ -179,7 +179,7 @@ impl<T: Runtime> env::EvmEnv<T> for EvmEnv<T> {
 		let (base_fee, _) = <T as pallet_evm::Config>::FeeCalculator::min_gas_price();
 
 		let res = <T as pallet_evm::Config>::Runner::call(
-			caller.into(),
+			caller.id_eth(),
 			contract_info.address(),
 			input,
 			value,

--- a/runtime/integration-tests/src/envs/evm_env.rs
+++ b/runtime/integration-tests/src/envs/evm_env.rs
@@ -134,7 +134,7 @@ impl<T: Runtime> env::EvmEnv<T> for EvmEnv<T> {
 			let (base_fee, _) = <T as pallet_evm::Config>::FeeCalculator::min_gas_price();
 
 			<T as pallet_evm::Config>::Runner::create(
-				who.id_eth(),
+				who.in_eth(),
 				init,
 				0u8.into(),
 				GAS_LIMIT,
@@ -179,7 +179,7 @@ impl<T: Runtime> env::EvmEnv<T> for EvmEnv<T> {
 		let (base_fee, _) = <T as pallet_evm::Config>::FeeCalculator::min_gas_price();
 
 		let res = <T as pallet_evm::Config>::Runner::call(
-			caller.id_eth(),
+			caller.in_eth(),
 			contract_info.address(),
 			input,
 			value,

--- a/runtime/integration-tests/src/utils/accounts.rs
+++ b/runtime/integration-tests/src/utils/accounts.rs
@@ -45,7 +45,17 @@ impl Keyring {
 
 	/// NOTE: Needs to be executed in an externalities environment
 	pub fn id_ecdsa<T: pallet_evm_chain_id::Config>(self) -> AccountId32 {
-		AccountConverter::evm_address_to_account::<T>(self.into())
+		AccountConverter::evm_address_to_account::<T>(self.id_eth())
+	}
+
+	/// Returns the Ethereum address.
+	/// The H160 retrived is NOT the local representation of that account in our
+	/// chain, it's the real Ethereum address.
+	pub fn id_eth(self) -> H160 {
+		let pair: ecdsa::Pair = self.into();
+		H160::from(H256::from(
+			sp_core::KeccakHasher::hash(&pair.public().as_ref()).0,
+		))
 	}
 
 	pub fn as_multi(self) -> sp_runtime::MultiSigner {
@@ -120,23 +130,6 @@ impl From<Keyring> for AccountId32 {
 impl From<Keyring> for [u8; 32] {
 	fn from(value: Keyring) -> Self {
 		value.id().into()
-	}
-}
-
-impl From<Keyring> for H160 {
-	fn from(value: Keyring) -> Self {
-		H160::from(H256::from(
-			sp_core::KeccakHasher::hash(&Into::<ecdsa::Pair>::into(value).public().as_ref()).0,
-		))
-	}
-}
-
-impl From<Keyring> for [u8; 20] {
-	fn from(value: Keyring) -> Self {
-		sp_core::H160::from(sp_core::H256::from(sp_core::KeccakHasher::hash(
-			&Into::<ecdsa::Pair>::into(value).public().as_ref(),
-		)))
-		.0
 	}
 }
 

--- a/runtime/integration-tests/src/utils/accounts.rs
+++ b/runtime/integration-tests/src/utils/accounts.rs
@@ -45,13 +45,13 @@ impl Keyring {
 
 	/// NOTE: Needs to be executed in an externalities environment
 	pub fn id_ecdsa<T: pallet_evm_chain_id::Config>(self) -> AccountId32 {
-		AccountConverter::evm_address_to_account::<T>(self.id_eth())
+		AccountConverter::evm_address_to_account::<T>(self.in_eth())
 	}
 
 	/// Returns the Ethereum address.
 	/// The H160 retrived is NOT the local representation of that account in our
-	/// chain, it's the real Ethereum address.
-	pub fn id_eth(self) -> H160 {
+	/// chain, it's the real address in ethereum.
+	pub fn in_eth(self) -> H160 {
 		let pair: ecdsa::Pair = self.into();
 		H160::from(H256::from(
 			sp_core::KeccakHasher::hash(&pair.public().as_ref()).0,

--- a/runtime/integration-tests/src/utils/evm.rs
+++ b/runtime/integration-tests/src/utils/evm.rs
@@ -4,12 +4,12 @@ use std::{
 	path::{Path, PathBuf},
 };
 
+use cfg_types::domain_address::DomainAddress;
 use cfg_utils::vec_to_fixed_array;
 use ethabi::{ethereum_types::H160, Contract};
 use ethereum::ReceiptV3;
 use frame_support::traits::{fungible::Mutate, OriginTrait};
 use pallet_evm::FeeCalculator;
-use runtime_common::account_conversion::AccountConverter;
 use sp_runtime::traits::Get;
 
 use crate::{config::Runtime, utils::ESSENTIAL};
@@ -184,11 +184,10 @@ pub fn receipt_ok(receipt: ReceiptV3) -> bool {
 	inner.status_code == 1
 }
 
-pub fn mint_balance_into_derived_account<T: Runtime>(address: impl AsRef<[u8]>, balance: u128) {
+pub fn mint_balance_into_derived_account<T: Runtime>(address: impl Into<[u8; 20]>, balance: u128) {
 	let chain_id = pallet_evm_chain_id::Pallet::<T>::get();
-	let derived_account =
-		AccountConverter::convert_evm_address(chain_id, vec_to_fixed_array(address));
-	pallet_balances::Pallet::<T>::mint_into(&derived_account.into(), balance)
+	let derived_account = DomainAddress::from_evm(chain_id, address).as_local();
+	pallet_balances::Pallet::<T>::mint_into(&derived_account, balance)
 		.expect("Minting into derived EVM accounf failed.");
 }
 


### PR DESCRIPTION
# Description
- Removed account conversions though `Convert` traits. Not `DomainAddress` know about to convert accounts.
- Unify DomainAddress to `[u8;32]`. See this [slack thread](https://kflabs.slack.com/archives/C06FRHCRQL9/p1723627567780339)
  - Before this PR you can transform a `DomainAddress` into `[u8;32]` in two ways:
     - Using `T::DomainAddressIntoAccount::convert()` which put 20 bytes from Eth + chain + "EVM" number.
     - Using `DomainAddress.address()` which put 20 bytes following by 0s.
     
    This is pretty confusing because is easy to use one or the other in different places, ending with different arrays values. From this PR, the second option is removed. We always add the extra information each time we extract the array from a `DomainAddress` 
      - We need to ensure this is not a problem with out current chain state. From Solidity it seems not because Solidity always reads the first 20 bytes.
- Added sugar method to `DomainAddress` to easy work with them safely
- Renamed `Centrifuge` to `Local` (or maybe I revert this)
- Renamed `EVM` to `Evm`
- (only in IT). Removed `From/Into` traits from `Keyring` to `H160` and `[u8;20]` and use instead an explicit method called `in_eth()` (open to name proposals). This method **represents the account in the Ethereum network**. Note that this differs from `Keyring::Alice.into()[0..20]`, which is used in other places where an ethereum account is stored as an `AccountId` and needs to be recovered. Because this is highly confusing, I've removed the `into/from` methods to be more explicit about when the first case happens.
