### PR TITLE
fix: typos in documentation files

### DIFF
--- a/ci/check_runtime_changes.sh
+++ b/ci/check_runtime_changes.sh
@@ -48,7 +48,7 @@ RUNTIME_FILE_CHANGED=$(echo "${CHANGED_FILES}" | grep -e ^runtime/ | wc -l)
 
 echo "There are ${RUNTIME_FILE_CHANGED} file(s) changed in runtime "
 
-# If there are no changes in the runtime file, exit sucessfully
+# If there are no changes in the runtime file, exit successfully
 if (( $RUNTIME_FILE_CHANGED == 0 ))
 then
 	echo -e "| ${OK} Nothing is changed in runtime"

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -301,7 +301,7 @@ pub mod pallet {
 		/// The metadata of the given asset does not declare it as transferable
 		/// via LiquidityPools'.
 		AssetNotLiquidityPoolsTransferable,
-		/// The asset is not a a wrapped token and thus cannot be
+		/// The asset is not a wrapped token and thus cannot be
 		/// transferred via liquidity pools.
 		AssetNotLiquidityPoolsWrappedToken,
 		/// A pool could not be found.

--- a/pallets/pool-system/src/tranches.rs
+++ b/pallets/pool-system/src/tranches.rs
@@ -2064,7 +2064,7 @@ pub mod test {
 		fn replace_tranche_less_interest_than_next_works() {
 			let mut tranches = default_tranches();
 
-			// ensure we have an interest rate lower than the the left side tranche with a
+			// ensure we have an interest rate lower than the left side tranche with a
 			// lower index, e.g. lower than 10% at index 1
 			let int_per_sec = Rate::one() / Rate::saturating_from_integer(SECS_PER_YEAR);
 			let min_risk_buffer = Perquintill::from_rational(4u64, 5);


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

Description correction:
Corrected `sucessfully` to `successfully`
Corrected `not a a wrapped` to `not a wrapped`
Corrected `than the the left` to `than the left`

Please review the changes and let me know if any additional changes are needed.