### PR TITLE
fix typo in runtime comments

### DIFF
--- a/runtime/centrifuge/src/lib.rs
+++ b/runtime/centrifuge/src/lib.rs
@@ -297,7 +297,7 @@ parameter_types! {
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
 	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
-	// Using weights for recomended hardware
+	// Using weights for recommended hardware
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
 	type OnSystemEvent = ();
 	type OutboundXcmpMessageSource = XcmpQueue;
@@ -318,7 +318,7 @@ parameter_types! {
 impl pallet_message_queue::Config for Runtime {
 	type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
 	type MaxStale = sp_core::ConstU32<8>;
-	// Using weights for recomended hardware
+	// Using weights for recommended hardware
 	#[cfg(feature = "runtime-benchmarks")]
 	type MessageProcessor =
 		pallet_message_queue::mock_helpers::NoopMessageProcessor<AggregateMessageOrigin>;

--- a/runtime/development/src/lib.rs
+++ b/runtime/development/src/lib.rs
@@ -308,7 +308,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	// to be able to recover quickly from a relay chains issue
 	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::AnyRelayNumber;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
-	// Using weights for recomended hardware
+	// Using weights for recommended hardware
 	type OnSystemEvent = ();
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type ReservedDmpWeight = ReservedDmpWeight;
@@ -328,7 +328,7 @@ parameter_types! {
 impl pallet_message_queue::Config for Runtime {
 	type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
 	type MaxStale = sp_core::ConstU32<8>;
-	// Using weights for recomended hardware
+	// Using weights for recommended hardware
 	#[cfg(feature = "runtime-benchmarks")]
 	type MessageProcessor =
 		pallet_message_queue::mock_helpers::NoopMessageProcessor<AggregateMessageOrigin>;


### PR DESCRIPTION


Description:
This pull request corrects a typo in comments within the runtime/centrifuge and runtime/development modules, changing `recomended hardware` to `recommended hardware` for improved clarity and professionalism. 