### PR TITLE
Refactor: Remove overusage of DomainAddress

### DIFF
--- a/libs/types/src/domain_address.rs
+++ b/libs/types/src/domain_address.rs
@@ -21,7 +21,7 @@ use crate::EVMChainId;
 const MAX_ADDRESS_SIZE: usize = 32;
 
 /// By just clamping the value to a smaller address
-pub fn account_to_eth_address(address: AccountId32) -> H160 {
+pub fn truncate_into_eth_address(address: AccountId32) -> H160 {
 	let bytes: [u8; 32] = address.into();
 	H160::from(
 		*(bytes)
@@ -99,7 +99,7 @@ impl DomainAddress {
 		match domain {
 			Domain::Centrifuge => DomainAddress::Centrifuge(address.into()),
 			Domain::Evm(chain_id) => {
-				DomainAddress::Evm(chain_id, account_to_eth_address(address.into()))
+				DomainAddress::Evm(chain_id, truncate_into_eth_address(address.into()))
 			}
 		}
 	}
@@ -122,7 +122,7 @@ impl DomainAddress {
 	/// clamping the inner address if needed.
 	pub fn h160(&self) -> H160 {
 		match self.clone() {
-			Self::Centrifuge(x) => account_to_eth_address(x),
+			Self::Centrifuge(x) => truncate_into_eth_address(x),
 			Self::Evm(_, x) => x,
 		}
 	}

--- a/pallets/axelar-router/src/lib.rs
+++ b/pallets/axelar-router/src/lib.rs
@@ -21,7 +21,7 @@ use cfg_traits::{
 	PreConditions,
 };
 use cfg_types::{
-	domain_address::{truncate_into_eth_address, DomainAddress},
+	domain_address::{truncate_into_eth_address, Domain},
 	EVMChainId,
 };
 use ethabi::{Contract, Function, Param, ParamType, Token};
@@ -131,7 +131,7 @@ pub mod pallet {
 		/// The target of the messages coming from other chains
 		type Receiver: MessageReceiver<
 			Middleware = Self::Middleware,
-			Origin = DomainAddress,
+			Origin = Domain,
 			Message = Vec<u8>,
 		>;
 
@@ -239,12 +239,13 @@ pub mod pallet {
 
 			match config.domain {
 				DomainConfig::Evm(EvmConfig { chain_id, .. }) => {
-					let source_address_bytes = decode_var_source::<EVM_ADDRESS_LEN>(source_address)
-						.ok_or(Error::<T>::InvalidSourceAddress)?;
+					let _source_address_bytes =
+						decode_var_source::<EVM_ADDRESS_LEN>(source_address)
+							.ok_or(Error::<T>::InvalidSourceAddress)?;
 
 					T::Receiver::receive(
 						AxelarId::Evm(chain_id).into(),
-						DomainAddress::Evm(chain_id, source_address_bytes.into()),
+						Domain::Evm(chain_id),
 						payload.to_vec(),
 					)
 				}

--- a/pallets/axelar-router/src/lib.rs
+++ b/pallets/axelar-router/src/lib.rs
@@ -20,7 +20,10 @@ use cfg_traits::{
 	liquidity_pools::{MessageReceiver, MessageSender},
 	PreConditions,
 };
-use cfg_types::{domain_address::DomainAddress, EVMChainId};
+use cfg_types::{
+	domain_address::{truncate_into_eth_address, DomainAddress},
+	EVMChainId,
+};
 use ethabi::{Contract, Function, Param, ParamType, Token};
 use fp_evm::PrecompileHandle;
 use frame_support::{
@@ -32,7 +35,7 @@ use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use precompile_utils::prelude::*;
 use scale_info::prelude::{format, string::String};
-use sp_core::{H160, H256, U256};
+use sp_core::{crypto::AccountId32, H160, H256, U256};
 use sp_std::{boxed::Box, collections::btree_map::BTreeMap, vec, vec::Vec};
 
 #[cfg(test)]
@@ -318,7 +321,7 @@ pub mod pallet {
 	impl<T: Config> MessageSender for Pallet<T> {
 		type Message = Vec<u8>;
 		type Middleware = AxelarId;
-		type Origin = DomainAddress;
+		type Origin = AccountId32;
 
 		fn send(
 			axelar_id: AxelarId,
@@ -340,7 +343,7 @@ pub mod pallet {
 					.map_err(DispatchError::Other)?;
 
 					T::Transactor::call(
-						origin.h160(),
+						truncate_into_eth_address(origin),
 						evm_config.target_contract_address,
 						message.as_slice(),
 						evm_config.fee_values.value,

--- a/pallets/axelar-router/src/tests.rs
+++ b/pallets/axelar-router/src/tests.rs
@@ -9,7 +9,7 @@ const LP_CONTRACT_ADDRESS: H160 = H160::repeat_byte(1);
 const AXELAR_CONTRACT_ADDRESS: H160 = H160::repeat_byte(2);
 const SOURCE_ADDRESS: H160 = H160::repeat_byte(3);
 const AXELAR_CONTRACT_HASH: H256 = H256::repeat_byte(42);
-const SENDER: DomainAddress = DomainAddress::Centrifuge(AccountId32::new([0; 32]));
+const SENDER: AccountId32 = AccountId32::new([0; 32]);
 const MESSAGE: &[u8] = &[1, 2, 3];
 const FEE_VALUE: U256 = U256::zero();
 const GAS_LIMIT: U256 = U256::one();
@@ -91,7 +91,7 @@ mod send {
 			correct_configuration();
 
 			Transactor::mock_call(move |from, to, data, value, gas_price, gas_limit| {
-				assert_eq!(from, SENDER.h160());
+				assert_eq!(from, truncate_into_eth_address(SENDER));
 				assert_eq!(to, AXELAR_CONTRACT_ADDRESS);
 				assert_eq!(data, &wrap_message(MESSAGE.to_vec()));
 				assert_eq!(value, FEE_VALUE);

--- a/pallets/liquidity-pools-forwarder/src/lib.rs
+++ b/pallets/liquidity-pools-forwarder/src/lib.rs
@@ -87,11 +87,7 @@ pub mod pallet {
 			+ FullCodec;
 
 		/// The entity of the messages coming from this chain.
-		type MessageSender: MessageSender<
-			Middleware = Self::RouterId,
-			Origin = DomainAddress,
-			Message = Self::Message,
-		>;
+		type MessageSender: MessageSender<Middleware = Self::RouterId, Message = Self::Message>;
 
 		/// The entity which acts on unwrapped messages.
 		type MessageReceiver: MessageReceiver<
@@ -202,11 +198,11 @@ pub mod pallet {
 	impl<T: Config> MessageSender for Pallet<T> {
 		type Message = T::Message;
 		type Middleware = T::RouterId;
-		type Origin = DomainAddress;
+		type Origin = <T::MessageSender as MessageSender>::Origin;
 
 		fn send(
 			router_id: T::RouterId,
-			origin: DomainAddress,
+			origin: Self::Origin,
 			message: T::Message,
 		) -> DispatchResult {
 			let msg = RouterForwarding::<T>::get(&router_id)

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -34,7 +34,7 @@ use cfg_traits::liquidity_pools::{
 	MessageHash, MessageProcessor, MessageQueue, MessageReceiver, MessageSender,
 	OutboundMessageHandler, RouterProvider,
 };
-use cfg_types::domain_address::{Domain, DomainAddress};
+use cfg_types::domain_address::Domain;
 use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
 use frame_system::pallet_prelude::{ensure_signed, OriginFor};
 use message::GatewayMessage;
@@ -108,10 +108,7 @@ pub mod pallet {
 		type RouterProvider: RouterProvider<Domain, RouterId = Self::RouterId>;
 
 		/// The type that processes inbound messages.
-		type InboundMessageHandler: InboundMessageHandler<
-			Sender = DomainAddress,
-			Message = Self::Message,
-		>;
+		type InboundMessageHandler: InboundMessageHandler<Sender = Domain, Message = Self::Message>;
 
 		type WeightInfo: WeightInfo;
 
@@ -144,12 +141,6 @@ pub mod pallet {
 			session_id: T::SessionId,
 		},
 
-		/// An instance was added to a domain.
-		InstanceAdded { instance: DomainAddress },
-
-		/// An instance was removed from a domain.
-		InstanceRemoved { instance: DomainAddress },
-
 		/// The domain hook address was initialized or updated.
 		DomainHookAddressSet {
 			domain: Domain,
@@ -158,27 +149,27 @@ pub mod pallet {
 
 		/// An inbound message was processed.
 		InboundMessageProcessed {
-			domain_address: DomainAddress,
+			domain: Domain,
 			message_hash: MessageHash,
 			router_id: T::RouterId,
 		},
 
 		/// An inbound message proof was processed.
 		InboundProofProcessed {
-			domain_address: DomainAddress,
+			domain: Domain,
 			message_hash: MessageHash,
 			router_id: T::RouterId,
 		},
 
 		/// An inbound message was executed.
 		InboundMessageExecuted {
-			domain_address: DomainAddress,
+			domain: Domain,
 			message_hash: MessageHash,
 		},
 
 		/// An outbound message was sent.
 		OutboundMessageSent {
-			domain_address: DomainAddress,
+			domain: Domain,
 			message_hash: MessageHash,
 			router_id: T::RouterId,
 		},
@@ -213,15 +204,6 @@ pub mod pallet {
 	#[pallet::getter(fn routers)]
 	pub type Routers<T: Config> =
 		StorageValue<_, BoundedVec<T::RouterId, T::MaxRouterCount>, ValueQuery>;
-
-	/// Storage that contains a limited number of whitelisted instances of
-	/// deployed liquidity pools for a particular domain.
-	///
-	/// This can only be modified by an admin.
-	#[pallet::storage]
-	#[pallet::getter(fn allowlist)]
-	pub type Allowlist<T: Config> =
-		StorageDoubleMap<_, Blake2_128Concat, Domain, Blake2_128Concat, DomainAddress, ()>;
 
 	/// Stores the hook address of a domain required for particular LP messages.
 	///
@@ -304,20 +286,8 @@ pub mod pallet {
 		/// Pending inbound entry not found.
 		PendingInboundEntryNotFound,
 
-		/// Message proof cannot be retrieved.
-		MessageProofRetrieval,
-
-		/// Recovery message not found.
-		RecoveryMessageNotFound,
-
 		/// Not enough routers are stored for a domain.
 		NotEnoughRoutersForDomain,
-
-		/// The messages of 2 inbound entries do not match.
-		InboundEntryMessageMismatch,
-
-		/// The domain addresses of 2 inbound entries do not match.
-		InboundEntryDomainAddressMismatch,
 	}
 
 	#[pallet::call]
@@ -347,52 +317,6 @@ pub mod pallet {
 
 			Ok(())
 		}
-
-		/// Add a known instance of a deployed liquidity pools integration for a
-		/// specific domain.
-		#[pallet::weight(T::WeightInfo::add_instance())]
-		#[pallet::call_index(1)]
-		pub fn add_instance(origin: OriginFor<T>, instance: DomainAddress) -> DispatchResult {
-			T::AdminOrigin::ensure_origin(origin)?;
-
-			ensure!(
-				instance.domain() != Domain::Centrifuge,
-				Error::<T>::DomainNotSupported
-			);
-
-			ensure!(
-				!Allowlist::<T>::contains_key(instance.domain(), instance.clone()),
-				Error::<T>::InstanceAlreadyAdded,
-			);
-
-			Allowlist::<T>::insert(instance.domain(), instance.clone(), ());
-
-			Self::deposit_event(Event::InstanceAdded { instance });
-
-			Ok(())
-		}
-
-		/// Remove an instance from a specific domain.
-		#[pallet::weight(T::WeightInfo::remove_instance())]
-		#[pallet::call_index(2)]
-		pub fn remove_instance(origin: OriginFor<T>, instance: DomainAddress) -> DispatchResult {
-			T::AdminOrigin::ensure_origin(origin.clone())?;
-
-			ensure!(
-				Allowlist::<T>::contains_key(instance.domain(), instance.clone()),
-				Error::<T>::UnknownInstance,
-			);
-
-			Allowlist::<T>::remove(instance.domain(), instance.clone());
-
-			Self::deposit_event(Event::InstanceRemoved { instance });
-
-			Ok(())
-		}
-
-		// Deprecated: receive_message with call_index(5)
-		//
-		// NOTE: If required, should be exposed by router.
 
 		/// Set the address of the domain hook
 		///
@@ -457,13 +381,13 @@ pub mod pallet {
 		#[pallet::call_index(11)]
 		pub fn execute_message_recovery(
 			origin: OriginFor<T>,
-			domain_address: DomainAddress,
+			domain: Domain,
 			message_hash: MessageHash,
 			router_id: T::RouterId,
 		) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 
-			let router_ids = Self::get_router_ids_for_domain(domain_address.domain())?;
+			let router_ids = Self::get_router_ids_for_domain(domain)?;
 
 			ensure!(
 				router_ids.iter().any(|x| x == &router_id),
@@ -500,7 +424,7 @@ pub mod pallet {
 				&router_ids,
 				session_id,
 				expected_proof_count,
-				domain_address,
+				domain,
 			)?;
 
 			Self::deposit_event(Event::<T>::MessageRecoveryExecuted {
@@ -623,18 +547,14 @@ pub mod pallet {
 		fn process(msg: Self::Message) -> (DispatchResult, Weight) {
 			match msg {
 				GatewayMessage::Inbound {
-					domain_address,
+					domain,
 					message,
 					router_id,
 				} => {
 					let mut counter = 0;
 
-					let res = Self::process_inbound_message(
-						domain_address,
-						message,
-						router_id,
-						&mut counter,
-					);
+					let res =
+						Self::process_inbound_message(domain, message, router_id, &mut counter);
 
 					let weight = match counter {
 						0 => LP_DEFENSIVE_WEIGHT / 10,
@@ -666,20 +586,11 @@ pub mod pallet {
 	impl<T: Config> MessageReceiver for Pallet<T> {
 		type Message = T::Message;
 		type Middleware = T::RouterId;
-		type Origin = DomainAddress;
+		type Origin = Domain;
 
-		fn receive(
-			router_id: T::RouterId,
-			origin_address: DomainAddress,
-			message: T::Message,
-		) -> DispatchResult {
-			ensure!(
-				Allowlist::<T>::contains_key(origin_address.domain(), origin_address.clone()),
-				Error::<T>::UnknownInstance,
-			);
-
+		fn receive(router_id: T::RouterId, domain: Domain, message: T::Message) -> DispatchResult {
 			let gateway_message = GatewayMessage::<T::Message, T::RouterId>::Inbound {
-				domain_address: origin_address,
+				domain,
 				message,
 				router_id,
 			};

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -97,7 +97,7 @@ pub mod pallet {
 		/// The target of the messages coming from this chain
 		type MessageSender: MessageSender<
 			Middleware = Self::RouterId,
-			Origin = DomainAddress,
+			Origin = Self::AccountId,
 			Message = Self::Message,
 		>;
 
@@ -122,7 +122,7 @@ pub mod pallet {
 		/// The sender account that will be used in the OutboundQueue
 		/// implementation.
 		#[pallet::constant]
-		type Sender: Get<DomainAddress>;
+		type Sender: Get<Self::AccountId>;
 
 		/// Type used for queueing messages.
 		type MessageQueue: MessageQueue<Message = GatewayMessage<Self::Message, Self::RouterId>>;

--- a/pallets/liquidity-pools-gateway/src/message.rs
+++ b/pallets/liquidity-pools-gateway/src/message.rs
@@ -1,11 +1,11 @@
-use cfg_types::domain_address::DomainAddress;
+use cfg_types::domain_address::Domain;
 use frame_support::pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo};
 
 /// Message type used by the LP gateway.
 #[derive(Debug, Encode, Decode, Clone, Eq, MaxEncodedLen, PartialEq, TypeInfo)]
 pub enum GatewayMessage<Message, RouterId> {
 	Inbound {
-		domain_address: DomainAddress,
+		domain: Domain,
 		message: Message,
 		router_id: RouterId,
 	},

--- a/pallets/liquidity-pools-gateway/src/message_processing.rs
+++ b/pallets/liquidity-pools-gateway/src/message_processing.rs
@@ -2,7 +2,7 @@ use cfg_traits::liquidity_pools::{
 	InboundMessageHandler, LpMessageBatch, LpMessageHash, LpMessageProof, MessageHash,
 	MessageQueue, RouterProvider,
 };
-use cfg_types::domain_address::{Domain, DomainAddress};
+use cfg_types::domain_address::Domain;
 use frame_support::{
 	dispatch::DispatchResult,
 	ensure,
@@ -29,7 +29,7 @@ pub struct MessageEntry<T: Config> {
 	///
 	/// NOTE - the `RouterProvider` ensures that we cannot have the same message
 	/// entry, for the same message, for different domain addresses.
-	pub domain_address: DomainAddress,
+	pub domain: Domain,
 
 	/// The LP message.
 	pub message: T::Message,
@@ -91,7 +91,7 @@ impl<T: Config> InboundEntry<T> {
 	pub fn create(
 		message: T::Message,
 		session_id: T::SessionId,
-		domain_address: DomainAddress,
+		domain: Domain,
 		expected_proof_count: u32,
 	) -> Self {
 		if message.is_proof_message() {
@@ -102,7 +102,7 @@ impl<T: Config> InboundEntry<T> {
 		} else {
 			InboundEntry::Message(MessageEntry {
 				session_id,
-				domain_address,
+				domain,
 				message,
 				expected_proof_count,
 			})
@@ -322,7 +322,7 @@ impl<T: Config> Pallet<T> {
 		router_ids: &[T::RouterId],
 		session_id: T::SessionId,
 		expected_proof_count: u32,
-		domain_address: DomainAddress,
+		domain: Domain,
 	) -> DispatchResult {
 		let mut message = None;
 		let mut votes = 0;
@@ -351,10 +351,10 @@ impl<T: Config> Pallet<T> {
 		if let Some(msg) = message {
 			Self::execute_post_voting_dispatch(message_hash, router_ids, expected_proof_count)?;
 
-			T::InboundMessageHandler::handle(domain_address.clone(), msg)?;
+			T::InboundMessageHandler::handle(domain, msg)?;
 
 			Self::deposit_event(Event::<T>::InboundMessageExecuted {
-				domain_address,
+				domain,
 				message_hash,
 			})
 		}
@@ -398,12 +398,12 @@ impl<T: Config> Pallet<T> {
 	/// Iterates over a batch of messages and checks if the requirements for
 	/// processing each message are met.
 	pub(crate) fn process_inbound_message(
-		domain_address: DomainAddress,
+		domain: Domain,
 		message: T::Message,
 		router_id: T::RouterId,
 		counter: &mut u64,
 	) -> DispatchResult {
-		let router_ids = Self::get_router_ids_for_domain(domain_address.domain())?;
+		let router_ids = Self::get_router_ids_for_domain(domain)?;
 		let session_id = SessionIdStore::<T>::get();
 		let expected_proof_count = Self::get_expected_proof_count(&router_ids)?;
 
@@ -412,29 +412,20 @@ impl<T: Config> Pallet<T> {
 
 			let message_hash = submessage.get_message_hash();
 
-			let inbound_entry: InboundEntry<T> = InboundEntry::create(
-				submessage.clone(),
-				session_id,
-				domain_address.clone(),
-				expected_proof_count,
-			);
+			let inbound_entry: InboundEntry<T> =
+				InboundEntry::create(submessage.clone(), session_id, domain, expected_proof_count);
 
 			inbound_entry.validate(&router_ids, &router_id.clone())?;
 			Self::upsert_pending_entry(message_hash, &router_id, inbound_entry)?;
 
-			Self::deposit_processing_event(
-				domain_address.clone(),
-				submessage,
-				message_hash,
-				router_id.clone(),
-			);
+			Self::deposit_processing_event(domain, submessage, message_hash, router_id.clone());
 
 			Self::execute_if_requirements_are_met(
 				message_hash,
 				&router_ids,
 				session_id,
 				expected_proof_count,
-				domain_address.clone(),
+				domain,
 			)?;
 		}
 
@@ -442,20 +433,20 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn deposit_processing_event(
-		domain_address: DomainAddress,
+		domain: Domain,
 		message: T::Message,
 		message_hash: MessageHash,
 		router_id: T::RouterId,
 	) {
 		if message.is_proof_message() {
 			Self::deposit_event(Event::<T>::InboundProofProcessed {
-				domain_address,
+				domain,
 				message_hash,
 				router_id,
 			})
 		} else {
 			Self::deposit_event(Event::<T>::InboundMessageProcessed {
-				domain_address,
+				domain,
 				message_hash,
 				router_id,
 			})

--- a/pallets/liquidity-pools-gateway/src/mock.rs
+++ b/pallets/liquidity-pools-gateway/src/mock.rs
@@ -189,11 +189,11 @@ impl cfg_mocks::queue::pallet::Config for Runtime {
 impl cfg_mocks::router_message::pallet::Config for Runtime {
 	type Message = Message;
 	type Middleware = RouterId;
-	type Origin = DomainAddress;
+	type Origin = AccountId32;
 }
 
 frame_support::parameter_types! {
-	pub Sender: DomainAddress = DomainAddress::Centrifuge(AccountId32::from([1; 32]));
+	pub const Sender: AccountId32 = AccountId32::new([1; 32]);
 	pub const MaxIncomingMessageSize: u32 = 1024;
 	pub const LpAdminAccount: AccountId32 = LP_ADMIN_ACCOUNT;
 	pub const MaxRouterCount: u32 = 8;

--- a/pallets/liquidity-pools/src/inbound.rs
+++ b/pallets/liquidity-pools/src/inbound.rs
@@ -151,7 +151,7 @@ impl<T: Config> Pallet<T> {
 		investor: T::AccountId,
 		amount: <T as Config>::Balance,
 		currency_index: GeneralCurrencyIndexOf<T>,
-		sending_domain: DomainAddress,
+		sending_domain: Domain,
 	) -> DispatchResult {
 		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let payout_currency = Self::try_get_currency_id(currency_index)?;
@@ -160,7 +160,7 @@ impl<T: Config> Pallet<T> {
 		// origination domain
 		T::Tokens::transfer(
 			invest_id.into(),
-			&sending_domain.domain().into_account(),
+			&sending_domain.into_account(),
 			&investor,
 			amount,
 			Preservation::Expendable,
@@ -186,7 +186,7 @@ impl<T: Config> Pallet<T> {
 		tranche_id: T::TrancheId,
 		investor: T::AccountId,
 		currency_index: GeneralCurrencyIndexOf<T>,
-		destination: DomainAddress,
+		destination: Domain,
 	) -> DispatchResult {
 		let invest_id = Self::derive_invest_id(pool_id, tranche_id)?;
 		let currency_u128 = currency_index.index;
@@ -198,7 +198,7 @@ impl<T: Config> Pallet<T> {
 		T::Tokens::transfer(
 			invest_id.into(),
 			&investor,
-			&destination.domain().into_account(),
+			&destination.into_account(),
 			amount,
 			Preservation::Expendable,
 		)?;
@@ -211,11 +211,7 @@ impl<T: Config> Pallet<T> {
 			tranche_tokens_payout: amount.into(),
 		};
 
-		T::OutboundMessageHandler::handle(
-			T::TreasuryAccount::get(),
-			destination.domain(),
-			message,
-		)?;
+		T::OutboundMessageHandler::handle(T::TreasuryAccount::get(), destination, message)?;
 
 		Ok(())
 	}

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -283,10 +283,7 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// An incoming LP message was
 		/// detected and is further processed
-		IncomingMessage {
-			sender: DomainAddress,
-			message: Message,
-		},
+		IncomingMessage { sender: Domain, message: Message },
 	}
 
 	#[pallet::error]
@@ -1207,12 +1204,12 @@ pub mod pallet {
 
 	impl<T: Config> InboundMessageHandler for Pallet<T> {
 		type Message = Message;
-		type Sender = DomainAddress;
+		type Sender = Domain;
 
 		#[transactional]
-		fn handle(sender: DomainAddress, msg: Message) -> DispatchResult {
+		fn handle(sender: Domain, msg: Message) -> DispatchResult {
 			Self::deposit_event(Event::<T>::IncomingMessage {
-				sender: sender.clone(),
+				sender,
 				message: msg.clone(),
 			});
 
@@ -1233,7 +1230,7 @@ pub mod pallet {
 				} => Self::handle_tranche_tokens_transfer(
 					pool_id.into(),
 					tranche_id.into(),
-					sender.domain(),
+					sender,
 					DomainAddress::new(domain.try_into()?, receiver),
 					amount.into(),
 				),
@@ -1246,7 +1243,7 @@ pub mod pallet {
 				} => Self::handle_deposit_request(
 					pool_id.into(),
 					tranche_id.into(),
-					DomainAddress::new(sender.domain(), investor).account(),
+					DomainAddress::new(sender, investor).account(),
 					currency.into(),
 					amount.into(),
 				),
@@ -1259,7 +1256,7 @@ pub mod pallet {
 				} => Self::handle_redeem_request(
 					pool_id.into(),
 					tranche_id.into(),
-					DomainAddress::new(sender.domain(), investor).account(),
+					DomainAddress::new(sender, investor).account(),
 					amount.into(),
 					currency.into(),
 					sender,
@@ -1272,7 +1269,7 @@ pub mod pallet {
 				} => Self::handle_cancel_deposit_request(
 					pool_id.into(),
 					tranche_id.into(),
-					DomainAddress::new(sender.domain(), investor).account(),
+					DomainAddress::new(sender, investor).account(),
 					currency.into(),
 				),
 				Message::CancelRedeemRequest {
@@ -1283,7 +1280,7 @@ pub mod pallet {
 				} => Self::handle_cancel_redeem_request(
 					pool_id.into(),
 					tranche_id.into(),
-					DomainAddress::new(sender.domain(), investor).account(),
+					DomainAddress::new(sender, investor).account(),
 					currency.into(),
 					sender,
 				),

--- a/runtime/altair/src/lib.rs
+++ b/runtime/altair/src/lib.rs
@@ -31,7 +31,6 @@ use cfg_primitives::{
 };
 use cfg_traits::{investments::OrderManager, Millis, PoolUpdateGuard, Seconds};
 use cfg_types::{
-	domain_address::DomainAddress,
 	fee_keys::{Fee, FeeKey},
 	fixed_point::{Quantity, Rate, Ratio},
 	investments::InvestmentPortfolio,
@@ -1767,7 +1766,7 @@ impl pallet_liquidity_pools_forwarder::Config for Runtime {
 }
 
 parameter_types! {
-	pub Sender: DomainAddress = gateway::get_gateway_domain_address::<Runtime>();
+	pub Sender: AccountId = gateway::get_gateway_account::<Runtime>();
 	pub const MaxIncomingMessageSize: u32 = 1024;
 	pub const MaxRouterCount: u32 = 8;
 }

--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -34,7 +34,6 @@ use cfg_traits::{
 	Seconds,
 };
 use cfg_types::{
-	domain_address::DomainAddress,
 	fee_keys::{Fee, FeeKey},
 	fixed_point::{Quantity, Rate, Ratio},
 	investments::InvestmentPortfolio,
@@ -1841,7 +1840,7 @@ impl pallet_liquidity_pools::Config for Runtime {
 }
 
 parameter_types! {
-	pub Sender: DomainAddress = gateway::get_gateway_domain_address::<Runtime>();
+	pub Sender: AccountId = gateway::get_gateway_account::<Runtime>();
 	pub const MaxIncomingMessageSize: u32 = 1024;
 	pub const MaxRouterCount: u32 = 8;
 }

--- a/runtime/common/src/gateway.rs
+++ b/runtime/common/src/gateway.rs
@@ -10,18 +10,19 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
-use cfg_types::domain_address::{Domain, DomainAddress};
+use cfg_primitives::AccountId;
+use cfg_types::domain_address::truncate_into_eth_address;
 use polkadot_parachain_primitives::primitives::Sibling;
-use sp_core::crypto::AccountId32;
-use sp_runtime::traits::{AccountIdConversion, Get};
+use sp_runtime::traits::AccountIdConversion;
 
-pub fn get_gateway_domain_address<T>() -> DomainAddress
+use crate::account_conversion::AccountConverter;
+
+pub fn get_gateway_account<T>() -> AccountId
 where
 	T: pallet_evm_chain_id::Config + staging_parachain_info::Config,
 {
-	let chain_id = pallet_evm_chain_id::Pallet::<T>::get();
 	let para_id = staging_parachain_info::Pallet::<T>::parachain_id();
-	let sender_account: AccountId32 = Sibling::from(para_id).into_account_truncating();
+	let sender_account: AccountId = Sibling::from(para_id).into_account_truncating();
 
-	DomainAddress::new(Domain::Evm(chain_id), sender_account.into())
+	AccountConverter::evm_address_to_account::<T>(truncate_into_eth_address(sender_account))
 }

--- a/runtime/common/src/routing.rs
+++ b/runtime/common/src/routing.rs
@@ -1,3 +1,4 @@
+use cfg_primitives::AccountId;
 use cfg_traits::{
 	liquidity_pools::{LpMessageSerializer, MessageReceiver, MessageSender, RouterProvider},
 	PreConditions,
@@ -60,7 +61,7 @@ where
 {
 	type Message = Vec<u8>;
 	type Middleware = RouterId;
-	type Origin = DomainAddress;
+	type Origin = AccountId;
 
 	fn send(router_id: RouterId, origin: Self::Origin, message: Self::Message) -> DispatchResult {
 		match router_id {
@@ -87,11 +88,11 @@ pub struct MessageSerializer<Sender, Receiver>(PhantomData<(Sender, Receiver)>);
 
 impl<Sender, Receiver> MessageSender for MessageSerializer<Sender, Receiver>
 where
-	Sender: MessageSender<Message = Vec<u8>, Middleware = RouterId, Origin = DomainAddress>,
+	Sender: MessageSender<Message = Vec<u8>, Middleware = RouterId, Origin = AccountId>,
 {
 	type Message = Message;
 	type Middleware = RouterId;
-	type Origin = DomainAddress;
+	type Origin = AccountId;
 
 	fn send(
 		middleware: Self::Middleware,

--- a/runtime/common/src/routing.rs
+++ b/runtime/common/src/routing.rs
@@ -3,7 +3,7 @@ use cfg_traits::{
 	liquidity_pools::{LpMessageSerializer, MessageReceiver, MessageSender, RouterProvider},
 	PreConditions,
 };
-use cfg_types::domain_address::{Domain, DomainAddress};
+use cfg_types::domain_address::Domain;
 use frame_support::{
 	dispatch::DispatchResult,
 	pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo},
@@ -105,11 +105,11 @@ where
 
 impl<Sender, Receiver> MessageReceiver for MessageSerializer<Sender, Receiver>
 where
-	Receiver: MessageReceiver<Middleware = RouterId, Origin = DomainAddress, Message = Message>,
+	Receiver: MessageReceiver<Middleware = RouterId, Origin = Domain, Message = Message>,
 {
 	type Message = Vec<u8>;
 	type Middleware = RouterId;
-	type Origin = DomainAddress;
+	type Origin = Domain;
 
 	fn receive(
 		middleware: Self::Middleware,

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -34,7 +34,6 @@ use cfg_traits::{
 	Seconds,
 };
 use cfg_types::{
-	domain_address::DomainAddress,
 	fee_keys::{Fee, FeeKey},
 	fixed_point::{Quantity, Rate, Ratio},
 	investments::InvestmentPortfolio,
@@ -1872,7 +1871,7 @@ impl pallet_liquidity_pools_forwarder::Config for Runtime {
 }
 
 parameter_types! {
-	pub Sender: DomainAddress = gateway::get_gateway_domain_address::<Runtime>();
+	pub Sender: AccountId = gateway::get_gateway_account::<Runtime>();
 	pub const MaxIncomingMessageSize: u32 = 1024;
 	pub const MaxRouterCount: u32 = 8;
 }

--- a/runtime/integration-tests/src/cases/foreign_investments.rs
+++ b/runtime/integration-tests/src/cases/foreign_investments.rs
@@ -32,7 +32,7 @@ use pallet_pool_system::tranches::{TrancheInput, TrancheLoc, TrancheType};
 use runtime_common::{
 	foreign_investments::IdentityPoolCurrencyConverter, routing::RouterId, xcm::general_key,
 };
-use sp_core::{Get, H160};
+use sp_core::H160;
 use sp_runtime::{
 	traits::{AccountIdConversion, EnsureAdd, One, Zero},
 	BoundedVec, DispatchError, FixedPointNumber, Perquintill, SaturatedConversion,
@@ -48,13 +48,6 @@ use crate::{
 	envs::{fudge_env::handle::SIBLING_ID, runtime_env::RuntimeEnv},
 	utils::{accounts::Keyring, genesis, genesis::Genesis, orml_asset_registry},
 };
-
-// ------------------
-//       NOTE
-// This file only contains foreign investments tests, but the name must remain
-// as it is until feature lpv2 is merged to avoid conflicts:
-// (https://github.com/centrifuge/centrifuge-chain/pull/1909)
-// ------------------
 
 /// The AUSD asset id
 pub const AUSD_CURRENCY_ID: CurrencyId = CurrencyId::ForeignAsset(3);
@@ -276,14 +269,6 @@ pub mod utils {
 		env.parachain_state_mut(|| {
 			register_ausd::<T>();
 			register_glmr::<T>();
-
-			assert_ok!(orml_tokens::Pallet::<T>::set_balance(
-				<T as frame_system::Config>::RuntimeOrigin::root(),
-				T::Sender::get().account().into(),
-				GLMR_CURRENCY_ID,
-				DEFAULT_BALANCE_GLMR,
-				0,
-			));
 
 			assert_ok!(pallet_liquidity_pools_gateway::Pallet::<T>::set_routers(
 				<T as frame_system::Config>::RuntimeOrigin::root(),

--- a/runtime/integration-tests/src/cases/lp/setup_lp.rs
+++ b/runtime/integration-tests/src/cases/lp/setup_lp.rs
@@ -41,7 +41,7 @@ pub fn setup<T: Runtime, F: FnOnce(&mut <RuntimeEnv<T> as EnvEvmExtension<T>>::E
 		evm.load_contracts();
 
 		// Fund gateway sender
-		give_balance::<T>(T::Sender::get().account(), DEFAULT_BALANCE * CFG);
+		give_balance::<T>(T::Sender::get(), DEFAULT_BALANCE * CFG);
 
 		// Register general local pool-currency
 		register_currency::<T>(LocalUSDC, |_| {});

--- a/runtime/integration-tests/src/cases/lp/utils.rs
+++ b/runtime/integration-tests/src/cases/lp/utils.rs
@@ -13,7 +13,7 @@
 use std::{cmp::min, fmt::Debug};
 
 use cfg_primitives::{AccountId, Balance, TrancheId};
-use cfg_types::domain_address::DomainAddress;
+use cfg_types::domain_address::{truncate_into_eth_address, DomainAddress};
 use ethabi::ethereum_types::{H160, H256, U256};
 use fp_evm::CallInfo;
 use frame_support::traits::{OriginTrait, PalletInfo};
@@ -92,7 +92,7 @@ pub fn verify_outbound_failure_on_lp<T: Runtime>(to: H160) {
 		.clone();
 
 	// The sender is the sender account on the gateway
-	assert_eq!(T::Sender::get().h160(), status.from);
+	assert_eq!(truncate_into_eth_address(T::Sender::get()), status.from);
 	assert_eq!(status.to.unwrap().0, to.0);
 	assert!(!receipt_ok(receipt));
 	assert!(matches!(

--- a/runtime/integration-tests/src/cases/routers.rs
+++ b/runtime/integration-tests/src/cases/routers.rs
@@ -1,7 +1,7 @@
 use cfg_primitives::Balance;
 use cfg_traits::liquidity_pools::{LpMessageSerializer, MessageProcessor};
 use cfg_types::{
-	domain_address::{Domain, DomainAddress},
+	domain_address::{truncate_into_eth_address, Domain, DomainAddress},
 	EVMChainId,
 };
 use ethabi::{Function, Param, ParamType, Token};
@@ -11,8 +11,8 @@ use pallet_axelar_router::{AxelarConfig, AxelarId, DomainConfig, EvmConfig, FeeV
 use pallet_liquidity_pools::Message;
 use pallet_liquidity_pools_gateway::message::GatewayMessage;
 use runtime_common::{
-	account_conversion::AccountConverter, evm::precompile::LP_AXELAR_GATEWAY,
-	gateway::get_gateway_domain_address, routing::RouterId,
+	account_conversion::AccountConverter, evm::precompile::LP_AXELAR_GATEWAY, gateway,
+	routing::RouterId,
 };
 use sp_core::{H160, H256, U256};
 use sp_runtime::traits::{BlakeTwo256, Hash};
@@ -123,7 +123,7 @@ mod axelar_evm {
 
 			utils::evm::mint_balance_into_derived_account::<T>(AXELAR_CONTRACT_ADDRESS, cfg(1));
 			utils::evm::mint_balance_into_derived_account::<T>(
-				get_gateway_domain_address::<T>().h160(),
+				truncate_into_eth_address(gateway::get_gateway_account::<T>()),
 				cfg(1),
 			);
 


### PR DESCRIPTION
# Description

We were overusing `DomainAddress` in places where we did not really need it, generating extra complexity that offuscate some parts of the codebase (i.e affecting to how the forwarder needs to be implemented).

Change list:
- Simplify sending/receiving methods:
  - Sending methods use as origin an `AccountId` instead of `DomainAddress`.
  - Receiving methods use as origin a `Domain` instead of `DomainAddress`.
- Move `gateway::Allowlist `storage for instances its methods from the `gateway` to the `axelar-router`.
  - The reason: we need to check if the address is valid or not as soon as possible. Doing it in the gateway is late. We want to only forward messages (which is reached before the gateway) for allowed instances.
  - This check could not be super ideal here. i.e, in the future, several routers can use the same allowlist information. If that is the case, this should be extracted as a precondition or as a new entity in the chain:
    - `axelar-router -> (new) allowlist-checker -> deserializer -> forwarder -> gatewat -> lp`
