### PR TITLE
Split LpMessage traits in subtraits

### DIFF
--- a/pallets/liquidity-pools-forwarder/src/lib.rs
+++ b/pallets/liquidity-pools-forwarder/src/lib.rs
@@ -35,7 +35,7 @@ mod tests;
 
 use core::fmt::Debug;
 
-use cfg_traits::liquidity_pools::{LpMessage as LpMessageT, MessageReceiver, MessageSender};
+use cfg_traits::liquidity_pools::{LpMessageForwarded, MessageReceiver, MessageSender};
 use cfg_types::domain_address::{Domain, DomainAddress};
 use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
 use frame_system::pallet_prelude::OriginFor;
@@ -77,7 +77,7 @@ pub mod pallet {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// The Liquidity Pools message type.
-		type Message: LpMessageT<Domain = Domain>
+		type Message: LpMessageForwarded<Domain = Domain>
 			+ Clone
 			+ Debug
 			+ PartialEq

--- a/pallets/liquidity-pools-forwarder/src/mock.rs
+++ b/pallets/liquidity-pools-forwarder/src/mock.rs
@@ -1,8 +1,7 @@
-use cfg_traits::liquidity_pools::{LpMessage, MessageHash};
+use cfg_traits::liquidity_pools::LpMessageForwarded;
 use cfg_types::domain_address::{Domain, DomainAddress};
 use frame_support::{
 	derive_impl,
-	dispatch::DispatchResult,
 	pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo},
 	weights::constants::RocksDbWeight,
 };
@@ -25,8 +24,6 @@ pub const SOURCE_DOMAIN_ADDRESS: DomainAddress =
 	DomainAddress::Evm(SOURCE_CHAIN_ID, FORWARD_CONTRACT);
 pub const FORWARD_CONTRACT: H160 = H160::repeat_byte(2);
 pub const ROUTER_ID: RouterId = 1u32;
-const FORWARD_SERIALIZED_MESSAGE_BYTES: [u8; 1] = [0x42];
-const NON_FORWARD_SERIALIZED_MESSAGE_BYTES: [u8; 1] = [0x43];
 pub const ERROR_NESTING: DispatchError = DispatchError::Other("Nesting forward msg not allowed");
 
 #[derive(Eq, PartialEq, Debug, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Hash)]
@@ -35,55 +32,8 @@ pub enum Message {
 	Forward,
 }
 
-impl LpMessage for Message {
+impl LpMessageForwarded for Message {
 	type Domain = Domain;
-
-	fn serialize(&self) -> Vec<u8> {
-		match self {
-			Message::NonForward => NON_FORWARD_SERIALIZED_MESSAGE_BYTES.to_vec(),
-			Message::Forward => FORWARD_SERIALIZED_MESSAGE_BYTES.to_vec(),
-		}
-	}
-
-	fn deserialize(input: &[u8]) -> Result<Self, DispatchError> {
-		match input {
-			x if x == &NON_FORWARD_SERIALIZED_MESSAGE_BYTES[..] => Ok(Self::NonForward),
-			x if x == &FORWARD_SERIALIZED_MESSAGE_BYTES[..] => Ok(Self::Forward),
-			_ => unimplemented!(),
-		}
-	}
-
-	fn pack_with(&mut self, _: Self) -> DispatchResult {
-		unimplemented!("out of scope")
-	}
-
-	fn submessages(&self) -> Vec<Self> {
-		unimplemented!("out of scope")
-	}
-
-	fn empty() -> Self {
-		unimplemented!("out of scope")
-	}
-
-	fn to_proof_message(&self) -> Self {
-		unimplemented!("out of scope")
-	}
-
-	fn is_proof_message(&self) -> bool {
-		unimplemented!("out of scope")
-	}
-
-	fn get_message_hash(&self) -> MessageHash {
-		unimplemented!("out of scope")
-	}
-
-	fn initiate_recovery_message(_: [u8; 32], _: [u8; 32]) -> Self {
-		unimplemented!("out of scope")
-	}
-
-	fn dispute_recovery_message(_: [u8; 32], _: [u8; 32]) -> Self {
-		unimplemented!("out of scope")
-	}
 
 	fn is_forwarded(&self) -> bool {
 		matches!(self, Self::Forward)

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -30,8 +30,9 @@ use core::fmt::Debug;
 
 use cfg_primitives::LP_DEFENSIVE_WEIGHT;
 use cfg_traits::liquidity_pools::{
-	InboundMessageHandler, LpMessage, MessageHash, MessageProcessor, MessageQueue, MessageReceiver,
-	MessageSender, OutboundMessageHandler, RouterProvider,
+	InboundMessageHandler, LpMessageBatch, LpMessageProof, LpMessageRecovery, LpMessageSerializer,
+	MessageHash, MessageProcessor, MessageQueue, MessageReceiver, MessageSender,
+	OutboundMessageHandler, RouterProvider,
 };
 use cfg_types::domain_address::{Domain, DomainAddress};
 use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
@@ -97,7 +98,10 @@ pub mod pallet {
 		type AdminOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 
 		/// The Liquidity Pools message type.
-		type Message: LpMessage
+		type Message: LpMessageSerializer
+			+ LpMessageBatch
+			+ LpMessageProof
+			+ LpMessageRecovery
 			+ Clone
 			+ Debug
 			+ PartialEq

--- a/pallets/liquidity-pools-gateway/src/message_processing.rs
+++ b/pallets/liquidity-pools-gateway/src/message_processing.rs
@@ -1,5 +1,6 @@
 use cfg_traits::liquidity_pools::{
-	InboundMessageHandler, LpMessage, MessageHash, MessageQueue, RouterProvider,
+	InboundMessageHandler, LpMessageBatch, LpMessageHash, LpMessageProof, MessageHash,
+	MessageQueue, RouterProvider,
 };
 use cfg_types::domain_address::{Domain, DomainAddress};
 use frame_support::{

--- a/pallets/liquidity-pools-gateway/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/src/tests.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use cfg_primitives::LP_DEFENSIVE_WEIGHT;
-use cfg_traits::liquidity_pools::{LpMessage, MessageProcessor, OutboundMessageHandler};
+use cfg_traits::liquidity_pools::{
+	LpMessageHash, LpMessageSerializer, MessageProcessor, OutboundMessageHandler,
+};
 use cfg_types::domain_address::*;
 use frame_support::{assert_err, assert_noop, assert_ok};
 use itertools::Itertools;

--- a/runtime/common/src/routing.rs
+++ b/runtime/common/src/routing.rs
@@ -1,5 +1,5 @@
 use cfg_traits::{
-	liquidity_pools::{LpMessage, MessageReceiver, MessageSender, RouterProvider},
+	liquidity_pools::{LpMessageSerializer, MessageReceiver, MessageSender, RouterProvider},
 	PreConditions,
 };
 use cfg_types::domain_address::{Domain, DomainAddress};
@@ -71,6 +71,7 @@ where
 	}
 }
 
+/// A precondition to ensure an evm account code is configured for a contract
 pub struct EvmAccountCodeChecker<Runtime>(PhantomData<Runtime>);
 impl<Runtime: pallet_evm::Config> PreConditions<(H160, H256)> for EvmAccountCodeChecker<Runtime> {
 	type Result = bool;
@@ -81,6 +82,7 @@ impl<Runtime: pallet_evm::Config> PreConditions<(H160, H256)> for EvmAccountCode
 	}
 }
 
+/// Entity in charge of serializing and deserializing messages
 pub struct MessageSerializer<Sender, Receiver>(PhantomData<(Sender, Receiver)>);
 
 impl<Sender, Receiver> MessageSender for MessageSerializer<Sender, Receiver>

--- a/runtime/integration-tests/src/cases/routers.rs
+++ b/runtime/integration-tests/src/cases/routers.rs
@@ -1,5 +1,5 @@
 use cfg_primitives::Balance;
-use cfg_traits::liquidity_pools::{LpMessage, MessageProcessor};
+use cfg_traits::liquidity_pools::{LpMessageSerializer, MessageProcessor};
 use cfg_types::{
 	domain_address::{Domain, DomainAddress},
 	EVMChainId,


### PR DESCRIPTION
# Description

Split the different behaviors of `LpMessage` in subtraits that can be handled separately. See [this thread](https://github.com/centrifuge/centrifuge-chain/pull/1971#discussion_r1720826602)

NOTE: It is not mandatory to be merged before the audit. Also does not requite to update any doc.