### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -1054,7 +1054,7 @@ pub mod pallet {
 			Ok(general_index.index)
 		}
 
-		/// Returns the local currency identifier from from its general index.
+		/// Returns the local currency identifier from its general index.
 		///
 		/// Requires the currency to be registered in the `AssetRegistry`.
 		///

--- a/pallets/pool-fees/src/lib.rs
+++ b/pallets/pool-fees/src/lib.rs
@@ -553,7 +553,7 @@ pub mod pallet {
 			})
 		}
 
-		/// Return the the last fee id and bump it for the next query
+		/// Return the last fee id and bump it for the next query
 		pub(crate) fn generate_fee_id() -> Result<T::FeeId, ArithmeticError> {
 			LastFeeId::<T>::try_mutate(|last_fee_id| {
 				last_fee_id.ensure_add_assign(One::one())?;

--- a/pallets/pool-system/src/tranches.rs
+++ b/pallets/pool-system/src/tranches.rs
@@ -2144,7 +2144,7 @@ pub mod test {
 			let mut tranches = default_tranches();
 
 			let min_risk_buffer = Perquintill::from_rational(4u64, 5);
-			// ensure we have an interest rate larger than the the right-side tranche with a
+			// ensure we have an interest rate larger than the right-side tranche with a
 			// greater index, e.g. larger than 5% at index 2
 			let int_per_sec = Rate::saturating_from_rational(6u64, 100)
 				/ Rate::saturating_from_integer(SECS_PER_YEAR)

--- a/runtime/integration-tests/src/cases/block_rewards.rs
+++ b/runtime/integration-tests/src/cases/block_rewards.rs
@@ -136,7 +136,7 @@ fn apply_and_check_session<T: Runtime>(
 	// The event exists in this list:
 	dbg!(frame_system::Pallet::<T>::events())
 
-	// But not in in this list (that is the implementation of find_event()),
+	// But not in this list (that is the implementation of find_event()),
 	// so try_into returns an Err for it.
 	dbg!(frame_system::Pallet::<T>::events()
 		.into_iter()


### PR DESCRIPTION
# Description

remove redundant words in comment



## Changes and Descriptions

[List your changes here]

# Checklist:

- [x] I have added Rust doc comments to structs, enums, traits and functions
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
