### PR TITLE
Typos fix

### DIFF
--- a/node/res/genesis/README.md
+++ b/node/res/genesis/README.md
@@ -1,4 +1,4 @@
 # Genesis Specifications of Live Networks
 This folder contains the genesis chain specifications of the live networks *Altair* and *Centrifuge*.
-The specs should not be changed or altered, so that nodes in the future can use theses files to sync with the live network.
+The specs should not be changed or altered, so that nodes in the future can use these, thesis files to sync with the live network.
 


### PR DESCRIPTION
### Changes

1. **File:** `/node/res/genesis/README.md`
    - Fixed `theses` to `these, thesis` (Line 3)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.