### PR TITLE
Fix typos in code comments

### DIFF
--- a/runtime/integration-tests/src/cases/routers.rs
+++ b/runtime/integration-tests/src/cases/routers.rs
@@ -139,7 +139,7 @@ mod axelar_evm {
 			};
 
 			// If the message is correctly processed, it means that the router sends
-			// correcly the message
+			// correctly the message
 			assert_ok!(pallet_liquidity_pools_gateway::Pallet::<T>::process(gateway_message).0);
 		});
 	}

--- a/runtime/integration-tests/src/lib.rs
+++ b/runtime/integration-tests/src/lib.rs
@@ -34,7 +34,7 @@ mod impls;
 /// Generate tests for the specified runtimes or all runtimes.
 /// Usage. Used as building block for #[test_runtimes] procedural macro.
 ///
-/// NOTE: Do not use it direclty, use `#[test_runtimes]` proc macro instead
+/// NOTE: Do not use it directly, use `#[test_runtimes]` proc macro instead
 #[macro_export]
 macro_rules! __test_for_runtimes {
 	( [ $($runtime_name:ident),* ], $test_name:ident $(, $ignore:meta)?) => {

--- a/runtime/integration-tests/src/utils/accounts.rs
+++ b/runtime/integration-tests/src/utils/accounts.rs
@@ -49,7 +49,7 @@ impl Keyring {
 	}
 
 	/// Returns the Ethereum address.
-	/// The H160 retrived is NOT the local representation of that account in our
+	/// The H160 retrieved is NOT the local representation of that account in our
 	/// chain, it's the real address in ethereum.
 	pub fn in_eth(self) -> H160 {
 		let pair: ecdsa::Pair = self.into();

--- a/runtime/integration-tests/src/utils/xcm.rs
+++ b/runtime/integration-tests/src/utils/xcm.rs
@@ -49,7 +49,7 @@ pub fn enable_para_to_sibling_communication<T: Runtime + FudgeSupport>(env: &mut
 	});
 
 	env.relay_state_mut(|| {
-		// Enable para -> sibling comunication though relay
+		// Enable para -> sibling communication though relay
 		assert_ok!(
 			polkadot_runtime_parachains::hrmp::Pallet::<RelayRuntime<T>>::force_open_hrmp_channel(
 				RawOrigin::Root.into(),


### PR DESCRIPTION


## Description

This PR fixes minor spelling errors in code comments across the integration tests module:

- **`routers.rs`**: Fixed "correcly" → "correctly" in comment
- **`lib.rs`**: Fixed "direclty" → "directly" in comment  
- **`accounts.rs`**: Fixed "retrived" → "retrieved" in comment
- **`xcm.rs`**: Fixed "comunication" → "communication" in comment

