### PR TITLE
lp-gateway: Add extrinsics for initiating and disputing message recovery

### DIFF
--- a/libs/traits/src/liquidity_pools.rs
+++ b/libs/traits/src/liquidity_pools.rs
@@ -15,11 +15,12 @@ use frame_support::{dispatch::DispatchResult, weights::Weight};
 use sp_runtime::DispatchError;
 use sp_std::vec::Vec;
 
-pub type Proof = [u8; 32];
+/// Type that represents the hash of an LP message.
+pub type MessageHash = [u8; 32];
 
 /// An encoding & decoding trait for the purpose of meeting the
 /// LiquidityPools General Message Passing Format
-pub trait LPEncoding: Sized {
+pub trait LPMessage: Sized {
 	fn serialize(&self) -> Vec<u8>;
 	fn deserialize(input: &[u8]) -> Result<Self, DispatchError>;
 
@@ -34,11 +35,23 @@ pub trait LPEncoding: Sized {
 	/// It's the identity message for composing messages with pack_with
 	fn empty() -> Self;
 
-	/// Retrieves the message proof hash, if the message is a proof type.
-	fn get_proof(&self) -> Option<Proof>;
+	/// Retrieves the message hash, if the message is a proof type.
+	fn get_message_hash(&self) -> Option<MessageHash>;
 
 	/// Converts the message into a message proof type.
 	fn to_proof_message(&self) -> Self;
+
+	/// Creates a message used for initiating message recovery.
+	///
+	/// Hash - hash of the message that should be recovered.
+	/// Router - the address of the recovery router.
+	fn initiate_message_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self;
+
+	/// Creates a message used for disputing message recovery.
+	///
+	/// Hash - hash of the message that should be disputed.
+	/// Router - the address of the recovery router.
+	fn dispute_message_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self;
 }
 
 pub trait RouterProvider<Domain>: Sized {

--- a/libs/traits/src/liquidity_pools.rs
+++ b/libs/traits/src/liquidity_pools.rs
@@ -45,13 +45,13 @@ pub trait LPMessage: Sized {
 	///
 	/// Hash - hash of the message that should be recovered.
 	/// Router - the address of the recovery router.
-	fn initiate_message_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self;
+	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self;
 
 	/// Creates a message used for disputing message recovery.
 	///
 	/// Hash - hash of the message that should be disputed.
 	/// Router - the address of the recovery router.
-	fn dispute_message_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self;
+	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self;
 }
 
 pub trait RouterProvider<Domain>: Sized {

--- a/libs/traits/src/liquidity_pools.rs
+++ b/libs/traits/src/liquidity_pools.rs
@@ -45,13 +45,13 @@ pub trait LPMessage: Sized {
 	///
 	/// Hash - hash of the message that should be recovered.
 	/// Router - the address of the recovery router.
-	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self;
+	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 32]) -> Self;
 
 	/// Creates a message used for disputing message recovery.
 	///
 	/// Hash - hash of the message that should be disputed.
 	/// Router - the address of the recovery router.
-	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self;
+	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 32]) -> Self;
 }
 
 pub trait RouterProvider<Domain>: Sized {

--- a/libs/traits/src/liquidity_pools.rs
+++ b/libs/traits/src/liquidity_pools.rs
@@ -35,8 +35,11 @@ pub trait LPMessage: Sized {
 	/// It's the identity message for composing messages with pack_with
 	fn empty() -> Self;
 
+	/// Returns whether the message is a proof or not.
+	fn is_proof_message(&self) -> bool;
+
 	/// Retrieves the message hash, if the message is a proof type.
-	fn get_message_hash(&self) -> Option<MessageHash>;
+	fn get_message_hash(&self) -> MessageHash;
 
 	/// Converts the message into a message proof type.
 	fn to_proof_message(&self) -> Self;

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -166,21 +166,27 @@ pub mod pallet {
 
 		/// An inbound message was processed.
 		InboundMessageProcessed {
+			domain_address: DomainAddress,
 			message_hash: MessageHash,
 			router_id: T::RouterId,
 		},
 
 		/// An inbound message proof was processed.
 		InboundProofProcessed {
+			domain_address: DomainAddress,
 			message_hash: MessageHash,
 			router_id: T::RouterId,
 		},
 
 		/// An inbound message was executed.
-		InboundMessageExecuted { message_hash: MessageHash },
+		InboundMessageExecuted {
+			domain_address: DomainAddress,
+			message_hash: MessageHash,
+		},
 
 		/// An outbound message was sent.
 		OutboundMessageSent {
+			domain_address: DomainAddress,
 			message_hash: MessageHash,
 			router_id: T::RouterId,
 		},

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -662,12 +662,9 @@ pub mod pallet {
 
 					(res, weight)
 				}
-				GatewayMessage::Outbound {
-					sender,
-					message,
-					router_id,
-				} => {
-					let res = T::MessageSender::send(router_id, sender, message.serialize());
+				GatewayMessage::Outbound { message, router_id } => {
+					let res =
+						T::MessageSender::send(router_id, T::Sender::get(), message.serialize());
 
 					(res, LP_DEFENSIVE_WEIGHT)
 				}

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -172,7 +172,7 @@ pub mod pallet {
 		MessageRecoveryInitiated {
 			domain: Domain,
 			message_hash: MessageHash,
-			recovery_router: [u8; 20],
+			recovery_router: [u8; 32],
 			messaging_router: T::RouterId,
 		},
 
@@ -180,7 +180,7 @@ pub mod pallet {
 		MessageRecoveryDisputed {
 			domain: Domain,
 			message_hash: MessageHash,
-			recovery_router: [u8; 20],
+			recovery_router: [u8; 32],
 			messaging_router: T::RouterId,
 		},
 	}
@@ -513,14 +513,14 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			domain: Domain,
 			message_hash: MessageHash,
-			recovery_router: [u8; 20],
+			recovery_router: [u8; 32],
 			messaging_router: T::RouterId,
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
 			let message = T::Message::initiate_recovery_message(message_hash, recovery_router);
 
-			Self::send_recovery_message(domain.clone(), message, messaging_router.clone())?;
+			Self::send_recovery_message(domain, message, messaging_router.clone())?;
 
 			Self::deposit_event(Event::<T>::MessageRecoveryInitiated {
 				domain,
@@ -542,14 +542,14 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			domain: Domain,
 			message_hash: MessageHash,
-			recovery_router: [u8; 20],
+			recovery_router: [u8; 32],
 			messaging_router: T::RouterId,
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
 			let message = T::Message::dispute_recovery_message(message_hash, recovery_router);
 
-			Self::send_recovery_message(domain.clone(), message, messaging_router.clone())?;
+			Self::send_recovery_message(domain, message, messaging_router.clone())?;
 
 			Self::deposit_event(Event::<T>::MessageRecoveryDisputed {
 				domain,

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -183,6 +183,11 @@ pub mod pallet {
 			recovery_router: [u8; 32],
 			messaging_router: T::RouterId,
 		},
+
+		/// A message has been processed.
+		ProcessedMessage {
+			message: GatewayMessage<T::Message, T::RouterId>,
+		},
 	}
 
 	/// Storage for routers.
@@ -611,6 +616,10 @@ pub mod pallet {
 		type Message = GatewayMessage<T::Message, T::RouterId>;
 
 		fn process(msg: Self::Message) -> (DispatchResult, Weight) {
+			Self::deposit_event(Event::<T>::ProcessedMessage {
+				message: msg.clone(),
+			});
+
 			match msg {
 				GatewayMessage::Inbound {
 					domain_address,

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -520,7 +520,7 @@ pub mod pallet {
 
 			let message = T::Message::initiate_recovery_message(message_hash, recovery_router);
 
-			Self::send_message_recovery_message(domain.clone(), message, messaging_router.clone())?;
+			Self::send_recovery_message(domain.clone(), message, messaging_router.clone())?;
 
 			Self::deposit_event(Event::<T>::MessageRecoveryInitiated {
 				domain,
@@ -549,7 +549,7 @@ pub mod pallet {
 
 			let message = T::Message::dispute_recovery_message(message_hash, recovery_router);
 
-			Self::send_message_recovery_message(domain.clone(), message, messaging_router.clone())?;
+			Self::send_recovery_message(domain.clone(), message, messaging_router.clone())?;
 
 			Self::deposit_event(Event::<T>::MessageRecoveryDisputed {
 				domain,

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -518,8 +518,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
-			let message =
-				T::Message::initiate_message_recovery_message(message_hash, recovery_router);
+			let message = T::Message::initiate_recovery_message(message_hash, recovery_router);
 
 			Self::send_message_recovery_message(domain.clone(), message, messaging_router.clone())?;
 
@@ -537,7 +536,7 @@ pub mod pallet {
 		/// messaging router.
 		///
 		/// Can only be called by `AdminOrigin`.
-		#[pallet::weight(T::WeightInfo::initiate_message_recovery())]
+		#[pallet::weight(T::WeightInfo::dispute_message_recovery())]
 		#[pallet::call_index(13)]
 		pub fn dispute_message_recovery(
 			origin: OriginFor<T>,
@@ -548,8 +547,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
-			let message =
-				T::Message::dispute_message_recovery_message(message_hash, recovery_router);
+			let message = T::Message::dispute_recovery_message(message_hash, recovery_router);
 
 			Self::send_message_recovery_message(domain.clone(), message, messaging_router.clone())?;
 
@@ -565,7 +563,7 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		fn send_message_recovery_message(
+		fn send_recovery_message(
 			domain: Domain,
 			message: T::Message,
 			messaging_router: T::RouterId,

--- a/pallets/liquidity-pools-gateway/src/message.rs
+++ b/pallets/liquidity-pools-gateway/src/message.rs
@@ -10,7 +10,6 @@ pub enum GatewayMessage<Message, RouterId> {
 		router_id: RouterId,
 	},
 	Outbound {
-		sender: DomainAddress,
 		message: Message,
 		router_id: RouterId,
 	},

--- a/pallets/liquidity-pools-gateway/src/message_processing.rs
+++ b/pallets/liquidity-pools-gateway/src/message_processing.rs
@@ -350,9 +350,12 @@ impl<T: Config> Pallet<T> {
 		if let Some(msg) = message {
 			Self::execute_post_voting_dispatch(message_hash, router_ids, expected_proof_count)?;
 
-			T::InboundMessageHandler::handle(domain_address, msg)?;
+			T::InboundMessageHandler::handle(domain_address.clone(), msg)?;
 
-			Self::deposit_event(Event::<T>::InboundMessageExecuted { message_hash })
+			Self::deposit_event(Event::<T>::InboundMessageExecuted {
+				domain_address,
+				message_hash,
+			})
 		}
 
 		Ok(())
@@ -431,17 +434,20 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn deposit_processing_event(
+		domain_address: DomainAddress,
 		message: T::Message,
 		message_hash: MessageHash,
 		router_id: T::RouterId,
 	) {
 		if message.is_proof_message() {
 			Self::deposit_event(Event::<T>::InboundProofProcessed {
+				domain_address,
 				message_hash,
 				router_id,
 			})
 		} else {
 			Self::deposit_event(Event::<T>::InboundMessageProcessed {
+				domain_address,
 				message_hash,
 				router_id,
 			})

--- a/pallets/liquidity-pools-gateway/src/message_processing.rs
+++ b/pallets/liquidity-pools-gateway/src/message_processing.rs
@@ -459,7 +459,6 @@ impl<T: Config> Pallet<T> {
 			// We are using the sender specified in the pallet config so that we can
 			// ensure that the account is funded
 			let gateway_message = GatewayMessage::<T::Message, T::RouterId>::Outbound {
-				sender: T::Sender::get(),
 				message: router_msg,
 				router_id,
 			};

--- a/pallets/liquidity-pools-gateway/src/message_processing.rs
+++ b/pallets/liquidity-pools-gateway/src/message_processing.rs
@@ -94,16 +94,16 @@ impl<T: Config> InboundEntry<T> {
 		expected_proof_count: u32,
 	) -> Self {
 		if message.is_proof_message() {
+			InboundEntry::Proof(ProofEntry {
+				session_id,
+				current_count: 1,
+			})
+		} else {
 			InboundEntry::Message(MessageEntry {
 				session_id,
 				domain_address,
 				message,
 				expected_proof_count,
-			})
-		} else {
-			InboundEntry::Proof(ProofEntry {
-				session_id,
-				current_count: 1,
 			})
 		}
 	}

--- a/pallets/liquidity-pools-gateway/src/message_processing.rs
+++ b/pallets/liquidity-pools-gateway/src/message_processing.rs
@@ -5,7 +5,7 @@ use cfg_types::domain_address::{Domain, DomainAddress};
 use frame_support::{
 	dispatch::DispatchResult,
 	ensure,
-	pallet_prelude::{Decode, Encode, Get, TypeInfo},
+	pallet_prelude::{Decode, Encode, TypeInfo},
 };
 use parity_scale_codec::MaxEncodedLen;
 use sp_arithmetic::traits::{EnsureAddAssign, EnsureSub, SaturatedConversion};
@@ -412,7 +412,7 @@ impl<T: Config> Pallet<T> {
 			let message_hash = submessage.get_message_hash();
 
 			let inbound_entry: InboundEntry<T> = InboundEntry::create(
-				submessage,
+				submessage.clone(),
 				session_id,
 				domain_address.clone(),
 				expected_proof_count,
@@ -420,6 +420,13 @@ impl<T: Config> Pallet<T> {
 
 			inbound_entry.validate(&router_ids, &router_id.clone())?;
 			Self::upsert_pending_entry(message_hash, &router_id, inbound_entry)?;
+
+			Self::deposit_processing_event(
+				domain_address.clone(),
+				submessage,
+				message_hash,
+				router_id.clone(),
+			);
 
 			Self::execute_if_requirements_are_met(
 				message_hash,

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -17,7 +17,7 @@ use crate::{pallet as pallet_liquidity_pools_gateway, EnsureLocal, GatewayMessag
 
 pub const TEST_SESSION_ID: u32 = 1;
 pub const TEST_EVM_CHAIN: EVMChainId = 1;
-pub const TEST_DOMAIN: Domain = Domain::EVM(TEST_EVM_CHAIN);
+pub const TEST_DOMAIN: Domain = Domain::Evm(TEST_EVM_CHAIN);
 pub const TEST_DOMAIN_ADDRESS: DomainAddress =
 	DomainAddress::Evm(TEST_EVM_CHAIN, H160::repeat_byte(1));
 
@@ -37,8 +37,8 @@ pub enum Message {
 	Simple,
 	Pack(Vec<Message>),
 	Proof([u8; 32]),
-	InitiateMessageRecovery(([u8; 32], [u8; 20])),
-	DisputeMessageRecovery(([u8; 32], [u8; 20])),
+	InitiateMessageRecovery(([u8; 32], [u8; 32])),
+	DisputeMessageRecovery(([u8; 32], [u8; 32])),
 }
 
 impl Debug for Message {
@@ -116,11 +116,11 @@ impl LPMessage for Message {
 		}
 	}
 
-	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
+	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 32]) -> Self {
 		Self::InitiateMessageRecovery((hash, router))
 	}
 
-	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
+	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 32]) -> Self {
 		Self::DisputeMessageRecovery((hash, router))
 	}
 }

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -102,17 +102,18 @@ impl LPMessage for Message {
 		Self::Pack(vec![])
 	}
 
-	fn get_message_hash(&self) -> Option<MessageHash> {
-		match self {
-			Message::Proof(p) => Some(p.clone()),
-			_ => None,
-		}
+	fn is_proof_message(&self) -> bool {
+		matches!(self, Message::Proof(..))
+	}
+
+	fn get_message_hash(&self) -> MessageHash {
+		MESSAGE_HASH
 	}
 
 	fn to_proof_message(&self) -> Self {
 		match self {
 			Message::Proof(_) => self.clone(),
-			_ => Message::Proof(MESSAGE_HASH),
+			_ => Message::Proof(self.get_message_hash()),
 		}
 	}
 

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -115,11 +115,11 @@ impl LPMessage for Message {
 		}
 	}
 
-	fn initiate_message_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
+	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
 		Self::InitiateMessageRecovery((hash, router))
 	}
 
-	fn dispute_message_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
+	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
 		Self::DisputeMessageRecovery((hash, router))
 	}
 }

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -17,6 +17,7 @@ use crate::{pallet as pallet_liquidity_pools_gateway, EnsureLocal, GatewayMessag
 
 pub const TEST_SESSION_ID: u32 = 1;
 pub const TEST_EVM_CHAIN: EVMChainId = 1;
+pub const TEST_DOMAIN: Domain = Domain::EVM(TEST_EVM_CHAIN);
 pub const TEST_DOMAIN_ADDRESS: DomainAddress =
 	DomainAddress::Evm(TEST_EVM_CHAIN, H160::repeat_byte(1));
 
@@ -29,7 +30,7 @@ pub const LP_ADMIN_ACCOUNT: AccountId32 = AccountId32::new([u8::MAX; 32]);
 pub const MAX_PACKED_MESSAGES_ERR: &str = "packed limit error";
 pub const MAX_PACKED_MESSAGES: usize = 10;
 
-pub const MESSAGE_PROOF: [u8; 32] = [1; 32];
+pub const MESSAGE_HASH: [u8; 32] = [1; 32];
 
 #[derive(Eq, PartialEq, Clone, Encode, Decode, TypeInfo, Hash)]
 pub enum Message {
@@ -111,7 +112,7 @@ impl LPMessage for Message {
 	fn to_proof_message(&self) -> Self {
 		match self {
 			Message::Proof(_) => self.clone(),
-			_ => Message::Proof(MESSAGE_PROOF),
+			_ => Message::Proof(MESSAGE_HASH),
 		}
 	}
 

--- a/pallets/liquidity-pools-gateway/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/src/tests.rs
@@ -898,18 +898,12 @@ mod implementations {
 						GatewayMessage::Inbound { .. } => {
 							assert!(false, "expected outbound message")
 						}
-						GatewayMessage::Outbound {
-							sender, message, ..
-						} => {
-							assert_eq!(sender, <Runtime as Config>::Sender::get());
-
-							match message {
-								Message::Proof(p) => {
-									assert_eq!(p, message_proof);
-								}
-								_ => {}
+						GatewayMessage::Outbound { message, .. } => match message {
+							Message::Proof(p) => {
+								assert_eq!(p, message_proof);
 							}
-						}
+							_ => {}
+						},
 					}
 
 					Ok(())
@@ -961,7 +955,6 @@ mod implementations {
 				));
 
 				let gateway_message = GatewayMessage::Outbound {
-					sender: <Runtime as Config>::Sender::get(),
 					message: msg.clone(),
 					router_id: ROUTER_ID_1,
 				};
@@ -3167,11 +3160,9 @@ mod implementations {
 			#[test]
 			fn success() {
 				new_test_ext().execute_with(|| {
-					let sender = TEST_DOMAIN_ADDRESS;
 					let message = Message::Simple;
 
 					let gateway_message = GatewayMessage::Outbound {
-						sender: sender.clone(),
 						message: message.clone(),
 						router_id: ROUTER_ID_1,
 					};
@@ -3179,7 +3170,7 @@ mod implementations {
 					let handler = MockMessageSender::mock_send(
 						move |mock_router_id, mock_sender, mock_message| {
 							assert_eq!(mock_router_id, ROUTER_ID_1);
-							assert_eq!(mock_sender, sender);
+							assert_eq!(mock_sender, <Runtime as Config>::Sender::get());
 							assert_eq!(mock_message, message.serialize());
 
 							Ok(())
@@ -3196,11 +3187,9 @@ mod implementations {
 			#[test]
 			fn message_sender_error() {
 				new_test_ext().execute_with(|| {
-					let sender = TEST_DOMAIN_ADDRESS;
 					let message = Message::Simple;
 
 					let gateway_message = GatewayMessage::Outbound {
-						sender: sender.clone(),
 						message: message.clone(),
 						router_id: ROUTER_ID_1,
 					};
@@ -3210,7 +3199,7 @@ mod implementations {
 					MockMessageSender::mock_send(
 						move |mock_router_id, mock_sender, mock_message| {
 							assert_eq!(mock_router_id, ROUTER_ID_1);
-							assert_eq!(mock_sender, sender);
+							assert_eq!(mock_sender, <Runtime as Config>::Sender::get());
 							assert_eq!(mock_message, message.serialize());
 
 							Err(router_err)

--- a/pallets/liquidity-pools-gateway/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/src/tests.rs
@@ -875,7 +875,7 @@ mod extrinsics {
 		#[test]
 		fn success() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				Routers::<Runtime>::set(BoundedVec::try_from(vec![ROUTER_ID_1]).unwrap());
 
@@ -911,7 +911,7 @@ mod extrinsics {
 		#[test]
 		fn bad_origin() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				assert_noop!(
 					LiquidityPoolsGateway::initiate_message_recovery(
@@ -929,7 +929,7 @@ mod extrinsics {
 		#[test]
 		fn not_enough_routers_for_domain() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				assert_noop!(
 					LiquidityPoolsGateway::initiate_message_recovery(
@@ -947,7 +947,7 @@ mod extrinsics {
 		#[test]
 		fn messaging_router_not_found() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				Routers::<Runtime>::set(BoundedVec::try_from(vec![ROUTER_ID_1]).unwrap());
 
@@ -979,7 +979,7 @@ mod extrinsics {
 		#[test]
 		fn message_sender_error() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				Routers::<Runtime>::set(BoundedVec::try_from(vec![ROUTER_ID_1]).unwrap());
 
@@ -1017,7 +1017,7 @@ mod extrinsics {
 		#[test]
 		fn success() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				Routers::<Runtime>::set(BoundedVec::try_from(vec![ROUTER_ID_1]).unwrap());
 
@@ -1053,7 +1053,7 @@ mod extrinsics {
 		#[test]
 		fn bad_origin() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				assert_noop!(
 					LiquidityPoolsGateway::dispute_message_recovery(
@@ -1071,7 +1071,7 @@ mod extrinsics {
 		#[test]
 		fn not_enough_routers_for_domain() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				assert_noop!(
 					LiquidityPoolsGateway::dispute_message_recovery(
@@ -1089,7 +1089,7 @@ mod extrinsics {
 		#[test]
 		fn messaging_router_not_found() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				Routers::<Runtime>::set(BoundedVec::try_from(vec![ROUTER_ID_1]).unwrap());
 
@@ -1121,7 +1121,7 @@ mod extrinsics {
 		#[test]
 		fn message_sender_error() {
 			new_test_ext().execute_with(|| {
-				let recovery_router = [1u8; 20];
+				let recovery_router = [1u8; 32];
 
 				Routers::<Runtime>::set(BoundedVec::try_from(vec![ROUTER_ID_1]).unwrap());
 

--- a/pallets/liquidity-pools-gateway/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/src/tests.rs
@@ -836,7 +836,7 @@ mod extrinsics {
 		}
 
 		#[test]
-		fn expected_message_proof_type() {
+		fn expected_message_hash_type() {
 			new_test_ext().execute_with(|| {
 				let domain_address = TEST_DOMAIN_ADDRESS;
 				let session_id = 1;
@@ -1166,7 +1166,7 @@ mod implementations {
 				let domain = Domain::Evm(0);
 				let sender = get_test_account_id();
 				let msg = Message::Simple;
-				let message_proof = msg.to_proof_message().get_message_hash().unwrap();
+				let message_hash = msg.get_message_hash();
 
 				assert_ok!(LiquidityPoolsGateway::set_routers(
 					RuntimeOrigin::root(),
@@ -1180,7 +1180,7 @@ mod implementations {
 						}
 						GatewayMessage::Outbound { message, .. } => match message {
 							Message::Proof(p) => {
-								assert_eq!(p, message_proof);
+								assert_eq!(p, message_hash);
 							}
 							_ => {}
 						},
@@ -1416,7 +1416,7 @@ mod implementations {
 				fn success() {
 					new_test_ext().execute_with(|| {
 						let message = Message::Simple;
-						let message_proof = message.to_proof_message().get_message_hash().unwrap();
+						let message_hash = message.get_message_hash();
 						let session_id = 1;
 						let domain_address = DomainAddress::Evm(1, H160::repeat_byte(1));
 						let router_id = ROUTER_ID_1;
@@ -1445,7 +1445,7 @@ mod implementations {
 						assert_eq!(handler.times(), 1);
 
 						assert!(
-							PendingInboundEntries::<Runtime>::get(message_proof, router_id)
+							PendingInboundEntries::<Runtime>::get(message_hash, router_id)
 								.is_none()
 						);
 					});
@@ -1494,10 +1494,10 @@ mod implementations {
 				}
 
 				#[test]
-				fn expected_message_proof_type() {
+				fn expected_message_hash_type() {
 					new_test_ext().execute_with(|| {
 						let message = Message::Simple;
-						let message_proof = message.to_proof_message().get_message_hash().unwrap();
+						let message_hash = message.get_message_hash();
 						let session_id = 1;
 						let domain_address = DomainAddress::Evm(1, H160::repeat_byte(1));
 						let router_id = ROUTER_ID_1;
@@ -1512,7 +1512,7 @@ mod implementations {
 						);
 						SessionIdStore::<Runtime>::set(session_id);
 						PendingInboundEntries::<Runtime>::insert(
-							message_proof,
+							message_hash,
 							router_id,
 							InboundEntry::Proof(ProofEntry {
 								session_id,
@@ -3844,7 +3844,7 @@ mod implementations {
 			}
 
 			#[test]
-			fn expected_message_proof_type() {
+			fn expected_message_hash_type() {
 				new_test_ext().execute_with(|| {
 					let inbound_entry: InboundEntry<Runtime> = ProofEntry {
 						session_id: 1,
@@ -4221,7 +4221,7 @@ mod inbound_entry {
 		}
 
 		#[test]
-		fn expected_message_proof_type() {
+		fn expected_message_hash_type() {
 			new_test_ext().execute_with(|| {
 				let mut inbound_entry = InboundEntry::<Runtime>::Message(MessageEntry {
 					session_id: 1,

--- a/pallets/liquidity-pools-gateway/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/src/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use cfg_primitives::LP_DEFENSIVE_WEIGHT;
-use cfg_traits::liquidity_pools::{LPEncoding, MessageProcessor, OutboundMessageHandler};
+use cfg_traits::liquidity_pools::{LPMessage, MessageProcessor, OutboundMessageHandler};
 use cfg_types::domain_address::*;
 use frame_support::{assert_err, assert_noop, assert_ok};
 use itertools::Itertools;
@@ -690,7 +690,7 @@ mod extrinsics {
 				));
 
 				event_exists(Event::<Runtime>::MessageRecoveryExecuted {
-					proof: MESSAGE_PROOF,
+					message_hash: MESSAGE_PROOF,
 					router_id: ROUTER_ID_2,
 				});
 
@@ -734,7 +734,7 @@ mod extrinsics {
 				));
 
 				event_exists(Event::<Runtime>::MessageRecoveryExecuted {
-					proof: MESSAGE_PROOF,
+					message_hash: MESSAGE_PROOF,
 					router_id: ROUTER_ID_2,
 				});
 
@@ -886,7 +886,7 @@ mod implementations {
 				let domain = Domain::Evm(0);
 				let sender = get_test_account_id();
 				let msg = Message::Simple;
-				let message_proof = msg.to_proof_message().get_proof().unwrap();
+				let message_proof = msg.to_proof_message().get_message_hash().unwrap();
 
 				assert_ok!(LiquidityPoolsGateway::set_routers(
 					RuntimeOrigin::root(),
@@ -1143,7 +1143,7 @@ mod implementations {
 				fn success() {
 					new_test_ext().execute_with(|| {
 						let message = Message::Simple;
-						let message_proof = message.to_proof_message().get_proof().unwrap();
+						let message_proof = message.to_proof_message().get_message_hash().unwrap();
 						let session_id = 1;
 						let domain_address = DomainAddress::Evm(1, H160::repeat_byte(1));
 						let router_id = ROUTER_ID_1;
@@ -1224,7 +1224,7 @@ mod implementations {
 				fn expected_message_proof_type() {
 					new_test_ext().execute_with(|| {
 						let message = Message::Simple;
-						let message_proof = message.to_proof_message().get_proof().unwrap();
+						let message_proof = message.to_proof_message().get_message_hash().unwrap();
 						let session_id = 1;
 						let domain_address = DomainAddress::Evm(1, H160::repeat_byte(1));
 						let router_id = ROUTER_ID_1;

--- a/pallets/liquidity-pools-gateway/src/weights.rs
+++ b/pallets/liquidity-pools-gateway/src/weights.rs
@@ -23,6 +23,8 @@ pub trait WeightInfo {
 	fn end_batch_message() -> Weight;
 	fn set_domain_hook_address() -> Weight;
 	fn execute_message_recovery() -> Weight;
+	fn initiate_message_recovery() -> Weight;
+	fn dispute_message_recovery() -> Weight;
 }
 
 // NOTE: We use temporary weights here. `execute_epoch` is by far our heaviest
@@ -137,6 +139,28 @@ impl WeightInfo for () {
 	}
 
 	fn execute_message_recovery() -> Weight {
+		// TODO: BENCHMARK CORRECTLY
+		//
+		// NOTE: Reasonable weight taken from `PoolSystem::set_max_reserve`
+		//       This one has one read and one write for sure and possible one
+		//       read for `AdminOrigin`
+		Weight::from_parts(30_117_000, 5991)
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(2))
+	}
+
+	fn initiate_message_recovery() -> Weight {
+		// TODO: BENCHMARK CORRECTLY
+		//
+		// NOTE: Reasonable weight taken from `PoolSystem::set_max_reserve`
+		//       This one has one read and one write for sure and possible one
+		//       read for `AdminOrigin`
+		Weight::from_parts(30_117_000, 5991)
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(2))
+	}
+
+	fn dispute_message_recovery() -> Weight {
 		// TODO: BENCHMARK CORRECTLY
 		//
 		// NOTE: Reasonable weight taken from `PoolSystem::set_max_reserve`

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -226,7 +226,7 @@ pub enum Message<BatchContent = BatchMessages> {
 		/// The hash of the message which shall be recovered
 		hash: [u8; 32],
 		/// The address of the router
-		router: [u8; 20],
+		router: [u8; 32],
 	},
 	/// Dispute the recovery of a message.
 	///
@@ -237,7 +237,7 @@ pub enum Message<BatchContent = BatchMessages> {
 		/// The hash of the message which shall be disputed
 		hash: [u8; 32],
 		/// The address of the router
-		router: [u8; 20],
+		router: [u8; 32],
 	},
 	/// A batch of ordered messages.
 	/// Don't allow nested batch messages.
@@ -575,11 +575,11 @@ impl LPMessage for Message {
 		Message::MessageProof { hash }
 	}
 
-	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
+	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 32]) -> Self {
 		Message::InitiateMessageRecovery { hash, router }
 	}
 
-	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
+	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 32]) -> Self {
 		Message::DisputeMessageRecovery { hash, router }
 	}
 }

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -562,17 +562,18 @@ impl LPMessage for Message {
 		Message::Batch(BatchMessages::default())
 	}
 
-	fn get_message_hash(&self) -> Option<MessageHash> {
-		match self {
-			Message::MessageProof { hash } => Some(*hash),
-			_ => None,
-		}
+	fn is_proof_message(&self) -> bool {
+		matches!(self, Message::MessageProof { .. })
+	}
+
+	fn get_message_hash(&self) -> MessageHash {
+		keccak_256(&LPMessage::serialize(self))
 	}
 
 	fn to_proof_message(&self) -> Self {
-		let hash = keccak_256(&LPMessage::serialize(self));
-
-		Message::MessageProof { hash }
+		Message::MessageProof {
+			hash: self.get_message_hash(),
+		}
 	}
 
 	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 32]) -> Self {

--- a/pallets/liquidity-pools/src/message.rs
+++ b/pallets/liquidity-pools/src/message.rs
@@ -212,7 +212,7 @@ pub enum Message<BatchContent = BatchMessages> {
 	// --- Gateway ---
 	/// Proof a message has been executed.
 	///
-	/// Directionality: Centrifuge -> EVM Domain.
+	/// Directionality: Centrifuge <-> EVM Domain.
 	MessageProof {
 		// Hash of the message for which the proof is provided
 		hash: [u8; 32],
@@ -575,11 +575,11 @@ impl LPMessage for Message {
 		Message::MessageProof { hash }
 	}
 
-	fn initiate_message_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
+	fn initiate_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
 		Message::InitiateMessageRecovery { hash, router }
 	}
 
-	fn dispute_message_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
+	fn dispute_recovery_message(hash: [u8; 32], router: [u8; 20]) -> Self {
 		Message::DisputeMessageRecovery { hash, router }
 	}
 }

--- a/runtime/integration-tests/src/cases/liquidity_pools.rs
+++ b/runtime/integration-tests/src/cases/liquidity_pools.rs
@@ -1026,15 +1026,12 @@ mod foreign_investments {
 
 				let nonce = MessageNonceStore::<T>::get();
 
-				let sender = T::Sender::get();
-
 				// Clearing of foreign InvestState should be dispatched
 				assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
 					e.event
 						== pallet_liquidity_pools_gateway_queue::Event::MessageSubmitted {
 							nonce,
 							message: GatewayMessage::Outbound {
-								sender: sender.clone(),
 								router_id: DEFAULT_ROUTER_ID,
 								message: LiquidityPoolMessage::FulfilledDepositRequest {
 									pool_id,
@@ -1130,14 +1127,11 @@ mod foreign_investments {
 
 				let nonce = MessageNonceStore::<T>::get();
 
-				let sender = T::Sender::get();
-
 				assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
 					e.event
 						== pallet_liquidity_pools_gateway_queue::Event::<T>::MessageSubmitted {
 							nonce,
 							message: GatewayMessage::Outbound {
-								sender: sender.clone(),
 								router_id: DEFAULT_ROUTER_ID,
 								message: Message::FulfilledDepositRequest {
 									pool_id,
@@ -1230,7 +1224,6 @@ mod foreign_investments {
 						== pallet_liquidity_pools_gateway_queue::Event::<T>::MessageSubmitted {
 							nonce,
 							message: GatewayMessage::Outbound {
-								sender: sender.clone(),
 								router_id: DEFAULT_ROUTER_ID,
 								message: LiquidityPoolMessage::FulfilledDepositRequest {
 									pool_id,
@@ -1265,12 +1258,11 @@ mod foreign_investments {
 								pallet_liquidity_pools_gateway_queue::Event::MessageSubmitted {
 									message:
 										GatewayMessage::Outbound {
-											sender: event_sender,
 											router_id: event_router_id,
 											message: Message::FulfilledDepositRequest { .. },
 										},
 									..
-								} => event_sender == sender && event_router_id == DEFAULT_ROUTER_ID,
+								} => event_router_id == DEFAULT_ROUTER_ID,
 								_ => false,
 							}
 						} else {
@@ -1502,14 +1494,11 @@ mod foreign_investments {
 
 				let nonce = MessageNonceStore::<T>::get();
 
-				let sender = T::Sender::get();
-
 				assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
 					e.event
 						== pallet_liquidity_pools_gateway_queue::Event::<T>::MessageSubmitted {
 							nonce,
 							message: GatewayMessage::Outbound {
-								sender: sender.clone(),
 								router_id: DEFAULT_ROUTER_ID,
 								message: LiquidityPoolMessage::FulfilledRedeemRequest {
 									pool_id,
@@ -1599,7 +1588,6 @@ mod foreign_investments {
 						== pallet_liquidity_pools_gateway_queue::Event::<T>::MessageSubmitted {
 							nonce,
 							message: GatewayMessage::Outbound {
-								sender: sender.clone(),
 								router_id: DEFAULT_ROUTER_ID,
 								message: LiquidityPoolMessage::FulfilledRedeemRequest {
 									pool_id,
@@ -1940,14 +1928,11 @@ mod foreign_investments {
 
 				let nonce = MessageNonceStore::<T>::get();
 
-				let sender = T::Sender::get();
-
 				assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
 					e.event
 						== pallet_liquidity_pools_gateway_queue::Event::<T>::MessageSubmitted {
 							nonce,
 							message: GatewayMessage::Outbound {
-								sender: sender.clone(),
 								router_id: DEFAULT_ROUTER_ID,
 								message: LiquidityPoolMessage::FulfilledDepositRequest {
 									pool_id,
@@ -2091,14 +2076,11 @@ mod foreign_investments {
 
 				let nonce = MessageNonceStore::<T>::get();
 
-				let sender = <T as pallet_liquidity_pools_gateway::Config>::Sender::get();
-
 				assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
 					e.event
 						== pallet_liquidity_pools_gateway_queue::Event::<T>::MessageSubmitted {
 							nonce,
 							message: GatewayMessage::Outbound {
-								sender: sender.clone(),
 								router_id: DEFAULT_ROUTER_ID,
 								message: LiquidityPoolMessage::FulfilledCancelDepositRequest {
 									pool_id,
@@ -2202,14 +2184,11 @@ mod foreign_investments {
 
 				let nonce = MessageNonceStore::<T>::get();
 
-				let sender = <T as pallet_liquidity_pools_gateway::Config>::Sender::get();
-
 				assert!(frame_system::Pallet::<T>::events().iter().any(|e| {
 					e.event
 						== pallet_liquidity_pools_gateway_queue::Event::<T>::MessageSubmitted {
 							nonce,
 							message: GatewayMessage::Outbound {
-								sender: sender.clone(),
 								router_id: DEFAULT_ROUTER_ID,
 								message: LiquidityPoolMessage::FulfilledCancelDepositRequest {
 									pool_id,

--- a/runtime/integration-tests/src/cases/liquidity_pools_gateway_queue.rs
+++ b/runtime/integration-tests/src/cases/liquidity_pools_gateway_queue.rs
@@ -1,4 +1,3 @@
-use cfg_primitives::AccountId;
 use cfg_traits::liquidity_pools::MessageQueue;
 use cfg_types::domain_address::DomainAddress;
 use frame_support::{assert_ok, traits::OriginTrait};
@@ -72,7 +71,6 @@ fn outbound<T: Runtime + FudgeSupport>() {
 
 		let nonce = <T as pallet_liquidity_pools_gateway_queue::Config>::MessageNonce::one();
 		let message = GatewayMessage::Outbound {
-			sender: DomainAddress::Centrifuge(AccountId::new([1; 32])),
 			router_id: DEFAULT_ROUTER_ID,
 			message: Message::Invalid,
 		};

--- a/runtime/integration-tests/src/cases/lp/utils.rs
+++ b/runtime/integration-tests/src/cases/lp/utils.rs
@@ -139,15 +139,7 @@ pub fn process_gateway_message<T: Runtime>(
 
 		match msg {
 			GatewayMessage::Inbound { message, .. } => verifier(message),
-			GatewayMessage::Outbound {
-				sender,
-				router_id,
-				message,
-			} => {
-				assert_eq!(
-					sender,
-					<T as pallet_liquidity_pools_gateway::Config>::Sender::get()
-				);
+			GatewayMessage::Outbound { router_id, message } => {
 				assert_eq!(router_id, EVM_ROUTER_ID);
 				verifier(message)
 			}

--- a/runtime/integration-tests/src/cases/routers.rs
+++ b/runtime/integration-tests/src/cases/routers.rs
@@ -1,5 +1,5 @@
 use cfg_primitives::Balance;
-use cfg_traits::liquidity_pools::{LPEncoding, MessageProcessor};
+use cfg_traits::liquidity_pools::{LPMessage, MessageProcessor};
 use cfg_types::{
 	domain_address::{Domain, DomainAddress},
 	EVMChainId,

--- a/runtime/integration-tests/src/cases/routers.rs
+++ b/runtime/integration-tests/src/cases/routers.rs
@@ -14,7 +14,7 @@ use runtime_common::{
 	account_conversion::AccountConverter, evm::precompile::LP_AXELAR_GATEWAY,
 	gateway::get_gateway_domain_address, routing::RouterId,
 };
-use sp_core::{Get, H160, H256, U256};
+use sp_core::{H160, H256, U256};
 use sp_runtime::traits::{BlakeTwo256, Hash};
 
 use crate::{
@@ -139,7 +139,6 @@ mod axelar_evm {
 			));
 
 			let gateway_message = GatewayMessage::Outbound {
-				sender: T::Sender::get(),
 				router_id: TEST_ROUTER_ID,
 				message: Message::Invalid,
 			};


### PR DESCRIPTION
# Description

Added:
- new extrinsics for initiating and disputing message recovery.
- new gateway events when processing inbound and outbound messages.

Changed:
- renamed `LPEncoding` to `LPMessage`.
   - added new methods from getting dispute messages.
   - changed message hash method.

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Added extra events for LP gateway, LP.
- [x] Removed sender field for outbound gateway message.