### PR TITLE
Fix/gateway message processing

### DIFF
--- a/libs/traits/src/liquidity_pools.rs
+++ b/libs/traits/src/liquidity_pools.rs
@@ -152,7 +152,7 @@ pub trait MessageProcessor {
 	/// Process a message.
 	fn process(msg: Self::Message) -> (DispatchResult, Weight);
 
-	/// Max weight that processing a message can take
+	/// Max weight that processing a message can take.
 	fn max_processing_weight(msg: &Self::Message) -> Weight;
 }
 

--- a/pallets/liquidity-pools-gateway-queue/src/lib.rs
+++ b/pallets/liquidity-pools-gateway-queue/src/lib.rs
@@ -236,10 +236,6 @@ pub mod pallet {
 				processed_entries.push(nonce);
 
 				weight_used = weight_used.saturating_add(weight);
-
-				if weight_used.any_gte(max_weight) {
-					break;
-				}
 			}
 
 			for entry in processed_entries {

--- a/pallets/liquidity-pools-gateway-queue/src/lib.rs
+++ b/pallets/liquidity-pools-gateway-queue/src/lib.rs
@@ -22,7 +22,6 @@ use parity_scale_codec::FullCodec;
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::BaseArithmetic;
 use sp_runtime::traits::{EnsureAddAssign, One};
-use sp_std::vec::Vec;
 
 #[cfg(test)]
 mod mock;
@@ -61,6 +60,12 @@ pub mod pallet {
 	#[pallet::getter(fn message_nonce_store)]
 	pub type MessageNonceStore<T: Config> = StorageValue<_, T::MessageNonce, ValueQuery>;
 
+	/// Storage that is used for keeping track of the last nonce that was
+	/// processed.
+	#[pallet::storage]
+	#[pallet::getter(fn last_processed_nonce)]
+	pub type LastProcessedNonce<T: Config> = StorageValue<_, T::MessageNonce, ValueQuery>;
+
 	/// Storage for messages that will be processed during the `on_idle` hook.
 	#[pallet::storage]
 	#[pallet::getter(fn message_queue)]
@@ -92,6 +97,11 @@ pub mod pallet {
 			nonce: T::MessageNonce,
 			message: T::Message,
 			error: DispatchError,
+		},
+
+		/// Maximum number of messages was reached.
+		MaxNumberOfMessagesWasReached {
+			last_processed_nonce: T::MessageNonce,
 		},
 	}
 
@@ -200,16 +210,42 @@ pub mod pallet {
 		}
 
 		fn service_message_queue(max_weight: Weight) -> Weight {
-			let mut weight_used = Weight::zero();
+			let mut last_processed_nonce = LastProcessedNonce::<T>::get();
 
-			let mut nonces = MessageQueue::<T>::iter_keys().collect::<Vec<_>>();
-			nonces.sort();
+			// 1 read for the last processed nonce
+			let mut weight_used = T::DbWeight::get().reads(1);
 
-			for nonce in nonces {
-				let message =
-					MessageQueue::<T>::get(nonce).expect("valid nonce ensured by `iter_keys`");
+			loop {
+				if last_processed_nonce.ensure_add_assign(One::one()).is_err() {
+					Self::deposit_event(Event::<T>::MaxNumberOfMessagesWasReached {
+						last_processed_nonce,
+					});
 
+					break;
+				}
+
+				// 1 read for the nonce
 				weight_used.saturating_accrue(T::DbWeight::get().reads(1));
+
+				if last_processed_nonce > MessageNonceStore::<T>::get() {
+					break;
+				}
+
+				// 1 read for the message
+				weight_used.saturating_accrue(T::DbWeight::get().reads(1));
+
+				let message = match MessageQueue::<T>::get(last_processed_nonce) {
+					Some(msg) => msg,
+					// No message found at this nonce, we can skip it.
+					None => {
+						LastProcessedNonce::<T>::set(last_processed_nonce);
+
+						// 1 write for setting the last processed nonce
+						weight_used.saturating_accrue(T::DbWeight::get().writes(1));
+
+						continue;
+					}
+				};
 
 				let remaining_weight = max_weight.saturating_sub(weight_used);
 				let next_weight = T::MessageProcessor::max_processing_weight(&message);
@@ -219,22 +255,28 @@ pub mod pallet {
 					break;
 				}
 
-				let weight = match Self::process_message_and_deposit_event(nonce, message.clone()) {
+				let processing_weight = match Self::process_message_and_deposit_event(
+					last_processed_nonce,
+					message.clone(),
+				) {
 					(Ok(()), weight) => weight,
 					(Err(e), weight) => {
-						FailedMessageQueue::<T>::insert(nonce, (message, e));
+						FailedMessageQueue::<T>::insert(last_processed_nonce, (message, e));
 
 						// 1 write for the failed message
 						weight.saturating_add(T::DbWeight::get().writes(1))
 					}
 				};
 
-				weight_used.saturating_accrue(weight);
+				weight_used.saturating_accrue(processing_weight);
 
-				MessageQueue::<T>::remove(nonce);
+				MessageQueue::<T>::remove(last_processed_nonce);
+
+				LastProcessedNonce::<T>::set(last_processed_nonce);
 
 				// 1 write for removing the message
-				weight_used.saturating_accrue(T::DbWeight::get().writes(1));
+				// 1 write for setting the last processed nonce
+				weight_used.saturating_accrue(T::DbWeight::get().writes(2));
 			}
 
 			weight_used

--- a/pallets/liquidity-pools-gateway-queue/src/lib.rs
+++ b/pallets/liquidity-pools-gateway-queue/src/lib.rs
@@ -100,7 +100,7 @@ pub mod pallet {
 		},
 
 		/// Maximum number of messages was reached.
-		MaxNumberOfMessagesWasReached {
+		MaxNumberOfMessagesReached {
 			last_processed_nonce: T::MessageNonce,
 		},
 	}
@@ -217,7 +217,7 @@ pub mod pallet {
 
 			loop {
 				if last_processed_nonce.ensure_add_assign(One::one()).is_err() {
-					Self::deposit_event(Event::<T>::MaxNumberOfMessagesWasReached {
+					Self::deposit_event(Event::<T>::MaxNumberOfMessagesReached {
 						last_processed_nonce,
 					});
 

--- a/pallets/liquidity-pools-gateway-queue/src/lib.rs
+++ b/pallets/liquidity-pools-gateway-queue/src/lib.rs
@@ -237,7 +237,7 @@ pub mod pallet {
 
 				weight_used = weight_used.saturating_add(weight);
 
-				if weight_used.all_gte(max_weight) {
+				if weight_used.any_gte(max_weight) {
 					break;
 				}
 			}

--- a/pallets/liquidity-pools-gateway-queue/src/tests.rs
+++ b/pallets/liquidity-pools-gateway-queue/src/tests.rs
@@ -323,7 +323,7 @@ mod on_idle {
 
 			let _ = Queue::on_idle(0, TOTAL_WEIGHT);
 
-			event_exists(Event::<Runtime>::MaxNumberOfMessagesWasReached {
+			event_exists(Event::<Runtime>::MaxNumberOfMessagesReached {
 				last_processed_nonce: u64::MAX,
 			})
 		});

--- a/pallets/liquidity-pools-gateway-queue/src/tests.rs
+++ b/pallets/liquidity-pools-gateway-queue/src/tests.rs
@@ -6,7 +6,7 @@ use sp_runtime::{traits::BadOrigin, DispatchError};
 
 use crate::{
 	mock::{new_test_ext, Processor, Queue, Runtime, RuntimeEvent as MockEvent, RuntimeOrigin},
-	Error, Event, FailedMessageQueue, MessageQueue,
+	Error, Event, FailedMessageQueue, LastProcessedNonce, MessageQueue,
 };
 
 mod utils {
@@ -181,7 +181,10 @@ mod process_failed_message {
 }
 
 mod message_queue_impl {
+	use sp_arithmetic::ArithmeticError::Overflow;
+
 	use super::*;
+	use crate::MessageNonceStore;
 
 	#[test]
 	fn success() {
@@ -197,6 +200,17 @@ mod message_queue_impl {
 			event_exists(Event::<Runtime>::MessageSubmitted { nonce, message })
 		});
 	}
+
+	#[test]
+	fn error_on_max_nonce() {
+		new_test_ext().execute_with(|| {
+			let message = 1;
+
+			MessageNonceStore::<Runtime>::set(u64::MAX);
+
+			assert_noop!(Queue::queue(message), Overflow);
+		});
+	}
 }
 
 mod on_idle {
@@ -209,7 +223,7 @@ mod on_idle {
 	#[test]
 	fn success_all() {
 		new_test_ext().execute_with(|| {
-			(1..=3).for_each(|i| MessageQueue::<Runtime>::insert(i as u64, i * 10));
+			(1..=3).for_each(|i| Queue::queue(i * 10).unwrap());
 
 			Processor::mock_max_processing_weight(|_| PROCESS_LIMIT_WEIGHT);
 			let handle = Processor::mock_process(|_| (Ok(()), PROCESS_WEIGHT));
@@ -220,13 +234,14 @@ mod on_idle {
 			assert_eq!(handle.times(), 3);
 			assert_eq!(MessageQueue::<Runtime>::iter().count(), 0);
 			assert_eq!(FailedMessageQueue::<Runtime>::iter().count(), 0);
+			assert_eq!(LastProcessedNonce::<Runtime>::get(), 3)
 		});
 	}
 
 	#[test]
 	fn not_all_messages_fit_in_the_block() {
 		new_test_ext().execute_with(|| {
-			(1..=5).for_each(|i| MessageQueue::<Runtime>::insert(i as u64, i * 10));
+			(1..=5).for_each(|i| Queue::queue(i * 10).unwrap());
 
 			Processor::mock_max_processing_weight(|_| PROCESS_LIMIT_WEIGHT);
 			let handle = Processor::mock_process(|_| (Ok(()), PROCESS_WEIGHT));
@@ -245,13 +260,14 @@ mod on_idle {
 			assert_eq!(weight, PROCESS_WEIGHT);
 			assert_eq!(handle.times(), 5);
 			assert_eq!(MessageQueue::<Runtime>::iter().count(), 0);
+			assert_eq!(LastProcessedNonce::<Runtime>::get(), 5)
 		});
 	}
 
 	#[test]
 	fn with_failed_messages() {
 		new_test_ext().execute_with(|| {
-			(1..=3).for_each(|i| MessageQueue::<Runtime>::insert(i as u64, i * 10));
+			(1..=3).for_each(|i| Queue::queue(i * 10).unwrap());
 
 			Processor::mock_max_processing_weight(|_| PROCESS_LIMIT_WEIGHT);
 			let handle = Processor::mock_process(|msg| match msg {
@@ -265,6 +281,51 @@ mod on_idle {
 			assert_eq!(handle.times(), 3);
 			assert_eq!(MessageQueue::<Runtime>::iter().count(), 0);
 			assert_eq!(FailedMessageQueue::<Runtime>::iter().count(), 1);
+			assert_eq!(LastProcessedNonce::<Runtime>::get(), 3)
+		});
+	}
+
+	#[test]
+	fn with_no_messages() {
+		new_test_ext().execute_with(|| {
+			let _ = Queue::on_idle(0, TOTAL_WEIGHT);
+
+			assert_eq!(LastProcessedNonce::<Runtime>::get(), 0)
+		});
+	}
+
+	#[test]
+	fn with_skipped_message_nonce() {
+		new_test_ext().execute_with(|| {
+			(1..=3).for_each(|i| Queue::queue(i * 10).unwrap());
+
+			Processor::mock_max_processing_weight(|_| PROCESS_LIMIT_WEIGHT);
+			let handle = Processor::mock_process(|_| (Ok(()), PROCESS_WEIGHT));
+
+			// Manually process the 2nd nonce, the on_idle hook should skip it and process
+			// the remaining nonces.
+			assert_ok!(Queue::process_message(RuntimeOrigin::signed(1), 2));
+
+			let weight = Queue::on_idle(0, TOTAL_WEIGHT);
+
+			assert_eq!(weight, PROCESS_WEIGHT * 2);
+			assert_eq!(handle.times(), 3);
+			assert_eq!(MessageQueue::<Runtime>::iter().count(), 0);
+			assert_eq!(FailedMessageQueue::<Runtime>::iter().count(), 0);
+			assert_eq!(LastProcessedNonce::<Runtime>::get(), 3)
+		});
+	}
+
+	#[test]
+	fn max_messages() {
+		new_test_ext().execute_with(|| {
+			LastProcessedNonce::<Runtime>::set(u64::MAX);
+
+			let _ = Queue::on_idle(0, TOTAL_WEIGHT);
+
+			event_exists(Event::<Runtime>::MaxNumberOfMessagesWasReached {
+				last_processed_nonce: u64::MAX,
+			})
 		});
 	}
 }

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -64,6 +64,7 @@ mod tests;
 
 #[frame_support::pallet]
 pub mod pallet {
+	use frame_support::transactional;
 	use super::*;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
@@ -620,6 +621,7 @@ pub mod pallet {
 	impl<T: Config> MessageProcessor for Pallet<T> {
 		type Message = GatewayMessage<T::Message, T::RouterId>;
 
+		#[transactional]
 		fn process(msg: Self::Message) -> (DispatchResult, Weight) {
 			match msg {
 				GatewayMessage::Inbound {

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -38,6 +38,7 @@ use cfg_types::domain_address::{Domain, DomainAddress};
 use frame_support::{
 	dispatch::{DispatchResult, PostDispatchInfo},
 	pallet_prelude::*,
+	storage::{with_transaction, TransactionOutcome},
 };
 use frame_system::pallet_prelude::{ensure_signed, OriginFor};
 use message::GatewayMessage;
@@ -637,8 +638,6 @@ pub mod pallet {
 		type Message = GatewayMessage<T::Message, T::RouterId>;
 
 		fn process(msg: Self::Message) -> (DispatchResult, Weight) {
-			use frame_support::storage::{with_transaction, TransactionOutcome};
-
 			// The #[transactional] macro only works for functions that return a
 			// `DispatchResult` therefore, we need to manually add this here.
 			with_transaction(|| {

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -65,6 +65,7 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	use frame_support::transactional;
+
 	use super::*;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);

--- a/pallets/liquidity-pools-gateway/src/lib.rs
+++ b/pallets/liquidity-pools-gateway/src/lib.rs
@@ -469,8 +469,8 @@ pub mod pallet {
 				router_ids.iter().any(|x| x == &router_id),
 				Error::<T>::UnknownRouter
 			);
-			// Message recovery shouldn't be supported for setups that have less than 1
-			// router since no proofs are required in that case.
+			// Message recovery shouldn't be supported for setups that have less than 2
+			// routers since no proofs are required in that case.
 			ensure!(router_ids.len() > 1, Error::<T>::NotEnoughRoutersForDomain);
 
 			let session_id = SessionIdStore::<T>::get();

--- a/pallets/liquidity-pools-gateway/src/message_processing.rs
+++ b/pallets/liquidity-pools-gateway/src/message_processing.rs
@@ -1,6 +1,5 @@
 use cfg_traits::liquidity_pools::{
-	InboundMessageHandler, LpMessageBatch, LpMessageHash, LpMessageProof, MessageHash,
-	MessageQueue, RouterProvider,
+	InboundMessageHandler, LpMessageHash, LpMessageProof, MessageHash, MessageQueue, RouterProvider,
 };
 use cfg_types::domain_address::{Domain, DomainAddress};
 use frame_support::{
@@ -323,7 +322,6 @@ impl<T: Config> Pallet<T> {
 		session_id: T::SessionId,
 		expected_proof_count: u32,
 		domain_address: DomainAddress,
-		counter: &mut u64,
 	) -> DispatchResult {
 		let mut message = None;
 		let mut votes = 0;
@@ -354,11 +352,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		if let Some(msg) = message {
-			for submessage in msg.submessages() {
-				counter.ensure_add_assign(1)?;
-
-				T::InboundMessageHandler::handle(domain_address.clone(), submessage)?;
-			}
+			T::InboundMessageHandler::handle(domain_address.clone(), msg)?;
 
 			Self::execute_post_voting_dispatch(message_hash, router_ids, expected_proof_count)?;
 
@@ -410,7 +404,6 @@ impl<T: Config> Pallet<T> {
 		domain_address: DomainAddress,
 		message: T::Message,
 		router_id: T::RouterId,
-		counter: &mut u64,
 	) -> DispatchResult {
 		let router_ids = Self::get_router_ids_for_domain(domain_address.domain())?;
 		let session_id = SessionIdStore::<T>::get();
@@ -440,7 +433,6 @@ impl<T: Config> Pallet<T> {
 			session_id,
 			expected_proof_count,
 			domain_address.clone(),
-			counter,
 		)?;
 
 		Ok(())

--- a/pallets/liquidity-pools-gateway/src/message_processing.rs
+++ b/pallets/liquidity-pools-gateway/src/message_processing.rs
@@ -334,7 +334,11 @@ impl<T: Config> Pallet<T> {
 				// we can return.
 				None => return Ok(()),
 				Some(stored_inbound_entry) => match stored_inbound_entry {
-					InboundEntry::Message(message_entry) => message = Some(message_entry.message),
+					InboundEntry::Message(message_entry)
+						if message_entry.session_id == session_id =>
+					{
+						message = Some(message_entry.message)
+					}
 					InboundEntry::Proof(proof_entry)
 						if proof_entry.has_valid_vote_for_session(session_id) =>
 					{

--- a/pallets/liquidity-pools-gateway/src/tests.rs
+++ b/pallets/liquidity-pools-gateway/src/tests.rs
@@ -3863,12 +3863,15 @@ mod implementations {
 						}),
 					);
 
+					let mut counter = 0;
+
 					assert_ok!(LiquidityPoolsGateway::execute_if_requirements_are_met(
 						MESSAGE_HASH,
 						&router_ids,
 						session_id,
 						expected_proof_count,
 						domain_address,
+						&mut counter,
 					));
 					assert!(
 						PendingInboundEntries::<Runtime>::get(MESSAGE_HASH, ROUTER_ID_1).is_some()

--- a/runtime/integration-tests/src/cases/lp/utils.rs
+++ b/runtime/integration-tests/src/cases/lp/utils.rs
@@ -33,7 +33,7 @@ use staging_xcm::{
 use crate::{
 	cases::lp::{EVM_DOMAIN_CHAIN_ID, EVM_ROUTER_ID, POOL_A, POOL_B, POOL_C},
 	config::Runtime,
-	utils::{accounts::Keyring, evm::receipt_ok, last_event, pool::get_tranche_ids},
+	utils::{accounts::Keyring, last_event, pool::get_tranche_ids},
 };
 
 /// Returns the local representation of a remote ethereum account
@@ -86,7 +86,7 @@ pub fn pool_c_tranche_1_id<T: Runtime>() -> TrancheId {
 }
 
 pub fn verify_outbound_failure_on_lp<T: Runtime>(to: H160) {
-	let (_tx, status, receipt) = pallet_ethereum::Pending::<T>::get()
+	let (_tx, status, _receipt) = pallet_ethereum::Pending::<T>::get()
 		.last()
 		.expect("Queue triggered evm tx.")
 		.clone();
@@ -94,7 +94,6 @@ pub fn verify_outbound_failure_on_lp<T: Runtime>(to: H160) {
 	// The sender is the sender account on the gateway
 	assert_eq!(T::Sender::get().h160(), status.from);
 	assert_eq!(status.to.unwrap().0, to.0);
-	assert!(!receipt_ok(receipt));
 	assert!(matches!(
 		last_event::<T, pallet_liquidity_pools_gateway_queue::Event::<T>>(),
 		pallet_liquidity_pools_gateway_queue::Event::<T>::MessageExecutionFailure { .. }


### PR DESCRIPTION
# Description

Various fixes for LP gateway-related logic.

## Changes and Descriptions

### LP Gateway
- Make `MessageProcessor` implementation transactional to ensure that storage changes are reverted on failure.
- Move iteration over inbound sub-messages in execution logic.
- Add session ID check for inbound message entries when checking for votes/proofs.
- Use defensive weight when executing message recovery.
- Add more tests that cover session ID changes and storage rollback.

### LP Gateway Queue
- Remove extra weight check.
- Get `MessageQueue` keys, order them, and iterate over them when servicing the `MessageQueue`. 

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
